### PR TITLE
Fix: Add database setup for physical inventory verification

### DIFF
--- a/src/SOLUCION_VERIFICACION_FISICA.md
+++ b/src/SOLUCION_VERIFICACION_FISICA.md
@@ -1,0 +1,275 @@
+# 🔧 Solución: Productos No Cargan en Verificación Física
+
+## 🎯 Problema Identificado
+
+Al intentar iniciar una verificación física de inventario, **no se están cargando los productos activos**.
+
+### Causa Raíz
+
+Las **tablas de base de datos necesarias para el módulo de Verificación Física NO existen** en tu proyecto de Supabase:
+
+- ❌ `verificaciones_inventario` - Tabla principal de verificaciones
+- ❌ `verificaciones_detalle` - Detalle de productos verificados
+- ❌ `vista_resumen_verificaciones` - Vista con resumen agregado
+- ❌ Triggers para calcular diferencias automáticamente
+- ⚠️ Posiblemente falta campo `activo` en tabla `productos`
+
+## ✅ Solución Completa (5 minutos)
+
+### Paso 1: Acceder al SQL Editor de Supabase
+
+1. Ve a tu proyecto en [Supabase](https://supabase.com)
+2. En el panel lateral, haz clic en **🛢️ SQL Editor**
+3. Haz clic en **"+ New query"**
+
+### Paso 2: Ejecutar el Script de Configuración
+
+1. Abre el archivo `VERIFICACION_INVENTARIO_SETUP.sql` (está en la carpeta `src`)
+2. **Copia TODO el contenido** del archivo
+3. **Pega** en el editor SQL de Supabase
+4. Haz clic en **"Run"** (botón verde, esquina inferior derecha)
+5. Espera 5-10 segundos mientras se ejecuta
+
+### Paso 3: Verificar Instalación Exitosa
+
+Deberías ver al final del resultado una tabla como esta:
+
+```
+tipo                          | cantidad
+------------------------------|----------
+Tablas creadas/verificadas    |    2
+Vistas creadas                |    1
+Triggers creados              |    1
+Funciones creadas             |    2
+```
+
+✅ **¡Si ves estos números, todo está correctamente configurado!**
+
+### Paso 4: Probar la Verificación Física
+
+1. Regresa a tu aplicación
+2. Ve a **Inventario** > **Verificaciones**
+3. Haz clic en **"Nueva Verificación"**
+4. **Deberías ver ahora la lista de todos tus productos activos** ✨
+
+---
+
+## 📊 ¿Qué Hace el Script?
+
+El script `VERIFICACION_INVENTARIO_SETUP.sql` configura automáticamente:
+
+### 1️⃣ Tablas Creadas
+
+#### `verificaciones_inventario`
+Registro principal de cada verificación física:
+- ID único de verificación
+- Fechas (inicio, fin, revisión)
+- Estado (En proceso, Completada, Pendiente Aprobación, Aprobada, Rechazada)
+- Usuario verificador y revisor
+- Observaciones generales
+
+#### `verificaciones_detalle`
+Detalle de cada producto en la verificación:
+- Cantidad teórica (del sistema)
+- Cantidad física (contada en bodega)
+- Diferencia calculada automáticamente
+- Porcentaje de diferencia
+- Valor monetario de la diferencia
+- Estado (Pendiente, OK, Sobrante, Faltante)
+- Flag de aprobación
+
+### 2️⃣ Vista Creada
+
+#### `vista_resumen_verificaciones`
+Vista agregada con métricas calculadas:
+- Total de productos
+- Productos contados vs pendientes
+- Productos OK vs con diferencias
+- Valor total de diferencias
+- Porcentaje de completado
+- Productos aprobados
+
+### 3️⃣ Triggers y Funciones
+
+#### Trigger: `calcular_diferencias_verificacion`
+Se ejecuta automáticamente cuando se ingresa la cantidad física y calcula:
+- **Diferencia** = cantidad_fisica - cantidad_teorica
+- **Porcentaje** = (diferencia / cantidad_teorica) × 100
+- **Valor** = diferencia × precio_unitario
+- **Estado** = OK / Sobrante / Faltante
+
+#### Función: `aplicar_ajustes_verificacion`
+Función que puede llamarse para aplicar los ajustes aprobados:
+- Actualiza `cantidad_actual` en tabla `productos`
+- Registra movimientos en `movimientos_inventario`
+- Marca verificación como "Aprobada"
+
+### 4️⃣ Políticas RLS Configuradas
+
+Row Level Security habilitado con políticas que permiten:
+- ✅ Usuarios autenticados pueden leer todas las verificaciones
+- ✅ Usuarios autenticados pueden crear verificaciones
+- ✅ Usuarios autenticados pueden actualizar verificaciones
+- ✅ Usuarios autenticados pueden eliminar verificaciones
+
+### 5️⃣ Campo `activo` en Productos
+
+Si tu tabla `productos` no tenía el campo `activo`, el script lo agrega automáticamente:
+```sql
+ALTER TABLE productos ADD COLUMN activo BOOLEAN DEFAULT true;
+```
+
+---
+
+## 🔄 Flujo Completo del Módulo
+
+### Fase 1: Iniciar Verificación (NuevaVerificacion.tsx)
+1. Usuario gerencia o verificador hace clic en "Nueva Verificación"
+2. El sistema **carga todos los productos activos** (activo !== false)
+3. Crea registro en `verificaciones_inventario` con estado "En proceso"
+4. Crea un registro en `verificaciones_detalle` por cada producto
+   - `cantidad_teorica` = cantidad actual del sistema
+   - `cantidad_fisica` = null (se llenará en el conteo)
+5. Redirige a pantalla de conteo físico
+
+### Fase 2: Conteo Físico (ConteoFisico.tsx)
+1. Interfaz optimizada para móvil/tablet
+2. Verificador navega producto por producto
+3. Ingresa cantidad encontrada en bodega
+4. Puede agregar observaciones
+5. Al guardar, **el trigger calcula automáticamente**:
+   - Diferencia nominal
+   - Porcentaje de diferencia
+   - Valor monetario de la diferencia
+   - Estado (OK, Sobrante, Faltante)
+6. Al terminar todos los productos, marca verificación como "Pendiente Aprobación"
+
+### Fase 3: Revisión y Aprobación (Próximamente)
+1. Gerencia recibe badge de notificación
+2. Revisa las diferencias encontradas
+3. Puede aprobar todas o solo algunas (checkbox individual)
+4. Todo lo aprobado se aplica oficialmente al inventario:
+   - Se actualiza `cantidad_actual` en `productos`
+   - Se registra en `movimientos_inventario`
+5. Sistema queda conciliado con bodega física
+
+---
+
+## 🐛 Solución de Problemas
+
+### ❌ Error: "relation verificaciones_inventario does not exist"
+**Problema**: No ejecutaste el script SQL
+**Solución**: Sigue los pasos 1-3 arriba
+
+### ❌ Error: "permission denied for table verificaciones_inventario"
+**Problema**: Las políticas RLS no se crearon correctamente
+**Solución**: El script incluye las políticas. Ejecuta el script completo nuevamente.
+
+### ❌ Error: "column activo does not exist in table productos"
+**Problema**: La tabla productos no tiene el campo activo
+**Solución**: El script lo agrega automáticamente. Ejecuta el script completo.
+
+### ❌ Aún no cargan los productos
+**Posibles causas**:
+1. **No hay productos en tu base de datos**
+   - Solución: Ejecuta `SAMPLE_DATA.sql` para insertar 23 productos de ejemplo
+   - O agrega productos manualmente desde Inventario > Nueva Compra
+
+2. **Todos los productos tienen activo = false**
+   - Solución: Actualiza productos a activo = true:
+   ```sql
+   UPDATE productos SET activo = true WHERE activo = false;
+   ```
+
+3. **Error de autenticación**
+   - Solución: Verifica que estés logueado correctamente
+   - Revisa la consola del navegador (F12) para ver errores
+
+### 🔍 Verificar Datos en la Base de Datos
+
+Para verificar que tienes productos activos:
+
+```sql
+-- Ver todos los productos activos
+SELECT id, nombre, categoria, cantidad_actual, activo
+FROM productos
+WHERE activo IS DISTINCT FROM false
+ORDER BY nombre;
+
+-- Contar productos activos
+SELECT COUNT(*) AS total_productos_activos
+FROM productos
+WHERE activo IS DISTINCT FROM false;
+```
+
+---
+
+## 📋 Checklist Final
+
+Antes de reportar un problema, verifica:
+
+- [ ] ✅ Ejecuté el script `VERIFICACION_INVENTARIO_SETUP.sql` completo
+- [ ] ✅ Vi la tabla de verificación con 2 tablas, 1 vista, 1 trigger, 2 funciones
+- [ ] ✅ Tengo productos en mi base de datos (mínimo 1)
+- [ ] ✅ Los productos tienen `activo = true` o `activo = null`
+- [ ] ✅ Estoy logueado con un usuario autenticado
+- [ ] ✅ Revisé la consola del navegador (F12) y no hay errores en rojo
+- [ ] ✅ Actualicé la página después de ejecutar el script
+
+---
+
+## 🎉 Resultado Esperado
+
+Después de seguir estos pasos:
+
+1. ✅ Al hacer clic en **"Nueva Verificación"** deberías ver:
+   - Lista completa de productos activos
+   - Cantidades actuales de cada producto
+   - Resumen con total de productos y valor total
+   - Botón "Iniciar Verificación" habilitado
+
+2. ✅ Al hacer clic en **"Iniciar Verificación"**:
+   - Se crea el registro de verificación
+   - Te redirige a pantalla de conteo físico
+   - Puedes navegar producto por producto
+   - Puedes ingresar las cantidades encontradas
+
+3. ✅ Al guardar una cantidad física:
+   - El sistema calcula automáticamente la diferencia
+   - Muestra si hay sobrante o faltante
+   - Calcula el valor monetario de la diferencia
+
+---
+
+## 📞 Soporte Adicional
+
+Si después de seguir todos estos pasos el problema persiste:
+
+1. **Revisa la consola del navegador** (F12 > Console)
+2. **Copia el mensaje de error exacto**
+3. **Verifica las tablas en Supabase**:
+   - Ve a **Table Editor** en Supabase
+   - Confirma que existen `verificaciones_inventario` y `verificaciones_detalle`
+4. **Consulta los logs de Supabase**:
+   - Ve a **Logs** > **Postgres Logs** en Supabase
+   - Busca errores recientes
+
+---
+
+**Tiempo estimado para aplicar la solución: 5 minutos** ⏱️
+
+✅ **Una vez configurado, funcionará perfectamente y no necesitarás volver a hacer este proceso**
+
+---
+
+## 📚 Archivos Relacionados
+
+- `VERIFICACION_INVENTARIO_SETUP.sql` - Script SQL completo (ejecutar en Supabase)
+- `src/components/inventory/NuevaVerificacion.tsx` - Componente para iniciar verificación
+- `src/components/inventory/ConteoFisico.tsx` - Componente de conteo físico
+- `src/components/inventory/VerificacionesList.tsx` - Lista de verificaciones
+- `SAMPLE_DATA.sql` - Datos de ejemplo (incluye 23 productos)
+
+---
+
+**¡Listo! Con esto deberías poder usar el módulo de Verificación Física sin problemas** 🎯

--- a/src/VERIFICACION_INVENTARIO_SETUP.sql
+++ b/src/VERIFICACION_INVENTARIO_SETUP.sql
@@ -1,0 +1,329 @@
+-- =====================================================
+-- CONFIGURACIÓN COMPLETA PARA VERIFICACIÓN FÍSICA DE INVENTARIO
+-- =====================================================
+-- Este script crea todas las tablas, vistas, triggers y políticas
+-- necesarias para el módulo de Verificación Física de Inventario
+-- =====================================================
+
+-- =====================================================
+-- 1. ASEGURAR QUE LA TABLA PRODUCTOS TIENE EL CAMPO ACTIVO
+-- =====================================================
+
+-- Si la tabla productos ya existe pero no tiene el campo 'activo', agregarlo
+DO $$
+BEGIN
+    IF NOT EXISTS (
+        SELECT 1 FROM information_schema.columns
+        WHERE table_name = 'productos' AND column_name = 'activo'
+    ) THEN
+        ALTER TABLE productos ADD COLUMN activo BOOLEAN DEFAULT true;
+    END IF;
+END $$;
+
+-- =====================================================
+-- 2. TABLA: verificaciones_inventario
+-- =====================================================
+-- Almacena el registro principal de cada verificación física
+
+CREATE TABLE IF NOT EXISTS verificaciones_inventario (
+  id SERIAL PRIMARY KEY,
+  fecha_inicio DATE NOT NULL DEFAULT CURRENT_DATE,
+  fecha_fin DATE,
+  estado TEXT NOT NULL DEFAULT 'En proceso',
+    -- Valores posibles: 'En proceso', 'Completada', 'Pendiente Aprobación', 'Aprobada', 'Rechazada'
+  usuario_verificador TEXT NOT NULL,
+  revisada_por TEXT,
+  fecha_revision DATE,
+  observaciones_generales TEXT,
+  motivo_rechazo TEXT,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- =====================================================
+-- 3. TABLA: verificaciones_detalle
+-- =====================================================
+-- Almacena el detalle de cada producto en la verificación
+
+CREATE TABLE IF NOT EXISTS verificaciones_detalle (
+  id SERIAL PRIMARY KEY,
+  verificacion_id INTEGER NOT NULL REFERENCES verificaciones_inventario(id) ON DELETE CASCADE,
+  producto_id INTEGER NOT NULL REFERENCES productos(id),
+  cantidad_teorica NUMERIC NOT NULL DEFAULT 0,
+  cantidad_fisica NUMERIC,
+  diferencia NUMERIC DEFAULT 0,
+  porcentaje_diferencia NUMERIC DEFAULT 0,
+  valor_diferencia NUMERIC DEFAULT 0,
+  estado_diferencia TEXT DEFAULT 'Pendiente',
+    -- Valores: 'Pendiente', 'OK', 'Sobrante', 'Faltante'
+  observaciones TEXT,
+  contado BOOLEAN DEFAULT false,
+  aprobado BOOLEAN DEFAULT false,
+  created_at TIMESTAMP DEFAULT NOW(),
+  updated_at TIMESTAMP DEFAULT NOW()
+);
+
+-- Índices para mejorar el rendimiento
+CREATE INDEX IF NOT EXISTS idx_verificaciones_detalle_verificacion
+  ON verificaciones_detalle(verificacion_id);
+CREATE INDEX IF NOT EXISTS idx_verificaciones_detalle_producto
+  ON verificaciones_detalle(producto_id);
+
+-- =====================================================
+-- 4. TRIGGER: Calcular diferencias automáticamente
+-- =====================================================
+-- Este trigger se ejecuta cuando se actualiza cantidad_fisica
+-- y calcula automáticamente: diferencia, porcentaje, valor y estado
+
+CREATE OR REPLACE FUNCTION calcular_diferencias_verificacion()
+RETURNS TRIGGER AS $$
+DECLARE
+  precio_producto NUMERIC;
+BEGIN
+  -- Solo calcular si se ingresó cantidad_fisica
+  IF NEW.cantidad_fisica IS NOT NULL THEN
+    -- Obtener el precio del producto
+    SELECT precio_unitario INTO precio_producto
+    FROM productos
+    WHERE id = NEW.producto_id;
+
+    -- Calcular diferencia (cantidad física - teórica)
+    NEW.diferencia := NEW.cantidad_fisica - NEW.cantidad_teorica;
+
+    -- Calcular porcentaje de diferencia
+    IF NEW.cantidad_teorica > 0 THEN
+      NEW.porcentaje_diferencia := (NEW.diferencia / NEW.cantidad_teorica) * 100;
+    ELSE
+      NEW.porcentaje_diferencia := 0;
+    END IF;
+
+    -- Calcular valor de la diferencia
+    NEW.valor_diferencia := NEW.diferencia * COALESCE(precio_producto, 0);
+
+    -- Determinar estado de la diferencia
+    IF ABS(NEW.diferencia) < 0.01 THEN
+      NEW.estado_diferencia := 'OK';
+    ELSIF NEW.diferencia > 0 THEN
+      NEW.estado_diferencia := 'Sobrante';
+    ELSE
+      NEW.estado_diferencia := 'Faltante';
+    END IF;
+
+    -- Marcar como contado
+    NEW.contado := true;
+
+    -- Actualizar timestamp
+    NEW.updated_at := NOW();
+  END IF;
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+-- Crear trigger en la tabla verificaciones_detalle
+DROP TRIGGER IF EXISTS trigger_calcular_diferencias ON verificaciones_detalle;
+CREATE TRIGGER trigger_calcular_diferencias
+  BEFORE INSERT OR UPDATE OF cantidad_fisica
+  ON verificaciones_detalle
+  FOR EACH ROW
+  EXECUTE FUNCTION calcular_diferencias_verificacion();
+
+-- =====================================================
+-- 5. VISTA: vista_resumen_verificaciones
+-- =====================================================
+-- Proporciona un resumen agregado de cada verificación
+
+CREATE OR REPLACE VIEW vista_resumen_verificaciones AS
+SELECT
+  v.id,
+  v.fecha_inicio,
+  v.fecha_fin,
+  v.estado,
+  v.usuario_verificador,
+  v.revisada_por,
+  v.fecha_revision,
+  v.observaciones_generales,
+  v.motivo_rechazo,
+
+  -- Contadores
+  COUNT(vd.id) AS total_productos,
+  COUNT(vd.id) FILTER (WHERE vd.contado = true) AS productos_contados,
+  COUNT(vd.id) FILTER (WHERE vd.estado_diferencia = 'OK') AS productos_ok,
+  COUNT(vd.id) FILTER (WHERE vd.estado_diferencia IN ('Sobrante', 'Faltante')) AS productos_diferencia,
+
+  -- Valores agregados
+  COALESCE(SUM(ABS(vd.valor_diferencia)), 0) AS valor_total_diferencias,
+
+  -- Porcentaje de completado
+  CASE
+    WHEN COUNT(vd.id) > 0 THEN
+      ROUND((COUNT(vd.id) FILTER (WHERE vd.contado = true)::NUMERIC / COUNT(vd.id)::NUMERIC) * 100, 2)
+    ELSE 0
+  END AS porcentaje_completado,
+
+  -- Aprobaciones
+  COUNT(vd.id) FILTER (WHERE vd.aprobado = true) AS productos_aprobados,
+
+  v.created_at,
+  v.updated_at
+FROM
+  verificaciones_inventario v
+  LEFT JOIN verificaciones_detalle vd ON v.id = vd.verificacion_id
+GROUP BY
+  v.id, v.fecha_inicio, v.fecha_fin, v.estado, v.usuario_verificador,
+  v.revisada_por, v.fecha_revision, v.observaciones_generales,
+  v.motivo_rechazo, v.created_at, v.updated_at;
+
+-- =====================================================
+-- 6. FUNCIÓN: Aplicar ajustes aprobados al inventario
+-- =====================================================
+-- Esta función actualiza las cantidades en productos y registra movimientos
+
+CREATE OR REPLACE FUNCTION aplicar_ajustes_verificacion(
+  p_verificacion_id INTEGER,
+  p_usuario TEXT
+)
+RETURNS TABLE (
+  productos_actualizados INTEGER,
+  movimientos_creados INTEGER
+) AS $$
+DECLARE
+  v_productos_actualizados INTEGER := 0;
+  v_movimientos_creados INTEGER := 0;
+  v_detalle RECORD;
+BEGIN
+  -- Iterar sobre todos los detalles aprobados con diferencias
+  FOR v_detalle IN
+    SELECT
+      vd.id,
+      vd.producto_id,
+      vd.cantidad_teorica,
+      vd.cantidad_fisica,
+      vd.diferencia,
+      vd.observaciones,
+      p.cantidad_actual,
+      p.nombre AS producto_nombre
+    FROM verificaciones_detalle vd
+    JOIN productos p ON p.id = vd.producto_id
+    WHERE vd.verificacion_id = p_verificacion_id
+      AND vd.aprobado = true
+      AND ABS(vd.diferencia) >= 0.01
+  LOOP
+    -- Actualizar cantidad en productos
+    UPDATE productos
+    SET cantidad_actual = v_detalle.cantidad_fisica
+    WHERE id = v_detalle.producto_id;
+
+    v_productos_actualizados := v_productos_actualizados + 1;
+
+    -- Registrar movimiento en tabla de movimientos_inventario
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'movimientos_inventario') THEN
+      INSERT INTO movimientos_inventario (
+        producto_id,
+        tipo_movimiento,
+        cantidad,
+        cantidad_anterior,
+        cantidad_nueva,
+        referencia_id,
+        tipo_referencia,
+        notas
+      ) VALUES (
+        v_detalle.producto_id,
+        CASE WHEN v_detalle.diferencia > 0 THEN 'entrada' ELSE 'salida' END,
+        ABS(v_detalle.diferencia),
+        v_detalle.cantidad_teorica,
+        v_detalle.cantidad_fisica,
+        p_verificacion_id,
+        'verificacion_fisica',
+        CONCAT(
+          'Ajuste por verificación física. ',
+          CASE
+            WHEN v_detalle.diferencia > 0 THEN 'Sobrante: +'
+            ELSE 'Faltante: '
+          END,
+          v_detalle.diferencia,
+          '. ',
+          COALESCE(v_detalle.observaciones, '')
+        )
+      );
+
+      v_movimientos_creados := v_movimientos_creados + 1;
+    END IF;
+  END LOOP;
+
+  -- Actualizar estado de la verificación
+  UPDATE verificaciones_inventario
+  SET
+    estado = 'Aprobada',
+    fecha_fin = CURRENT_DATE,
+    fecha_revision = CURRENT_DATE,
+    revisada_por = p_usuario
+  WHERE id = p_verificacion_id;
+
+  RETURN QUERY SELECT v_productos_actualizados, v_movimientos_creados;
+END;
+$$ LANGUAGE plpgsql;
+
+-- =====================================================
+-- 7. POLÍTICAS RLS (Row Level Security)
+-- =====================================================
+
+-- Habilitar RLS en las nuevas tablas
+ALTER TABLE verificaciones_inventario ENABLE ROW LEVEL SECURITY;
+ALTER TABLE verificaciones_detalle ENABLE ROW LEVEL SECURITY;
+
+-- Políticas para verificaciones_inventario
+-- Permitir todas las operaciones a usuarios autenticados
+DROP POLICY IF EXISTS "Usuarios autenticados - verificaciones" ON verificaciones_inventario;
+CREATE POLICY "Usuarios autenticados - verificaciones"
+  ON verificaciones_inventario
+  FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- Políticas para verificaciones_detalle
+-- Permitir todas las operaciones a usuarios autenticados
+DROP POLICY IF EXISTS "Usuarios autenticados - verificaciones detalle" ON verificaciones_detalle;
+CREATE POLICY "Usuarios autenticados - verificaciones detalle"
+  ON verificaciones_detalle
+  FOR ALL
+  TO authenticated
+  USING (true)
+  WITH CHECK (true);
+
+-- =====================================================
+-- 8. VERIFICACIÓN DE INSTALACIÓN
+-- =====================================================
+
+-- Mostrar resumen de objetos creados
+SELECT 'Tablas creadas/verificadas' AS tipo, COUNT(*) AS cantidad
+FROM information_schema.tables
+WHERE table_schema = 'public'
+  AND table_name IN ('verificaciones_inventario', 'verificaciones_detalle')
+UNION ALL
+SELECT 'Vistas creadas', COUNT(*)
+FROM information_schema.views
+WHERE table_schema = 'public'
+  AND table_name = 'vista_resumen_verificaciones'
+UNION ALL
+SELECT 'Triggers creados', COUNT(*)
+FROM information_schema.triggers
+WHERE trigger_schema = 'public'
+  AND trigger_name = 'trigger_calcular_diferencias'
+UNION ALL
+SELECT 'Funciones creadas', COUNT(*)
+FROM information_schema.routines
+WHERE routine_schema = 'public'
+  AND routine_name IN ('calcular_diferencias_verificacion', 'aplicar_ajustes_verificacion');
+
+-- =====================================================
+-- FIN DEL SCRIPT
+-- =====================================================
+-- ✅ Tablas: verificaciones_inventario, verificaciones_detalle
+-- ✅ Vista: vista_resumen_verificaciones
+-- ✅ Trigger: calcular_diferencias_verificacion (auto-calcula diferencias)
+-- ✅ Función: aplicar_ajustes_verificacion (aplica ajustes al inventario)
+-- ✅ Políticas RLS configuradas
+-- ✅ Campo 'activo' agregado a tabla productos (si no existía)
+-- =====================================================


### PR DESCRIPTION
Problem:
- Products not loading when starting a physical inventory verification
- Missing database tables: verificaciones_inventario, verificaciones_detalle
- Missing view: vista_resumen_verificaciones
- Missing triggers and functions for automatic calculations

Solution:
- Created VERIFICACION_INVENTARIO_SETUP.sql with complete database schema
- Includes tables, views, triggers, functions, and RLS policies
- Adds 'activo' field to productos table if missing
- Created detailed solution guide in SOLUCION_VERIFICACION_FISICA.md

Files added:
- src/VERIFICACION_INVENTARIO_SETUP.sql: Complete SQL setup script
- src/SOLUCION_VERIFICACION_FISICA.md: Step-by-step solution guide in Spanish