### PR TITLE
Support fertilization applications with bulk units instead of cans

### DIFF
--- a/src/components/aplicaciones/DetalleAplicacion.tsx
+++ b/src/components/aplicaciones/DetalleAplicacion.tsx
@@ -99,10 +99,13 @@ export function DetalleAplicacion({
         setBlancoBiologico('No especificado');
       }
 
-      // 2. Cargar canecas planeadas (filtrar por lote si está seleccionado)
+      // 2. Cargar canecas/bultos planeados (filtrar por lote si está seleccionado)
+      const esFertilizacion = aplicacion.tipo === 'fertilizacion';
+      const campoUnidad = esFertilizacion ? 'numero_bultos' : 'numero_canecas';
+
       let calculosQuery = supabase
         .from('aplicaciones_calculos')
-        .select('numero_canecas, lote_id')
+        .select(`${campoUnidad}, lote_id`)
         .eq('aplicacion_id', aplicacion.id);
 
       if (selectedLote) {
@@ -112,19 +115,19 @@ export function DetalleAplicacion({
       const { data: calculos, error: errorCalculos } = await calculosQuery;
 
       if (errorCalculos) {
-        console.error('Error loading canecas planeadas:', errorCalculos);
+        console.error('Error loading planeadas:', errorCalculos);
       }
 
       const totalCanecasPlaneadas = calculos?.reduce(
-        (sum, calc) => sum + (calc.numero_canecas || 0),
+        (sum: number, calc: any) => sum + (calc[campoUnidad] || 0),
         0
       ) || 0;
       setCanecasPlaneadas(totalCanecasPlaneadas);
 
-      // 3. Cargar canecas aplicadas (filtrar por lote si está seleccionado)
+      // 3. Cargar canecas/bultos aplicados (filtrar por lote si está seleccionado)
       let movimientosQuery = supabase
         .from('movimientos_diarios')
-        .select('numero_canecas, lote_id')
+        .select(`${campoUnidad}, lote_id`)
         .eq('aplicacion_id', aplicacion.id);
 
       if (selectedLote) {
@@ -134,11 +137,11 @@ export function DetalleAplicacion({
       const { data: movimientosDiarios, error: errorMovimientos } = await movimientosQuery;
 
       if (errorMovimientos) {
-        console.error('Error loading canecas aplicadas:', errorMovimientos);
+        console.error('Error loading aplicadas:', errorMovimientos);
       }
 
       const totalCanecasAplicadas = movimientosDiarios?.reduce(
-        (sum, mov) => sum + (mov.numero_canecas || 0),
+        (sum: number, mov: any) => sum + (mov[campoUnidad] || 0),
         0
       ) || 0;
       setCanecasAplicadas(totalCanecasAplicadas);
@@ -463,12 +466,16 @@ export function DetalleAplicacion({
                 </div>
               </div>
 
-              {/* Card de Resumen de Canecas */}
+              {/* Card de Resumen de Canecas/Bultos */}
               <div className="bg-white rounded-2xl border border-[#73991C]/10 shadow-[0_2px_12px_rgba(115,153,28,0.06)] overflow-hidden">
                 <div className="px-5 py-3 bg-gradient-to-r from-[#73991C]/5 to-transparent border-b border-[#73991C]/10">
                   <h3 className="text-sm text-[#172E08] flex items-center gap-2">
-                    <Droplet className="w-4 h-4 text-[#73991C]" />
-                    Resumen de Canecas
+                    {aplicacion.tipo === 'fertilizacion' ? (
+                      <Package className="w-4 h-4 text-[#73991C]" />
+                    ) : (
+                      <Droplet className="w-4 h-4 text-[#73991C]" />
+                    )}
+                    {aplicacion.tipo === 'fertilizacion' ? 'Resumen de Bultos' : 'Resumen de Canecas'}
                   </h3>
                 </div>
                 <div className="p-5">


### PR DESCRIPTION
## Summary
Updated the DetalleAplicacion component to support both liquid applications (measured in cans/canecas) and fertilization applications (measured in bulk units/bultos). The component now dynamically selects the appropriate unit field based on the application type.

## Key Changes
- Added logic to detect application type (`fertilizacion` vs other types) and use the corresponding database field (`numero_bultos` for fertilization, `numero_canecas` for liquids)
- Updated database queries for both planned and applied quantities to use the dynamic field name
- Modified the summary card header to display the appropriate icon (Package for bultos, Droplet for canecas) and label based on application type
- Added proper TypeScript typing to reduce/accumulator functions for better type safety
- Updated console error messages to be more generic since they now handle both unit types

## Implementation Details
- The `esFertilizacion` flag and `campoUnidad` variable are determined once at the start of the data loading logic
- Both `aplicaciones_calculos` and `movimientos_diarios` queries use the same dynamic field selection
- The summary card conditionally renders the appropriate icon and text based on `aplicacion.tipo`
- All calculations and state management remain the same, only the field names change dynamically

https://claude.ai/code/session_01GJe3jfwCAopqrVF4EE3mBg