### PR TITLE
Refactor closure workflow to use labor records instead of manual jornal matrix

### DIFF
--- a/src/types/aplicaciones.ts
+++ b/src/types/aplicaciones.ts
@@ -406,3 +406,47 @@ export interface ResumenCierre {
   productos_con_desviacion_alta: number; // > 20%
   alertas: string[];
 }
+
+// ============================================================================
+// CIERRE UNIFICADO - Registros de trabajo para revisión en cierre
+// ============================================================================
+
+export interface RegistroTrabajoCierre {
+  id?: string;
+  tarea_id: string;
+  empleado_id?: string;
+  contratista_id?: string;
+  trabajador_nombre: string;
+  trabajador_tipo: 'empleado' | 'contratista';
+  lote_id: string;
+  lote_nombre: string;
+  fecha_trabajo: string;
+  fraccion_jornal: number;
+  costo_jornal: number;
+  observaciones?: string;
+  // Datos del trabajador para recálculos
+  salario?: number;
+  prestaciones?: number;
+  auxilios?: number;
+  horas_semanales?: number;
+  tarifa_jornal?: number;
+  // Flags de edición durante cierre
+  _isNew?: boolean;
+  _deleted?: boolean;
+  _modified?: boolean;
+}
+
+export interface ResumenLaboresCierre {
+  tarea_id: string;
+  registros: RegistroTrabajoCierre[];
+  porLote: {
+    lote_id: string;
+    lote_nombre: string;
+    total_jornales: number;
+    total_costo: number;
+  }[];
+  totalJornales: number;
+  totalCosto: number;
+  diasTrabajados: number;
+  trabajadoresUnicos: number;
+}


### PR DESCRIPTION
## Summary
This PR refactors the application closure workflow to leverage existing labor records (`registros_trabajo`) instead of requiring manual entry of a jornal matrix. The closure process now fetches, displays, and allows inline editing of labor records linked to the application's task, with automatic cost calculations based on worker salary/tariff data.

## Key Changes

### CierreAplicacion Component (`src/components/aplicaciones/CierreAplicacion.tsx`)
- **Removed manual jornal matrix**: Eliminated the `JornalPorLote` interface and matrix-based data entry in step 2
- **Added labor record management**: 
  - Fetch `registros_trabajo` from linked task via new `fetchRegistrosTrabajoParaCierre()` utility
  - Display labor records grouped by lote with expandable sections
  - Support inline editing of `fraccion_jornal` with predefined options (0.25, 0.5, 0.75, 1.0, 1.5, 2.0)
  - Allow adding new labor records with worker/lote/date selection
  - Support deletion of records (soft delete via `_deleted` flag)
- **Enhanced UI**:
  - Renamed step 2 from "Jornales" to "Labores"
  - Added summary cards showing total jornales, labor cost, worker count, and days worked
  - Added warning alerts for missing task linkage or no labor records
  - Replaced emoji indicators with cleaner text labels
- **Improved cost calculations**:
  - Labor costs now derived from actual `registros_trabajo` records instead of manual jornal count × fixed rate
  - Auto-derive `fechaInicioReal` and `fechaFinReal` from labor record dates when available
  - Calculate average jornal value from actual labor costs

### Labor Cost Utilities (`src/utils/laborCosts.ts`)
- **New `recalcularCostoJornal()` function**: Recalculates labor cost when fraction changes, using worker's stored salary/tariff data
- **New `fetchRegistrosTrabajoParaCierre()` function**: 
  - Fetches labor records for a task with worker and lote enrichment
  - Returns aggregated summary (`ResumenLaboresCierre`) with per-lote totals and statistics
  - Handles both employee and contractor workers with parallel batch lookups

### Type Definitions (`src/types/aplicaciones.ts`)
- **New `RegistroTrabajoCierre` interface**: Represents a labor record during closure with:
  - Worker info (name, type, salary/tariff data)
  - Lote and date information
  - Fraction and cost fields
  - Edit flags (`_isNew`, `_deleted`, `_modified`) for tracking changes
- **New `ResumenLaboresCierre` interface**: Aggregated labor summary with per-lote breakdown and statistics

### Closure Persistence Logic
- **Step 0 (new)**: Persist labor record edits before creating closure record:
  - Delete records marked with `_deleted`
  - Insert new records with calculated `valor_jornal_empleado`
  - Update existing records with modified fraction/cost
- **Step 1-3**: Updated to use actual labor costs instead of manual calculations
  - Calculate `valor_jornal` as average from actual labor records
  - Update `jornales_utilizados` from labor record fractions
  - Mark linked task as "Completada" with actual end date

## Notable Implementation Details
- Labor records are optional; closure can proceed without them (non-blocking)
- Inline fraction editing uses a select dropdown with predefined options for consistency
- Cost recalculation preserves worker salary/tariff data for accurate updates
- Soft deletion via `_deleted` flag allows undo before persistence
- Auto-derived dates from labor records improve data accuracy without manual entry

https://claude.ai/code/session_01NhxF8NLQyrdoe8fiMLYU9W