### PR TITLE
feat: deterministic HTML template for weekly reports + fix blank PDF …

### DIFF
--- a/src/components/reportes/ReporteSemanalWizard.tsx
+++ b/src/components/reportes/ReporteSemanalWizard.tsx
@@ -164,9 +164,11 @@ export function ReporteSemanalWizard() {
       setHtmlGenerado(resultado.html);
       setPdfBlob(resultado.pdfBlob);
       if (resultado.metadata) {
-        toast.success(`Reporte generado y guardado (${resultado.tokensUsados} tokens)`);
+        toast.success('Reporte generado y guardado');
+      } else if (resultado.storageWarning) {
+        toast.warning(resultado.storageWarning, { duration: 8000 });
       } else {
-        toast.success(`Reporte generado (${resultado.tokensUsados} tokens). No se pudo guardar en almacenamiento.`);
+        toast.warning('Reporte generado pero no se pudo guardar en almacenamiento.', { duration: 8000 });
       }
     } catch (error: any) {
       console.error('[ReporteSemanal] Error en handleGenerar:', error);

--- a/src/sql/migrations/019_storage_policies_reportes.sql
+++ b/src/sql/migrations/019_storage_policies_reportes.sql
@@ -1,0 +1,21 @@
+-- Migration 019: Add storage RLS policies for reportes-semanales bucket
+-- The bucket was created manually via Supabase Dashboard.
+-- This migration adds the missing RLS policies for storage.objects.
+
+-- Allow authenticated users to upload reports
+CREATE POLICY "Authenticated users can upload reports"
+  ON storage.objects FOR INSERT
+  TO authenticated
+  WITH CHECK (bucket_id = 'reportes-semanales');
+
+-- Allow authenticated users to read/download reports
+CREATE POLICY "Authenticated users can read reports"
+  ON storage.objects FOR SELECT
+  TO authenticated
+  USING (bucket_id = 'reportes-semanales');
+
+-- Allow authenticated users to update (upsert) reports
+CREATE POLICY "Authenticated users can update reports"
+  ON storage.objects FOR UPDATE
+  TO authenticated
+  USING (bucket_id = 'reportes-semanales');

--- a/src/supabase/functions/server/generar-reporte-semanal.tsx
+++ b/src/supabase/functions/server/generar-reporte-semanal.tsx
@@ -1,6 +1,6 @@
 // generar-reporte-semanal.tsx
-// Módulo de Edge Function para generar reportes semanales usando Google Gemini
-// Recibe datos estructurados del frontend y devuelve HTML estilizado para conversión a PDF
+// Módulo de Edge Function para generar reportes semanales
+// Flujo: datos → Gemini (solo análisis JSON) → plantilla HTML determinística → PDF
 
 // ============================================================================
 // TIPOS
@@ -18,58 +18,41 @@ interface GenerateReportResponse {
   tokens_usados?: number;
 }
 
+interface AnalisisGemini {
+  resumen_ejecutivo: string;
+  conclusiones: Array<{
+    icono: string;
+    texto: string;
+    prioridad: 'alta' | 'media' | 'baja';
+  }>;
+  interpretacion_monitoreo: string;
+}
+
 // ============================================================================
-// PROMPT TEMPLATE
+// PROMPT TEMPLATE — Solo pide análisis JSON, NO HTML
 // ============================================================================
 
-const SYSTEM_PROMPT = `Eres un asistente especializado en generar reportes semanales ALTAMENTE VISUALES para una operación agrícola de aguacate Hass en Colombia.
-Tu tarea es generar un reporte HTML que PRIORICE elementos visuales sobre texto. Mínimo texto, máximo impacto visual.
+const SYSTEM_PROMPT = `Eres un asistente agrícola experto para la finca de aguacate Hass "Escocia Hass" en Colombia.
+Tu tarea es analizar datos operativos semanales y producir un análisis breve, concreto y accionable.
 
-FILOSOFÍA: "Show, don't tell" — cada dato debe presentarse como tabla, barra, indicador visual o métrica destacada. Evitar párrafos largos.
+RESPONDE EXCLUSIVAMENTE en formato JSON con esta estructura exacta:
+{
+  "resumen_ejecutivo": "2-3 oraciones resumiendo lo más importante de la semana operativa. Menciona cifras clave.",
+  "conclusiones": [
+    { "icono": "⚠️", "texto": "Recomendación concreta y accionable con verbo de acción", "prioridad": "alta" }
+  ],
+  "interpretacion_monitoreo": "Interpretación breve de las tendencias fitosanitarias. Indica si suben, bajan o están estables."
+}
 
-REGLAS DE DISEÑO:
-- HTML completo con CSS inline (necesario para conversión a PDF)
-- Paleta Escocia Hass:
-  - Verde primario: #73991C (headers, acentos, barras positivas)
-  - Verde claro: #BFD97D (fondos de secciones, highlights)
-  - Marrón oscuro: #4D240F (texto principal)
-  - Rojo alerta: #D32F2F (alertas, valores negativos)
-  - Amarillo: #F9A825 (advertencias, atención)
-  - Blanco: #FFFFFF / Gris claro: #F5F5F0 (fondos)
-- Fuente: Arial, sans-serif
-- Ancho fijo: 794px (A4). Márgenes de 15mm
-- IMPORTANTE: NO usar tags <img> ni imágenes base64. SOLO texto, Unicode y CSS
-
-ELEMENTOS VISUALES OBLIGATORIOS (usar CSS puro):
-1. KPI Cards: Métricas clave en cards grandes con número prominente, label pequeño, y color de fondo según contexto (verde=bueno, amarillo=atención, rojo=alerta)
-2. Barras horizontales CSS: Para distribución de jornales por actividad y por lote (div con background-color y width porcentual). Mostrar el valor numérico dentro de la barra
-3. Tabla de calor (heatmap): Para la matriz jornales × lotes, usar intensidad de color de fondo según el valor (más oscuro = más jornales)
-4. Barras de progreso: Para aplicaciones activas, barras con % completado visualmente
-5. Indicadores semáforo: Círculos CSS (●) coloreados verde/amarillo/rojo para gravedad de monitoreo
-6. Mini sparklines CSS: Tendencias de monitoreo como barras verticales consecutivas mostrando evolución
-7. Íconos Unicode abundantes: ✅ ⚠️ 🔴 📊 📈 📉 🌱 💧 🐛 👷 💰
-
-ESTRUCTURA DEL REPORTE:
-1. Header: Fondo verde #73991C, texto blanco "ESCOCIA HASS — Reporte Semana {N}" con fechas
-2. Dashboard KPIs: Fila de 4-5 cards con métricas clave (total jornales, costo total, trabajadores, aplicaciones activas, alertas fitosanitarias)
-3. Jornales: Heatmap de la matriz actividad×lote + barras horizontales para top actividades
-4. Aplicaciones: Cards con barras de progreso por lote
-5. Monitoreo: Tabla con indicadores semáforo + mini barras de tendencia
-6. Temas Adicionales (si hay): Formato card compacto
-7. Conclusiones: Máximo 3-4 bullets con íconos, NO párrafos largos
-
-REGLAS DE CONTENIDO:
+REGLAS:
 - Todo en español
-- MÍNIMO texto explicativo. Solo bullets cortos donde sea imprescindible
-- Cada sección debe ser 80% visual, 20% texto máximo
-- Usar negrita para destacar valores numéricos clave
-- Las conclusiones deben ser actionable items, no descripciones
-
-FORMATO DE SALIDA:
-- SOLO HTML (sin markdown, sin explicaciones)
-- Empezar con <!DOCTYPE html>
-- Incluir @media print para impresión
-- Usar page-break-before para separar secciones grandes`;
+- Mínimo 3 conclusiones, máximo 5
+- Las conclusiones DEBEN ser actionable items que empiecen con verbos de acción (Evaluar, Priorizar, Continuar, Revisar, Programar, etc.)
+- El resumen ejecutivo debe mencionar las cifras más relevantes (total jornales, costo, alertas)
+- La interpretación del monitoreo debe mencionar si las tendencias van subiendo, bajando o están estables, y qué plagas requieren atención
+- Usa estos íconos según prioridad: 🔴 (alta/urgente), ⚠️ (media/atención), ✅ (baja/bueno), 📊 (informativo)
+- NO incluir HTML, markdown, ni código. SOLO el objeto JSON.
+- NO envolver el JSON en bloques de código (\`\`\`).`;
 
 // ============================================================================
 // FUNCIONES DE FORMATEO DE DATOS PARA EL PROMPT
@@ -213,10 +196,10 @@ Fechas de monitoreo analizadas: ${datos.monitoreo.fechasMonitoreo.join(', ')}`);
 }
 
 // ============================================================================
-// LLAMADA A GEMINI
+// LLAMADA A GEMINI — Retorna análisis JSON, no HTML
 // ============================================================================
 
-async function llamarGemini(datosFormateados: string, instruccionesAdicionales?: string): Promise<{ html: string; tokens: number }> {
+async function llamarGemini(datosFormateados: string, instruccionesAdicionales?: string): Promise<{ analisis: AnalisisGemini; tokens: number }> {
   const apiKey = Deno.env.get('GEMINI_API_KEY');
   if (!apiKey) {
     throw new Error('GEMINI_API_KEY no está configurada en las variables de entorno');
@@ -235,14 +218,15 @@ async function llamarGemini(datosFormateados: string, instruccionesAdicionales?:
         role: 'user',
         parts: [
           { text: SYSTEM_PROMPT },
-          { text: `Genera el reporte semanal HTML basado en estos datos:\n\n${userMessage}` }
+          { text: `Analiza estos datos operativos semanales y genera el JSON de análisis:\n\n${userMessage}` }
         ]
       }
     ],
     generationConfig: {
       temperature: 0.3,
-      maxOutputTokens: 8192,
+      maxOutputTokens: 2048,
       topP: 0.8,
+      responseMimeType: 'application/json',
     }
   };
 
@@ -295,7 +279,6 @@ async function llamarGemini(datosFormateados: string, instruccionesAdicionales?:
     throw new Error('Gemini bloqueó la respuesta por detección de recitación.');
   }
 
-  // Extraer el HTML del response
   const text = candidate.content?.parts?.[0]?.text || '';
 
   if (!text) {
@@ -303,28 +286,518 @@ async function llamarGemini(datosFormateados: string, instruccionesAdicionales?:
     throw new Error('Gemini no generó contenido de texto en la respuesta.');
   }
 
-  // Gemini puede envolver el HTML en bloques de código markdown
-  let html = text;
-  if (html.startsWith('```html')) {
-    html = html.slice(7);
-  } else if (html.startsWith('```')) {
-    html = html.slice(3);
+  // Parsear JSON — limpiar posibles fences markdown
+  let jsonText = text.trim();
+  if (jsonText.startsWith('```json')) {
+    jsonText = jsonText.slice(7);
+  } else if (jsonText.startsWith('```')) {
+    jsonText = jsonText.slice(3);
   }
-  if (html.endsWith('```')) {
-    html = html.slice(0, -3);
+  if (jsonText.endsWith('```')) {
+    jsonText = jsonText.slice(0, -3);
   }
-  html = html.trim();
+  jsonText = jsonText.trim();
 
-  // Si fue truncado, cerrar HTML gracefully
-  if (finishReason === 'MAX_TOKENS' && !html.endsWith('</html>')) {
-    console.warn('Truncated HTML detected, appending closing tags');
-    html += '</body></html>';
+  let analisis: AnalisisGemini;
+  try {
+    analisis = JSON.parse(jsonText);
+  } catch {
+    console.error('Failed to parse Gemini JSON:', jsonText.slice(0, 300));
+    // Fallback: análisis genérico
+    analisis = {
+      resumen_ejecutivo: 'Semana operativa procesada. Consulte los datos del reporte para detalles específicos.',
+      conclusiones: [
+        { icono: '📊', texto: 'Revisar los indicadores detallados en las secciones del reporte', prioridad: 'media' },
+        { icono: '📋', texto: 'Verificar el avance de las aplicaciones en curso', prioridad: 'media' },
+        { icono: '🌱', texto: 'Monitorear la evolución fitosanitaria en la próxima semana', prioridad: 'media' },
+      ],
+      interpretacion_monitoreo: 'Consulte la sección de monitoreo para detalles sobre las tendencias fitosanitarias.',
+    };
+    console.warn('Using fallback analysis due to JSON parse failure');
+  }
+
+  // Validar estructura mínima
+  if (!analisis.resumen_ejecutivo) {
+    analisis.resumen_ejecutivo = 'Semana operativa procesada.';
+  }
+  if (!Array.isArray(analisis.conclusiones) || analisis.conclusiones.length === 0) {
+    analisis.conclusiones = [
+      { icono: '📊', texto: 'Revisar los indicadores del reporte', prioridad: 'media' },
+    ];
+  }
+  if (!analisis.interpretacion_monitoreo) {
+    analisis.interpretacion_monitoreo = '';
   }
 
   const tokens = result.usageMetadata?.totalTokenCount || 0;
-  console.log('Gemini response: HTML length:', html.length, 'tokens:', tokens);
+  console.log('Gemini response: analysis parsed, tokens:', tokens);
 
-  return { html, tokens };
+  return { analisis, tokens };
+}
+
+// ============================================================================
+// HELPERS PARA HTML
+// ============================================================================
+
+function formatCOP(n: number): string {
+  return '$' + Math.round(n).toLocaleString('es-CO');
+}
+
+function formatNum(n: number, decimals = 2): string {
+  return n.toFixed(decimals).replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+}
+
+function getHeatmapColor(value: number, maxValue: number): string {
+  if (value === 0 || maxValue === 0) return '#FFFFFF';
+  const intensity = Math.min(value / maxValue, 1);
+  const r = Math.round(245 - intensity * (245 - 115));
+  const g = Math.round(248 - intensity * (248 - 153));
+  const b = Math.round(230 - intensity * (230 - 28));
+  return `rgb(${r},${g},${b})`;
+}
+
+function getTextColorForHeatmap(value: number, maxValue: number): string {
+  if (maxValue === 0) return '#4D240F';
+  const intensity = value / maxValue;
+  return intensity > 0.6 ? '#FFFFFF' : '#4D240F';
+}
+
+function getBadgeHTML(texto: string, tipo: string): string {
+  const colors: Record<string, { bg: string; text: string }> = {
+    'Alta': { bg: '#FFCDD2', text: '#C62828' },
+    'Media': { bg: '#FFF9C4', text: '#F57F17' },
+    'Baja': { bg: '#C8E6C9', text: '#2E7D32' },
+  };
+  const c = colors[tipo] || colors['Baja'];
+  return `<span style="display:inline-block;padding:2px 10px;border-radius:12px;font-size:11px;font-weight:600;background:${c.bg};color:${c.text};">${texto}</span>`;
+}
+
+function getInsightStyles(tipo: string): { border: string; bg: string; icon: string } {
+  if (tipo === 'urgente') return { border: '#D32F2F', bg: '#FFF5F5', icon: '🔴' };
+  if (tipo === 'atencion') return { border: '#F9A825', bg: '#FFFDF0', icon: '⚠️' };
+  return { border: '#73991C', bg: '#F5F9EE', icon: '✅' };
+}
+
+// ============================================================================
+// PLANTILLA HTML DETERMINÍSTICA
+// ============================================================================
+
+function construirHTMLReporte(datos: any, analisis: AnalisisGemini): string {
+  const { semana, personal, jornales, aplicaciones, monitoreo, temasAdicionales } = datos;
+
+  // Calcular KPIs
+  const totalJornales = jornales?.totalGeneral?.jornales || 0;
+  const costoTotal = jornales?.totalGeneral?.costo || 0;
+  const trabajadoresActivos = personal?.totalTrabajadores || 0;
+  const aplicacionesActivas = aplicaciones?.activas?.length || 0;
+  const alertasFito = monitoreo?.insights?.filter((i: any) => i.tipo === 'urgente' || i.tipo === 'atencion')?.length || 0;
+
+  // Encontrar el valor máximo en la matriz para heatmap
+  let maxJornalCelda = 0;
+  if (jornales?.datos) {
+    for (const act of jornales.actividades || []) {
+      for (const lote of jornales.lotes || []) {
+        const val = jornales.datos[act]?.[lote]?.jornales || 0;
+        if (val > maxJornalCelda) maxJornalCelda = val;
+      }
+    }
+  }
+
+  const html = `<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: Arial, sans-serif; width: 794px; margin: 0 auto; color: #4D240F; background: #FFFFFF; font-size: 13px; line-height: 1.5; }
+  @media print {
+    .page-break { page-break-before: always; }
+    body { margin: 0; width: 100%; }
+  }
+  table { border-collapse: collapse; }
+</style>
+</head>
+<body>
+
+<!-- ========== HEADER ========== -->
+<div style="background:#73991C;padding:20px 28px;display:flex;justify-content:space-between;align-items:center;">
+  <div>
+    <div style="font-size:24px;font-weight:800;color:#FFFFFF;letter-spacing:1px;">ESCOCIA HASS</div>
+    <div style="font-size:12px;color:#E8F0D0;margin-top:2px;">Finca Aguacate Hass</div>
+  </div>
+  <div style="text-align:right;">
+    <div style="font-size:16px;font-weight:600;color:#FFFFFF;">Reporte Semanal</div>
+    <div style="font-size:20px;font-weight:700;color:#FFFFFF;">Semana ${semana.numero} / ${semana.ano}</div>
+    <div style="font-size:11px;color:#E8F0D0;margin-top:2px;">${semana.inicio} — ${semana.fin}</div>
+  </div>
+</div>
+
+<!-- ========== RESUMEN EJECUTIVO ========== -->
+<div style="background:#F5F5F0;padding:14px 20px;margin:16px 20px 0;border-radius:8px;border-left:4px solid #73991C;">
+  <div style="font-size:12px;font-weight:700;color:#73991C;margin-bottom:6px;">📋 RESUMEN EJECUTIVO</div>
+  <div style="font-size:13px;color:#4D240F;line-height:1.6;">${analisis.resumen_ejecutivo}</div>
+</div>
+
+<!-- ========== KPI CARDS ========== -->
+<div style="display:flex;gap:12px;padding:16px 20px 0;justify-content:space-between;">
+  ${construirKPICard('Total Jornales', formatNum(totalJornales), 'jornales registrados', '#73991C')}
+  ${construirKPICard('Costo Total', formatCOP(costoTotal), 'pesos colombianos', '#1976D2')}
+  ${construirKPICard('Trabajadores', String(trabajadoresActivos), `${personal?.empleados || 0} emp. / ${personal?.contratistas || 0} cont.`, '#00897B')}
+  ${construirKPICard('Aplicaciones', String(aplicacionesActivas), 'en ejecución', '#F57C00')}
+  ${construirKPICard('Alertas Fito', String(alertasFito), 'requieren atención', '#D32F2F')}
+</div>
+
+<!-- ========== PERSONAL RÁPIDO ========== -->
+${(personal?.fallas > 0 || personal?.permisos > 0) ? `
+<div style="display:flex;gap:12px;padding:8px 20px 0;">
+  ${personal.fallas > 0 ? `<div style="font-size:11px;color:#F57C00;">⚠️ Fallas: <strong>${personal.fallas}</strong></div>` : ''}
+  ${personal.permisos > 0 ? `<div style="font-size:11px;color:#1976D2;">📋 Permisos: <strong>${personal.permisos}</strong></div>` : ''}
+</div>` : ''}
+
+<!-- ========== DISTRIBUCIÓN DE JORNALES ========== -->
+${jornales ? construirSeccionJornales(jornales, maxJornalCelda) : ''}
+
+<!-- ========== PAGE BREAK ========== -->
+<div class="page-break"></div>
+
+<!-- ========== APLICACIONES ========== -->
+${construirSeccionAplicaciones(aplicaciones)}
+
+<!-- ========== MONITOREO FITOSANITARIO ========== -->
+${monitoreo ? construirSeccionMonitoreo(monitoreo, analisis.interpretacion_monitoreo) : ''}
+
+<!-- ========== PAGE BREAK ========== -->
+<div class="page-break"></div>
+
+<!-- ========== TEMAS ADICIONALES ========== -->
+${(temasAdicionales && temasAdicionales.length > 0) ? construirSeccionTemasAdicionales(temasAdicionales) : ''}
+
+<!-- ========== CONCLUSIONES ========== -->
+${construirSeccionConclusiones(analisis.conclusiones)}
+
+<!-- ========== FOOTER ========== -->
+<div style="text-align:center;padding:20px;margin-top:20px;border-top:1px solid #E0E0E0;">
+  <div style="font-size:10px;color:#999;">Generado automáticamente — Escocia Hass — ${new Date().toLocaleDateString('es-CO', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+</div>
+
+</body>
+</html>`;
+
+  return html;
+}
+
+// ============================================================================
+// SUB-CONSTRUCTORES DE SECCIONES
+// ============================================================================
+
+function construirKPICard(label: string, value: string, subtitle: string, color: string): string {
+  return `<div style="flex:1;background:#FFFFFF;border-radius:8px;border-top:4px solid ${color};padding:14px 10px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+    <div style="font-size:24px;font-weight:800;color:${color};">${value}</div>
+    <div style="font-size:11px;font-weight:600;color:#4D240F;margin-top:2px;">${label}</div>
+    <div style="font-size:10px;color:#888;margin-top:1px;">${subtitle}</div>
+  </div>`;
+}
+
+function construirSeccionJornales(jornales: any, maxJornalCelda: number): string {
+  const { actividades, lotes, datos, totalesPorActividad, totalesPorLote, totalGeneral } = jornales;
+
+  // Heatmap table
+  let tableRows = '';
+  for (const act of actividades) {
+    let cells = '';
+    for (const lote of lotes) {
+      const val = datos[act]?.[lote]?.jornales || 0;
+      const bg = getHeatmapColor(val, maxJornalCelda);
+      const textColor = getTextColorForHeatmap(val, maxJornalCelda);
+      cells += `<td style="padding:8px 10px;text-align:center;font-size:12px;font-weight:600;background:${bg};color:${textColor};border:1px solid #E8E8E8;">${val > 0 ? val.toFixed(2) : '-'}</td>`;
+    }
+    const actTotal = totalesPorActividad[act]?.jornales || 0;
+    cells += `<td style="padding:8px 10px;text-align:center;font-size:12px;font-weight:700;background:#F5F5F0;color:#4D240F;border:1px solid #E8E8E8;">${actTotal.toFixed(2)}</td>`;
+    tableRows += `<tr><td style="padding:8px 12px;font-size:12px;font-weight:600;color:#4D240F;border:1px solid #E8E8E8;background:#FAFAFA;">${act}</td>${cells}</tr>`;
+  }
+
+  // Fila de totales
+  let totalCells = '';
+  for (const lote of lotes) {
+    const val = totalesPorLote[lote]?.jornales || 0;
+    totalCells += `<td style="padding:8px 10px;text-align:center;font-size:12px;font-weight:700;background:#E8F0D0;color:#4D240F;border:1px solid #E8E8E8;">${val.toFixed(2)}</td>`;
+  }
+  totalCells += `<td style="padding:8px 10px;text-align:center;font-size:13px;font-weight:800;background:#73991C;color:#FFFFFF;border:1px solid #E8E8E8;">${totalGeneral.jornales.toFixed(2)}</td>`;
+  tableRows += `<tr><td style="padding:8px 12px;font-size:12px;font-weight:700;color:#4D240F;border:1px solid #E8E8E8;background:#E8F0D0;">TOTAL</td>${totalCells}</tr>`;
+
+  // Header de tabla
+  let tableHeaders = '<th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:left;">Actividad</th>';
+  for (const lote of lotes) {
+    tableHeaders += `<th style="padding:8px 10px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;">${lote}</th>`;
+  }
+  tableHeaders += '<th style="padding:8px 10px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;">Total</th>';
+
+  // Barras horizontales por actividad
+  const actividadesOrdenadas = [...actividades].sort((a: string, b: string) => {
+    return (totalesPorActividad[b]?.jornales || 0) - (totalesPorActividad[a]?.jornales || 0);
+  });
+
+  let barrasHTML = '';
+  for (const act of actividadesOrdenadas) {
+    const val = totalesPorActividad[act]?.jornales || 0;
+    const pct = totalGeneral.jornales > 0 ? (val / totalGeneral.jornales * 100) : 0;
+    const costo = totalesPorActividad[act]?.costo || 0;
+    barrasHTML += `
+    <div style="display:flex;align-items:center;margin-bottom:6px;">
+      <div style="width:120px;font-size:11px;font-weight:600;color:#4D240F;text-align:right;padding-right:10px;flex-shrink:0;">${act}</div>
+      <div style="flex:1;background:#E8E8E8;border-radius:4px;height:22px;position:relative;overflow:hidden;">
+        <div style="background:#73991C;height:100%;border-radius:4px;width:${Math.max(pct, 2)}%;transition:width 0.3s;"></div>
+        <span style="position:absolute;left:8px;top:3px;font-size:11px;font-weight:600;color:${pct > 30 ? '#FFFFFF' : '#4D240F'};">${val.toFixed(1)} jorn. (${pct.toFixed(0)}%)</span>
+      </div>
+      <div style="width:90px;font-size:10px;color:#888;text-align:right;padding-left:8px;flex-shrink:0;">${formatCOP(costo)}</div>
+    </div>`;
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #73991C;padding-left:10px;">📊 Distribución de Jornales</div>
+
+    <table style="width:100%;border-collapse:collapse;margin-bottom:16px;">
+      <thead><tr>${tableHeaders}</tr></thead>
+      <tbody>${tableRows}</tbody>
+    </table>
+
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;">Distribución por Actividad</div>
+    ${barrasHTML}
+  </div>`;
+}
+
+function construirSeccionAplicaciones(aplicaciones: any): string {
+  const planeadas = aplicaciones?.planeadas || [];
+  const activas = aplicaciones?.activas || [];
+
+  if (planeadas.length === 0 && activas.length === 0) {
+    return `
+    <div style="padding:20px 20px 0;">
+      <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #F57C00;padding-left:10px;">🧪 Aplicaciones</div>
+      <div style="padding:16px;background:#F5F5F0;border-radius:8px;font-size:12px;color:#888;text-align:center;">Sin aplicaciones planeadas ni en ejecución esta semana</div>
+    </div>`;
+  }
+
+  let activasHTML = '';
+  for (const app of activas) {
+    let lotesHTML = '';
+    for (const lote of app.progresoPorLote || []) {
+      lotesHTML += `
+      <div style="margin-bottom:6px;">
+        <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px;">
+          <span style="font-weight:600;">${lote.loteNombre}</span>
+          <span style="color:#888;">${lote.ejecutado}/${lote.planeado} ${lote.unidad} (${lote.porcentaje}%)</span>
+        </div>
+        <div style="background:#E0E0E0;border-radius:4px;height:16px;overflow:hidden;">
+          <div style="background:${lote.porcentaje >= 100 ? '#73991C' : lote.porcentaje >= 50 ? '#8DB440' : '#BFD97D'};height:100%;border-radius:4px;width:${Math.min(lote.porcentaje, 100)}%;"></div>
+        </div>
+      </div>`;
+    }
+
+    // Barra global
+    const globalPct = app.porcentajeGlobal || 0;
+    activasHTML += `
+    <div style="background:#FFFFFF;border-radius:8px;border:1px solid #E8E8E8;padding:16px;margin-bottom:12px;box-shadow:0 1px 2px rgba(0,0,0,0.05);">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+        <div>
+          <span style="font-size:14px;font-weight:700;color:#4D240F;">${app.nombre}</span>
+          <span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:10px;font-weight:600;background:#FFF3E0;color:#F57C00;margin-left:8px;">${app.tipo}</span>
+        </div>
+        <div style="font-size:20px;font-weight:800;color:${globalPct >= 80 ? '#73991C' : globalPct >= 40 ? '#F57C00' : '#D32F2F'};">${globalPct}%</div>
+      </div>
+      <div style="font-size:11px;color:#888;margin-bottom:10px;">${app.proposito || ''}</div>
+
+      <div style="background:#E0E0E0;border-radius:6px;height:22px;overflow:hidden;margin-bottom:12px;position:relative;">
+        <div style="background:#73991C;height:100%;border-radius:6px;width:${Math.min(globalPct, 100)}%;"></div>
+        <span style="position:absolute;left:50%;top:3px;transform:translateX(-50%);font-size:11px;font-weight:700;color:${globalPct > 45 ? '#FFFFFF' : '#4D240F'};">Global: ${app.totalEjecutado}/${app.totalPlaneado} ${app.unidad}</span>
+      </div>
+
+      ${lotesHTML}
+    </div>`;
+  }
+
+  let planeadasHTML = '';
+  for (const app of planeadas) {
+    const comprasItems = (app.listaCompras || []).map((item: any) =>
+      `<span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:10px;background:#F0F0F0;color:#555;margin:2px;">${item.productoNombre}: ${item.cantidadNecesaria} ${item.unidad}</span>`
+    ).join(' ');
+
+    planeadasHTML += `
+    <div style="background:#FFFDF0;border-radius:8px;border:1px solid #F9E4A0;padding:12px;margin-bottom:8px;">
+      <div style="font-size:13px;font-weight:700;color:#4D240F;">${app.nombre} <span style="font-size:10px;color:#F57C00;">(${app.tipo})</span></div>
+      <div style="font-size:11px;color:#888;margin:4px 0;">📅 Planeada: ${app.fechaInicioPlaneada} | 💰 Estimado: ${formatCOP(app.costoTotalEstimado)}</div>
+      <div style="font-size:11px;color:#555;margin-top:4px;">${app.proposito}</div>
+      ${comprasItems ? `<div style="margin-top:6px;">${comprasItems}</div>` : ''}
+    </div>`;
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #F57C00;padding-left:10px;">🧪 Aplicaciones</div>
+
+    ${activas.length > 0 ? `
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;">En Ejecución (${activas.length})</div>
+    ${activasHTML}` : ''}
+
+    ${planeadas.length > 0 ? `
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;margin-top:12px;">Planeadas (${planeadas.length})</div>
+    ${planeadasHTML}` : ''}
+  </div>`;
+}
+
+function construirSeccionMonitoreo(monitoreo: any, interpretacion: string): string {
+  const { detallePorLote, insights, tendencias, fechasMonitoreo } = monitoreo;
+
+  if ((!detallePorLote || detallePorLote.length === 0) && (!insights || insights.length === 0)) {
+    return `
+    <div style="padding:20px 20px 0;">
+      <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #D32F2F;padding-left:10px;">🐛 Monitoreo Fitosanitario</div>
+      <div style="padding:16px;background:#F5F5F0;border-radius:8px;font-size:12px;color:#888;text-align:center;">Sin datos de monitoreo esta semana</div>
+    </div>`;
+  }
+
+  // Construir mapa de tendencias por plaga para mini barras
+  const tendenciasPorPlaga = new Map<string, number[]>();
+  if (tendencias && tendencias.length > 0) {
+    for (const t of tendencias) {
+      if (!tendenciasPorPlaga.has(t.plagaNombre)) tendenciasPorPlaga.set(t.plagaNombre, []);
+      tendenciasPorPlaga.get(t.plagaNombre)!.push(t.incidenciaPromedio);
+    }
+  }
+
+  // Tabla de detalle
+  let tableRows = '';
+  for (const lote of detallePorLote || []) {
+    for (let i = 0; i < lote.sublotes.length; i++) {
+      const s = lote.sublotes[i];
+      const showLote = i === 0;
+
+      // Mini barras de tendencia
+      const plagaTendencia = tendenciasPorPlaga.get(s.plagaNombre) || [];
+      let miniBarrasHTML = '';
+      if (plagaTendencia.length > 0) {
+        const maxTend = Math.max(...plagaTendencia, 1);
+        miniBarrasHTML = plagaTendencia.map((val: number) => {
+          const h = Math.max((val / maxTend) * 24, 3);
+          const barColor = val > 20 ? '#D32F2F' : val > 10 ? '#F9A825' : '#73991C';
+          return `<div style="display:inline-block;width:10px;height:${h}px;background:${barColor};border-radius:2px;margin-right:3px;vertical-align:bottom;"></div>`;
+        }).join('');
+        miniBarrasHTML = `<div style="display:flex;align-items:flex-end;height:28px;">${miniBarrasHTML}</div>`;
+      } else {
+        miniBarrasHTML = '<span style="font-size:10px;color:#CCC;">—</span>';
+      }
+
+      tableRows += `<tr style="border-bottom:1px solid #F0F0F0;">
+        ${showLote ? `<td rowspan="${lote.sublotes.length}" style="padding:8px 10px;font-size:12px;font-weight:600;color:#4D240F;border-right:1px solid #E8E8E8;vertical-align:top;background:#FAFAFA;">${lote.loteNombre}</td>` : ''}
+        <td style="padding:6px 10px;font-size:11px;color:#555;">${s.subloteNombre}</td>
+        <td style="padding:6px 10px;font-size:11px;font-weight:600;color:#4D240F;">${s.plagaNombre}</td>
+        <td style="padding:6px 10px;font-size:12px;font-weight:700;text-align:center;color:${s.incidencia > 20 ? '#D32F2F' : s.incidencia > 10 ? '#F57C00' : '#4D240F'};">${s.incidencia}%</td>
+        <td style="padding:6px 10px;text-align:center;">${getBadgeHTML(s.gravedad, s.gravedad)}</td>
+        <td style="padding:6px 10px;font-size:11px;text-align:center;color:#555;">${s.arboresAfectados}/${s.arboresMonitoreados}</td>
+        <td style="padding:6px 10px;text-align:center;">${miniBarrasHTML}</td>
+      </tr>`;
+    }
+  }
+
+  // Insights cards
+  let insightsHTML = '';
+  if (insights && insights.length > 0) {
+    for (const insight of insights) {
+      const styles = getInsightStyles(insight.tipo);
+      insightsHTML += `
+      <div style="border-left:4px solid ${styles.border};background:${styles.bg};padding:10px 14px;border-radius:0 6px 6px 0;margin-bottom:8px;">
+        <div style="font-size:12px;font-weight:700;color:#4D240F;">${styles.icon} ${insight.titulo}</div>
+        <div style="font-size:11px;color:#555;margin-top:3px;">${insight.descripcion}</div>
+        ${insight.accion ? `<div style="font-size:11px;color:${styles.border};font-weight:600;margin-top:4px;">→ ${insight.accion}</div>` : ''}
+      </div>`;
+    }
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:4px;border-left:4px solid #D32F2F;padding-left:10px;">🐛 Monitoreo Fitosanitario</div>
+    ${fechasMonitoreo?.length > 0 ? `<div style="font-size:10px;color:#999;margin-bottom:12px;padding-left:14px;">Monitoreos: ${fechasMonitoreo.join(', ')}</div>` : ''}
+
+    ${detallePorLote && detallePorLote.length > 0 ? `
+    <table style="width:100%;border-collapse:collapse;margin-bottom:16px;">
+      <thead>
+        <tr style="background:#F5F5F0;">
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:left;border-bottom:2px solid #E0E0E0;">Lote</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:left;border-bottom:2px solid #E0E0E0;">Sublote</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:left;border-bottom:2px solid #E0E0E0;">Plaga</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Incid. %</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Gravedad</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Árboles</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Tendencia</th>
+        </tr>
+      </thead>
+      <tbody>${tableRows}</tbody>
+    </table>` : ''}
+
+    ${insightsHTML ? `
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;">Alertas e Insights</div>
+    ${insightsHTML}` : ''}
+
+    ${interpretacion ? `
+    <div style="background:#F0F7E8;padding:12px 16px;border-radius:8px;margin-top:12px;">
+      <div style="font-size:11px;font-weight:700;color:#73991C;margin-bottom:4px;">🔬 Interpretación de Tendencias</div>
+      <div style="font-size:12px;color:#4D240F;line-height:1.5;">${interpretacion}</div>
+    </div>` : ''}
+  </div>`;
+}
+
+function construirSeccionTemasAdicionales(temas: any[]): string {
+  let contenidoHTML = '';
+  for (const bloque of temas) {
+    if (bloque.tipo === 'texto') {
+      contenidoHTML += `
+      <div style="background:#FFFFFF;border:1px solid #E8E8E8;border-radius:8px;padding:14px;margin-bottom:8px;">
+        ${bloque.titulo ? `<div style="font-size:13px;font-weight:700;color:#4D240F;margin-bottom:6px;">${bloque.titulo}</div>` : ''}
+        <div style="font-size:12px;color:#555;line-height:1.6;">${(bloque.contenido || '').replace(/\n/g, '<br>')}</div>
+      </div>`;
+    } else if (bloque.tipo === 'imagen_con_texto') {
+      contenidoHTML += `
+      <div style="background:#FFFFFF;border:1px solid #E8E8E8;border-radius:8px;padding:14px;margin-bottom:8px;">
+        ${bloque.titulo ? `<div style="font-size:13px;font-weight:700;color:#4D240F;margin-bottom:6px;">📷 ${bloque.titulo}</div>` : ''}
+        <div style="font-size:12px;color:#555;line-height:1.6;">${bloque.descripcion || ''}</div>
+      </div>`;
+    }
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #1976D2;padding-left:10px;">📝 Temas Adicionales</div>
+    ${contenidoHTML}
+  </div>`;
+}
+
+function construirSeccionConclusiones(conclusiones: AnalisisGemini['conclusiones']): string {
+  const prioridadColor: Record<string, { bg: string; dot: string }> = {
+    alta: { bg: '#FFF5F5', dot: '#D32F2F' },
+    media: { bg: '#FFFDF0', dot: '#F9A825' },
+    baja: { bg: '#F5F9EE', dot: '#73991C' },
+  };
+
+  let items = '';
+  for (const c of conclusiones) {
+    const colors = prioridadColor[c.prioridad] || prioridadColor.media;
+    items += `
+    <div style="display:flex;align-items:flex-start;gap:10px;padding:10px 14px;background:${colors.bg};border-radius:6px;margin-bottom:6px;">
+      <div style="font-size:18px;flex-shrink:0;line-height:1;">${c.icono}</div>
+      <div style="flex:1;">
+        <div style="font-size:12px;color:#4D240F;line-height:1.5;">${c.texto}</div>
+      </div>
+      <div style="width:8px;height:8px;border-radius:50%;background:${colors.dot};flex-shrink:0;margin-top:5px;"></div>
+    </div>`;
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #73991C;padding-left:10px;">🎯 Conclusiones y Recomendaciones</div>
+    ${items}
+  </div>`;
 }
 
 // ============================================================================
@@ -345,19 +818,24 @@ export async function generarReporteSemanal(body: GenerateReportRequest): Promis
 
     console.log(`Semana ${datos.semana.numero}/${datos.semana.ano}`);
 
-    // Formatear datos para el prompt
+    // Paso 1: Formatear datos para el prompt
     const datosFormateados = formatearDatosParaPrompt(datos);
     console.log('Datos formateados:', datosFormateados.length, 'chars');
 
-    // Llamar a Gemini
-    console.log('Calling Gemini API...');
+    // Paso 2: Llamar a Gemini para análisis (solo JSON)
+    console.log('Calling Gemini API for analysis...');
     const geminiStart = Date.now();
-    const { html, tokens } = await llamarGemini(datosFormateados, instrucciones);
+    const { analisis, tokens } = await llamarGemini(datosFormateados, instrucciones);
     console.log(`Gemini completed in ${Date.now() - geminiStart}ms`);
 
-    if (!html || html.length < 100) {
+    // Paso 3: Construir HTML determinístico
+    console.log('Building deterministic HTML template...');
+    const html = construirHTMLReporte(datos, analisis);
+    console.log('HTML built:', html.length, 'chars');
+
+    if (!html || html.length < 500) {
       console.error('HTML too short:', html.length, 'chars');
-      return { success: false, error: 'Gemini no generó un HTML válido (respuesta demasiado corta)' };
+      return { success: false, error: 'Error interno al construir el HTML del reporte' };
     }
 
     console.log(`=== generarReporteSemanal SUCCESS in ${Date.now() - startTime}ms ===`);

--- a/supabase/functions/make-server-1ccce916/generar-reporte-semanal.ts
+++ b/supabase/functions/make-server-1ccce916/generar-reporte-semanal.ts
@@ -1,6 +1,6 @@
-// generar-reporte-semanal.ts
-// Módulo de Edge Function para generar reportes semanales usando Google Gemini
-// Recibe datos estructurados del frontend y devuelve HTML estilizado para conversión a PDF
+// generar-reporte-semanal.tsx
+// Módulo de Edge Function para generar reportes semanales
+// Flujo: datos → Gemini (solo análisis JSON) → plantilla HTML determinística → PDF
 
 // ============================================================================
 // TIPOS
@@ -18,58 +18,41 @@ interface GenerateReportResponse {
   tokens_usados?: number;
 }
 
+interface AnalisisGemini {
+  resumen_ejecutivo: string;
+  conclusiones: Array<{
+    icono: string;
+    texto: string;
+    prioridad: 'alta' | 'media' | 'baja';
+  }>;
+  interpretacion_monitoreo: string;
+}
+
 // ============================================================================
-// PROMPT TEMPLATE
+// PROMPT TEMPLATE — Solo pide análisis JSON, NO HTML
 // ============================================================================
 
-const SYSTEM_PROMPT = `Eres un asistente especializado en generar reportes semanales ALTAMENTE VISUALES para una operación agrícola de aguacate Hass en Colombia.
-Tu tarea es generar un reporte HTML que PRIORICE elementos visuales sobre texto. Mínimo texto, máximo impacto visual.
+const SYSTEM_PROMPT = `Eres un asistente agrícola experto para la finca de aguacate Hass "Escocia Hass" en Colombia.
+Tu tarea es analizar datos operativos semanales y producir un análisis breve, concreto y accionable.
 
-FILOSOFÍA: "Show, don't tell" — cada dato debe presentarse como tabla, barra, indicador visual o métrica destacada. Evitar párrafos largos.
+RESPONDE EXCLUSIVAMENTE en formato JSON con esta estructura exacta:
+{
+  "resumen_ejecutivo": "2-3 oraciones resumiendo lo más importante de la semana operativa. Menciona cifras clave.",
+  "conclusiones": [
+    { "icono": "⚠️", "texto": "Recomendación concreta y accionable con verbo de acción", "prioridad": "alta" }
+  ],
+  "interpretacion_monitoreo": "Interpretación breve de las tendencias fitosanitarias. Indica si suben, bajan o están estables."
+}
 
-REGLAS DE DISEÑO:
-- HTML completo con CSS inline (necesario para conversión a PDF)
-- Paleta Escocia Hass:
-  - Verde primario: #73991C (headers, acentos, barras positivas)
-  - Verde claro: #BFD97D (fondos de secciones, highlights)
-  - Marrón oscuro: #4D240F (texto principal)
-  - Rojo alerta: #D32F2F (alertas, valores negativos)
-  - Amarillo: #F9A825 (advertencias, atención)
-  - Blanco: #FFFFFF / Gris claro: #F5F5F0 (fondos)
-- Fuente: Arial, sans-serif
-- Ancho fijo: 794px (A4). Márgenes de 15mm
-- IMPORTANTE: NO usar tags <img> ni imágenes base64. SOLO texto, Unicode y CSS
-
-ELEMENTOS VISUALES OBLIGATORIOS (usar CSS puro):
-1. KPI Cards: Métricas clave en cards grandes con número prominente, label pequeño, y color de fondo según contexto (verde=bueno, amarillo=atención, rojo=alerta)
-2. Barras horizontales CSS: Para distribución de jornales por actividad y por lote (div con background-color y width porcentual). Mostrar el valor numérico dentro de la barra
-3. Tabla de calor (heatmap): Para la matriz jornales × lotes, usar intensidad de color de fondo según el valor (más oscuro = más jornales)
-4. Barras de progreso: Para aplicaciones activas, barras con % completado visualmente
-5. Indicadores semáforo: Círculos CSS (●) coloreados verde/amarillo/rojo para gravedad de monitoreo
-6. Mini sparklines CSS: Tendencias de monitoreo como barras verticales consecutivas mostrando evolución
-7. Íconos Unicode abundantes: ✅ ⚠️ 🔴 📊 📈 📉 🌱 💧 🐛 👷 💰
-
-ESTRUCTURA DEL REPORTE:
-1. Header: Fondo verde #73991C, texto blanco "ESCOCIA HASS — Reporte Semana {N}" con fechas
-2. Dashboard KPIs: Fila de 4-5 cards con métricas clave (total jornales, costo total, trabajadores, aplicaciones activas, alertas fitosanitarias)
-3. Jornales: Heatmap de la matriz actividad×lote + barras horizontales para top actividades
-4. Aplicaciones: Cards con barras de progreso por lote
-5. Monitoreo: Tabla con indicadores semáforo + mini barras de tendencia
-6. Temas Adicionales (si hay): Formato card compacto
-7. Conclusiones: Máximo 3-4 bullets con íconos, NO párrafos largos
-
-REGLAS DE CONTENIDO:
+REGLAS:
 - Todo en español
-- MÍNIMO texto explicativo. Solo bullets cortos donde sea imprescindible
-- Cada sección debe ser 80% visual, 20% texto máximo
-- Usar negrita para destacar valores numéricos clave
-- Las conclusiones deben ser actionable items, no descripciones
-
-FORMATO DE SALIDA:
-- SOLO HTML (sin markdown, sin explicaciones)
-- Empezar con <!DOCTYPE html>
-- Incluir @media print para impresión
-- Usar page-break-before para separar secciones grandes`;
+- Mínimo 3 conclusiones, máximo 5
+- Las conclusiones DEBEN ser actionable items que empiecen con verbos de acción (Evaluar, Priorizar, Continuar, Revisar, Programar, etc.)
+- El resumen ejecutivo debe mencionar las cifras más relevantes (total jornales, costo, alertas)
+- La interpretación del monitoreo debe mencionar si las tendencias van subiendo, bajando o están estables, y qué plagas requieren atención
+- Usa estos íconos según prioridad: 🔴 (alta/urgente), ⚠️ (media/atención), ✅ (baja/bueno), 📊 (informativo)
+- NO incluir HTML, markdown, ni código. SOLO el objeto JSON.
+- NO envolver el JSON en bloques de código (\`\`\`).`;
 
 // ============================================================================
 // FUNCIONES DE FORMATEO DE DATOS PARA EL PROMPT
@@ -213,10 +196,10 @@ Fechas de monitoreo analizadas: ${datos.monitoreo.fechasMonitoreo.join(', ')}`);
 }
 
 // ============================================================================
-// LLAMADA A GEMINI
+// LLAMADA A GEMINI — Retorna análisis JSON, no HTML
 // ============================================================================
 
-async function llamarGemini(datosFormateados: string, instruccionesAdicionales?: string): Promise<{ html: string; tokens: number }> {
+async function llamarGemini(datosFormateados: string, instruccionesAdicionales?: string): Promise<{ analisis: AnalisisGemini; tokens: number }> {
   const apiKey = Deno.env.get('GEMINI_API_KEY');
   if (!apiKey) {
     throw new Error('GEMINI_API_KEY no está configurada en las variables de entorno');
@@ -235,14 +218,15 @@ async function llamarGemini(datosFormateados: string, instruccionesAdicionales?:
         role: 'user',
         parts: [
           { text: SYSTEM_PROMPT },
-          { text: `Genera el reporte semanal HTML basado en estos datos:\n\n${userMessage}` }
+          { text: `Analiza estos datos operativos semanales y genera el JSON de análisis:\n\n${userMessage}` }
         ]
       }
     ],
     generationConfig: {
       temperature: 0.3,
-      maxOutputTokens: 8192,
+      maxOutputTokens: 2048,
       topP: 0.8,
+      responseMimeType: 'application/json',
     }
   };
 
@@ -295,7 +279,6 @@ async function llamarGemini(datosFormateados: string, instruccionesAdicionales?:
     throw new Error('Gemini bloqueó la respuesta por detección de recitación.');
   }
 
-  // Extraer el HTML del response
   const text = candidate.content?.parts?.[0]?.text || '';
 
   if (!text) {
@@ -303,28 +286,518 @@ async function llamarGemini(datosFormateados: string, instruccionesAdicionales?:
     throw new Error('Gemini no generó contenido de texto en la respuesta.');
   }
 
-  // Gemini puede envolver el HTML en bloques de código markdown
-  let html = text;
-  if (html.startsWith('```html')) {
-    html = html.slice(7);
-  } else if (html.startsWith('```')) {
-    html = html.slice(3);
+  // Parsear JSON — limpiar posibles fences markdown
+  let jsonText = text.trim();
+  if (jsonText.startsWith('```json')) {
+    jsonText = jsonText.slice(7);
+  } else if (jsonText.startsWith('```')) {
+    jsonText = jsonText.slice(3);
   }
-  if (html.endsWith('```')) {
-    html = html.slice(0, -3);
+  if (jsonText.endsWith('```')) {
+    jsonText = jsonText.slice(0, -3);
   }
-  html = html.trim();
+  jsonText = jsonText.trim();
 
-  // Si fue truncado, cerrar HTML gracefully
-  if (finishReason === 'MAX_TOKENS' && !html.endsWith('</html>')) {
-    console.warn('Truncated HTML detected, appending closing tags');
-    html += '</body></html>';
+  let analisis: AnalisisGemini;
+  try {
+    analisis = JSON.parse(jsonText);
+  } catch {
+    console.error('Failed to parse Gemini JSON:', jsonText.slice(0, 300));
+    // Fallback: análisis genérico
+    analisis = {
+      resumen_ejecutivo: 'Semana operativa procesada. Consulte los datos del reporte para detalles específicos.',
+      conclusiones: [
+        { icono: '📊', texto: 'Revisar los indicadores detallados en las secciones del reporte', prioridad: 'media' },
+        { icono: '📋', texto: 'Verificar el avance de las aplicaciones en curso', prioridad: 'media' },
+        { icono: '🌱', texto: 'Monitorear la evolución fitosanitaria en la próxima semana', prioridad: 'media' },
+      ],
+      interpretacion_monitoreo: 'Consulte la sección de monitoreo para detalles sobre las tendencias fitosanitarias.',
+    };
+    console.warn('Using fallback analysis due to JSON parse failure');
+  }
+
+  // Validar estructura mínima
+  if (!analisis.resumen_ejecutivo) {
+    analisis.resumen_ejecutivo = 'Semana operativa procesada.';
+  }
+  if (!Array.isArray(analisis.conclusiones) || analisis.conclusiones.length === 0) {
+    analisis.conclusiones = [
+      { icono: '📊', texto: 'Revisar los indicadores del reporte', prioridad: 'media' },
+    ];
+  }
+  if (!analisis.interpretacion_monitoreo) {
+    analisis.interpretacion_monitoreo = '';
   }
 
   const tokens = result.usageMetadata?.totalTokenCount || 0;
-  console.log('Gemini response: HTML length:', html.length, 'tokens:', tokens);
+  console.log('Gemini response: analysis parsed, tokens:', tokens);
 
-  return { html, tokens };
+  return { analisis, tokens };
+}
+
+// ============================================================================
+// HELPERS PARA HTML
+// ============================================================================
+
+function formatCOP(n: number): string {
+  return '$' + Math.round(n).toLocaleString('es-CO');
+}
+
+function formatNum(n: number, decimals = 2): string {
+  return n.toFixed(decimals).replace(/\B(?=(\d{3})+(?!\d))/g, '.');
+}
+
+function getHeatmapColor(value: number, maxValue: number): string {
+  if (value === 0 || maxValue === 0) return '#FFFFFF';
+  const intensity = Math.min(value / maxValue, 1);
+  const r = Math.round(245 - intensity * (245 - 115));
+  const g = Math.round(248 - intensity * (248 - 153));
+  const b = Math.round(230 - intensity * (230 - 28));
+  return `rgb(${r},${g},${b})`;
+}
+
+function getTextColorForHeatmap(value: number, maxValue: number): string {
+  if (maxValue === 0) return '#4D240F';
+  const intensity = value / maxValue;
+  return intensity > 0.6 ? '#FFFFFF' : '#4D240F';
+}
+
+function getBadgeHTML(texto: string, tipo: string): string {
+  const colors: Record<string, { bg: string; text: string }> = {
+    'Alta': { bg: '#FFCDD2', text: '#C62828' },
+    'Media': { bg: '#FFF9C4', text: '#F57F17' },
+    'Baja': { bg: '#C8E6C9', text: '#2E7D32' },
+  };
+  const c = colors[tipo] || colors['Baja'];
+  return `<span style="display:inline-block;padding:2px 10px;border-radius:12px;font-size:11px;font-weight:600;background:${c.bg};color:${c.text};">${texto}</span>`;
+}
+
+function getInsightStyles(tipo: string): { border: string; bg: string; icon: string } {
+  if (tipo === 'urgente') return { border: '#D32F2F', bg: '#FFF5F5', icon: '🔴' };
+  if (tipo === 'atencion') return { border: '#F9A825', bg: '#FFFDF0', icon: '⚠️' };
+  return { border: '#73991C', bg: '#F5F9EE', icon: '✅' };
+}
+
+// ============================================================================
+// PLANTILLA HTML DETERMINÍSTICA
+// ============================================================================
+
+function construirHTMLReporte(datos: any, analisis: AnalisisGemini): string {
+  const { semana, personal, jornales, aplicaciones, monitoreo, temasAdicionales } = datos;
+
+  // Calcular KPIs
+  const totalJornales = jornales?.totalGeneral?.jornales || 0;
+  const costoTotal = jornales?.totalGeneral?.costo || 0;
+  const trabajadoresActivos = personal?.totalTrabajadores || 0;
+  const aplicacionesActivas = aplicaciones?.activas?.length || 0;
+  const alertasFito = monitoreo?.insights?.filter((i: any) => i.tipo === 'urgente' || i.tipo === 'atencion')?.length || 0;
+
+  // Encontrar el valor máximo en la matriz para heatmap
+  let maxJornalCelda = 0;
+  if (jornales?.datos) {
+    for (const act of jornales.actividades || []) {
+      for (const lote of jornales.lotes || []) {
+        const val = jornales.datos[act]?.[lote]?.jornales || 0;
+        if (val > maxJornalCelda) maxJornalCelda = val;
+      }
+    }
+  }
+
+  const html = `<!DOCTYPE html>
+<html lang="es">
+<head>
+<meta charset="UTF-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
+<style>
+  * { margin: 0; padding: 0; box-sizing: border-box; }
+  body { font-family: Arial, sans-serif; width: 794px; margin: 0 auto; color: #4D240F; background: #FFFFFF; font-size: 13px; line-height: 1.5; }
+  @media print {
+    .page-break { page-break-before: always; }
+    body { margin: 0; width: 100%; }
+  }
+  table { border-collapse: collapse; }
+</style>
+</head>
+<body>
+
+<!-- ========== HEADER ========== -->
+<div style="background:#73991C;padding:20px 28px;display:flex;justify-content:space-between;align-items:center;">
+  <div>
+    <div style="font-size:24px;font-weight:800;color:#FFFFFF;letter-spacing:1px;">ESCOCIA HASS</div>
+    <div style="font-size:12px;color:#E8F0D0;margin-top:2px;">Finca Aguacate Hass</div>
+  </div>
+  <div style="text-align:right;">
+    <div style="font-size:16px;font-weight:600;color:#FFFFFF;">Reporte Semanal</div>
+    <div style="font-size:20px;font-weight:700;color:#FFFFFF;">Semana ${semana.numero} / ${semana.ano}</div>
+    <div style="font-size:11px;color:#E8F0D0;margin-top:2px;">${semana.inicio} — ${semana.fin}</div>
+  </div>
+</div>
+
+<!-- ========== RESUMEN EJECUTIVO ========== -->
+<div style="background:#F5F5F0;padding:14px 20px;margin:16px 20px 0;border-radius:8px;border-left:4px solid #73991C;">
+  <div style="font-size:12px;font-weight:700;color:#73991C;margin-bottom:6px;">📋 RESUMEN EJECUTIVO</div>
+  <div style="font-size:13px;color:#4D240F;line-height:1.6;">${analisis.resumen_ejecutivo}</div>
+</div>
+
+<!-- ========== KPI CARDS ========== -->
+<div style="display:flex;gap:12px;padding:16px 20px 0;justify-content:space-between;">
+  ${construirKPICard('Total Jornales', formatNum(totalJornales), 'jornales registrados', '#73991C')}
+  ${construirKPICard('Costo Total', formatCOP(costoTotal), 'pesos colombianos', '#1976D2')}
+  ${construirKPICard('Trabajadores', String(trabajadoresActivos), `${personal?.empleados || 0} emp. / ${personal?.contratistas || 0} cont.`, '#00897B')}
+  ${construirKPICard('Aplicaciones', String(aplicacionesActivas), 'en ejecución', '#F57C00')}
+  ${construirKPICard('Alertas Fito', String(alertasFito), 'requieren atención', '#D32F2F')}
+</div>
+
+<!-- ========== PERSONAL RÁPIDO ========== -->
+${(personal?.fallas > 0 || personal?.permisos > 0) ? `
+<div style="display:flex;gap:12px;padding:8px 20px 0;">
+  ${personal.fallas > 0 ? `<div style="font-size:11px;color:#F57C00;">⚠️ Fallas: <strong>${personal.fallas}</strong></div>` : ''}
+  ${personal.permisos > 0 ? `<div style="font-size:11px;color:#1976D2;">📋 Permisos: <strong>${personal.permisos}</strong></div>` : ''}
+</div>` : ''}
+
+<!-- ========== DISTRIBUCIÓN DE JORNALES ========== -->
+${jornales ? construirSeccionJornales(jornales, maxJornalCelda) : ''}
+
+<!-- ========== PAGE BREAK ========== -->
+<div class="page-break"></div>
+
+<!-- ========== APLICACIONES ========== -->
+${construirSeccionAplicaciones(aplicaciones)}
+
+<!-- ========== MONITOREO FITOSANITARIO ========== -->
+${monitoreo ? construirSeccionMonitoreo(monitoreo, analisis.interpretacion_monitoreo) : ''}
+
+<!-- ========== PAGE BREAK ========== -->
+<div class="page-break"></div>
+
+<!-- ========== TEMAS ADICIONALES ========== -->
+${(temasAdicionales && temasAdicionales.length > 0) ? construirSeccionTemasAdicionales(temasAdicionales) : ''}
+
+<!-- ========== CONCLUSIONES ========== -->
+${construirSeccionConclusiones(analisis.conclusiones)}
+
+<!-- ========== FOOTER ========== -->
+<div style="text-align:center;padding:20px;margin-top:20px;border-top:1px solid #E0E0E0;">
+  <div style="font-size:10px;color:#999;">Generado automáticamente — Escocia Hass — ${new Date().toLocaleDateString('es-CO', { year: 'numeric', month: 'long', day: 'numeric' })}</div>
+</div>
+
+</body>
+</html>`;
+
+  return html;
+}
+
+// ============================================================================
+// SUB-CONSTRUCTORES DE SECCIONES
+// ============================================================================
+
+function construirKPICard(label: string, value: string, subtitle: string, color: string): string {
+  return `<div style="flex:1;background:#FFFFFF;border-radius:8px;border-top:4px solid ${color};padding:14px 10px;text-align:center;box-shadow:0 1px 3px rgba(0,0,0,0.08);">
+    <div style="font-size:24px;font-weight:800;color:${color};">${value}</div>
+    <div style="font-size:11px;font-weight:600;color:#4D240F;margin-top:2px;">${label}</div>
+    <div style="font-size:10px;color:#888;margin-top:1px;">${subtitle}</div>
+  </div>`;
+}
+
+function construirSeccionJornales(jornales: any, maxJornalCelda: number): string {
+  const { actividades, lotes, datos, totalesPorActividad, totalesPorLote, totalGeneral } = jornales;
+
+  // Heatmap table
+  let tableRows = '';
+  for (const act of actividades) {
+    let cells = '';
+    for (const lote of lotes) {
+      const val = datos[act]?.[lote]?.jornales || 0;
+      const bg = getHeatmapColor(val, maxJornalCelda);
+      const textColor = getTextColorForHeatmap(val, maxJornalCelda);
+      cells += `<td style="padding:8px 10px;text-align:center;font-size:12px;font-weight:600;background:${bg};color:${textColor};border:1px solid #E8E8E8;">${val > 0 ? val.toFixed(2) : '-'}</td>`;
+    }
+    const actTotal = totalesPorActividad[act]?.jornales || 0;
+    cells += `<td style="padding:8px 10px;text-align:center;font-size:12px;font-weight:700;background:#F5F5F0;color:#4D240F;border:1px solid #E8E8E8;">${actTotal.toFixed(2)}</td>`;
+    tableRows += `<tr><td style="padding:8px 12px;font-size:12px;font-weight:600;color:#4D240F;border:1px solid #E8E8E8;background:#FAFAFA;">${act}</td>${cells}</tr>`;
+  }
+
+  // Fila de totales
+  let totalCells = '';
+  for (const lote of lotes) {
+    const val = totalesPorLote[lote]?.jornales || 0;
+    totalCells += `<td style="padding:8px 10px;text-align:center;font-size:12px;font-weight:700;background:#E8F0D0;color:#4D240F;border:1px solid #E8E8E8;">${val.toFixed(2)}</td>`;
+  }
+  totalCells += `<td style="padding:8px 10px;text-align:center;font-size:13px;font-weight:800;background:#73991C;color:#FFFFFF;border:1px solid #E8E8E8;">${totalGeneral.jornales.toFixed(2)}</td>`;
+  tableRows += `<tr><td style="padding:8px 12px;font-size:12px;font-weight:700;color:#4D240F;border:1px solid #E8E8E8;background:#E8F0D0;">TOTAL</td>${totalCells}</tr>`;
+
+  // Header de tabla
+  let tableHeaders = '<th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:left;">Actividad</th>';
+  for (const lote of lotes) {
+    tableHeaders += `<th style="padding:8px 10px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;">${lote}</th>`;
+  }
+  tableHeaders += '<th style="padding:8px 10px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;">Total</th>';
+
+  // Barras horizontales por actividad
+  const actividadesOrdenadas = [...actividades].sort((a: string, b: string) => {
+    return (totalesPorActividad[b]?.jornales || 0) - (totalesPorActividad[a]?.jornales || 0);
+  });
+
+  let barrasHTML = '';
+  for (const act of actividadesOrdenadas) {
+    const val = totalesPorActividad[act]?.jornales || 0;
+    const pct = totalGeneral.jornales > 0 ? (val / totalGeneral.jornales * 100) : 0;
+    const costo = totalesPorActividad[act]?.costo || 0;
+    barrasHTML += `
+    <div style="display:flex;align-items:center;margin-bottom:6px;">
+      <div style="width:120px;font-size:11px;font-weight:600;color:#4D240F;text-align:right;padding-right:10px;flex-shrink:0;">${act}</div>
+      <div style="flex:1;background:#E8E8E8;border-radius:4px;height:22px;position:relative;overflow:hidden;">
+        <div style="background:#73991C;height:100%;border-radius:4px;width:${Math.max(pct, 2)}%;transition:width 0.3s;"></div>
+        <span style="position:absolute;left:8px;top:3px;font-size:11px;font-weight:600;color:${pct > 30 ? '#FFFFFF' : '#4D240F'};">${val.toFixed(1)} jorn. (${pct.toFixed(0)}%)</span>
+      </div>
+      <div style="width:90px;font-size:10px;color:#888;text-align:right;padding-left:8px;flex-shrink:0;">${formatCOP(costo)}</div>
+    </div>`;
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #73991C;padding-left:10px;">📊 Distribución de Jornales</div>
+
+    <table style="width:100%;border-collapse:collapse;margin-bottom:16px;">
+      <thead><tr>${tableHeaders}</tr></thead>
+      <tbody>${tableRows}</tbody>
+    </table>
+
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;">Distribución por Actividad</div>
+    ${barrasHTML}
+  </div>`;
+}
+
+function construirSeccionAplicaciones(aplicaciones: any): string {
+  const planeadas = aplicaciones?.planeadas || [];
+  const activas = aplicaciones?.activas || [];
+
+  if (planeadas.length === 0 && activas.length === 0) {
+    return `
+    <div style="padding:20px 20px 0;">
+      <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #F57C00;padding-left:10px;">🧪 Aplicaciones</div>
+      <div style="padding:16px;background:#F5F5F0;border-radius:8px;font-size:12px;color:#888;text-align:center;">Sin aplicaciones planeadas ni en ejecución esta semana</div>
+    </div>`;
+  }
+
+  let activasHTML = '';
+  for (const app of activas) {
+    let lotesHTML = '';
+    for (const lote of app.progresoPorLote || []) {
+      lotesHTML += `
+      <div style="margin-bottom:6px;">
+        <div style="display:flex;justify-content:space-between;font-size:11px;margin-bottom:2px;">
+          <span style="font-weight:600;">${lote.loteNombre}</span>
+          <span style="color:#888;">${lote.ejecutado}/${lote.planeado} ${lote.unidad} (${lote.porcentaje}%)</span>
+        </div>
+        <div style="background:#E0E0E0;border-radius:4px;height:16px;overflow:hidden;">
+          <div style="background:${lote.porcentaje >= 100 ? '#73991C' : lote.porcentaje >= 50 ? '#8DB440' : '#BFD97D'};height:100%;border-radius:4px;width:${Math.min(lote.porcentaje, 100)}%;"></div>
+        </div>
+      </div>`;
+    }
+
+    // Barra global
+    const globalPct = app.porcentajeGlobal || 0;
+    activasHTML += `
+    <div style="background:#FFFFFF;border-radius:8px;border:1px solid #E8E8E8;padding:16px;margin-bottom:12px;box-shadow:0 1px 2px rgba(0,0,0,0.05);">
+      <div style="display:flex;justify-content:space-between;align-items:center;margin-bottom:10px;">
+        <div>
+          <span style="font-size:14px;font-weight:700;color:#4D240F;">${app.nombre}</span>
+          <span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:10px;font-weight:600;background:#FFF3E0;color:#F57C00;margin-left:8px;">${app.tipo}</span>
+        </div>
+        <div style="font-size:20px;font-weight:800;color:${globalPct >= 80 ? '#73991C' : globalPct >= 40 ? '#F57C00' : '#D32F2F'};">${globalPct}%</div>
+      </div>
+      <div style="font-size:11px;color:#888;margin-bottom:10px;">${app.proposito || ''}</div>
+
+      <div style="background:#E0E0E0;border-radius:6px;height:22px;overflow:hidden;margin-bottom:12px;position:relative;">
+        <div style="background:#73991C;height:100%;border-radius:6px;width:${Math.min(globalPct, 100)}%;"></div>
+        <span style="position:absolute;left:50%;top:3px;transform:translateX(-50%);font-size:11px;font-weight:700;color:${globalPct > 45 ? '#FFFFFF' : '#4D240F'};">Global: ${app.totalEjecutado}/${app.totalPlaneado} ${app.unidad}</span>
+      </div>
+
+      ${lotesHTML}
+    </div>`;
+  }
+
+  let planeadasHTML = '';
+  for (const app of planeadas) {
+    const comprasItems = (app.listaCompras || []).map((item: any) =>
+      `<span style="display:inline-block;padding:2px 8px;border-radius:10px;font-size:10px;background:#F0F0F0;color:#555;margin:2px;">${item.productoNombre}: ${item.cantidadNecesaria} ${item.unidad}</span>`
+    ).join(' ');
+
+    planeadasHTML += `
+    <div style="background:#FFFDF0;border-radius:8px;border:1px solid #F9E4A0;padding:12px;margin-bottom:8px;">
+      <div style="font-size:13px;font-weight:700;color:#4D240F;">${app.nombre} <span style="font-size:10px;color:#F57C00;">(${app.tipo})</span></div>
+      <div style="font-size:11px;color:#888;margin:4px 0;">📅 Planeada: ${app.fechaInicioPlaneada} | 💰 Estimado: ${formatCOP(app.costoTotalEstimado)}</div>
+      <div style="font-size:11px;color:#555;margin-top:4px;">${app.proposito}</div>
+      ${comprasItems ? `<div style="margin-top:6px;">${comprasItems}</div>` : ''}
+    </div>`;
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #F57C00;padding-left:10px;">🧪 Aplicaciones</div>
+
+    ${activas.length > 0 ? `
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;">En Ejecución (${activas.length})</div>
+    ${activasHTML}` : ''}
+
+    ${planeadas.length > 0 ? `
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;margin-top:12px;">Planeadas (${planeadas.length})</div>
+    ${planeadasHTML}` : ''}
+  </div>`;
+}
+
+function construirSeccionMonitoreo(monitoreo: any, interpretacion: string): string {
+  const { detallePorLote, insights, tendencias, fechasMonitoreo } = monitoreo;
+
+  if ((!detallePorLote || detallePorLote.length === 0) && (!insights || insights.length === 0)) {
+    return `
+    <div style="padding:20px 20px 0;">
+      <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #D32F2F;padding-left:10px;">🐛 Monitoreo Fitosanitario</div>
+      <div style="padding:16px;background:#F5F5F0;border-radius:8px;font-size:12px;color:#888;text-align:center;">Sin datos de monitoreo esta semana</div>
+    </div>`;
+  }
+
+  // Construir mapa de tendencias por plaga para mini barras
+  const tendenciasPorPlaga = new Map<string, number[]>();
+  if (tendencias && tendencias.length > 0) {
+    for (const t of tendencias) {
+      if (!tendenciasPorPlaga.has(t.plagaNombre)) tendenciasPorPlaga.set(t.plagaNombre, []);
+      tendenciasPorPlaga.get(t.plagaNombre)!.push(t.incidenciaPromedio);
+    }
+  }
+
+  // Tabla de detalle
+  let tableRows = '';
+  for (const lote of detallePorLote || []) {
+    for (let i = 0; i < lote.sublotes.length; i++) {
+      const s = lote.sublotes[i];
+      const showLote = i === 0;
+
+      // Mini barras de tendencia
+      const plagaTendencia = tendenciasPorPlaga.get(s.plagaNombre) || [];
+      let miniBarrasHTML = '';
+      if (plagaTendencia.length > 0) {
+        const maxTend = Math.max(...plagaTendencia, 1);
+        miniBarrasHTML = plagaTendencia.map((val: number) => {
+          const h = Math.max((val / maxTend) * 24, 3);
+          const barColor = val > 20 ? '#D32F2F' : val > 10 ? '#F9A825' : '#73991C';
+          return `<div style="display:inline-block;width:10px;height:${h}px;background:${barColor};border-radius:2px;margin-right:3px;vertical-align:bottom;"></div>`;
+        }).join('');
+        miniBarrasHTML = `<div style="display:flex;align-items:flex-end;height:28px;">${miniBarrasHTML}</div>`;
+      } else {
+        miniBarrasHTML = '<span style="font-size:10px;color:#CCC;">—</span>';
+      }
+
+      tableRows += `<tr style="border-bottom:1px solid #F0F0F0;">
+        ${showLote ? `<td rowspan="${lote.sublotes.length}" style="padding:8px 10px;font-size:12px;font-weight:600;color:#4D240F;border-right:1px solid #E8E8E8;vertical-align:top;background:#FAFAFA;">${lote.loteNombre}</td>` : ''}
+        <td style="padding:6px 10px;font-size:11px;color:#555;">${s.subloteNombre}</td>
+        <td style="padding:6px 10px;font-size:11px;font-weight:600;color:#4D240F;">${s.plagaNombre}</td>
+        <td style="padding:6px 10px;font-size:12px;font-weight:700;text-align:center;color:${s.incidencia > 20 ? '#D32F2F' : s.incidencia > 10 ? '#F57C00' : '#4D240F'};">${s.incidencia}%</td>
+        <td style="padding:6px 10px;text-align:center;">${getBadgeHTML(s.gravedad, s.gravedad)}</td>
+        <td style="padding:6px 10px;font-size:11px;text-align:center;color:#555;">${s.arboresAfectados}/${s.arboresMonitoreados}</td>
+        <td style="padding:6px 10px;text-align:center;">${miniBarrasHTML}</td>
+      </tr>`;
+    }
+  }
+
+  // Insights cards
+  let insightsHTML = '';
+  if (insights && insights.length > 0) {
+    for (const insight of insights) {
+      const styles = getInsightStyles(insight.tipo);
+      insightsHTML += `
+      <div style="border-left:4px solid ${styles.border};background:${styles.bg};padding:10px 14px;border-radius:0 6px 6px 0;margin-bottom:8px;">
+        <div style="font-size:12px;font-weight:700;color:#4D240F;">${styles.icon} ${insight.titulo}</div>
+        <div style="font-size:11px;color:#555;margin-top:3px;">${insight.descripcion}</div>
+        ${insight.accion ? `<div style="font-size:11px;color:${styles.border};font-weight:600;margin-top:4px;">→ ${insight.accion}</div>` : ''}
+      </div>`;
+    }
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:4px;border-left:4px solid #D32F2F;padding-left:10px;">🐛 Monitoreo Fitosanitario</div>
+    ${fechasMonitoreo?.length > 0 ? `<div style="font-size:10px;color:#999;margin-bottom:12px;padding-left:14px;">Monitoreos: ${fechasMonitoreo.join(', ')}</div>` : ''}
+
+    ${detallePorLote && detallePorLote.length > 0 ? `
+    <table style="width:100%;border-collapse:collapse;margin-bottom:16px;">
+      <thead>
+        <tr style="background:#F5F5F0;">
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:left;border-bottom:2px solid #E0E0E0;">Lote</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:left;border-bottom:2px solid #E0E0E0;">Sublote</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:left;border-bottom:2px solid #E0E0E0;">Plaga</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Incid. %</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Gravedad</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Árboles</th>
+          <th style="padding:8px 10px;font-size:10px;font-weight:700;color:#555;text-align:center;border-bottom:2px solid #E0E0E0;">Tendencia</th>
+        </tr>
+      </thead>
+      <tbody>${tableRows}</tbody>
+    </table>` : ''}
+
+    ${insightsHTML ? `
+    <div style="font-size:12px;font-weight:600;color:#4D240F;margin-bottom:8px;">Alertas e Insights</div>
+    ${insightsHTML}` : ''}
+
+    ${interpretacion ? `
+    <div style="background:#F0F7E8;padding:12px 16px;border-radius:8px;margin-top:12px;">
+      <div style="font-size:11px;font-weight:700;color:#73991C;margin-bottom:4px;">🔬 Interpretación de Tendencias</div>
+      <div style="font-size:12px;color:#4D240F;line-height:1.5;">${interpretacion}</div>
+    </div>` : ''}
+  </div>`;
+}
+
+function construirSeccionTemasAdicionales(temas: any[]): string {
+  let contenidoHTML = '';
+  for (const bloque of temas) {
+    if (bloque.tipo === 'texto') {
+      contenidoHTML += `
+      <div style="background:#FFFFFF;border:1px solid #E8E8E8;border-radius:8px;padding:14px;margin-bottom:8px;">
+        ${bloque.titulo ? `<div style="font-size:13px;font-weight:700;color:#4D240F;margin-bottom:6px;">${bloque.titulo}</div>` : ''}
+        <div style="font-size:12px;color:#555;line-height:1.6;">${(bloque.contenido || '').replace(/\n/g, '<br>')}</div>
+      </div>`;
+    } else if (bloque.tipo === 'imagen_con_texto') {
+      contenidoHTML += `
+      <div style="background:#FFFFFF;border:1px solid #E8E8E8;border-radius:8px;padding:14px;margin-bottom:8px;">
+        ${bloque.titulo ? `<div style="font-size:13px;font-weight:700;color:#4D240F;margin-bottom:6px;">📷 ${bloque.titulo}</div>` : ''}
+        <div style="font-size:12px;color:#555;line-height:1.6;">${bloque.descripcion || ''}</div>
+      </div>`;
+    }
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #1976D2;padding-left:10px;">📝 Temas Adicionales</div>
+    ${contenidoHTML}
+  </div>`;
+}
+
+function construirSeccionConclusiones(conclusiones: AnalisisGemini['conclusiones']): string {
+  const prioridadColor: Record<string, { bg: string; dot: string }> = {
+    alta: { bg: '#FFF5F5', dot: '#D32F2F' },
+    media: { bg: '#FFFDF0', dot: '#F9A825' },
+    baja: { bg: '#F5F9EE', dot: '#73991C' },
+  };
+
+  let items = '';
+  for (const c of conclusiones) {
+    const colors = prioridadColor[c.prioridad] || prioridadColor.media;
+    items += `
+    <div style="display:flex;align-items:flex-start;gap:10px;padding:10px 14px;background:${colors.bg};border-radius:6px;margin-bottom:6px;">
+      <div style="font-size:18px;flex-shrink:0;line-height:1;">${c.icono}</div>
+      <div style="flex:1;">
+        <div style="font-size:12px;color:#4D240F;line-height:1.5;">${c.texto}</div>
+      </div>
+      <div style="width:8px;height:8px;border-radius:50%;background:${colors.dot};flex-shrink:0;margin-top:5px;"></div>
+    </div>`;
+  }
+
+  return `
+  <div style="padding:20px 20px 0;">
+    <div style="font-size:15px;font-weight:700;color:#4D240F;margin-bottom:12px;border-left:4px solid #73991C;padding-left:10px;">🎯 Conclusiones y Recomendaciones</div>
+    ${items}
+  </div>`;
 }
 
 // ============================================================================
@@ -345,19 +818,24 @@ export async function generarReporteSemanal(body: GenerateReportRequest): Promis
 
     console.log(`Semana ${datos.semana.numero}/${datos.semana.ano}`);
 
-    // Formatear datos para el prompt
+    // Paso 1: Formatear datos para el prompt
     const datosFormateados = formatearDatosParaPrompt(datos);
     console.log('Datos formateados:', datosFormateados.length, 'chars');
 
-    // Llamar a Gemini
-    console.log('Calling Gemini API...');
+    // Paso 2: Llamar a Gemini para análisis (solo JSON)
+    console.log('Calling Gemini API for analysis...');
     const geminiStart = Date.now();
-    const { html, tokens } = await llamarGemini(datosFormateados, instrucciones);
+    const { analisis, tokens } = await llamarGemini(datosFormateados, instrucciones);
     console.log(`Gemini completed in ${Date.now() - geminiStart}ms`);
 
-    if (!html || html.length < 100) {
+    // Paso 3: Construir HTML determinístico
+    console.log('Building deterministic HTML template...');
+    const html = construirHTMLReporte(datos, analisis);
+    console.log('HTML built:', html.length, 'chars');
+
+    if (!html || html.length < 500) {
       console.error('HTML too short:', html.length, 'chars');
-      return { success: false, error: 'Gemini no generó un HTML válido (respuesta demasiado corta)' };
+      return { success: false, error: 'Error interno al construir el HTML del reporte' };
     }
 
     console.log(`=== generarReporteSemanal SUCCESS in ${Date.now() - startTime}ms ===`);


### PR DESCRIPTION
…+ fix storage

Major changes:
- Replace Gemini full-HTML generation with deterministic HTML template built in code. Gemini now only generates analysis JSON (resumen, conclusiones, interpretacion_monitoreo), reducing tokens from 8192 to 2048 and eliminating truncation issues
- Fix blank PDF: change html2pdf.js container from opacity:0/fixed to opacity:1/absolute off-screen, increase render timeout to 1500ms
- Fix storage: add migration 019 with RLS policies for storage.objects bucket, surface storage errors via storageWarning instead of silently suppressing them
- Update tests for new JSON-based Gemini response format

HTML template matches user mockups with:
- Green header with Escocia Hass branding
- 5 KPI cards (jornales, costo, trabajadores, aplicaciones, alertas)
- Heatmap table for jornales distribution (activity x lot)
- Horizontal bar charts by activity
- Progress bars for active applications per lot
- Monitoring table with severity badges and trend mini-bars
- Alert cards with color-coded borders
- AI-generated conclusions with priority indicators

https://claude.ai/code/session_01MdtykyPXswMEKBhaWXuBqT