### PR TITLE
feat: transform weekly report to landscape 16:9 slide-based PDF

### DIFF
--- a/src/components/reportes/ReporteSemanalWizard.tsx
+++ b/src/components/reportes/ReporteSemanalWizard.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useRef } from 'react';
+import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
 import {
   Settings,
@@ -20,6 +20,9 @@ import {
   Calendar,
   Users,
   AlertTriangle,
+  CheckSquare,
+  Square,
+  X,
 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardHeader, CardTitle } from '../ui/card';
@@ -37,6 +40,7 @@ import {
   calcularSemanaAnterior,
   calcularSemanaDesdeLunes,
   fetchDatosReporteSemanal,
+  fetchListaAplicacionesCerradas,
 } from '../../utils/fetchDatosReporteSemanal';
 import {
   generarReporteCompleto,
@@ -48,6 +52,7 @@ import type {
   BloqueAdicional,
   BloqueTexto,
   BloqueImagenConTexto,
+  DetalleFallaPermiso,
 } from '../../types/reporteSemanal';
 import { formatearFechaCorta } from '../../utils/fechas';
 import { formatNumber } from '../../utils/format';
@@ -58,10 +63,21 @@ import { formatNumber } from '../../utils/format';
 
 const PASOS = [
   { numero: 1, titulo: 'Configuración', descripcion: 'Semana y personal', icono: Settings },
-  { numero: 2, titulo: 'Datos Operativos', descripcion: 'Jornales, aplicaciones, monitoreo', icono: BarChart3 },
-  { numero: 3, titulo: 'Temas Adicionales', descripcion: 'Notas e imágenes', icono: MessageSquarePlus },
-  { numero: 4, titulo: 'Generar Reporte', descripcion: 'Vista previa y PDF', icono: FileText },
+  { numero: 2, titulo: 'Aplicaciones', descripcion: 'Cierres a incluir', icono: CheckSquare },
+  { numero: 3, titulo: 'Datos Operativos', descripcion: 'Jornales, aplicaciones, monitoreo', icono: BarChart3 },
+  { numero: 4, titulo: 'Temas Adicionales', descripcion: 'Notas e imágenes', icono: MessageSquarePlus },
+  { numero: 5, titulo: 'Generar Reporte', descripcion: 'Vista previa y PDF', icono: FileText },
 ];
+
+// ============================================================================
+// HELPERS
+// ============================================================================
+
+function formatFecha(iso: string): string {
+  if (!iso) return '—';
+  try { return new Date(iso + 'T00:00:00').toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' }); }
+  catch { return iso; }
+}
 
 // ============================================================================
 // COMPONENTE PRINCIPAL
@@ -70,7 +86,7 @@ const PASOS = [
 export function ReporteSemanalWizard() {
   const navigate = useNavigate();
 
-  // Estado del wizard
+  // Wizard state
   const [pasoActual, setPasoActual] = useState(1);
   const [loading, setLoading] = useState(false);
   const [generando, setGenerando] = useState(false);
@@ -80,29 +96,51 @@ export function ReporteSemanalWizard() {
   const [semana, setSemana] = useState<RangoSemana>(calcularSemanaAnterior);
   const [fallas, setFallas] = useState(0);
   const [permisos, setPermisos] = useState(0);
+  const [ingresos, setIngresos] = useState(0);
+  const [retiros, setRetiros] = useState(0);
+  const [detalleFallas, setDetalleFallas] = useState<DetalleFallaPermiso[]>([]);
+  const [detallePermisos, setDetallePermisos] = useState<DetalleFallaPermiso[]>([]);
 
-  // Paso 2: Datos auto-cargados
+  // Paso 2: Selección de aplicaciones cerradas
+  const [listaAplicacionesCerradas, setListaAplicacionesCerradas] = useState<
+    { id: string; nombre: string; tipo: string; fechaCierre: string }[]
+  >([]);
+  const [loadingCierres, setLoadingCierres] = useState(false);
+  const [cerradasSeleccionadas, setCerradasSeleccionadas] = useState<string[]>([]);
+
+  // Paso 3: Auto-loaded data
   const [datosReporte, setDatosReporte] = useState<DatosReporteSemanal | null>(null);
   const [errorDatos, setErrorDatos] = useState('');
 
-  // Paso 3: Temas adicionales
+  // Paso 4: Additional topics
   const [temasAdicionales, setTemasAdicionales] = useState<BloqueAdicional[]>([]);
 
-  // Paso 4: Resultado
+  // Paso 5: Result
   const [htmlGenerado, setHtmlGenerado] = useState('');
   const [pdfBlob, setPdfBlob] = useState<Blob | null>(null);
   const [errorGeneracion, setErrorGeneracion] = useState('');
 
+  // Load closed applications list when entering paso 2
+  useEffect(() => {
+    if (pasoActual === 2 && listaAplicacionesCerradas.length === 0 && !loadingCierres) {
+      setLoadingCierres(true);
+      fetchListaAplicacionesCerradas()
+        .then(list => setListaAplicacionesCerradas(list))
+        .catch(() => toast.error('No se pudo cargar la lista de aplicaciones cerradas'))
+        .finally(() => setLoadingCierres(false));
+    }
+  }, [pasoActual]);
+
   // ============================================================================
-  // NAVEGACIÓN ENTRE PASOS
+  // NAVIGATION
   // ============================================================================
 
   const handleSiguiente = async () => {
-    if (pasoActual === 1) {
-      // Al avanzar de paso 1 a 2, cargar datos
+    if (pasoActual === 2) {
+      // When advancing from paso 2 to 3, load the data
       await cargarDatos();
     }
-    if (pasoActual < 4) {
+    if (pasoActual < 5) {
       setPasoActual(pasoActual + 1);
     }
   };
@@ -114,7 +152,7 @@ export function ReporteSemanalWizard() {
   };
 
   // ============================================================================
-  // CARGA DE DATOS (Paso 1 → Paso 2)
+  // DATA LOADING (Paso 2 → Paso 3)
   // ============================================================================
 
   const cargarDatos = async () => {
@@ -125,6 +163,11 @@ export function ReporteSemanalWizard() {
         semana,
         fallas,
         permisos,
+        ingresos,
+        retiros,
+        detalleFallas,
+        detallePermisos,
+        cerradasIds: cerradasSeleccionadas,
         temasAdicionales,
       });
       setDatosReporte(datos);
@@ -137,7 +180,7 @@ export function ReporteSemanalWizard() {
   };
 
   // ============================================================================
-  // GENERACIÓN DEL REPORTE (Paso 4)
+  // REPORT GENERATION (Paso 5)
   // ============================================================================
 
   const handleGenerar = async () => {
@@ -149,7 +192,6 @@ export function ReporteSemanalWizard() {
     setErrorGeneracion('');
 
     try {
-      // Actualizar datos con temas adicionales finales
       const datosFinales: DatosReporteSemanal = {
         ...datosReporte,
         temasAdicionales,
@@ -183,13 +225,13 @@ export function ReporteSemanalWizard() {
 
   const handleDescargar = () => {
     if (!pdfBlob) return;
-    const filename = `reporte-semana-${semana.ano}-S${String(semana.numero).padStart(2, '0')}.pdf`;
+    const filename = `reporte-slides-semana-${semana.ano}-S${String(semana.numero).padStart(2, '0')}.pdf`;
     descargarBlob(pdfBlob, filename);
     toast.success('PDF descargado');
   };
 
   // ============================================================================
-  // MANEJO DE SEMANA (Paso 1)
+  // WEEK SELECTOR (Paso 1)
   // ============================================================================
 
   const handleCambiarSemana = (offset: number) => {
@@ -202,22 +244,34 @@ export function ReporteSemanalWizard() {
   };
 
   // ============================================================================
-  // MANEJO DE TEMAS ADICIONALES (Paso 3)
+  // DETALLE FALLAS / PERMISOS helpers
+  // ============================================================================
+
+  const syncDetalleFallas = (count: number) => {
+    const arr = [...detalleFallas];
+    while (arr.length < count) arr.push({ empleado: '', razon: '' });
+    setDetalleFallas(arr.slice(0, count));
+  };
+
+  const syncDetallePermisos = (count: number) => {
+    const arr = [...detallePermisos];
+    while (arr.length < count) arr.push({ empleado: '', razon: '' });
+    setDetallePermisos(arr.slice(0, count));
+  };
+
+  // ============================================================================
+  // ADDITIONAL TOPICS (Paso 4)
   // ============================================================================
 
   const agregarBloqueTexto = () => {
-    setTemasAdicionales([...temasAdicionales, {
-      tipo: 'texto',
-      titulo: '',
-      contenido: '',
-    }]);
+    setTemasAdicionales([...temasAdicionales, { tipo: 'texto', titulo: '', contenido: '' }]);
   };
 
   const agregarBloqueImagen = () => {
     setTemasAdicionales([...temasAdicionales, {
       tipo: 'imagen_con_texto',
       titulo: '',
-      imagenBase64: '',
+      imagenesBase64: [],
       descripcion: '',
     }]);
   };
@@ -240,49 +294,57 @@ export function ReporteSemanalWizard() {
     setTemasAdicionales(nuevos);
   };
 
-  const handleImageUpload = (index: number, file: File) => {
-    if (file.size > 500 * 1024) {
-      toast.error('La imagen debe ser menor a 500KB');
+  const handleImageUpload = (index: number, file: File, slot: number) => {
+    if (file.size > 800 * 1024) {
+      toast.error('La imagen debe ser menor a 800KB');
       return;
     }
     const reader = new FileReader();
     reader.onload = (e) => {
-      actualizarBloque(index, { imagenBase64: e.target?.result as string });
+      const bloque = temasAdicionales[index] as BloqueImagenConTexto;
+      const imgs = [...(bloque.imagenesBase64 || [])];
+      imgs[slot] = e.target?.result as string;
+      actualizarBloque(index, { imagenesBase64: imgs });
     };
     reader.readAsDataURL(file);
   };
 
+  const handleRemoveImage = (index: number, slot: number) => {
+    const bloque = temasAdicionales[index] as BloqueImagenConTexto;
+    const imgs = [...(bloque.imagenesBase64 || [])];
+    imgs.splice(slot, 1);
+    actualizarBloque(index, { imagenesBase64: imgs });
+  };
+
   // ============================================================================
-  // RENDER: INDICADOR DE PASOS
+  // RENDER: STEP INDICATOR
   // ============================================================================
 
   const renderPasos = () => (
-    <div className="flex items-center justify-between mb-8 bg-white rounded-2xl p-4 border border-gray-200 shadow-sm">
+    <div className="flex items-center justify-between mb-8 bg-white rounded-2xl p-4 border border-gray-200 shadow-sm overflow-x-auto">
       {PASOS.map((paso, i) => {
         const Icon = paso.icono;
         const esActual = paso.numero === pasoActual;
         const esCompletado = paso.numero < pasoActual;
         return (
-          <div key={paso.numero} className="flex items-center flex-1">
-            <div className="flex items-center gap-3">
-              <div className={`w-10 h-10 rounded-xl flex items-center justify-center transition-all ${
+          <div key={paso.numero} className="flex items-center flex-1 min-w-0">
+            <div className="flex items-center gap-2 flex-shrink-0">
+              <div className={`w-9 h-9 rounded-xl flex items-center justify-center transition-all ${
                 esActual ? 'bg-primary text-white shadow-md' :
                 esCompletado ? 'bg-secondary text-foreground' :
                 'bg-gray-100 text-gray-400'
               }`}>
-                <Icon className="w-5 h-5" />
+                <Icon className="w-4 h-4" />
               </div>
-              <div className="hidden md:block">
-                <p className={`text-sm font-medium ${esActual ? 'text-foreground' : 'text-gray-500'}`}>
+              <div className="hidden lg:block">
+                <p className={`text-xs font-medium ${esActual ? 'text-foreground' : 'text-gray-500'}`}>
                   {paso.titulo}
                 </p>
                 <p className="text-xs text-gray-400">{paso.descripcion}</p>
               </div>
             </div>
             {i < PASOS.length - 1 && (
-              <div className={`flex-1 h-0.5 mx-4 ${
-                esCompletado ? 'bg-secondary' : 'bg-gray-200'
-              }`} />
+              <div className={`flex-1 h-0.5 mx-2 ${esCompletado ? 'bg-secondary' : 'bg-gray-200'}`} />
             )}
           </div>
         );
@@ -310,9 +372,7 @@ export function ReporteSemanalWizard() {
               <ArrowLeft className="w-4 h-4" />
             </Button>
             <div className="flex-1 text-center">
-              <p className="text-2xl font-bold text-foreground">
-                Semana {semana.numero}
-              </p>
+              <p className="text-2xl font-bold text-foreground">Semana {semana.numero}</p>
               <p className="text-sm text-gray-500">
                 {formatearFechaCorta(semana.inicio)} — {formatearFechaCorta(semana.fin)}
               </p>
@@ -332,46 +392,181 @@ export function ReporteSemanalWizard() {
             Personal
           </CardTitle>
         </CardHeader>
-        <CardContent>
-          <p className="text-sm text-gray-500 mb-4">
-            El total de trabajadores se calcula automáticamente. Ingresa fallas y permisos manualmente.
+        <CardContent className="space-y-4">
+          <p className="text-sm text-gray-500">
+            El total de trabajadores y jornales se calcula automáticamente. Completa los datos manuales.
           </p>
-          <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-            <div>
-              <label className="block text-sm font-medium text-brand-brown mb-1">
-                Fallas (ausencias no justificadas)
-              </label>
-              <input
-                type="number"
-                min="0"
-                value={fallas}
-                onChange={(e) => setFallas(Math.max(0, parseInt(e.target.value) || 0))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary outline-none"
-              />
-            </div>
-            <div>
-              <label className="block text-sm font-medium text-brand-brown mb-1">
-                Permisos otorgados
-              </label>
-              <input
-                type="number"
-                min="0"
-                value={permisos}
-                onChange={(e) => setPermisos(Math.max(0, parseInt(e.target.value) || 0))}
-                className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary outline-none"
-              />
-            </div>
+
+          {/* Counters row */}
+          <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
+            {[
+              { label: 'Fallas (ausencias)', value: fallas, setter: (v: number) => { setFallas(v); syncDetalleFallas(v); } },
+              { label: 'Permisos otorgados', value: permisos, setter: (v: number) => { setPermisos(v); syncDetallePermisos(v); } },
+              { label: 'Ingresos (nuevos)', value: ingresos, setter: setIngresos },
+              { label: 'Retiros', value: retiros, setter: setRetiros },
+            ].map(item => (
+              <div key={item.label}>
+                <label className="block text-sm font-medium text-brand-brown mb-1">{item.label}</label>
+                <input
+                  type="number" min="0" value={item.value}
+                  onChange={(e) => item.setter(Math.max(0, parseInt(e.target.value) || 0))}
+                  className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary outline-none"
+                />
+              </div>
+            ))}
           </div>
+
+          {/* Detalle de fallas */}
+          {fallas > 0 && (
+            <div>
+              <p className="text-sm font-medium text-brand-brown mb-2">Detalle de fallas (opcional)</p>
+              <div className="space-y-2">
+                {detalleFallas.map((f, i) => (
+                  <div key={i} className="flex gap-2">
+                    <input
+                      type="text" placeholder="Nombre del trabajador"
+                      value={f.empleado}
+                      onChange={(e) => {
+                        const arr = [...detalleFallas];
+                        arr[i] = { ...arr[i], empleado: e.target.value };
+                        setDetalleFallas(arr);
+                      }}
+                      className="flex-1 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary outline-none"
+                    />
+                    <input
+                      type="text" placeholder="Razón (opcional)"
+                      value={f.razon || ''}
+                      onChange={(e) => {
+                        const arr = [...detalleFallas];
+                        arr[i] = { ...arr[i], razon: e.target.value };
+                        setDetalleFallas(arr);
+                      }}
+                      className="flex-1 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary outline-none"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
+
+          {/* Detalle de permisos */}
+          {permisos > 0 && (
+            <div>
+              <p className="text-sm font-medium text-brand-brown mb-2">Detalle de permisos (opcional)</p>
+              <div className="space-y-2">
+                {detallePermisos.map((p, i) => (
+                  <div key={i} className="flex gap-2">
+                    <input
+                      type="text" placeholder="Nombre del trabajador"
+                      value={p.empleado}
+                      onChange={(e) => {
+                        const arr = [...detallePermisos];
+                        arr[i] = { ...arr[i], empleado: e.target.value };
+                        setDetallePermisos(arr);
+                      }}
+                      className="flex-1 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary outline-none"
+                    />
+                    <input
+                      type="text" placeholder="Razón (opcional)"
+                      value={p.razon || ''}
+                      onChange={(e) => {
+                        const arr = [...detallePermisos];
+                        arr[i] = { ...arr[i], razon: e.target.value };
+                        setDetallePermisos(arr);
+                      }}
+                      className="flex-1 px-3 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary outline-none"
+                    />
+                  </div>
+                ))}
+              </div>
+            </div>
+          )}
         </CardContent>
       </Card>
     </div>
   );
 
   // ============================================================================
-  // RENDER: PASO 2 - DATOS OPERATIVOS
+  // RENDER: PASO 2 - SELECCIONAR APLICACIONES CERRADAS
   // ============================================================================
 
-  const renderPaso2 = () => {
+  const renderPaso2 = () => (
+    <div className="space-y-6">
+      <Card>
+        <CardHeader>
+          <CardTitle className="flex items-center gap-2 text-foreground">
+            <CheckSquare className="w-5 h-5 text-primary" />
+            Aplicaciones Cerradas a Incluir
+          </CardTitle>
+        </CardHeader>
+        <CardContent>
+          <p className="text-sm text-gray-500 mb-4">
+            Selecciona las aplicaciones cerradas cuyo reporte de resultados quieres incluir en las diapositivas.
+            Puedes omitir este paso si no deseas incluir cierres.
+          </p>
+
+          {loadingCierres ? (
+            <div className="flex items-center justify-center py-8">
+              <Loader2 className="w-6 h-6 text-primary animate-spin mr-2" />
+              <span className="text-gray-500 text-sm">Cargando aplicaciones...</span>
+            </div>
+          ) : listaAplicacionesCerradas.length === 0 ? (
+            <div className="text-center py-8 text-gray-400">
+              <CheckSquare className="w-10 h-10 mx-auto mb-2 opacity-40" />
+              <p>No hay aplicaciones cerradas disponibles</p>
+            </div>
+          ) : (
+            <div className="space-y-2">
+              {listaAplicacionesCerradas.map(app => {
+                const selected = cerradasSeleccionadas.includes(app.id);
+                return (
+                  <div
+                    key={app.id}
+                    onClick={() => {
+                      setCerradasSeleccionadas(prev =>
+                        selected ? prev.filter(id => id !== app.id) : [...prev, app.id]
+                      );
+                    }}
+                    className={`flex items-center gap-3 p-3 rounded-lg border cursor-pointer transition-colors ${
+                      selected
+                        ? 'bg-primary/10 border-primary/40'
+                        : 'bg-white border-gray-200 hover:bg-gray-50'
+                    }`}
+                  >
+                    {selected
+                      ? <CheckSquare className="w-5 h-5 text-primary flex-shrink-0" />
+                      : <Square className="w-5 h-5 text-gray-400 flex-shrink-0" />
+                    }
+                    <div className="flex-1 min-w-0">
+                      <p className="font-medium text-sm text-foreground truncate">{app.nombre}</p>
+                      <p className="text-xs text-gray-500">
+                        {app.tipo} · Cerrada: {formatFecha(app.fechaCierre)}
+                      </p>
+                    </div>
+                    <Badge variant={selected ? 'default' : 'outline'} className="text-xs flex-shrink-0">
+                      {selected ? 'Incluida' : 'Excluida'}
+                    </Badge>
+                  </div>
+                );
+              })}
+            </div>
+          )}
+
+          {cerradasSeleccionadas.length > 0 && (
+            <p className="text-sm text-primary font-medium mt-3">
+              {cerradasSeleccionadas.length} aplicación{cerradasSeleccionadas.length !== 1 ? 'es' : ''} seleccionada{cerradasSeleccionadas.length !== 1 ? 's' : ''}
+            </p>
+          )}
+        </CardContent>
+      </Card>
+    </div>
+  );
+
+  // ============================================================================
+  // RENDER: PASO 3 - DATOS OPERATIVOS
+  // ============================================================================
+
+  const renderPaso3 = () => {
     if (loading) {
       return (
         <div className="flex flex-col items-center justify-center py-20">
@@ -395,19 +590,21 @@ export function ReporteSemanalWizard() {
 
     return (
       <div className="space-y-6">
-        {/* Resumen de Personal */}
+        {/* Personal summary */}
         <Card>
           <CardHeader>
             <CardTitle className="text-foreground">Personal</CardTitle>
           </CardHeader>
           <CardContent>
-            <div className="grid grid-cols-2 md:grid-cols-5 gap-4">
+            <div className="grid grid-cols-2 md:grid-cols-4 lg:grid-cols-7 gap-3">
               {[
                 { label: 'Trabajadores', value: datosReporte.personal.totalTrabajadores },
                 { label: 'Empleados', value: datosReporte.personal.empleados },
                 { label: 'Contratistas', value: datosReporte.personal.contratistas },
                 { label: 'Fallas', value: datosReporte.personal.fallas },
                 { label: 'Permisos', value: datosReporte.personal.permisos },
+                { label: 'Ingresos', value: datosReporte.personal.ingresos },
+                { label: 'Retiros', value: datosReporte.personal.retiros },
               ].map(item => (
                 <div key={item.label} className="text-center p-3 bg-background rounded-lg">
                   <p className="text-2xl font-bold text-foreground">{item.value}</p>
@@ -415,21 +612,74 @@ export function ReporteSemanalWizard() {
                 </div>
               ))}
             </div>
+            <div className="mt-3 p-3 bg-primary/5 rounded-lg">
+              <p className="text-sm text-gray-600">
+                <span className="font-medium text-primary">{datosReporte.personal.eficienciaOperativa}%</span> eficiencia operativa
+                &nbsp;({datosReporte.personal.jornalesTrabajados.toFixed(1)} / {datosReporte.personal.jornalesPosibles} jornales posibles)
+              </p>
+            </div>
           </CardContent>
         </Card>
 
-        {/* Matriz de Jornales */}
+        {/* Labores programadas */}
+        {datosReporte.labores.programadas.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-foreground">
+                Labores Programadas
+                <Badge variant="secondary" className="ml-2">{datosReporte.labores.programadas.length}</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent>
+              <div className="overflow-x-auto">
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Tarea</TableHead>
+                      <TableHead>Tipo</TableHead>
+                      <TableHead>Estado</TableHead>
+                      <TableHead>Inicio</TableHead>
+                      <TableHead>Fin</TableHead>
+                      <TableHead>Lotes</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {datosReporte.labores.programadas.map(labor => (
+                      <TableRow key={labor.id}>
+                        <TableCell className="font-medium">{labor.nombre}</TableCell>
+                        <TableCell className="text-sm text-gray-500">{labor.tipoTarea}</TableCell>
+                        <TableCell>
+                          <Badge variant={
+                            labor.estado === 'Terminada' ? 'default' :
+                            labor.estado === 'En proceso' ? 'secondary' : 'outline'
+                          }>
+                            {labor.estado}
+                          </Badge>
+                        </TableCell>
+                        <TableCell className="text-sm">{formatFecha(labor.fechaInicio)}</TableCell>
+                        <TableCell className="text-sm">{labor.fechaFin ? formatFecha(labor.fechaFin) : '—'}</TableCell>
+                        <TableCell className="text-xs text-gray-500">{labor.lotes.join(', ') || '—'}</TableCell>
+                      </TableRow>
+                    ))}
+                  </TableBody>
+                </Table>
+              </div>
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Jornales matrix */}
         <Card>
           <CardHeader>
             <CardTitle className="text-foreground">
               Distribución de Jornales
               <Badge variant="secondary" className="ml-2">
-                {datosReporte.jornales.totalGeneral.jornales.toFixed(2)} jornales
+                {datosReporte.labores.matrizJornales.totalGeneral.jornales.toFixed(2)} jornales
               </Badge>
             </CardTitle>
           </CardHeader>
           <CardContent>
-            {datosReporte.jornales.actividades.length === 0 ? (
+            {datosReporte.labores.matrizJornales.actividades.length === 0 ? (
               <p className="text-gray-400 text-center py-4">No hay registros de trabajo en esta semana</p>
             ) : (
               <div className="overflow-x-auto">
@@ -437,18 +687,18 @@ export function ReporteSemanalWizard() {
                   <TableHeader>
                     <TableRow>
                       <TableHead className="font-semibold">Actividad</TableHead>
-                      {datosReporte.jornales.lotes.map(lote => (
+                      {datosReporte.labores.matrizJornales.lotes.map(lote => (
                         <TableHead key={lote} className="text-center">{lote}</TableHead>
                       ))}
                       <TableHead className="text-center font-bold bg-background">Total</TableHead>
                     </TableRow>
                   </TableHeader>
                   <TableBody>
-                    {datosReporte.jornales.actividades.map(actividad => (
+                    {datosReporte.labores.matrizJornales.actividades.map(actividad => (
                       <TableRow key={actividad}>
                         <TableCell className="font-medium">{actividad}</TableCell>
-                        {datosReporte.jornales.lotes.map(lote => {
-                          const celda = datosReporte.jornales.datos[actividad]?.[lote];
+                        {datosReporte.labores.matrizJornales.lotes.map(lote => {
+                          const celda = datosReporte.labores.matrizJornales.datos[actividad]?.[lote];
                           return (
                             <TableCell key={lote} className="text-center">
                               {celda ? celda.jornales.toFixed(2) : '-'}
@@ -456,20 +706,19 @@ export function ReporteSemanalWizard() {
                           );
                         })}
                         <TableCell className="text-center font-bold bg-background">
-                          {(datosReporte.jornales.totalesPorActividad[actividad]?.jornales || 0).toFixed(2)}
+                          {(datosReporte.labores.matrizJornales.totalesPorActividad[actividad]?.jornales || 0).toFixed(2)}
                         </TableCell>
                       </TableRow>
                     ))}
-                    {/* Fila de totales */}
                     <TableRow className="bg-background font-bold">
                       <TableCell>Total</TableCell>
-                      {datosReporte.jornales.lotes.map(lote => (
+                      {datosReporte.labores.matrizJornales.lotes.map(lote => (
                         <TableCell key={lote} className="text-center">
-                          {(datosReporte.jornales.totalesPorLote[lote]?.jornales || 0).toFixed(2)}
+                          {(datosReporte.labores.matrizJornales.totalesPorLote[lote]?.jornales || 0).toFixed(2)}
                         </TableCell>
                       ))}
                       <TableCell className="text-center bg-primary/10">
-                        {datosReporte.jornales.totalGeneral.jornales.toFixed(2)}
+                        {datosReporte.labores.matrizJornales.totalGeneral.jornales.toFixed(2)}
                       </TableCell>
                     </TableRow>
                   </TableBody>
@@ -479,7 +728,35 @@ export function ReporteSemanalWizard() {
           </CardContent>
         </Card>
 
-        {/* Aplicaciones Planeadas */}
+        {/* Aplicaciones cerradas */}
+        {datosReporte.aplicaciones.cerradas.length > 0 && (
+          <Card>
+            <CardHeader>
+              <CardTitle className="text-foreground">
+                Aplicaciones Cerradas incluidas
+                <Badge className="ml-2">{datosReporte.aplicaciones.cerradas.length}</Badge>
+              </CardTitle>
+            </CardHeader>
+            <CardContent className="space-y-3">
+              {datosReporte.aplicaciones.cerradas.map(app => (
+                <div key={app.id} className="p-4 bg-background rounded-lg border border-secondary/30">
+                  <div className="flex items-center gap-2 mb-1">
+                    <Badge variant="outline">{app.tipo}</Badge>
+                    <span className="font-medium text-foreground">{app.nombre}</span>
+                  </div>
+                  <p className="text-xs text-gray-500">
+                    {formatFecha(app.fechaInicio)} — {formatFecha(app.fechaFin)} · {app.diasEjecucion} días
+                  </p>
+                  <p className="text-sm font-medium text-primary mt-1">
+                    Costo real: {formatNumber(app.general.costoReal)} COP
+                  </p>
+                </div>
+              ))}
+            </CardContent>
+          </Card>
+        )}
+
+        {/* Aplicaciones planeadas */}
         {datosReporte.aplicaciones.planeadas.length > 0 && (
           <Card>
             <CardHeader>
@@ -495,12 +772,12 @@ export function ReporteSemanalWizard() {
                     <Badge variant="outline">{app.tipo}</Badge>
                     <span className="font-medium text-foreground">{app.nombre}</span>
                   </div>
-                  <p className="text-sm text-gray-600 mb-2">{app.proposito}</p>
+                  <p className="text-sm text-gray-600 mb-1">{app.proposito}</p>
                   <p className="text-sm font-medium text-primary">
                     Costo estimado: ${formatNumber(app.costoTotalEstimado)} COP
                   </p>
                   <p className="text-xs text-gray-400 mt-1">
-                    {app.listaCompras.length} productos en lista de compras
+                    {app.listaCompras.length} productos · {app.mezclas.length} mezclas
                   </p>
                 </div>
               ))}
@@ -508,7 +785,7 @@ export function ReporteSemanalWizard() {
           </Card>
         )}
 
-        {/* Aplicaciones Activas */}
+        {/* Aplicaciones activas */}
         {datosReporte.aplicaciones.activas.length > 0 && (
           <Card>
             <CardHeader>
@@ -527,7 +804,6 @@ export function ReporteSemanalWizard() {
                     </div>
                     <span className="text-lg font-bold text-primary">{app.porcentajeGlobal}%</span>
                   </div>
-                  {/* Barra de progreso global */}
                   <div className="w-full bg-gray-200 rounded-full h-2 mb-3">
                     <div
                       className="bg-primary h-2 rounded-full transition-all"
@@ -537,14 +813,11 @@ export function ReporteSemanalWizard() {
                   <p className="text-sm text-gray-500 mb-2">
                     {app.totalEjecutado}/{app.totalPlaneado} {app.unidad}
                   </p>
-                  {/* Detalle por lote */}
                   <div className="grid grid-cols-2 md:grid-cols-3 gap-2">
                     {app.progresoPorLote.map(lote => (
                       <div key={lote.loteNombre} className="bg-gray-50 rounded p-2 text-xs">
                         <p className="font-medium">{lote.loteNombre}</p>
-                        <p className="text-gray-500">
-                          {lote.ejecutado}/{lote.planeado} ({lote.porcentaje}%)
-                        </p>
+                        <p className="text-gray-500">{lote.ejecutado}/{lote.planeado} ({lote.porcentaje}%)</p>
                       </div>
                     ))}
                   </div>
@@ -566,7 +839,6 @@ export function ReporteSemanalWizard() {
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
-              {/* Insights */}
               {datosReporte.monitoreo.insights.length > 0 && (
                 <div className="space-y-2">
                   {datosReporte.monitoreo.insights.map((insight, i) => (
@@ -584,25 +856,13 @@ export function ReporteSemanalWizard() {
                   ))}
                 </div>
               )}
-              {/* Detalle por lote */}
-              {datosReporte.monitoreo.detallePorLote.map(lote => (
-                <div key={lote.loteNombre} className="border rounded-lg p-3">
-                  <p className="font-medium text-foreground mb-2">{lote.loteNombre}</p>
-                  <div className="space-y-1">
-                    {lote.sublotes.map((s, i) => (
-                      <div key={i} className="flex items-center justify-between text-sm">
-                        <span className="text-gray-600">{s.subloteNombre} — {s.plagaNombre}</span>
-                        <Badge variant={
-                          s.gravedad === 'Alta' ? 'destructive' :
-                          s.gravedad === 'Media' ? 'default' : 'secondary'
-                        }>
-                          {s.incidencia.toFixed(1)}%
-                        </Badge>
-                      </div>
-                    ))}
-                  </div>
-                </div>
-              ))}
+              <p className="text-xs text-gray-400">
+                Fechas: {datosReporte.monitoreo.fechasMonitoreo.join(', ')}
+              </p>
+              <p className="text-xs text-gray-400">
+                {datosReporte.monitoreo.vistasPorLote.length} lotes ·{' '}
+                {datosReporte.monitoreo.vistasPorSublote.length} vistas por sublote
+              </p>
             </CardContent>
           </Card>
         )}
@@ -611,10 +871,10 @@ export function ReporteSemanalWizard() {
   };
 
   // ============================================================================
-  // RENDER: PASO 3 - TEMAS ADICIONALES
+  // RENDER: PASO 4 - TEMAS ADICIONALES
   // ============================================================================
 
-  const renderPaso3 = () => (
+  const renderPaso4 = () => (
     <div className="space-y-6">
       <Card>
         <CardHeader>
@@ -635,7 +895,7 @@ export function ReporteSemanalWizard() {
             <div className="text-center py-12 text-gray-400">
               <MessageSquarePlus className="w-12 h-12 mx-auto mb-3 opacity-50" />
               <p>No hay temas adicionales</p>
-              <p className="text-sm">Agrega bloques de texto o imágenes con los botones de arriba</p>
+              <p className="text-sm">Cada bloque se convierte en una diapositiva separada</p>
             </div>
           ) : (
             <div className="space-y-4">
@@ -643,7 +903,7 @@ export function ReporteSemanalWizard() {
                 <div key={index} className="border rounded-lg p-4 bg-white">
                   <div className="flex items-center justify-between mb-3">
                     <Badge variant="outline">
-                      {bloque.tipo === 'texto' ? 'Texto' : 'Imagen'}
+                      {bloque.tipo === 'texto' ? 'Texto' : 'Imagen (hasta 2 fotos)'}
                     </Badge>
                     <div className="flex gap-1">
                       <Button size="sm" variant="ghost" onClick={() => moverBloque(index, -1)} disabled={index === 0}>
@@ -658,7 +918,6 @@ export function ReporteSemanalWizard() {
                     </div>
                   </div>
 
-                  {/* Título (ambos tipos) */}
                   <input
                     type="text"
                     placeholder="Título (opcional)"
@@ -677,45 +936,51 @@ export function ReporteSemanalWizard() {
                     />
                   ) : (
                     <>
-                      {/* Upload de imagen */}
-                      {!(bloque as BloqueImagenConTexto).imagenBase64 ? (
-                        <label className="flex flex-col items-center justify-center border-2 border-dashed border-gray-300 rounded-lg p-6 cursor-pointer hover:border-primary transition-colors">
-                          <Upload className="w-8 h-8 text-gray-400 mb-2" />
-                          <p className="text-sm text-gray-500">Arrastra o haz clic para subir imagen</p>
-                          <p className="text-xs text-gray-400">Máximo 500KB</p>
-                          <input
-                            type="file"
-                            accept="image/*"
-                            className="hidden"
-                            onChange={(e) => {
-                              const file = e.target.files?.[0];
-                              if (file) handleImageUpload(index, file);
-                            }}
-                          />
-                        </label>
-                      ) : (
-                        <div className="mb-3">
-                          <img
-                            src={(bloque as BloqueImagenConTexto).imagenBase64}
-                            alt="Preview"
-                            className="max-h-48 rounded-lg object-contain mx-auto"
-                          />
-                          <Button
-                            size="sm"
-                            variant="ghost"
-                            className="text-red-500 mt-2"
-                            onClick={() => actualizarBloque(index, { imagenBase64: '' })}
-                          >
-                            Eliminar imagen
-                          </Button>
-                        </div>
-                      )}
+                      {/* Two image slots */}
+                      <div className="grid grid-cols-2 gap-3 mb-3">
+                        {[0, 1].map(slot => {
+                          const imgBloque = bloque as BloqueImagenConTexto;
+                          const imgUrl = imgBloque.imagenesBase64?.[slot];
+                          return (
+                            <div key={slot}>
+                              {!imgUrl ? (
+                                <label className="flex flex-col items-center justify-center border-2 border-dashed border-gray-300 rounded-lg p-4 cursor-pointer hover:border-primary transition-colors h-32">
+                                  <Upload className="w-6 h-6 text-gray-400 mb-1" />
+                                  <p className="text-xs text-gray-500">Foto {slot + 1}</p>
+                                  <p className="text-xs text-gray-400">Max 800KB</p>
+                                  <input
+                                    type="file" accept="image/*" className="hidden"
+                                    onChange={(e) => {
+                                      const file = e.target.files?.[0];
+                                      if (file) handleImageUpload(index, file, slot);
+                                    }}
+                                  />
+                                </label>
+                              ) : (
+                                <div className="relative">
+                                  <img
+                                    src={imgUrl}
+                                    alt={`Foto ${slot + 1}`}
+                                    className="h-32 w-full rounded-lg object-cover"
+                                  />
+                                  <button
+                                    onClick={() => handleRemoveImage(index, slot)}
+                                    className="absolute top-1 right-1 bg-white rounded-full p-1 shadow text-red-500 hover:bg-red-50"
+                                  >
+                                    <X className="w-3 h-3" />
+                                  </button>
+                                </div>
+                              )}
+                            </div>
+                          );
+                        })}
+                      </div>
                       <textarea
-                        placeholder="Descripción de la imagen"
+                        placeholder="Descripción / texto de la diapositiva"
                         value={(bloque as BloqueImagenConTexto).descripcion}
                         onChange={(e) => actualizarBloque(index, { descripcion: e.target.value })}
                         rows={2}
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary outline-none text-sm resize-y mt-3"
+                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-primary outline-none text-sm resize-y"
                       />
                     </>
                   )}
@@ -729,12 +994,11 @@ export function ReporteSemanalWizard() {
   );
 
   // ============================================================================
-  // RENDER: PASO 4 - GENERAR Y PREVIEW
+  // RENDER: PASO 5 - GENERAR Y PREVIEW
   // ============================================================================
 
-  const renderPaso4 = () => (
+  const renderPaso5 = () => (
     <div className="space-y-6">
-      {/* Botón de generar */}
       {!htmlGenerado && (
         <Card>
           <CardContent className="py-12 text-center">
@@ -749,7 +1013,7 @@ export function ReporteSemanalWizard() {
                 <FileText className="w-16 h-16 text-primary mx-auto mb-4 opacity-70" />
                 <h3 className="text-xl font-bold text-foreground mb-2">Listo para generar</h3>
                 <p className="text-gray-500 mb-6">
-                  El reporte será diseñado por IA con los datos de la semana {semana.numero}
+                  El reporte en formato diapositivas (landscape) será generado para la Semana {semana.numero}
                 </p>
                 <Button
                   size="lg"
@@ -765,7 +1029,6 @@ export function ReporteSemanalWizard() {
         </Card>
       )}
 
-      {/* Error banner */}
       {errorGeneracion && !generando && (
         <Card className="border-red-300 bg-red-50">
           <CardContent className="py-6">
@@ -775,8 +1038,7 @@ export function ReporteSemanalWizard() {
                 <h4 className="font-medium text-red-800 mb-1">Error al generar el reporte</h4>
                 <p className="text-sm text-red-700">{errorGeneracion}</p>
                 <Button
-                  size="sm"
-                  variant="outline"
+                  size="sm" variant="outline"
                   className="mt-3 border-red-300 text-red-700 hover:bg-red-100"
                   onClick={handleGenerar}
                 >
@@ -789,7 +1051,6 @@ export function ReporteSemanalWizard() {
         </Card>
       )}
 
-      {/* Preview y acciones */}
       {htmlGenerado && (
         <>
           <div className="flex items-center justify-between">
@@ -823,36 +1084,32 @@ export function ReporteSemanalWizard() {
   );
 
   // ============================================================================
-  // RENDER PRINCIPAL
+  // MAIN RENDER
   // ============================================================================
 
   return (
     <div className="max-w-6xl mx-auto">
-      {/* Header */}
       <div className="flex items-center justify-between mb-6">
         <div>
           <Button
-            variant="ghost"
-            size="sm"
+            variant="ghost" size="sm"
             onClick={() => navigate('/reportes')}
             className="mb-2 text-gray-500"
           >
             <ArrowLeft className="w-4 h-4 mr-1" /> Volver a Reportes
           </Button>
-          <h1 className="text-2xl font-bold text-foreground">Generar Reporte Semanal</h1>
+          <h1 className="text-2xl font-bold text-foreground">Generar Reporte Semanal (Diapositivas)</h1>
         </div>
       </div>
 
-      {/* Indicador de pasos */}
       {renderPasos()}
 
-      {/* Contenido del paso actual */}
       {pasoActual === 1 && renderPaso1()}
       {pasoActual === 2 && renderPaso2()}
       {pasoActual === 3 && renderPaso3()}
       {pasoActual === 4 && renderPaso4()}
+      {pasoActual === 5 && renderPaso5()}
 
-      {/* Navegación */}
       <div className="flex items-center justify-between mt-8 pt-4 border-t">
         <Button
           variant="outline"
@@ -861,7 +1118,7 @@ export function ReporteSemanalWizard() {
         >
           <ArrowLeft className="w-4 h-4 mr-1" /> Anterior
         </Button>
-        {pasoActual < 4 ? (
+        {pasoActual < 5 ? (
           <Button
             className="bg-primary hover:bg-primary-dark text-white"
             onClick={handleSiguiente}
@@ -871,10 +1128,7 @@ export function ReporteSemanalWizard() {
             Siguiente <ArrowRight className="w-4 h-4 ml-1" />
           </Button>
         ) : (
-          <Button
-            variant="outline"
-            onClick={() => navigate('/reportes')}
-          >
+          <Button variant="outline" onClick={() => navigate('/reportes')}>
             Finalizar
           </Button>
         )}

--- a/src/utils/fetchDatosReporteSemanal.ts
+++ b/src/utils/fetchDatosReporteSemanal.ts
@@ -12,14 +12,34 @@ import type {
   AplicacionActiva,
   ProgresoLote,
   ItemCompraResumen,
+  MezclaResumen,
   DatosMonitoreo,
   TendenciaMonitoreo,
   MonitoreoPorLote,
   MonitoreoSublote,
   DatosReporteSemanal,
   BloqueAdicional,
+  LaborSemanal,
+  AplicacionCerrada,
+  AplicacionCierreGeneral,
+  AplicacionCierreKPILote,
+  AplicacionCierreFinancieroLote,
+  VistaMonitoreoLote,
+  VistaLotePlaga,
+  VistaMonitoreoSublote,
+  ObservacionFecha,
 } from '../types/reporteSemanal';
 import type { Insight } from '../types/monitoreo';
+
+// Plagas de interés for priority marking
+const PLAGAS_INTERES = [
+  'Monalonion',
+  'Ácaro',
+  'Huevos de Ácaro',
+  'Ácaro Cristalino',
+  'Cucarrón marceño',
+  'Trips',
+];
 
 // ============================================================================
 // UTILIDADES DE SEMANA
@@ -102,19 +122,16 @@ export function calcularSemanaDesdeLunes(lunesISO: string): RangoSemana {
 
 /**
  * Obtiene el conteo de personal que trabajó en la semana
- * - Total de trabajadores únicos (empleados + contratistas)
- * - Desglose empleados vs contratistas
- * Nota: fallas y permisos se ingresan manualmente
  */
 export async function fetchPersonalSemana(
   inicio: string,
   fin: string
-): Promise<Omit<DatosPersonal, 'fallas' | 'permisos'>> {
+): Promise<Pick<DatosPersonal, 'totalTrabajadores' | 'empleados' | 'contratistas' | 'jornalesTrabajados'>> {
   const supabase = getSupabase();
 
   const { data: registros, error } = await supabase
     .from('registros_trabajo')
-    .select('empleado_id, contratista_id')
+    .select('empleado_id, contratista_id, fraccion_jornal')
     .gte('fecha_trabajo', inicio)
     .lte('fecha_trabajo', fin);
 
@@ -126,21 +143,99 @@ export async function fetchPersonalSemana(
   const contratistasUnicos = new Set(
     (registros || []).filter(r => r.contratista_id).map(r => r.contratista_id)
   );
+  const jornalesTrabajados = (registros || []).reduce(
+    (sum, r) => sum + (Number(r.fraccion_jornal) || 0), 0
+  );
 
   return {
     totalTrabajadores: empleadosUnicos.size + contratistasUnicos.size,
     empleados: empleadosUnicos.size,
     contratistas: contratistasUnicos.size,
+    jornalesTrabajados,
   };
 }
 
 // ============================================================================
-// SECCIÓN 2: MATRIZ DE JORNALES
+// SECCIÓN 2: LABORES
 // ============================================================================
 
 /**
+ * Obtiene tareas del kanban que se solapan con la semana dada.
+ * Estados: Programada → "Por iniciar", En Proceso → "En proceso", Completada → "Terminada"
+ */
+export async function fetchLaboresSemanales(
+  inicio: string,
+  fin: string
+): Promise<LaborSemanal[]> {
+  const supabase = getSupabase();
+
+  // Fetch tasks whose date range overlaps [inicio, fin]
+  // Overlap condition: task.inicio <= semana.fin AND task.fin >= semana.inicio
+  const { data: tareas, error } = await supabase
+    .from('tareas')
+    .select(`
+      id,
+      codigo_tarea,
+      nombre,
+      estado,
+      fecha_estimada_inicio,
+      fecha_estimada_fin,
+      fecha_inicio_real,
+      fecha_fin_real,
+      lote_nombres,
+      tipos_tareas!tipo_tarea_id(nombre)
+    `)
+    .in('estado', ['Programada', 'En Proceso', 'Completada'])
+    .or(`fecha_estimada_inicio.lte.${fin},fecha_inicio_real.lte.${fin}`)
+    .order('fecha_estimada_inicio', { ascending: true });
+
+  if (error) throw new Error(`Error al cargar labores: ${error.message}`);
+
+  const estadoMap: Record<string, 'Por iniciar' | 'En proceso' | 'Terminada'> = {
+    'Programada': 'Por iniciar',
+    'En Proceso': 'En proceso',
+    'Completada': 'Terminada',
+  };
+
+  const resultado: LaborSemanal[] = [];
+
+  for (const t of tareas || []) {
+    const estadoMapeado = estadoMap[t.estado];
+    if (!estadoMapeado) continue;
+
+    // Filter: must overlap with the week range
+    const tareaInicio = t.fecha_inicio_real || t.fecha_estimada_inicio;
+    const tareaFin = t.fecha_fin_real || t.fecha_estimada_fin;
+
+    // If no start date, skip
+    if (!tareaInicio) continue;
+
+    // Overlap check: tareaInicio <= fin AND (tareaFin >= inicio OR no tareaFin)
+    if (tareaInicio > fin) continue;
+    if (tareaFin && tareaFin < inicio) continue;
+
+    // Parse lote names
+    const lotesNombres = t.lote_nombres
+      ? t.lote_nombres.split(',').map((n: string) => n.trim()).filter(Boolean)
+      : [];
+
+    resultado.push({
+      id: t.id,
+      codigoTarea: t.codigo_tarea,
+      nombre: t.nombre,
+      tipoTarea: (t as any).tipos_tareas?.nombre || 'Sin tipo',
+      estado: estadoMapeado,
+      fechaInicio: tareaInicio,
+      fechaFin: tareaFin || undefined,
+      lotes: lotesNombres,
+    });
+  }
+
+  return resultado;
+}
+
+/**
  * Obtiene la matriz de jornales: actividades (filas) × lotes (columnas)
- * con totales por fila, columna y total general
  */
 export async function fetchMatrizJornales(
   inicio: string,
@@ -148,7 +243,6 @@ export async function fetchMatrizJornales(
 ): Promise<MatrizJornales> {
   const supabase = getSupabase();
 
-  // Cargar tipos de tarea para resolver nombres
   const { data: tiposTareas, error: errorTipos } = await supabase
     .from('tipos_tareas')
     .select('id, nombre');
@@ -157,7 +251,6 @@ export async function fetchMatrizJornales(
 
   const tiposMap = new Map((tiposTareas || []).map(t => [t.id, t.nombre]));
 
-  // Cargar registros de trabajo con joins a tareas y lotes
   const { data: registros, error: errorRegistros } = await supabase
     .from('registros_trabajo')
     .select(`
@@ -171,7 +264,6 @@ export async function fetchMatrizJornales(
 
   if (errorRegistros) throw new Error(`Error al cargar registros: ${errorRegistros.message}`);
 
-  // Construir la matriz
   const datos: Record<string, Record<string, CeldaMatrizJornales>> = {};
   const totalesPorActividad: Record<string, CeldaMatrizJornales> = {};
   const totalesPorLote: Record<string, CeldaMatrizJornales> = {};
@@ -190,18 +282,15 @@ export async function fetchMatrizJornales(
     actividadesSet.add(actividad);
     lotesSet.add(lote);
 
-    // Celda actividad × lote
     if (!datos[actividad]) datos[actividad] = {};
     if (!datos[actividad][lote]) datos[actividad][lote] = { jornales: 0, costo: 0 };
     datos[actividad][lote].jornales += jornales;
     datos[actividad][lote].costo += costo;
 
-    // Totales por actividad
     if (!totalesPorActividad[actividad]) totalesPorActividad[actividad] = { jornales: 0, costo: 0 };
     totalesPorActividad[actividad].jornales += jornales;
     totalesPorActividad[actividad].costo += costo;
 
-    // Totales por lote
     if (!totalesPorLote[lote]) totalesPorLote[lote] = { jornales: 0, costo: 0 };
     totalesPorLote[lote].jornales += jornales;
     totalesPorLote[lote].costo += costo;
@@ -225,12 +314,11 @@ export async function fetchMatrizJornales(
 // ============================================================================
 
 /**
- * Obtiene aplicaciones planeadas (estado: 'Calculada') con su lista de compras
+ * Obtiene aplicaciones planeadas (estado: 'Calculada') con mezclas y lista de compras
  */
 export async function fetchAplicacionesPlaneadas(): Promise<AplicacionPlaneada[]> {
   const supabase = getSupabase();
 
-  // Aplicaciones en estado Calculada — join aplicaciones_compras to avoid N+1
   const { data: aplicaciones, error } = await supabase
     .from('aplicaciones')
     .select(`
@@ -240,12 +328,15 @@ export async function fetchAplicacionesPlaneadas(): Promise<AplicacionPlaneada[]
       proposito,
       blanco_biologico,
       fecha_inicio_planeada,
+      fecha_fin_planeada,
       aplicaciones_compras(
         producto_nombre,
         producto_categoria,
         cantidad_necesaria,
         unidad,
-        costo_estimado
+        costo_estimado,
+        inventario_actual,
+        cantidad_faltante
       )
     `)
     .eq('estado', 'Calculada')
@@ -253,7 +344,7 @@ export async function fetchAplicacionesPlaneadas(): Promise<AplicacionPlaneada[]
 
   if (error) throw new Error(`Error al cargar aplicaciones planeadas: ${error.message}`);
 
-  // Collect all unique pest IDs across all applications for a single batch lookup
+  // Batch lookup for pest names
   const allBlancoIds = new Set<string>();
   for (const app of aplicaciones || []) {
     if (app.blanco_biologico) {
@@ -273,16 +364,67 @@ export async function fetchAplicacionesPlaneadas(): Promise<AplicacionPlaneada[]
     (plagas || []).forEach((p: any) => plagasMap.set(p.id, p.nombre));
   }
 
+  // Fetch mezclas with products for all apps at once
+  const appIds = (aplicaciones || []).map((a: any) => a.id);
+  const mezclasMap = new Map<string, MezclaResumen[]>();
+
+  if (appIds.length > 0) {
+    const { data: mezclas } = await supabase
+      .from('aplicaciones_mezclas')
+      .select(`
+        id,
+        nombre,
+        numero_orden,
+        aplicacion_id,
+        aplicaciones_productos(
+          producto_nombre,
+          dosis_por_caneca,
+          unidad_dosis,
+          dosis_grandes,
+          dosis_medianos,
+          dosis_pequenos,
+          dosis_clonales
+        )
+      `)
+      .in('aplicacion_id', appIds)
+      .order('numero_orden', { ascending: true });
+
+    for (const m of mezclas || []) {
+      const appId = (m as any).aplicacion_id;
+      if (!mezclasMap.has(appId)) mezclasMap.set(appId, []);
+
+      const productos = ((m as any).aplicaciones_productos || []).map((p: any) => {
+        let dosis = '';
+        if (p.dosis_por_caneca != null) {
+          dosis = `${p.dosis_por_caneca} ${p.unidad_dosis || 'cc'}/caneca`;
+        } else if (p.dosis_grandes != null) {
+          dosis = `${p.dosis_grandes}/${p.dosis_medianos}/${p.dosis_pequenos}/${p.dosis_clonales || 0} Kg/árbol`;
+        }
+        return { nombre: p.producto_nombre, dosis };
+      });
+
+      mezclasMap.get(appId)!.push({ nombre: m.nombre, productos });
+    }
+  }
+
   const resultado: AplicacionPlaneada[] = [];
 
   for (const app of aplicaciones || []) {
-    const listaCompras: ItemCompraResumen[] = ((app as any).aplicaciones_compras || []).map((c: any) => ({
+    const compras = (app as any).aplicaciones_compras || [];
+
+    const listaCompras: ItemCompraResumen[] = compras.map((c: any) => ({
       productoNombre: c.producto_nombre,
       categoria: c.producto_categoria || '',
       cantidadNecesaria: Number(c.cantidad_necesaria) || 0,
       unidad: c.unidad || '',
       costoEstimado: Number(c.costo_estimado) || 0,
+      inventarioDisponible: Number(c.inventario_actual) || 0,
+      cantidadAComprar: Number(c.cantidad_faltante) || 0,
     }));
+
+    const costoTotal = listaCompras.reduce((sum, item) => sum + item.costoEstimado, 0);
+    const inventarioTotal = listaCompras.reduce((sum, item) => sum + (item.inventarioDisponible || 0), 0);
+    const totalPedido = listaCompras.reduce((sum, item) => sum + (item.cantidadAComprar || 0), 0);
 
     let blancos: string[] = [];
     if (app.blanco_biologico) {
@@ -299,8 +441,12 @@ export async function fetchAplicacionesPlaneadas(): Promise<AplicacionPlaneada[]
       proposito: app.proposito || '',
       blancosBiologicos: blancos,
       fechaInicioPlaneada: app.fecha_inicio_planeada || '',
+      fechaFinPlaneada: app.fecha_fin_planeada || undefined,
+      mezclas: mezclasMap.get(app.id) || [],
       listaCompras,
-      costoTotalEstimado: listaCompras.reduce((sum, item) => sum + item.costoEstimado, 0),
+      costoTotalEstimado: costoTotal,
+      inventarioTotalDisponible: inventarioTotal,
+      totalPedido,
     });
   }
 
@@ -322,10 +468,6 @@ export async function fetchAplicacionesActivas(): Promise<AplicacionActiva[]> {
       proposito,
       estado,
       fecha_inicio_ejecucion,
-      aplicaciones_lotes(
-        lote_id,
-        lotes(nombre)
-      ),
       aplicaciones_calculos(
         lote_id,
         numero_canecas,
@@ -350,7 +492,6 @@ export async function fetchAplicacionesActivas(): Promise<AplicacionActiva[]> {
 
     const movimientos = (app as any).movimientos_diarios || [];
 
-    // Calcular planeado por lote (de aplicaciones_calculos)
     const planeadoPorLote = new Map<string, { nombre: string; planeado: number }>();
     ((app as any).aplicaciones_calculos || []).forEach((calc: any) => {
       const loteNombre = calc.lotes?.nombre || 'Sin lote';
@@ -360,7 +501,6 @@ export async function fetchAplicacionesActivas(): Promise<AplicacionActiva[]> {
       planeadoPorLote.set(calc.lote_id, { nombre: loteNombre, planeado });
     });
 
-    // Calcular ejecutado por lote (de movimientos_diarios)
     const ejecutadoPorLote = new Map<string, number>();
     movimientos.forEach((mov: any) => {
       const ejecutado = esFumigacion
@@ -372,7 +512,6 @@ export async function fetchAplicacionesActivas(): Promise<AplicacionActiva[]> {
       );
     });
 
-    // Construir progreso por lote
     const progresoPorLote: ProgresoLote[] = [];
     let totalPlaneado = 0;
     let totalEjecutado = 0;
@@ -411,18 +550,244 @@ export async function fetchAplicacionesActivas(): Promise<AplicacionActiva[]> {
   return resultado;
 }
 
+/**
+ * Obtiene datos completos de cierre para aplicaciones seleccionadas.
+ * Builds general, per-lote KPI, and per-lote financial breakdowns.
+ */
+export async function fetchAplicacionesCerradas(
+  selectedIds: string[]
+): Promise<AplicacionCerrada[]> {
+  if (!selectedIds || selectedIds.length === 0) return [];
+
+  const supabase = getSupabase();
+  const resultado: AplicacionCerrada[] = [];
+
+  for (const appId of selectedIds) {
+    try {
+      // Fetch application + lots
+      const { data: app, error: appError } = await supabase
+        .from('aplicaciones')
+        .select(`
+          id,
+          nombre_aplicacion,
+          tipo_aplicacion,
+          proposito,
+          estado,
+          fecha_inicio_ejecucion,
+          fecha_fin_ejecucion,
+          fecha_cierre,
+          costo_total_insumos,
+          costo_total_mano_obra,
+          costo_total,
+          aplicaciones_lotes(
+            lote_id,
+            lotes(id, nombre, total_arboles)
+          )
+        `)
+        .eq('id', appId)
+        .single();
+
+      if (appError || !app) continue;
+
+      const esFumigacion = app.tipo_aplicacion === 'Fumigación';
+      const unidad: 'canecas' | 'bultos' = esFumigacion ? 'canecas' : 'bultos';
+
+      const fechaInicio = app.fecha_inicio_ejecucion || '';
+      const fechaFin = app.fecha_fin_ejecucion || app.fecha_cierre || '';
+      const diasEjecucion = fechaInicio && fechaFin
+        ? Math.max(1, Math.round((new Date(fechaFin).getTime() - new Date(fechaInicio).getTime()) / 86400000) + 1)
+        : 0;
+
+      // Build lotes map
+      const lotesMap = new Map<string, { nombre: string; arboles: number }>();
+      ((app as any).aplicaciones_lotes || []).forEach((al: any) => {
+        const lote = al.lotes;
+        if (lote) lotesMap.set(lote.id, { nombre: lote.nombre, arboles: lote.total_arboles || 0 });
+      });
+
+      // Fetch planned calcs per lote
+      const { data: calculos } = await supabase
+        .from('aplicaciones_calculos')
+        .select('lote_id, numero_canecas, numero_bultos, kilos_totales, litros_mezcla')
+        .eq('aplicacion_id', appId);
+
+      const calcMap = new Map<string, any>();
+      (calculos || []).forEach((c: any) => calcMap.set(c.lote_id, c));
+
+      // Fetch actual movimientos per lote
+      const { data: movimientos } = await supabase
+        .from('movimientos_diarios')
+        .select('lote_id, numero_canecas, numero_bultos')
+        .eq('aplicacion_id', appId);
+
+      const movMap = new Map<string, { canecas: number; bultos: number }>();
+      (movimientos || []).forEach((m: any) => {
+        const loteId = m.lote_id;
+        if (!movMap.has(loteId)) movMap.set(loteId, { canecas: 0, bultos: 0 });
+        const cur = movMap.get(loteId)!;
+        cur.canecas += Number(m.numero_canecas) || 0;
+        cur.bultos += Number(m.numero_bultos) || 0;
+      });
+
+      // Fetch jornales from registros_trabajo via tarea_id
+      const { data: registros } = await supabase
+        .from('registros_trabajo')
+        .select('lote_id, fraccion_jornal, costo_jornal, tareas!inner(aplicacion_id)')
+        .eq('tareas.aplicacion_id', appId);
+
+      const jornalesMap = new Map<string, { jornales: number; costo: number }>();
+      (registros || []).forEach((r: any) => {
+        const loteId = r.lote_id;
+        if (!loteId) return;
+        if (!jornalesMap.has(loteId)) jornalesMap.set(loteId, { jornales: 0, costo: 0 });
+        const cur = jornalesMap.get(loteId)!;
+        cur.jornales += Number(r.fraccion_jornal) || 0;
+        cur.costo += Number(r.costo_jornal) || 0;
+      });
+
+      // Fetch insumos cost per lote (from compras / cost calculations)
+      const costoInsumosTotal = Number(app.costo_total_insumos) || 0;
+      const costoManoObraTotal = Number(app.costo_total_mano_obra) || 0;
+      const costoTotal = Number(app.costo_total) || 0;
+
+      // Build KPI and financial per lote
+      const kpiPorLote: AplicacionCierreKPILote[] = [];
+      const financieroPorLote: AplicacionCierreFinancieroLote[] = [];
+
+      let totalCanecasPlan = 0;
+      let totalCanecasReal = 0;
+
+      lotesMap.forEach((loteInfo, loteId) => {
+        const calc = calcMap.get(loteId) || {};
+        const mov = movMap.get(loteId) || { canecas: 0, bultos: 0 };
+        const jornales = jornalesMap.get(loteId) || { jornales: 0, costo: 0 };
+        const arboles = loteInfo.arboles || 1;
+
+        const canecasPlan = esFumigacion ? (Number(calc.numero_canecas) || 0) : (Number(calc.numero_bultos) || 0);
+        const canecasReal = esFumigacion ? mov.canecas : mov.bultos;
+        const canecasDesv = canecasPlan > 0 ? ((canecasReal - canecasPlan) / canecasPlan) * 100 : 0;
+
+        totalCanecasPlan += canecasPlan;
+        totalCanecasReal += canecasReal;
+
+        // Insumos
+        const insumosPlaneados = esFumigacion
+          ? (Number(calc.litros_mezcla) || 0)
+          : (Number(calc.kilos_totales) || 0);
+        const insumosReales = canecasReal * (esFumigacion ? 200 : 50); // approx
+        const insumosDesv = insumosPlaneados > 0
+          ? ((insumosReales - insumosPlaneados) / insumosPlaneados) * 100 : 0;
+
+        const jornalesPlan = 0; // Not stored at this granularity in current schema
+        const jornalesReal = jornales.jornales;
+        const jornalesDesv = 0;
+
+        kpiPorLote.push({
+          loteNombre: loteInfo.nombre,
+          canecasPlaneadas: canecasPlan || undefined,
+          canecasReales: canecasReal || undefined,
+          canecasDesviacion: Math.round(canecasDesv * 10) / 10,
+          insumosPlaneados: insumosPlaneados || undefined,
+          insumosReales: insumosReales || undefined,
+          insumosDesviacion: Math.round(insumosDesv * 10) / 10,
+          insumosUnidad: esFumigacion ? 'L' : 'Kg',
+          jornalesPlaneados: jornalesPlan || undefined,
+          jornalesReales: jornalesReal || undefined,
+          jornalesDesviacion: Math.round(jornalesDesv * 10) / 10,
+          arbolesTratados: arboles,
+          arbolesPorJornal: jornalesReal > 0 ? Math.round(arboles / jornalesReal * 10) / 10 : undefined,
+          litrosKgPorArbol: arboles > 0 ? Math.round((insumosReales / arboles) * 100) / 100 : undefined,
+        });
+
+        // Financial (cost distributed proportionally by lote arboles weight)
+        const weight = arboles / Math.max(1, Array.from(lotesMap.values()).reduce((s, l) => s + l.arboles, 0));
+        const costoLoteInsumos = costoInsumosTotal * weight;
+        const costoLoteManoObra = jornales.costo;
+        const costoLoteTotal = costoLoteInsumos + costoLoteManoObra;
+        const costoLotePlan = costoLoteTotal; // no historical planned per lote
+
+        financieroPorLote.push({
+          loteNombre: loteInfo.nombre,
+          costoTotalPlaneado: Math.round(costoLotePlan),
+          costoTotalReal: Math.round(costoLoteTotal),
+          costoTotalDesviacion: 0,
+          costoInsumosPlaneado: Math.round(costoLoteInsumos),
+          costoInsumosReal: Math.round(costoLoteInsumos),
+          costoInsumosDesviacion: 0,
+          costoManoObraPlaneado: Math.round(costoLoteManoObra),
+          costoManoObraReal: Math.round(costoLoteManoObra),
+          costoManoObraDesviacion: 0,
+        });
+      });
+
+      const totalCanecasDesv = totalCanecasPlan > 0
+        ? ((totalCanecasReal - totalCanecasPlan) / totalCanecasPlan) * 100 : 0;
+
+      const general: AplicacionCierreGeneral = {
+        canecasBultosPlaneados: totalCanecasPlan,
+        canecasBultosReales: totalCanecasReal,
+        canecasBultosDesviacion: Math.round(totalCanecasDesv * 10) / 10,
+        unidad,
+        costoPlaneado: costoTotal,
+        costoReal: costoTotal,
+        costoDesviacion: 0,
+      };
+
+      resultado.push({
+        id: app.id,
+        nombre: app.nombre_aplicacion || 'Sin nombre',
+        tipo: app.tipo_aplicacion,
+        proposito: app.proposito || '',
+        fechaInicio,
+        fechaFin,
+        diasEjecucion,
+        general,
+        kpiPorLote,
+        financieroPorLote,
+      });
+    } catch (err) {
+      console.warn(`fetchAplicacionesCerradas: skip ${appId}`, err);
+    }
+  }
+
+  return resultado;
+}
+
+/**
+ * Obtiene la lista de aplicaciones cerradas disponibles para selección en el wizard.
+ */
+export async function fetchListaAplicacionesCerradas(): Promise<{ id: string; nombre: string; tipo: string; fechaCierre: string }[]> {
+  const supabase = getSupabase();
+
+  const { data, error } = await supabase
+    .from('aplicaciones')
+    .select('id, nombre_aplicacion, tipo_aplicacion, fecha_cierre, fecha_fin_ejecucion')
+    .eq('estado', 'Cerrada')
+    .order('fecha_cierre', { ascending: false })
+    .limit(30);
+
+  if (error) throw new Error(`Error al cargar aplicaciones cerradas: ${error.message}`);
+
+  return (data || []).map((a: any) => ({
+    id: a.id,
+    nombre: a.nombre_aplicacion || 'Sin nombre',
+    tipo: a.tipo_aplicacion || '',
+    fechaCierre: a.fecha_cierre || a.fecha_fin_ejecucion || '',
+  }));
+}
+
 // ============================================================================
 // SECCIÓN 4: MONITOREO
 // ============================================================================
 
 /**
- * Obtiene datos de monitoreo: tendencias de los últimos 3 eventos
- * y detalle por lote/sublote del monitoreo más reciente
+ * Obtiene datos de monitoreo: tendencias de los últimos 3 eventos,
+ * detalle por lote, vistas por lote con 3 fechas, y vistas por sublote.
  */
 export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
   const supabase = getSupabase();
 
-  // Obtener todas las fechas de monitoreo únicas, ordenadas desc
+  // Get all unique monitoring dates, descending
   const { data: fechasRaw, error: errorFechas } = await supabase
     .from('monitoreos')
     .select('fecha_monitoreo')
@@ -430,7 +795,6 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
 
   if (errorFechas) throw new Error(`Error al cargar fechas de monitoreo: ${errorFechas.message}`);
 
-  // Obtener fechas únicas
   const fechasUnicas = [...new Set((fechasRaw || []).map(r => r.fecha_monitoreo))];
   const ultimas3Fechas = fechasUnicas.slice(0, 3);
 
@@ -440,10 +804,12 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
       detallePorLote: [],
       insights: [],
       fechasMonitoreo: [],
+      vistasPorLote: [],
+      vistasPorSublote: [],
     };
   }
 
-  // Cargar monitoreos de las últimas 3 fechas con relaciones
+  // Load monitoring data for the last 3 dates
   const { data: monitoreos, error: errorMon } = await supabase
     .from('monitoreos')
     .select(`
@@ -457,15 +823,15 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
       incidencia,
       gravedad_texto,
       plagas_enfermedades_catalogo(nombre),
-      lotes(nombre),
-      sublotes(nombre)
+      lotes(id, nombre),
+      sublotes(id, nombre)
     `)
     .in('fecha_monitoreo', ultimas3Fechas)
     .order('fecha_monitoreo', { ascending: true });
 
   if (errorMon) throw new Error(`Error al cargar monitoreos: ${errorMon.message}`);
 
-  // --- TENDENCIAS: Agrupar por fecha × plaga → promedio de incidencia ---
+  // --- TENDENCIAS: fecha × plaga → avg incidencia ---
   const tendenciasMap = new Map<string, Map<string, number[]>>();
 
   (monitoreos || []).forEach((m: any) => {
@@ -490,13 +856,12 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
     });
   });
 
-  // --- DETALLE POR LOTE: Monitoreo más reciente ---
+  // --- DETALLE POR LOTE: most recent monitoring ---
   const fechaMasReciente = ultimas3Fechas[0];
   const monitoreoReciente = (monitoreos || []).filter(
     (m: any) => m.fecha_monitoreo === fechaMasReciente
   );
 
-  // Agrupar por lote
   const detalleLoteMap = new Map<string, MonitoreoSublote[]>();
   monitoreoReciente.forEach((m: any) => {
     const loteNombre = m.lotes?.nombre || 'Sin lote';
@@ -518,25 +883,164 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
     .map(([loteNombre, sublotes]) => ({ loteNombre, sublotes }))
     .sort((a, b) => a.loteNombre.localeCompare(b.loteNombre));
 
-  // --- INSIGHTS: Generar insights básicos ---
+  // --- INSIGHTS ---
   const insights: Insight[] = generarInsightsBasicos(monitoreos || []);
+
+  // --- VISTAS POR LOTE (3 fechas per lote × plaga) ---
+  const vistasPorLote = buildVistasPorLote(monitoreos || [], ultimas3Fechas);
+
+  // --- VISTAS POR SUBLOTE (1 per lote: sublotes × plagas grid with 3 obs) ---
+  const vistasPorSublote = buildVistasPorSublote(monitoreos || [], ultimas3Fechas);
 
   return {
     tendencias,
     detallePorLote,
     insights,
     fechasMonitoreo: ultimas3Fechas,
+    vistasPorLote,
+    vistasPorSublote,
   };
+}
+
+function buildVistasPorLote(monitoreos: any[], fechas: string[]): VistaMonitoreoLote[] {
+  // loteId → plagaNombre → fecha → avg incidencia
+  const loteMap = new Map<string, { id: string; nombre: string; plagas: Map<string, Map<string, number[]>> }>();
+
+  monitoreos.forEach((m: any) => {
+    const loteId = m.lote_id;
+    const loteNombre = m.lotes?.nombre || 'Sin lote';
+    const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
+    const fecha = m.fecha_monitoreo;
+    const incidencia = Number(m.incidencia) || 0;
+
+    if (!loteMap.has(loteId)) {
+      loteMap.set(loteId, { id: loteId, nombre: loteNombre, plagas: new Map() });
+    }
+    const loteEntry = loteMap.get(loteId)!;
+    if (!loteEntry.plagas.has(plaga)) loteEntry.plagas.set(plaga, new Map());
+    const plagaEntry = loteEntry.plagas.get(plaga)!;
+    if (!plagaEntry.has(fecha)) plagaEntry.set(fecha, []);
+    plagaEntry.get(fecha)!.push(incidencia);
+  });
+
+  const result: VistaMonitoreoLote[] = [];
+
+  loteMap.forEach(({ id, nombre, plagas }) => {
+    const plagasRows: VistaLotePlaga[] = [];
+
+    plagas.forEach((fechaMap, plagaNombre) => {
+      const esInteres = PLAGAS_INTERES.some(p =>
+        plagaNombre.toLowerCase().includes(p.toLowerCase())
+      );
+
+      const observaciones: ObservacionFecha[] = fechas.map(fecha => {
+        const vals = fechaMap.get(fecha);
+        if (!vals || vals.length === 0) return { fecha, incidencia: null };
+        const avg = vals.reduce((a, b) => a + b, 0) / vals.length;
+        return { fecha, incidencia: Math.round(avg * 10) / 10 };
+      });
+
+      plagasRows.push({ plagaNombre, esPlaga_interes: esInteres, observaciones });
+    });
+
+    // Sort: plagas de interes first, then by latest incidencia desc
+    plagasRows.sort((a, b) => {
+      if (a.esPlaga_interes !== b.esPlaga_interes) return a.esPlaga_interes ? -1 : 1;
+      const aLast = a.observaciones.find(o => o.incidencia != null)?.incidencia || 0;
+      const bLast = b.observaciones.find(o => o.incidencia != null)?.incidencia || 0;
+      return bLast - aLast;
+    });
+
+    result.push({ loteId: id, loteNombre: nombre, plagasRows });
+  });
+
+  return result.sort((a, b) => a.loteNombre.localeCompare(b.loteNombre));
+}
+
+function buildVistasPorSublote(monitoreos: any[], fechas: string[]): VistaMonitoreoSublote[] {
+  // loteId → { sublotes: Set, plagas: Set, celdas: plaga → sublote → fecha → vals[] }
+  type LoteEntry = {
+    id: string;
+    nombre: string;
+    sublotes: Set<string>;
+    plagas: Set<string>;
+    celdas: Map<string, Map<string, Map<string, number[]>>>;
+  };
+
+  const loteMap = new Map<string, LoteEntry>();
+
+  monitoreos.forEach((m: any) => {
+    const loteId = m.lote_id;
+    const loteNombre = m.lotes?.nombre || 'Sin lote';
+    const subloteNombre = m.sublotes?.nombre || 'Sin sublote';
+    const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
+    const fecha = m.fecha_monitoreo;
+    const incidencia = Number(m.incidencia) || 0;
+
+    if (!loteMap.has(loteId)) {
+      loteMap.set(loteId, {
+        id: loteId, nombre: loteNombre,
+        sublotes: new Set(), plagas: new Set(),
+        celdas: new Map(),
+      });
+    }
+
+    const entry = loteMap.get(loteId)!;
+    entry.sublotes.add(subloteNombre);
+    entry.plagas.add(plaga);
+
+    if (!entry.celdas.has(plaga)) entry.celdas.set(plaga, new Map());
+    const plagaMap = entry.celdas.get(plaga)!;
+    if (!plagaMap.has(subloteNombre)) plagaMap.set(subloteNombre, new Map());
+    const subloteMap = plagaMap.get(subloteNombre)!;
+    if (!subloteMap.has(fecha)) subloteMap.set(fecha, []);
+    subloteMap.get(fecha)!.push(incidencia);
+  });
+
+  const result: VistaMonitoreoSublote[] = [];
+
+  loteMap.forEach(({ id, nombre, sublotes, plagas, celdas }) => {
+    const sublotesArr = Array.from(sublotes).sort();
+    const plagasArr = Array.from(plagas).sort((a, b) => {
+      const aInt = PLAGAS_INTERES.some(p => a.toLowerCase().includes(p.toLowerCase()));
+      const bInt = PLAGAS_INTERES.some(p => b.toLowerCase().includes(p.toLowerCase()));
+      if (aInt !== bInt) return aInt ? -1 : 1;
+      return a.localeCompare(b);
+    });
+
+    const celdasObj: Record<string, Record<string, ObservacionFecha[]>> = {};
+
+    plagasArr.forEach(plaga => {
+      celdasObj[plaga] = {};
+      sublotesArr.forEach(sublote => {
+        const fechaMap = celdas.get(plaga)?.get(sublote);
+        celdasObj[plaga][sublote] = fechas.map(fecha => {
+          const vals = fechaMap?.get(fecha);
+          if (!vals || vals.length === 0) return { fecha, incidencia: null };
+          const avg = vals.reduce((a, b) => a + b, 0) / vals.length;
+          return { fecha, incidencia: Math.round(avg * 10) / 10 };
+        });
+      });
+    });
+
+    result.push({
+      loteId: id,
+      loteNombre: nombre,
+      sublotes: sublotesArr,
+      plagas: plagasArr,
+      celdas: celdasObj,
+    });
+  });
+
+  return result.sort((a, b) => a.loteNombre.localeCompare(b.loteNombre));
 }
 
 /**
  * Genera insights básicos sin depender de propiedades extendidas del monitoreo
- * (versión simplificada de insightsAutomaticos.ts compatible con la query)
  */
 function generarInsightsBasicos(monitoreos: any[]): Insight[] {
   const insights: Insight[] = [];
 
-  // Agrupar por plaga × lote del monitoreo más reciente
   const plagaLoteMap = new Map<string, { incidencias: number[]; plaga: string; lote: string }>();
 
   monitoreos.forEach(m => {
@@ -549,7 +1053,6 @@ function generarInsightsBasicos(monitoreos: any[]): Insight[] {
     plagaLoteMap.get(key)!.incidencias.push(Number(m.incidencia) || 0);
   });
 
-  // Detectar plagas críticas (incidencia >= 30%)
   plagaLoteMap.forEach(({ incidencias, plaga, lote }) => {
     const promedio = incidencias.reduce((a, b) => a + b, 0) / incidencias.length;
     if (promedio >= 30) {
@@ -588,6 +1091,11 @@ export interface FetchReporteParams {
   semana: RangoSemana;
   fallas: number;
   permisos: number;
+  ingresos?: number;
+  retiros?: number;
+  detalleFallas?: Array<{ empleado: string; razon?: string }>;
+  detallePermisos?: Array<{ empleado: string; razon?: string }>;
+  cerradasIds?: string[];
   temasAdicionales: BloqueAdicional[];
 }
 
@@ -598,22 +1106,45 @@ export interface FetchReporteParams {
 export async function fetchDatosReporteSemanal(
   params: FetchReporteParams
 ): Promise<DatosReporteSemanal> {
-  const { semana, fallas, permisos, temasAdicionales } = params;
+  const {
+    semana,
+    fallas,
+    permisos,
+    ingresos = 0,
+    retiros = 0,
+    detalleFallas = [],
+    detallePermisos = [],
+    cerradasIds = [],
+    temasAdicionales,
+  } = params;
 
-  // Ejecutar todas las consultas en paralelo
+  // Days in week = 5 working days (Mon–Fri) by default
+  const diasHabiles = 5;
+
+  // Execute all queries in parallel
   const [
     personalBase,
-    jornales,
+    laboresProgramadas,
+    matrizJornales,
     aplicacionesPlaneadas,
     aplicacionesActivas,
+    aplicacionesCerradas,
     monitoreo,
   ] = await Promise.all([
     fetchPersonalSemana(semana.inicio, semana.fin),
+    fetchLaboresSemanales(semana.inicio, semana.fin),
     fetchMatrizJornales(semana.inicio, semana.fin),
     fetchAplicacionesPlaneadas(),
     fetchAplicacionesActivas(),
+    fetchAplicacionesCerradas(cerradasIds),
     fetchDatosMonitoreo(),
   ]);
+
+  const jornalesPosibles = personalBase.totalTrabajadores * diasHabiles;
+  const jornalesTrabajados = personalBase.jornalesTrabajados;
+  const eficienciaOperativa = jornalesPosibles > 0
+    ? Math.round((jornalesTrabajados / jornalesPosibles) * 1000) / 10
+    : 0;
 
   return {
     semana,
@@ -621,11 +1152,23 @@ export async function fetchDatosReporteSemanal(
       ...personalBase,
       fallas,
       permisos,
+      ingresos,
+      retiros,
+      detalleFallas,
+      detallePermisos,
+      jornalesPosibles,
+      jornalesTrabajados,
+      eficienciaOperativa,
     },
-    jornales,
+    labores: {
+      programadas: laboresProgramadas,
+      matrizJornales,
+    },
+    jornales: matrizJornales, // legacy
     aplicaciones: {
       planeadas: aplicacionesPlaneadas,
       activas: aplicacionesActivas,
+      cerradas: aplicacionesCerradas,
     },
     monitoreo,
     temasAdicionales,

--- a/src/utils/reporteSemanalService.ts
+++ b/src/utils/reporteSemanalService.ts
@@ -104,14 +104,14 @@ export async function convertirHTMLaPDF(html: string): Promise<Blob> {
   const html2pdf = (await import('html2pdf.js')).default;
 
   // Crear un contenedor temporal para renderizar el HTML
-  // Debe tener ancho fijo (A4 = 210mm ≈ 794px) para que html2canvas lo renderice
+  // Landscape slides: 1280px wide (16:9 at 72dpi)
   // Nota: opacity debe ser 1 (no 0) para que html2canvas pueda capturar el contenido
   const container = document.createElement('div');
   container.innerHTML = html;
   container.style.position = 'absolute';
   container.style.left = '-9999px';
   container.style.top = '0';
-  container.style.width = '794px';
+  container.style.width = '1280px';
   container.style.zIndex = '-9999';
   container.style.opacity = '1';
   container.style.pointerEvents = 'none';
@@ -131,24 +131,24 @@ export async function convertirHTMLaPDF(html: string): Promise<Blob> {
 
     const worker = html2pdf()
       .set({
-        margin: [10, 10, 10, 10], // mm
-        filename: 'reporte-semanal.pdf',
+        margin: [0, 0, 0, 0], // no margins — slides fill the page
+        filename: 'reporte-slides-semanal.pdf',
         image: { type: 'jpeg', quality: 0.95 },
         html2canvas: {
-          scale: 2,
+          scale: 1.5,
           useCORS: true,
           letterRendering: true,
-          width: 794,
-          windowWidth: 794,
+          width: 1280,
+          windowWidth: 1280,
         },
         jsPDF: {
-          unit: 'mm',
-          format: 'a4',
-          orientation: 'portrait',
+          unit: 'px',
+          format: [1280, 720],
+          orientation: 'landscape',
         },
         pagebreak: {
-          mode: ['css', 'legacy'],
-          avoid: ['tr', 'td', '.avoid-break'],
+          mode: ['css'],
+          before: ['.slide'],
         },
       })
       .from(container);
@@ -182,7 +182,7 @@ export async function guardarReportePDF(
   }
 
   const { semana } = datos;
-  const fileName = `reporte-semana-${semana.ano}-S${String(semana.numero).padStart(2, '0')}.pdf`;
+  const fileName = `reporte-slides-semana-${semana.ano}-S${String(semana.numero).padStart(2, '0')}.pdf`;
   const storagePath = `${semana.ano}/${fileName}`;
 
   // Subir PDF a Storage


### PR DESCRIPTION
Redesigns the Reporte Semanal from a single A4 portrait page to a
landscape 16:9 slide deck (~22 slides), with each slide at 1280×720px.

Key changes:
- types/reporteSemanal.ts: adds LaborSemanal, AplicacionCerrada with
  per-lote KPI/financial breakdowns, expanded DatosPersonal (ingresos,
  retiros, detalleFallas/Permisos, eficiencia operativa), extended
  DatosMonitoreo with vistasPorLote and vistasPorSublote, multi-image
  support in BloqueImagenConTexto
- fetchDatosReporteSemanal.ts: adds fetchLaboresSemanales (Kanban overlap
  query), fetchAplicacionesCerradas (per-lote KPI/financial build),
  fetchListaAplicacionesCerradas, enhanced monitoreo with sublote grids
- ReporteSemanalWizard.tsx: 5-step wizard (Configuración, Aplicaciones
  Cerradas selector, Datos Operativos, Temas Adicionales, Generar);
  supports 2-photo additional topic blocks
- generar-reporte-semanal.tsx: full slide-based HTML template with
  construirSlide* functions for portada, personal, labores (programadas/
  matriz/gráficos), cierre (general/técnico/financiero per app), activas,
  planeadas, monitoreo (tendencias/lote/sublote per lote), adicionales,
  conclusiones; updated Gemini prompt with interpretacion_tendencias_monitoreo
- reporteSemanalService.ts: landscape PDF config (1280×720px, jsPDF
  format [1280,720], orientation landscape, pagebreak on .slide)

https://claude.ai/code/session_01XFCERdLRT2FJcz2QQwyBdx