### PR TITLE
Fix Kanban UI: full-width columns, visible action buttons, lote data bug

### DIFF
--- a/src/components/labores/KanbanColumn.tsx
+++ b/src/components/labores/KanbanColumn.tsx
@@ -1,5 +1,5 @@
 import React, { useState } from 'react';
-import { Plus, ChevronDown, ChevronUp } from 'lucide-react';
+import { Plus, ChevronDown, ChevronUp, Inbox } from 'lucide-react';
 import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import { ScrollArea } from '../ui/scroll-area';
@@ -34,10 +34,9 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
 
   return (
     <div
-      className={`${config.bgClass} rounded-lg border ${config.borderClass} flex-shrink-0 w-[272px] flex flex-col`}
-      style={{ height: 'calc(100vh - 280px)', minHeight: '400px' }}
+      className={`${config.bgClass} rounded-lg border ${config.borderClass} flex-1 min-w-[220px] flex flex-col`}
     >
-      {/* Sticky header */}
+      {/* Column header */}
       <div className="flex items-center justify-between p-3 pb-2 flex-shrink-0">
         <div className="flex items-center gap-2">
           <Icon className={`h-4 w-4 ${config.iconColorClass}`} />
@@ -49,57 +48,67 @@ const KanbanColumn: React.FC<KanbanColumnProps> = ({
       </div>
 
       {/* Scrollable card area */}
-      <ScrollArea className="flex-1 min-h-0 px-3 pb-3">
+      <ScrollArea className="flex-1 min-h-0 px-3 pb-3" style={{ maxHeight: 'calc(100vh - 260px)' }}>
         <div className="space-y-2">
-          {visibleTareas.map((tarea) => (
-            <TareaCard
-              key={tarea.id}
-              tarea={tarea}
-              estado={config.key}
-              actions={actions}
-              isArchived={isArchive}
-            />
-          ))}
+          {tareas.length === 0 ? (
+            /* Empty state */
+            <div className="flex flex-col items-center justify-center py-8 text-gray-400">
+              <Inbox className="h-8 w-8 mb-2" />
+              <p className="text-xs">Sin tareas</p>
+            </div>
+          ) : (
+            <>
+              {visibleTareas.map((tarea) => (
+                <TareaCard
+                  key={tarea.id}
+                  tarea={tarea}
+                  estado={config.key}
+                  actions={actions}
+                  isArchived={isArchive}
+                />
+              ))}
 
-          {/* Archive expand/collapse for Completada/Cancelada */}
-          {isArchive && hiddenCount > 0 && (
-            <Collapsible open={showAllArchived} onOpenChange={setShowAllArchived}>
-              <CollapsibleTrigger asChild>
-                <button className="w-full text-xs text-gray-500 hover:text-gray-700 py-2 flex items-center justify-center gap-1 transition-colors">
-                  {showAllArchived ? (
-                    <>
-                      <ChevronUp className="h-3 w-3" />
-                      Ocultar
-                    </>
-                  ) : (
-                    <>
-                      <ChevronDown className="h-3 w-3" />
-                      Ver todas ({hiddenCount} más)
-                    </>
-                  )}
-                </button>
-              </CollapsibleTrigger>
-              <CollapsibleContent>
-                <div className="space-y-2">
-                  {tareas.slice(ARCHIVE_VISIBLE_COUNT).map((tarea) => (
-                    <TareaCard
-                      key={tarea.id}
-                      tarea={tarea}
-                      estado={config.key}
-                      actions={actions}
-                      isArchived={isArchive}
-                    />
-                  ))}
-                </div>
-              </CollapsibleContent>
-            </Collapsible>
+              {/* Archive expand/collapse for Completada/Cancelada */}
+              {isArchive && hiddenCount > 0 && (
+                <Collapsible open={showAllArchived} onOpenChange={setShowAllArchived}>
+                  <CollapsibleTrigger asChild>
+                    <button className="w-full text-xs text-gray-500 hover:text-gray-700 py-2 flex items-center justify-center gap-1 transition-colors">
+                      {showAllArchived ? (
+                        <>
+                          <ChevronUp className="h-3 w-3" />
+                          Ocultar
+                        </>
+                      ) : (
+                        <>
+                          <ChevronDown className="h-3 w-3" />
+                          Ver todas ({hiddenCount} más)
+                        </>
+                      )}
+                    </button>
+                  </CollapsibleTrigger>
+                  <CollapsibleContent>
+                    <div className="space-y-2">
+                      {tareas.slice(ARCHIVE_VISIBLE_COUNT).map((tarea) => (
+                        <TareaCard
+                          key={tarea.id}
+                          tarea={tarea}
+                          estado={config.key}
+                          actions={actions}
+                          isArchived={isArchive}
+                        />
+                      ))}
+                    </div>
+                  </CollapsibleContent>
+                </Collapsible>
+              )}
+            </>
           )}
 
           {/* Add task button */}
           {config.showAddButton && onNuevaTarea && (
             <Button
               variant="ghost"
-              className={`w-full text-gray-500 hover:text-gray-700 border-2 border-dashed border-gray-300 hover:border-gray-400 h-8 text-xs`}
+              className="w-full text-gray-500 hover:text-gray-700 border-2 border-dashed border-gray-300 hover:border-gray-400 h-8 text-xs"
               onClick={() => onNuevaTarea(config.key)}
             >
               <Plus className="h-3.5 w-3.5 mr-1" />

--- a/src/components/labores/TareaCard.tsx
+++ b/src/components/labores/TareaCard.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
-import { MoreVertical, Eye, Pencil, ClipboardList, ArrowRight, Trash2, Calendar as CalendarIcon } from 'lucide-react';
+import { MoreVertical, Eye, Pencil, ClipboardList, ArrowRight, Trash2, Calendar as CalendarIcon, Tag, MapPin } from 'lucide-react';
+import { Badge } from '../ui/badge';
 import { Button } from '../ui/button';
 import {
   DropdownMenu,
@@ -38,89 +39,51 @@ const PRIORITY_BORDER: Record<string, string> = {
   Baja: 'border-l-gray-300',
 };
 
+const PRIORITY_BADGE_STYLE: Record<string, { variant: 'destructive' | 'default' | 'secondary'; className?: string }> = {
+  Alta: { variant: 'destructive' },
+  Media: { variant: 'default' },
+  Baja: { variant: 'secondary' },
+};
+
 const TareaCard: React.FC<TareaCardProps> = ({ tarea, estado, actions, isArchived }) => {
   const loteNames = getLoteNames(tarea);
   const priorityBorder = PRIORITY_BORDER[tarea.prioridad] || 'border-l-gray-300';
+  const priorityBadge = PRIORITY_BADGE_STYLE[tarea.prioridad] || { variant: 'secondary' as const };
 
   return (
     <div
       className={`
-        bg-white rounded-lg border border-gray-200 shadow-sm
+        bg-white rounded-lg border border-gray-200 shadow-sm overflow-hidden
         border-l-[3px] ${priorityBorder}
-        cursor-pointer group relative
         hover:shadow-md hover:border-gray-300 transition-all duration-150
-        ${isArchived ? 'opacity-70' : ''}
+        ${isArchived ? 'opacity-75' : ''}
       `}
-      onClick={() => actions.onVerDetalles(tarea)}
     >
-      <div className="p-2.5 space-y-1.5">
-        {/* Row 1: Title + hover menu */}
-        <div className="flex items-start justify-between gap-1">
-          <h4 className="font-medium text-sm text-gray-900 line-clamp-1 flex-1 min-w-0">
+      {/* Card content */}
+      <div className="p-3 space-y-2">
+        {/* Row 1: Title + Priority badge */}
+        <div className="flex items-start justify-between gap-2">
+          <h4 className="font-medium text-sm text-gray-900 line-clamp-2 flex-1 min-w-0">
             {tarea.nombre}
           </h4>
-          {/* Three-dot menu: always visible on mobile, hover on desktop */}
-          <DropdownMenu>
-            <DropdownMenuTrigger asChild>
-              <Button
-                variant="ghost"
-                size="icon"
-                className="h-6 w-6 flex-shrink-0 opacity-100 md:opacity-0 md:group-hover:opacity-100 transition-opacity"
-                onClick={(e) => e.stopPropagation()}
-              >
-                <MoreVertical className="h-3.5 w-3.5 text-gray-500" />
-              </Button>
-            </DropdownMenuTrigger>
-            <DropdownMenuContent align="end" className="w-44">
-              <DropdownMenuItem onClick={() => actions.onVerDetalles(tarea)}>
-                <Eye className="h-4 w-4" />
-                Ver Detalles
-              </DropdownMenuItem>
-
-              {estado !== 'Completada' && estado !== 'Cancelada' && (
-                <>
-                  <DropdownMenuItem onClick={() => actions.onEditar(tarea)}>
-                    <Pencil className="h-4 w-4" />
-                    Editar
-                  </DropdownMenuItem>
-
-                  {estado === 'Banco' && (
-                    <DropdownMenuItem onClick={() => actions.onCambiarEstado(tarea, 'Programada')}>
-                      <CalendarIcon className="h-4 w-4" />
-                      Programar
-                    </DropdownMenuItem>
-                  )}
-
-                  {(estado === 'Programada' || estado === 'En Proceso') && (
-                    <DropdownMenuItem onClick={() => actions.onRegistrarTrabajo(tarea)}>
-                      <ClipboardList className="h-4 w-4" />
-                      Registrar Trabajo
-                    </DropdownMenuItem>
-                  )}
-
-                  {estado === 'En Proceso' && (
-                    <DropdownMenuItem onClick={() => actions.onCambiarEstado(tarea, 'Completada')}>
-                      <ArrowRight className="h-4 w-4" />
-                      Completar
-                    </DropdownMenuItem>
-                  )}
-
-                  <DropdownMenuSeparator />
-                  <DropdownMenuItem
-                    variant="destructive"
-                    onClick={() => actions.onEliminar(tarea)}
-                  >
-                    <Trash2 className="h-4 w-4" />
-                    Eliminar
-                  </DropdownMenuItem>
-                </>
-              )}
-            </DropdownMenuContent>
-          </DropdownMenu>
+          <Badge
+            variant={priorityBadge.variant}
+            className="text-[10px] px-1.5 py-0 h-5 flex-shrink-0"
+          >
+            {tarea.prioridad}
+          </Badge>
         </div>
 
-        {/* Row 2: Lote pills */}
-        <div className="flex flex-wrap gap-1">
+        {/* Row 2: Description (1-line) */}
+        {tarea.descripcion && (
+          <p className="text-xs text-gray-500 line-clamp-1">
+            {tarea.descripcion}
+          </p>
+        )}
+
+        {/* Row 3: Lote pills */}
+        <div className="flex items-center gap-1 flex-wrap">
+          <MapPin className="h-3 w-3 text-gray-400 flex-shrink-0" />
           {loteNames.length > 0 ? (
             <>
               {loteNames.slice(0, 2).map((name) => {
@@ -128,7 +91,7 @@ const TareaCard: React.FC<TareaCardProps> = ({ tarea, estado, actions, isArchive
                 return (
                   <span
                     key={name}
-                    className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border"
+                    className="inline-flex items-center px-1.5 py-0.5 rounded text-[10px] font-medium border truncate max-w-[100px]"
                     style={{
                       color: color,
                       backgroundColor: color + '15',
@@ -140,7 +103,7 @@ const TareaCard: React.FC<TareaCardProps> = ({ tarea, estado, actions, isArchive
                 );
               })}
               {loteNames.length > 2 && (
-                <span className="text-[10px] text-gray-400 font-medium px-1 self-center">
+                <span className="text-[10px] text-gray-400 font-medium px-1">
                   +{loteNames.length - 2}
                 </span>
               )}
@@ -150,9 +113,109 @@ const TareaCard: React.FC<TareaCardProps> = ({ tarea, estado, actions, isArchive
           )}
         </div>
 
-        {/* Row 3: Task type */}
-        <div className="text-xs text-gray-500 truncate">
-          {tarea.tipo_tarea?.nombre || 'Sin tipo'}
+        {/* Row 4: Task type */}
+        <div className="flex items-center gap-1 text-xs text-gray-500">
+          <Tag className="h-3 w-3 flex-shrink-0" />
+          <span className="truncate">{tarea.tipo_tarea?.nombre || 'Sin tipo'}</span>
+        </div>
+      </div>
+
+      {/* Action buttons row */}
+      <div className="px-3 pb-2.5 pt-0">
+        <div className="flex items-center gap-1 border-t border-gray-100 pt-2">
+          {/* Primary actions - visible, state-dependent */}
+          {estado === 'Banco' && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => actions.onCambiarEstado(tarea, 'Programada')}
+              className="h-7 px-2 text-xs"
+            >
+              <CalendarIcon className="h-3 w-3 mr-1" />
+              Programar
+            </Button>
+          )}
+
+          {estado === 'Programada' && (
+            <Button
+              size="sm"
+              onClick={() => actions.onRegistrarTrabajo(tarea)}
+              className="h-7 px-2 text-xs bg-[#73991C] hover:bg-[#5a7716] text-white"
+            >
+              <ClipboardList className="h-3 w-3 mr-1" />
+              Registrar
+            </Button>
+          )}
+
+          {estado === 'En Proceso' && (
+            <>
+              <Button
+                size="sm"
+                onClick={() => actions.onRegistrarTrabajo(tarea)}
+                className="h-7 px-2 text-xs bg-[#73991C] hover:bg-[#5a7716] text-white"
+              >
+                <ClipboardList className="h-3 w-3 mr-1" />
+                Registrar
+              </Button>
+              <Button
+                size="sm"
+                variant="outline"
+                onClick={() => actions.onCambiarEstado(tarea, 'Completada')}
+                className="h-7 px-2 text-xs text-green-700 border-green-300 hover:bg-green-50"
+              >
+                <ArrowRight className="h-3 w-3 mr-1" />
+                Completar
+              </Button>
+            </>
+          )}
+
+          {(estado === 'Completada' || estado === 'Cancelada') && (
+            <Button
+              size="sm"
+              variant="outline"
+              onClick={() => actions.onVerDetalles(tarea)}
+              className="h-7 px-2 text-xs"
+            >
+              <Eye className="h-3 w-3 mr-1" />
+              Ver Detalles
+            </Button>
+          )}
+
+          {/* Spacer to push overflow menu to the right */}
+          <div className="flex-1" />
+
+          {/* Overflow menu for secondary actions */}
+          {estado !== 'Completada' && estado !== 'Cancelada' && (
+            <DropdownMenu>
+              <DropdownMenuTrigger asChild>
+                <Button
+                  variant="ghost"
+                  size="icon"
+                  className="h-7 w-7 flex-shrink-0"
+                >
+                  <MoreVertical className="h-3.5 w-3.5 text-gray-500" />
+                </Button>
+              </DropdownMenuTrigger>
+              <DropdownMenuContent align="end" className="w-44">
+                <DropdownMenuItem onClick={() => actions.onVerDetalles(tarea)}>
+                  <Eye className="h-4 w-4" />
+                  Ver Detalles
+                </DropdownMenuItem>
+                <DropdownMenuItem onClick={() => actions.onEditar(tarea)}>
+                  <Pencil className="h-4 w-4" />
+                  Editar
+                </DropdownMenuItem>
+                <DropdownMenuSeparator />
+                <DropdownMenuItem
+                  variant="destructive"
+                  onClick={() => actions.onEliminar(tarea)}
+                >
+                  <Trash2 className="h-4 w-4" />
+                  Eliminar
+                </DropdownMenuItem>
+              </DropdownMenuContent>
+            </DropdownMenu>
+          )}
         </div>
       </div>
     </div>


### PR DESCRIPTION
- Fix stale closure in cargarTareas: pass lotesData from cargarLotes return value instead of reading stale React state, so lote_ids map correctly
- Restore visible action buttons per column state (Programar, Registrar, Completar) with overflow menu for Edit/Delete
- Change columns from fixed w-[272px] to flex-1 min-w-[220px] so they fill 100% of available width
- Add priority badges back alongside colored left border
- Restore 1-line description on cards
- Add MapPin/Tag icons for lote and task type properties
- Add empty column state (Inbox icon + "Sin tareas")
- Increase card padding from p-2.5 to p-3, title from line-clamp-1 to line-clamp-2
- Add overflow-hidden to card container for proper text bounding

https://claude.ai/code/session_018ox7YhShSTCqeWayzkPkAS