### PR TITLE
Allow decimal values for canecas quantity in daily movements

### DIFF
--- a/src/components/aplicaciones/DailyMovementForm.tsx
+++ b/src/components/aplicaciones/DailyMovementForm.tsx
@@ -452,7 +452,7 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
         fecha_movimiento: fechaMovimiento,
         lote_id: loteId,
         lote_nombre: lote.nombre,
-        numero_canecas: (aplicacion.tipo_aplicacion === 'Fumigación' || aplicacion.tipo_aplicacion === 'Drench') ? parseInt(numeroCanecas, 10) : undefined,
+        numero_canecas: (aplicacion.tipo_aplicacion === 'Fumigación' || aplicacion.tipo_aplicacion === 'Drench') ? parseFloat(numeroCanecas) : undefined,
         numero_bultos: aplicacion.tipo_aplicacion === 'Fertilización' ? parseInt(numeroBultos, 10) : undefined,
         equipo_aplicacion: equipoAplicacion.trim() || undefined, // 🆕 NUEVO CAMPO
         personal: personal.trim() || undefined, //  NUEVO CAMPO
@@ -782,7 +782,7 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
                 value={numeroCanecas}
                 onChange={(e) => setNumeroCanecas(e.target.value)}
                 placeholder="0"
-                step="1"
+                step="any"
                 min="0"
                 disabled={loading}
                 className="flex-1 bg-white border-[#73991C]/20 focus:border-[#73991C] disabled:opacity-50 disabled:cursor-not-allowed"


### PR DESCRIPTION
## Summary
Updated the DailyMovementForm to support decimal values for the `numero_canecas` field instead of only accepting integers. This change allows users to input fractional quantities when recording fumigation and drench applications.

## Key Changes
- Changed `parseInt(numeroCanecas, 10)` to `parseFloat(numeroCanecas)` when processing the canecas quantity for Fumigación and Drench application types
- Updated the input field's `step` attribute from `"1"` to `"any"` to allow decimal increments in the number input

## Implementation Details
These changes enable the form to accept and properly parse decimal values (e.g., 2.5 canecas) for fumigation and drench applications, providing greater flexibility in recording precise application quantities. The `step="any"` attribute allows users to input any decimal value, while `parseFloat()` ensures the value is correctly converted to a number type for storage.

https://claude.ai/code/session_01RKd5DKZmRs5oXNbKLSkRor