### PR TITLE
Move edit/delete from card three-dot menu to detail dialog footer

### DIFF
--- a/src/components/labores/Labores.tsx
+++ b/src/components/labores/Labores.tsx
@@ -498,6 +498,8 @@ const Labores: React.FC = () => {
         open={showDetalleDialog}
         onOpenChange={setShowDetalleDialog}
         tarea={tareaSeleccionada}
+        onEditar={handleEditarTarea}
+        onEliminar={handleEliminarTarea}
       />
     </div>
   );

--- a/src/components/labores/TareaCard.tsx
+++ b/src/components/labores/TareaCard.tsx
@@ -1,13 +1,6 @@
 import React from 'react';
-import { MoreVertical, Pencil, ClipboardList, ArrowRight, Trash2, Calendar as CalendarIcon, Eye, MapPin } from 'lucide-react';
+import { ClipboardList, ArrowRight, Calendar as CalendarIcon, Eye, MapPin } from 'lucide-react';
 import { Button } from '../ui/button';
-import {
-  DropdownMenu,
-  DropdownMenuContent,
-  DropdownMenuItem,
-  DropdownMenuSeparator,
-  DropdownMenuTrigger,
-} from '../ui/dropdown-menu';
 import type { Tarea } from './Labores';
 import type { ColumnActions } from './kanban-types';
 
@@ -29,11 +22,6 @@ function getLoteNames(tarea: Tarea): string[] {
     return [tarea.lote.nombre];
   }
   return [];
-}
-
-/** Prevent pointer + click events from reaching the card's onClick. */
-function stopAll(e: React.SyntheticEvent) {
-  e.stopPropagation();
 }
 
 // Soft pastel pill — rounded-lg like Figma, not rounded-full
@@ -60,7 +48,7 @@ const TareaCard: React.FC<TareaCardProps> = ({ tarea, estado, actions, isArchive
     >
       <div className="p-4 flex flex-col gap-3">
 
-        {/* ── Row 1: Title + Priority pill + three-dot ── */}
+        {/* ── Row 1: Title + Priority pill ── */}
         <div className="flex items-start justify-between gap-2">
           <h4 className="font-bold text-base text-gray-900 line-clamp-2 flex-1 min-w-0 leading-snug">
             {tarea.nombre}
@@ -69,38 +57,6 @@ const TareaCard: React.FC<TareaCardProps> = ({ tarea, estado, actions, isArchive
             <span className={`text-xs font-semibold px-2.5 py-1 rounded-lg ${priorityClasses}`}>
               {tarea.prioridad}
             </span>
-            {/* Three-dot menu: Edit & Delete only.
-                Wrapped in a div that blocks BOTH onPointerDown and onClick
-                so the card's onClick never fires when interacting with the menu. */}
-            {!isArchiveColumn && (
-              <div onPointerDown={stopAll} onClick={stopAll}>
-                <DropdownMenu>
-                  <DropdownMenuTrigger asChild>
-                    <Button
-                      variant="ghost"
-                      size="icon"
-                      className="h-7 w-7 text-gray-400 hover:text-gray-600"
-                    >
-                      <MoreVertical className="h-4 w-4" />
-                    </Button>
-                  </DropdownMenuTrigger>
-                  <DropdownMenuContent align="end" className="w-44">
-                    <DropdownMenuItem onClick={() => actions.onEditar(tarea)}>
-                      <Pencil className="h-4 w-4" />
-                      Editar
-                    </DropdownMenuItem>
-                    <DropdownMenuSeparator />
-                    <DropdownMenuItem
-                      variant="destructive"
-                      onClick={() => actions.onEliminar(tarea)}
-                    >
-                      <Trash2 className="h-4 w-4" />
-                      Eliminar
-                    </DropdownMenuItem>
-                  </DropdownMenuContent>
-                </DropdownMenu>
-              </div>
-            )}
           </div>
         </div>
 
@@ -131,11 +87,8 @@ const TareaCard: React.FC<TareaCardProps> = ({ tarea, estado, actions, isArchive
         </div>
 
         {/* ── Row 4: Task type (left) + Primary action (right) ── */}
-        <div
-          className="flex items-center justify-between gap-2"
-          onPointerDown={stopAll}
-          onClick={stopAll}
-        >
+        {/* eslint-disable-next-line jsx-a11y/click-events-have-key-events, jsx-a11y/no-static-element-interactions */}
+        <div className="flex items-center justify-between gap-2" onClick={(e) => e.stopPropagation()}>
           {/* Task type with gray dot */}
           <div className="flex items-center gap-1.5 min-w-0">
             <span className="h-2 w-2 rounded-full bg-gray-400 flex-shrink-0" />

--- a/src/components/labores/TareaDetalleDialog.tsx
+++ b/src/components/labores/TareaDetalleDialog.tsx
@@ -36,8 +36,11 @@ import {
   User,
   MapPin,
   Tag,
-  AlertTriangle
+  AlertTriangle,
+  Pencil,
+  Trash2,
 } from 'lucide-react';
+import { Button } from '../ui/button';
 
 // Import types from main component
 import type { Tarea, RegistroTrabajo, Empleado, Lote } from './Labores';
@@ -49,12 +52,16 @@ interface TareaDetalleDialogProps {
   open: boolean;
   onOpenChange: (open: boolean) => void;
   tarea: Tarea | null;
+  onEditar?: (tarea: Tarea) => void;
+  onEliminar?: (tarea: Tarea) => void;
 }
 
 const TareaDetalleDialog: React.FC<TareaDetalleDialogProps> = ({
   open,
   onOpenChange,
   tarea,
+  onEditar,
+  onEliminar,
 }) => {
   const [registrosTrabajo, setRegistrosTrabajo] = useState<RegistroTrabajo[]>([]);
   const [empleados, setEmpleados] = useState<Empleado[]>([]);
@@ -525,6 +532,26 @@ const TareaDetalleDialog: React.FC<TareaDetalleDialogProps> = ({
             </div>
           </div>
         </DialogBody>
+
+        {/* Footer with Edit / Delete actions (hidden for archived tasks) */}
+        {tarea.estado !== 'Completada' && tarea.estado !== 'Cancelada' && onEditar && onEliminar && (
+          <div className="px-6 md:px-8 py-4 border-t bg-white flex-shrink-0 flex items-center justify-end gap-3">
+            <Button
+              variant="outline"
+              onClick={() => { onEditar(tarea); onOpenChange(false); }}
+            >
+              <Pencil className="h-4 w-4 mr-2" />
+              Editar
+            </Button>
+            <Button
+              variant="destructive"
+              onClick={() => { onEliminar(tarea); onOpenChange(false); }}
+            >
+              <Trash2 className="h-4 w-4 mr-2" />
+              Eliminar
+            </Button>
+          </div>
+        )}
       </DialogContent>
     </Dialog>
   );


### PR DESCRIPTION
Remove the three-dot dropdown menu from task cards entirely — it had persistent Radix pointer event conflicts with the card's onClick handler.

Instead, add Editar and Eliminar CTA buttons pinned to the bottom of the detail dialog. Hidden for archived tasks (Completada/Cancelada).

https://claude.ai/code/session_018ox7YhShSTCqeWayzkPkAS