### PR TITLE
fix: corregir precios ausentes en lista de compras

### DIFF
--- a/src/components/aplicaciones/PasoListaCompras.tsx
+++ b/src/components/aplicaciones/PasoListaCompras.tsx
@@ -101,7 +101,7 @@ export function PasoListaCompras({
           ? `${p.presentacion_kg_l} ${p.unidad_medida === 'kilos' ? 'Kg' : p.unidad_medida === 'litros' ? 'L' : p.unidad_medida}`
           : `1 ${p.unidad_medida === 'kilos' ? 'Kg' : p.unidad_medida === 'litros' ? 'L' : p.unidad_medida}`,
         ultimo_precio_unitario: p.precio_unitario || 0,      // Precio por Kg/L
-        precio_presentacion: p.precio_presentacion || 0,     // Precio por bulto/envase
+        precio_presentacion: p.precio_por_presentacion || 0, // Precio por bulto/envase
         cantidad_actual: p.cantidad_actual || 0,
         permitido_gerencia: p.permitido_gerencia,
       }));

--- a/src/utils/generarPDFListaCompras.ts
+++ b/src/utils/generarPDFListaCompras.ts
@@ -198,7 +198,7 @@ export function generarPDFListaCompras(
       `${formatearNumero(item.cantidad_necesaria)} ${item.unidad}`,
       `${formatearNumero(item.cantidad_faltante)} ${item.unidad}`,
       `${item.unidades_a_comprar} × ${item.presentacion_comercial}`,
-      item.ultimo_precio_unitario 
+      item.precio_presentacion
         ? formatearMoneda(item.costo_estimado || 0)
         : 'Sin precio'
     ]);


### PR DESCRIPTION
Bug 1 (crítico): PasoListaCompras.tsx leía p.precio_presentacion del resultado de Supabase, pero la columna en la BD se llama precio_por_presentacion. Esto hacía que el precio siempre fuera undefined → 0, marcando todos los productos como "Sin precio".

Bug 2 (inconsistencia): generarPDFListaCompras.ts usaba item.ultimo_precio_unitario para determinar si mostrar "Sin precio" en el PDF, mientras que la lógica de la UI usa item.precio_presentacion. Ahora ambos usan el mismo campo para coherencia.

https://claude.ai/code/session_01YBWaNsnHzLMCvuXw6VW6HJ