### PR TITLE
fix: avoid base64 images in Gemini output and handle storage errors g…

### DIFF
--- a/src/components/reportes/ReporteSemanalWizard.tsx
+++ b/src/components/reportes/ReporteSemanalWizard.tsx
@@ -163,7 +163,11 @@ export function ReporteSemanalWizard() {
 
       setHtmlGenerado(resultado.html);
       setPdfBlob(resultado.pdfBlob);
-      toast.success(`Reporte generado (${resultado.tokensUsados} tokens)`);
+      if (resultado.metadata) {
+        toast.success(`Reporte generado y guardado (${resultado.tokensUsados} tokens)`);
+      } else {
+        toast.success(`Reporte generado (${resultado.tokensUsados} tokens). No se pudo guardar en almacenamiento.`);
+      }
     } catch (error: any) {
       console.error('[ReporteSemanal] Error en handleGenerar:', error);
       const errorMsg = error.message || 'Error desconocido al generar el reporte';

--- a/src/supabase/functions/server/generar-reporte-semanal.tsx
+++ b/src/supabase/functions/server/generar-reporte-semanal.tsx
@@ -35,11 +35,12 @@ REGLAS DE DISEÑO:
   - Gris claro: #F5F5F0 (fondos alternos)
 - Fuente: Arial, sans-serif
 - Tamaño de página: A4 (210mm × 297mm) con márgenes de 15mm
-- Incluir header con logo placeholder y nombre "Escocia Hass" en cada sección
+- Para el header usa texto estilizado con CSS (fondo verde #73991C, texto blanco, nombre "Escocia Hass" grande). NO uses imágenes ni tags <img>
 - Tablas con bordes sutiles y filas alternas coloreadas
 - Usar íconos Unicode cuando sea apropiado (✅ ⚠️ 🔴 📊 📈 📉)
-- Barras de progreso con CSS para aplicaciones activas
+- Barras de progreso con CSS (divs con background-color y width porcentual) para aplicaciones activas
 - Código de colores para gravedad de monitoreo: Verde (Baja), Amarillo (Media), Rojo (Alta)
+- IMPORTANTE: NO incluir ningún tag <img> ni imágenes base64. Usar SOLO texto, Unicode, y CSS para todo el diseño visual
 
 REGLAS DE CONTENIDO:
 - Todo el texto debe estar en español

--- a/supabase/functions/make-server-1ccce916/generar-reporte-semanal.ts
+++ b/supabase/functions/make-server-1ccce916/generar-reporte-semanal.ts
@@ -35,11 +35,12 @@ REGLAS DE DISEÑO:
   - Gris claro: #F5F5F0 (fondos alternos)
 - Fuente: Arial, sans-serif
 - Tamaño de página: A4 (210mm × 297mm) con márgenes de 15mm
-- Incluir header con logo placeholder y nombre "Escocia Hass" en cada sección
+- Para el header usa texto estilizado con CSS (fondo verde #73991C, texto blanco, nombre "Escocia Hass" grande). NO uses imágenes ni tags <img>
 - Tablas con bordes sutiles y filas alternas coloreadas
 - Usar íconos Unicode cuando sea apropiado (✅ ⚠️ 🔴 📊 📈 📉)
-- Barras de progreso con CSS para aplicaciones activas
+- Barras de progreso con CSS (divs con background-color y width porcentual) para aplicaciones activas
 - Código de colores para gravedad de monitoreo: Verde (Baja), Amarillo (Media), Rojo (Alta)
+- IMPORTANTE: NO incluir ningún tag <img> ni imágenes base64. Usar SOLO texto, Unicode, y CSS para todo el diseño visual
 
 REGLAS DE CONTENIDO:
 - Todo el texto debe estar en español


### PR DESCRIPTION
…racefully

- Update Gemini system prompt to explicitly forbid <img> tags and base64 images, using only text/Unicode/CSS for visual design. This fixes html2canvas errors that produced empty 3KB PDFs.
- Make storage upload (step 3) non-blocking: if the bucket doesn't exist or upload fails, the user still gets their HTML preview and PDF download.
- Show appropriate toast message depending on whether storage succeeded.

https://claude.ai/code/session_01MdtykyPXswMEKBhaWXuBqT