### PR TITLE
Refactor monitoring data to use 2-date comparison with trend analysis

### DIFF
--- a/src/__tests__/generarReporteSemanal.test.ts
+++ b/src/__tests__/generarReporteSemanal.test.ts
@@ -106,9 +106,55 @@ const MOCK_DATOS_COMPLETOS = {
     ],
   },
   monitoreo: {
+    // New fields
+    fechaActual: '2026-02-15',
+    fechaAnterior: '2026-02-08',
+    avisoFechaDesactualizada: null,
+    resumenGlobal: [
+      {
+        plagaNombre: 'Monalonion',
+        esPlaga_interes: true,
+        promedioActual: 27.1,
+        minLote: 27.1,
+        maxLote: 27.1,
+        promedioAnterior: 14.3,
+        tendencia: 'subiendo',
+      },
+    ],
+    vistasPorLote: [
+      {
+        loteId: 'lote-1',
+        loteNombre: 'Lote PP',
+        sinDatos: false,
+        plagas: [
+          { plagaNombre: 'Monalonion', esPlaga_interes: true, actual: 27.1, anterior: 14.3, tendencia: 'subiendo' },
+        ],
+      },
+      {
+        loteId: 'lote-2',
+        loteNombre: 'Lote ST',
+        sinDatos: true,
+        plagas: [],
+      },
+    ],
+    vistasPorSublote: [
+      {
+        loteId: 'lote-1',
+        loteNombre: 'Lote PP',
+        sinDatos: false,
+        sublotes: ['Sublote A', 'Sublote B'],
+        plagas: ['Monalonion'],
+        celdas: {
+          'Monalonion': {
+            'Sublote A': { actual: 20, anterior: 14.3, tendencia: 'subiendo' },
+            'Sublote B': { actual: 34.3, anterior: null, tendencia: 'sin_referencia' },
+          },
+        },
+      },
+    ],
+    // Legacy fields (for Gemini prompt)
     tendencias: [
-      { fecha: '2026-02-01', plagaNombre: 'Monalonion', incidenciaPromedio: 12.5 },
-      { fecha: '2026-02-08', plagaNombre: 'Monalonion', incidenciaPromedio: 18.3 },
+      { fecha: '2026-02-08', plagaNombre: 'Monalonion', incidenciaPromedio: 14.3 },
       { fecha: '2026-02-15', plagaNombre: 'Monalonion', incidenciaPromedio: 27.1 },
     ],
     detallePorLote: [
@@ -131,7 +177,7 @@ const MOCK_DATOS_COMPLETOS = {
         accion: 'Evaluar aplicación de tratamiento',
       },
     ],
-    fechasMonitoreo: ['2026-02-15', '2026-02-08', '2026-02-01'],
+    fechasMonitoreo: ['2026-02-15', '2026-02-08'],
   },
   temasAdicionales: [
     {
@@ -397,10 +443,9 @@ describe('Edge Function: generarReporteSemanal', () => {
 
       const resultado = await generarReporteSemanal({ datos: MOCK_DATOS_COMPLETOS });
 
-      expect(resultado.html).toContain('Análisis de Tendencias Fitosanitarias');
+      expect(resultado.html).toContain('Resumen General');
       expect(resultado.html).toContain('Monalonion');
-      expect(resultado.html).toContain('Media');
-      expect(resultado.html).toContain('Alta');
+      expect(resultado.html).toContain('Incidencia Promedio');
     });
 
     it('incluye conclusiones del análisis de Gemini', async () => {
@@ -413,6 +458,7 @@ describe('Edge Function: generarReporteSemanal', () => {
 
       expect(resultado.html).toContain('Conclusiones y Recomendaciones');
       expect(resultado.html).toContain('Priorizar tratamiento contra Monalonion');
+      // Gemini analysis is shown in the monitoring slide's ANÁLISIS section
       expect(resultado.html).toContain('incidencia de Monalonion muestra una tendencia ascendente');
     });
 
@@ -625,7 +671,7 @@ describe('Edge Function: generarReporteSemanal', () => {
 
       expect(texto).toContain('MONITOREO FITOSANITARIO');
       expect(texto).toContain('Monalonion');
-      expect(texto).toContain('Tendencias');
+      expect(texto).toContain('Resumen general');
       expect(texto).toContain('URGENTE');
     });
 

--- a/src/__tests__/reporteSemanal.test.ts
+++ b/src/__tests__/reporteSemanal.test.ts
@@ -8,7 +8,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest';
 function createChainableMock(resolvedData: any = { data: [], error: null }) {
   const chain: any = {};
   const methods = ['select', 'insert', 'update', 'upsert', 'delete', 'eq', 'neq',
-    'gte', 'lte', 'in', 'or', 'order', 'limit', 'single', 'maybeSingle'];
+    'gt', 'gte', 'lt', 'lte', 'in', 'or', 'order', 'limit', 'single', 'maybeSingle'];
 
   methods.forEach(method => {
     chain[method] = vi.fn(() => chain);
@@ -181,6 +181,24 @@ const MOCK_MONITOREOS_FECHAS = [
   { fecha_monitoreo: '2026-02-01' },
   { fecha_monitoreo: '2026-02-01' },
 ];
+
+const MOCK_LOTES = [
+  { id: 'lote-1', nombre: 'Lote PP' },
+  { id: 'lote-2', nombre: 'Lote ST' },
+];
+
+const MOCK_SUBLOTES = [
+  { id: 'sub-1', nombre: 'Sublote A', lote_id: 'lote-1' },
+  { id: 'sub-2', nombre: 'Sublote B', lote_id: 'lote-1' },
+  { id: 'sub-3', nombre: 'Sublote C', lote_id: 'lote-2' },
+];
+
+const MOCK_SEMANA_MONITOREO = {
+  inicio: '2026-02-09',
+  fin: '2026-02-15',
+  numero: 7,
+  ano: 2026,
+};
 
 const MOCK_MONITOREOS = [
   {
@@ -650,91 +668,103 @@ describe('fetchDatosMonitoreo', () => {
     vi.clearAllMocks();
   });
 
-  it('obtiene tendencias de los últimos 3 monitoreos', async () => {
-    const fechasChain = createChainableMock({ data: MOCK_MONITOREOS_FECHAS, error: null });
-    const monChain = createChainableMock({ data: MOCK_MONITOREOS, error: null });
+  // Helper to set up mocks for the new fetchDatosMonitoreo which queries:
+  // 1. lotes, 2. sublotes (in parallel), 3. monitoreos (fechas), 4. monitoreos (anterior), 5. monitoreos (full)
+  function setupMonitoreoMocks(opts: {
+    fechas?: any[];
+    monitoreos?: any[];
+    anteriorFecha?: any[];
+  } = {}) {
+    const lotesChain = createChainableMock({ data: MOCK_LOTES, error: null });
+    const sublotesChain = createChainableMock({ data: MOCK_SUBLOTES, error: null });
+    const fechasChain = createChainableMock({ data: opts.fechas ?? MOCK_MONITOREOS_FECHAS, error: null });
+    const anteriorChain = createChainableMock({ data: opts.anteriorFecha ?? [{ fecha_monitoreo: '2026-02-08' }], error: null });
+    const monChain = createChainableMock({ data: opts.monitoreos ?? MOCK_MONITOREOS, error: null });
 
     mockFrom.mockImplementation((table: string) => {
-      // First call returns fechas, second returns monitoreos
-      return mockFrom.mock.calls.length <= 1 ? fechasChain : monChain;
+      if (table === 'lotes') return lotesChain;
+      if (table === 'sublotes') return sublotesChain;
+      // monitoreos table is called multiple times; use call count to differentiate
+      return fechasChain;
     });
 
-    // Reset call tracking
-    mockFrom.mockClear();
-    mockFrom.mockImplementation(() => {
-      const callNum = mockFrom.mock.calls.length;
-      if (callNum === 1) return fechasChain;
-      return monChain;
+    // More sophisticated mock: track monitoreos calls
+    let monitoreoCallCount = 0;
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'lotes') return lotesChain;
+      if (table === 'sublotes') return sublotesChain;
+      if (table === 'monitoreos') {
+        monitoreoCallCount++;
+        if (monitoreoCallCount === 1) return fechasChain;    // fechas query
+        if (monitoreoCallCount === 2) return anteriorChain;   // anterior query
+        return monChain;                                       // full data query
+      }
+      return createChainableMock({ data: [], error: null });
     });
+  }
 
-    const resultado = await fetchDatosMonitoreo();
+  it('obtiene resumen global con comparativo', async () => {
+    setupMonitoreoMocks();
 
-    // Debe tener tendencias
-    expect(resultado.tendencias.length).toBeGreaterThan(0);
+    const resultado = await fetchDatosMonitoreo(MOCK_SEMANA_MONITOREO);
 
-    // Debe tener 3 fechas
-    expect(resultado.fechasMonitoreo.length).toBe(3);
-    expect(resultado.fechasMonitoreo).toContain('2026-02-15');
-    expect(resultado.fechasMonitoreo).toContain('2026-02-08');
-    expect(resultado.fechasMonitoreo).toContain('2026-02-01');
+    // Debe tener fechaActual (2026-02-15 cae dentro de la semana)
+    expect(resultado.fechaActual).toBe('2026-02-15');
+    expect(resultado.fechaAnterior).toBe('2026-02-08');
+
+    // Resumen global debe tener plagas
+    expect(resultado.resumenGlobal.length).toBeGreaterThan(0);
   });
 
   it('genera insights para plagas críticas (>= 30% incidencia)', async () => {
-    const fechasChain = createChainableMock({ data: MOCK_MONITOREOS_FECHAS, error: null });
-    const monChain = createChainableMock({ data: MOCK_MONITOREOS, error: null });
+    setupMonitoreoMocks();
 
-    mockFrom.mockClear();
-    mockFrom.mockImplementation(() => {
-      const callNum = mockFrom.mock.calls.length;
-      if (callNum === 1) return fechasChain;
-      return monChain;
-    });
-
-    const resultado = await fetchDatosMonitoreo();
+    const resultado = await fetchDatosMonitoreo(MOCK_SEMANA_MONITOREO);
 
     // Monalonion en Lote PP tiene promedio de (20+34.3)/2 = 27.15% en la fecha más reciente
-    // Dependiendo del cálculo, puede generar insight urgente o de atención
-    const insightsMonalonion = resultado.insights.filter(i =>
+    const insightsMonalonion = resultado.insights.filter((i: any) =>
       i.plaga === 'Monalonion'
     );
     expect(insightsMonalonion.length).toBeGreaterThanOrEqual(0);
   });
 
-  it('construye detalle por lote del monitoreo más reciente', async () => {
-    const fechasChain = createChainableMock({ data: MOCK_MONITOREOS_FECHAS, error: null });
-    const monChain = createChainableMock({ data: MOCK_MONITOREOS, error: null });
+  it('construye vistas por lote incluyendo todos los lotes', async () => {
+    setupMonitoreoMocks();
 
-    mockFrom.mockClear();
-    mockFrom.mockImplementation(() => {
-      const callNum = mockFrom.mock.calls.length;
-      if (callNum === 1) return fechasChain;
-      return monChain;
-    });
+    const resultado = await fetchDatosMonitoreo(MOCK_SEMANA_MONITOREO);
 
-    const resultado = await fetchDatosMonitoreo();
+    // Debe incluir TODOS los lotes de la BD (Lote PP y Lote ST)
+    expect(resultado.vistasPorLote.length).toBe(2);
 
-    // Fecha más reciente es 2026-02-15, solo Lote PP tiene datos
-    const lotePP = resultado.detallePorLote.find(l => l.loteNombre === 'Lote PP');
+    const lotePP = resultado.vistasPorLote.find((l: any) => l.loteNombre === 'Lote PP');
+    expect(lotePP).toBeDefined();
+    expect(lotePP!.sinDatos).toBe(false);
+    expect(lotePP!.plagas.length).toBeGreaterThan(0);
+  });
+
+  it('construye detalle por lote del monitoreo más reciente (legacy)', async () => {
+    setupMonitoreoMocks();
+
+    const resultado = await fetchDatosMonitoreo(MOCK_SEMANA_MONITOREO);
+
+    // Legacy detallePorLote still populated for Gemini
+    const lotePP = resultado.detallePorLote.find((l: any) => l.loteNombre === 'Lote PP');
     expect(lotePP).toBeDefined();
     expect(lotePP!.sublotes.length).toBe(2); // Sublote A y B
-
-    const subloteA = lotePP!.sublotes.find(s => s.subloteNombre === 'Sublote A');
-    expect(subloteA).toBeDefined();
-    expect(subloteA!.plagaNombre).toBe('Monalonion');
-    expect(subloteA!.incidencia).toBe(20.0);
-    expect(subloteA!.gravedad).toBe('Media');
   });
 
   it('retorna datos vacíos cuando no hay monitoreos', async () => {
-    const fechasChain = createChainableMock({ data: [], error: null });
-    mockFrom.mockReturnValue(fechasChain);
+    setupMonitoreoMocks({ fechas: [], monitoreos: [] });
 
-    const resultado = await fetchDatosMonitoreo();
+    const resultado = await fetchDatosMonitoreo(MOCK_SEMANA_MONITOREO);
 
-    expect(resultado.tendencias.length).toBe(0);
+    expect(resultado.resumenGlobal.length).toBe(0);
     expect(resultado.detallePorLote.length).toBe(0);
     expect(resultado.insights.length).toBe(0);
-    expect(resultado.fechasMonitoreo.length).toBe(0);
+    expect(resultado.fechaActual).toBeNull();
+    // Should still have lotes in vistasPorLote (all sinDatos)
+    expect(resultado.vistasPorLote.length).toBe(2);
+    expect(resultado.vistasPorLote[0].sinDatos).toBe(true);
   });
 });
 
@@ -831,6 +861,9 @@ describe('fetchDatosReporteSemanal', () => {
     expect(resultado).toHaveProperty('monitoreo.tendencias');
     expect(resultado).toHaveProperty('monitoreo.detallePorLote');
     expect(resultado).toHaveProperty('monitoreo.insights');
+    expect(resultado).toHaveProperty('monitoreo.resumenGlobal');
+    expect(resultado).toHaveProperty('monitoreo.vistasPorLote');
+    expect(resultado).toHaveProperty('monitoreo.vistasPorSublote');
     expect(resultado).toHaveProperty('temasAdicionales');
   });
 });

--- a/src/components/reportes/ReporteSemanalWizard.tsx
+++ b/src/components/reportes/ReporteSemanalWizard.tsx
@@ -862,17 +862,24 @@ export function ReporteSemanalWizard() {
         )}
 
         {/* Monitoreo */}
-        {datosReporte.monitoreo.fechasMonitoreo.length > 0 && (
+        {(datosReporte.monitoreo.fechaActual || datosReporte.monitoreo.avisoFechaDesactualizada) && (
           <Card>
             <CardHeader>
               <CardTitle className="text-foreground">
                 Monitoreo Fitosanitario
-                <Badge variant="secondary" className="ml-2">
-                  {datosReporte.monitoreo.fechasMonitoreo.length} monitoreos
-                </Badge>
+                {datosReporte.monitoreo.fechaActual && (
+                  <Badge variant="secondary" className="ml-2">
+                    {datosReporte.monitoreo.fechaActual}
+                  </Badge>
+                )}
               </CardTitle>
             </CardHeader>
             <CardContent className="space-y-4">
+              {datosReporte.monitoreo.avisoFechaDesactualizada && (
+                <div className="p-3 rounded-lg border-l-4 bg-yellow-50 border-yellow-500">
+                  <p className="text-xs text-yellow-700 font-medium">{datosReporte.monitoreo.avisoFechaDesactualizada}</p>
+                </div>
+              )}
               {datosReporte.monitoreo.insights.length > 0 && (
                 <div className="space-y-2">
                   {datosReporte.monitoreo.insights.map((insight, i) => (
@@ -891,11 +898,16 @@ export function ReporteSemanalWizard() {
                 </div>
               )}
               <p className="text-xs text-gray-400">
-                Fechas: {datosReporte.monitoreo.fechasMonitoreo.join(', ')}
+                {datosReporte.monitoreo.fechaAnterior
+                  ? `Observación: ${datosReporte.monitoreo.fechaActual} · Referencia: ${datosReporte.monitoreo.fechaAnterior}`
+                  : datosReporte.monitoreo.fechaActual
+                    ? `Observación: ${datosReporte.monitoreo.fechaActual} · Sin referencia anterior`
+                    : 'Sin monitoreos recientes'}
               </p>
               <p className="text-xs text-gray-400">
+                {datosReporte.monitoreo.resumenGlobal.length} plagas ·{' '}
                 {datosReporte.monitoreo.vistasPorLote.length} lotes ·{' '}
-                {datosReporte.monitoreo.vistasPorSublote.length} vistas por sublote
+                {datosReporte.monitoreo.vistasPorSublote.filter(v => !v.sinDatos).length} lotes con datos de sublote
               </p>
             </CardContent>
           </Card>

--- a/src/supabase/functions/server/generar-reporte-semanal.tsx
+++ b/src/supabase/functions/server/generar-reporte-semanal.tsx
@@ -185,39 +185,55 @@ Datos de la matriz:`);
   }
 
   if (datos.monitoreo) {
+    const mon = datos.monitoreo;
+    const fechaInfo = mon.fechaActual
+      ? `Observación principal: ${mon.fechaActual}${mon.fechaAnterior ? ` · Referencia: ${mon.fechaAnterior}` : ''}`
+      : 'Sin monitoreos recientes';
     partes.push(`## MONITOREO FITOSANITARIO
-Fechas de monitoreo analizadas: ${datos.monitoreo.fechasMonitoreo.join(', ')}`);
+${fechaInfo}${mon.avisoFechaDesactualizada ? `\n⚠ ${mon.avisoFechaDesactualizada}` : ''}`);
 
-    if (datos.monitoreo.tendencias.length > 0) {
-      partes.push(`### Tendencias (últimos 3 monitoreos)`);
-
-      const porPlaga = new Map<string, any[]>();
-      datos.monitoreo.tendencias.forEach((t: any) => {
-        if (!porPlaga.has(t.plagaNombre)) porPlaga.set(t.plagaNombre, []);
-        porPlaga.get(t.plagaNombre)!.push(t);
-      });
-
-      porPlaga.forEach((tendencias, plaga) => {
-        const valores = tendencias
-          .sort((a: any, b: any) => a.fecha.localeCompare(b.fecha))
-          .map((t: any) => `${t.fecha}: ${t.incidenciaPromedio}%`);
-        partes.push(`  - ${plaga}: ${valores.join(' → ')}`);
+    // Resumen global
+    if (mon.resumenGlobal && mon.resumenGlobal.length > 0) {
+      partes.push(`### Resumen general de incidencia`);
+      mon.resumenGlobal.forEach((r: any) => {
+        const rango = r.minLote !== null ? `(rango: ${r.minLote}%-${r.maxLote}%)` : '';
+        const tend = r.tendencia !== 'sin_referencia' && r.promedioAnterior !== null
+          ? ` — tendencia: ${r.tendencia} (era ${r.promedioAnterior}%)`
+          : '';
+        partes.push(`  - ${r.plagaNombre}: ${r.promedioActual !== null ? r.promedioActual + '%' : 'Sin datos'} ${rango}${tend}`);
       });
     }
 
-    if (datos.monitoreo.detallePorLote.length > 0) {
-      partes.push(`### Detalle por lote (monitoreo más reciente)`);
-      datos.monitoreo.detallePorLote.forEach((lote: any) => {
+    // Detalle por lote
+    if (mon.vistasPorLote && mon.vistasPorLote.length > 0) {
+      partes.push(`### Detalle por lote`);
+      mon.vistasPorLote.forEach((lote: any) => {
+        if (lote.sinDatos) {
+          partes.push(`  ${lote.loteNombre}: Sin monitoreo`);
+        } else {
+          partes.push(`  ${lote.loteNombre}:`);
+          (lote.plagas || []).forEach((p: any) => {
+            const tend = p.tendencia !== 'sin_referencia' && p.anterior !== null ? ` (${p.tendencia}, era ${p.anterior}%)` : '';
+            partes.push(`    - ${p.plagaNombre}: ${p.actual !== null ? p.actual + '%' : 'Sin datos'}${tend}`);
+          });
+        }
+      });
+    }
+
+    // Legacy detail for compatibility
+    if (mon.detallePorLote && mon.detallePorLote.length > 0) {
+      partes.push(`### Detalle granular por sublote (monitoreo más reciente)`);
+      mon.detallePorLote.forEach((lote: any) => {
         partes.push(`  ${lote.loteNombre}:`);
-        lote.sublotes.forEach((s: any) => {
+        (lote.sublotes || []).forEach((s: any) => {
           partes.push(`    - ${s.subloteNombre} | ${s.plagaNombre}: ${s.incidencia}% (${s.gravedad}) [${s.arboresAfectados}/${s.arboresMonitoreados} árboles]`);
         });
       });
     }
 
-    if (datos.monitoreo.insights.length > 0) {
+    if (mon.insights && mon.insights.length > 0) {
       partes.push(`### Alertas e insights automáticos`);
-      datos.monitoreo.insights.forEach((insight: any) => {
+      mon.insights.forEach((insight: any) => {
         const icono = insight.tipo === 'urgente' ? '🔴' : insight.tipo === 'atencion' ? '⚠️' : '✅';
         partes.push(`  ${icono} [${insight.tipo.toUpperCase()}] ${insight.titulo}: ${insight.descripcion}`);
         if (insight.accion) partes.push(`    → Acción: ${insight.accion}`);
@@ -988,107 +1004,156 @@ function construirSlideAplicacionPlaneada(app: any, semana: any): string {
 }
 
 
+// --- Helpers for trend arrows ---
+function getTendenciaArrow(tendencia: string): string {
+  switch (tendencia) {
+    case 'subiendo': return '↑';
+    case 'bajando': return '↓';
+    case 'estable': return '→';
+    default: return '';
+  }
+}
+
+function getTendenciaColor(tendencia: string): string {
+  switch (tendencia) {
+    case 'subiendo': return '#D32F2F'; // red — increasing is bad
+    case 'bajando': return '#388E3C';  // green — decreasing is good
+    case 'estable': return '#F9A825';  // yellow
+    default: return '#888';
+  }
+}
+
+function formatTendenciaCell(actual: number | null, anterior: number | null, tendencia: string): string {
+  if (actual === null) return '<span style="color:#CCC;">Sin datos</span>';
+  const arrow = getTendenciaArrow(tendencia);
+  const color = getTendenciaColor(tendencia);
+  if (anterior === null || tendencia === 'sin_referencia') {
+    return `<span style="font-weight:700;">${formatNum(actual, 1)}%</span>`;
+  }
+  return `<span style="font-weight:700;">${formatNum(actual, 1)}%</span> <span style="color:${color};font-weight:600;">${arrow}</span><span style="color:#888;font-size:0.85em;">(era ${formatNum(anterior, 1)}%)</span>`;
+}
+
+function monitoreoLeyendaHTML(): string {
+  return `<div style="margin-top:10px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
+    <span style="font-size:10px;color:#888;font-weight:600;">LEYENDA INCIDENCIA:</span>
+    <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFFFFF;border:1px solid #CCC;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">0%</span></span>
+    <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFF9C4;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">&lt;10%</span></span>
+    <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFB74D;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">&lt;20%</span></span>
+    <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#EF9A9A;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">≥20%</span></span>
+    <span style="display:inline-flex;align-items:center;gap:6px;margin-left:12px;"><span style="font-size:10px;color:#888;font-weight:600;">TENDENCIA:</span></span>
+    <span style="display:inline-flex;align-items:center;gap:3px;"><span style="color:#D32F2F;font-weight:700;">↑</span><span style="font-size:10px;color:#555;">Subiendo</span></span>
+    <span style="display:inline-flex;align-items:center;gap:3px;"><span style="color:#388E3C;font-weight:700;">↓</span><span style="font-size:10px;color:#555;">Bajando</span></span>
+    <span style="display:inline-flex;align-items:center;gap:3px;"><span style="color:#F9A825;font-weight:700;">→</span><span style="font-size:10px;color:#555;">Estable</span></span>
+  </div>`;
+}
+
+// ============================================================================
+// SLIDE 1: RESUMEN GENERAL DE PLAGAS
+// ============================================================================
+
 function construirSlideMonitoreoTendencias(datos: any, analisis: AnalisisGemini): string {
   const monitoreo = datos.monitoreo;
-  if (!monitoreo || !monitoreo.tendencias || monitoreo.tendencias.length === 0) return '';
+  if (!monitoreo) return '';
+  const resumen: any[] = monitoreo.resumenGlobal || [];
+  if (resumen.length === 0 && !monitoreo.avisoFechaDesactualizada) return '';
   const { semana } = datos;
-  const { tendencias, fechasMonitoreo } = monitoreo;
 
-  // Build plagas list and dates
-  const plagasSet = new Set<string>();
-  tendencias.forEach((t: any) => plagasSet.add(t.plagaNombre));
-  const plagas = Array.from(plagasSet);
-  const fechas = (fechasMonitoreo || []).slice(-3);
+  // Date info banner
+  const fechaActual = monitoreo.fechaActual;
+  const fechaAnterior = monitoreo.fechaAnterior;
+  const aviso = monitoreo.avisoFechaDesactualizada;
 
-  // Build map: plaga -> fecha -> incidenciaPromedio
-  const tendMap: Record<string, Record<string, number>> = {};
-  tendencias.forEach((t: any) => {
-    if (!tendMap[t.plagaNombre]) tendMap[t.plagaNombre] = {};
-    tendMap[t.plagaNombre][t.fecha] = t.incidenciaPromedio;
-  });
+  let fechaBanner = '';
+  if (aviso) {
+    fechaBanner = `<div style="background:#FFF3E0;border:1px solid #FFB74D;border-radius:6px;padding:8px 14px;margin-bottom:12px;font-size:11px;color:#E65100;font-weight:600;">⚠ ${aviso}</div>`;
+  }
+  if (fechaActual) {
+    const refText = fechaAnterior ? ` · Referencia: ${fechaAnterior}` : ' · Sin observación de referencia';
+    fechaBanner += `<div style="font-size:11px;color:#666;margin-bottom:10px;">Monitoreo: <strong>${fechaActual}</strong>${refText}</div>`;
+  }
 
-  const tendRows = plagas.map(plaga => {
-    const cells = fechas.map((f: string) => {
-      const v = tendMap[plaga]?.[f] ?? null;
-      const bg = getIncidenciaColor(v);
-      return `<td style="padding:8px 12px;text-align:center;font-size:12px;font-weight:700;background:${bg};color:#4D240F;border:1px solid #E8E8E8;">${v !== null ? formatNum(v, 1) + '%' : '—'}</td>`;
-    }).join('');
-    return `<tr><td style="padding:8px 12px;font-size:12px;font-weight:600;color:#4D240F;border:1px solid #E8E8E8;background:#FAFAFA;">${plaga}</td>${cells}</tr>`;
+  // Table rows
+  const rows = resumen.map((r: any) => {
+    const bg = getIncidenciaColor(r.promedioActual);
+    const rangoText = r.minLote !== null && r.maxLote !== null
+      ? `${formatNum(r.minLote, 1)}%–${formatNum(r.maxLote, 1)}%`
+      : '—';
+    const tendenciaHTML = formatTendenciaCell(r.promedioActual, r.promedioAnterior, r.tendencia);
+
+    return `<tr>
+      <td style="padding:8px 12px;font-size:12px;font-weight:600;color:#4D240F;border:1px solid #E8E8E8;background:#FAFAFA;${r.esPlaga_interes ? 'border-left:3px solid #73991C;' : ''}">${r.plagaNombre}</td>
+      <td style="padding:8px 12px;text-align:center;font-size:12px;font-weight:700;background:${bg};color:#4D240F;border:1px solid #E8E8E8;">${r.promedioActual !== null ? formatNum(r.promedioActual, 1) + '%' : '—'}</td>
+      <td style="padding:8px 12px;text-align:center;font-size:11px;color:#4D240F;border:1px solid #E8E8E8;">${rangoText}</td>
+      <td style="padding:8px 12px;font-size:11px;color:#4D240F;border:1px solid #E8E8E8;">${tendenciaHTML}</td>
+    </tr>`;
   }).join('');
 
-  const fechaHeaders = fechas.map((f: string) => `<th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#4D6B15;border:1px solid #3A5010;text-align:center;">${f}</th>`).join('');
+  // Gemini analysis paragraph (reduced to a brief section below the table)
+  let geminiParagraph = '';
+  const geminiText = analisis.interpretacion_monitoreo || analisis.interpretacion_tendencias_monitoreo || '';
+  if (geminiText) {
+    geminiParagraph = `<div style="background:#F5F9EE;border-left:4px solid #73991C;border-radius:0 6px 6px 0;padding:10px 14px;margin-top:14px;">
+      <div style="font-size:10px;font-weight:700;color:#73991C;letter-spacing:0.5px;margin-bottom:4px;">ANÁLISIS</div>
+      <div style="font-size:11px;color:#4D240F;line-height:1.5;">${geminiText}</div>
+    </div>`;
+  }
 
   return `<div class="slide page-break">
-  ${slideHeader('MONITOREO', 'Análisis de Tendencias Fitosanitarias', semana)}
-  <div style="padding:16px 22px 0;display:flex;gap:20px;">
-    <div style="flex:0 0 480px;">
-      <div style="background:#F5F9EE;border-left:5px solid #73991C;border-radius:0 8px 8px 0;padding:14px 16px;margin-bottom:14px;">
-        <div style="font-size:11px;font-weight:800;color:#73991C;letter-spacing:1px;margin-bottom:6px;">ANÁLISIS GEMINI — TENDENCIAS</div>
-        <div style="font-size:12px;color:#4D240F;line-height:1.65;">${analisis.interpretacion_tendencias_monitoreo || 'Sin análisis disponible.'}</div>
-      </div>
-      ${analisis.interpretacion_monitoreo ? `<div style="background:#FFF8F0;border-left:4px solid #F57C00;border-radius:0 8px 8px 0;padding:12px 14px;">
-        <div style="font-size:11px;font-weight:700;color:#F57C00;margin-bottom:4px;">RESUMEN FITOSANITARIO</div>
-        <div style="font-size:12px;color:#4D240F;line-height:1.5;">${analisis.interpretacion_monitoreo}</div>
-      </div>` : ''}
-    </div>
-    <div style="flex:1;">
-      <div style="font-size:12px;font-weight:700;color:#4D240F;margin-bottom:8px;">Incidencia Promedio por Plaga (últimas 3 fechas)</div>
-      <table style="width:100%;border-collapse:collapse;">
-        <thead><tr>
-          <th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:left;">Plaga</th>
-          ${fechaHeaders}
-        </tr></thead>
-        <tbody>${tendRows}</tbody>
-      </table>
-      <div style="margin-top:12px;display:flex;gap:8px;align-items:center;flex-wrap:wrap;">
-        <span style="font-size:10px;color:#888;font-weight:600;">LEYENDA:</span>
-        <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFFFFF;border:1px solid #CCC;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">0%</span></span>
-        <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFF9C4;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">&lt;10%</span></span>
-        <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFB74D;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">&lt;20%</span></span>
-        <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#EF9A9A;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">≥20%</span></span>
-      </div>
-    </div>
+  ${slideHeader('MONITOREO', 'Resumen General — Estado Fitosanitario', semana)}
+  <div style="padding:16px 22px 0;">
+    ${fechaBanner}
+    <table style="width:100%;border-collapse:collapse;">
+      <thead><tr>
+        <th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:left;">Plaga</th>
+        <th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;">Incidencia Promedio</th>
+        <th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;">Rango (Min–Max)</th>
+        <th style="padding:8px 12px;font-size:11px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:left;">Tendencia</th>
+      </tr></thead>
+      <tbody>${rows}</tbody>
+    </table>
+    ${monitoreoLeyendaHTML()}
+    ${geminiParagraph}
   </div>
 </div>`;
 }
 
+// ============================================================================
+// SLIDE 2: VISTA POR LOTE
+// ============================================================================
+
 function construirSlideMonitoreoPorLote(datos: any): string {
   const monitoreo = datos.monitoreo;
   if (!monitoreo) return '';
-  const vistasPorLote = monitoreo.detallePorLote || [];
-  if (vistasPorLote.length === 0) return '';
+  const vistas: any[] = monitoreo.vistasPorLote || [];
+  if (vistas.length === 0) return '';
   const { semana } = datos;
-  const fechas = (monitoreo.fechasMonitoreo || []).slice(-3);
 
-  // Build tendencias map per lote per plaga per fecha
-  const tendMap: Record<string, Record<string, Record<string, number>>> = {};
-  (monitoreo.tendencias || []).forEach((t: any) => {
-    if (!tendMap[t.plagaNombre]) tendMap[t.plagaNombre] = {};
-    if (!tendMap[t.plagaNombre][t.fecha]) tendMap[t.plagaNombre][t.fecha] = {};
-  });
+  const loteCards = vistas.map((lote: any) => {
+    if (lote.sinDatos) {
+      return `<div style="background:#F5F5F0;border-radius:8px;border:1px solid #E0E0E0;padding:12px;flex:1;min-width:280px;max-width:400px;">
+        <div style="font-size:13px;font-weight:700;color:#999;margin-bottom:8px;border-bottom:2px solid #E0E0E0;padding-bottom:4px;">${lote.loteNombre}</div>
+        <div style="font-size:11px;color:#AAA;text-align:center;padding:16px 0;">No se monitoreó este lote</div>
+      </div>`;
+    }
 
-  const loteCards = vistasPorLote.slice(0, 6).map((loteVista: any) => {
-    const plagasLote = new Set<string>();
-    (loteVista.sublotes || []).forEach((s: any) => plagasLote.add(s.plagaNombre));
-    const plagasArr = Array.from(plagasLote);
-
-    const rows = plagasArr.map(plaga => {
-      const cellsFecha = fechas.map((f: string) => {
-        // Find incidencia for this lote/plaga/fecha in tendencias
-        const tend = (monitoreo.tendencias || []).find((t: any) => t.plagaNombre === plaga && t.fecha === f);
-        const v = tend?.incidenciaPromedio ?? null;
-        const bg = getIncidenciaColor(v);
-        return `<td style="padding:4px 6px;text-align:center;font-size:10px;font-weight:600;background:${bg};border:1px solid #E8E8E8;">${v !== null ? formatNum(v, 1) + '%' : '—'}</td>`;
-      }).join('');
-      return `<tr><td style="padding:4px 6px;font-size:10px;font-weight:600;color:#4D240F;border:1px solid #E8E8E8;background:#FAFAFA;white-space:nowrap;">${plaga}</td>${cellsFecha}</tr>`;
+    const rows = (lote.plagas || []).map((p: any) => {
+      const bg = getIncidenciaColor(p.actual);
+      const tendenciaHTML = formatTendenciaCell(p.actual, p.anterior, p.tendencia);
+      return `<tr>
+        <td style="padding:4px 6px;font-size:10px;font-weight:600;color:#4D240F;border:1px solid #E8E8E8;background:#FAFAFA;white-space:nowrap;${p.esPlaga_interes ? 'border-left:2px solid #73991C;' : ''}">${p.plagaNombre}</td>
+        <td style="padding:4px 6px;text-align:center;font-size:10px;font-weight:700;background:${bg};border:1px solid #E8E8E8;">${p.actual !== null ? formatNum(p.actual, 1) + '%' : '—'}</td>
+        <td style="padding:4px 6px;font-size:10px;border:1px solid #E8E8E8;">${tendenciaHTML}</td>
+      </tr>`;
     }).join('');
 
-    const fecheHds = fechas.map((f: string) => `<th style="padding:4px 6px;font-size:9px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;min-width:60px;">${f}</th>`).join('');
-
     return `<div style="background:#FFFFFF;border-radius:8px;border:1px solid #E8E8E8;padding:12px;flex:1;min-width:280px;max-width:400px;box-shadow:0 1px 4px rgba(0,0,0,0.05);">
-      <div style="font-size:13px;font-weight:700;color:#4D240F;margin-bottom:8px;border-bottom:2px solid #73991C;padding-bottom:4px;">${loteVista.loteNombre}</div>
+      <div style="font-size:13px;font-weight:700;color:#4D240F;margin-bottom:8px;border-bottom:2px solid #73991C;padding-bottom:4px;">${lote.loteNombre}</div>
       <table style="width:100%;border-collapse:collapse;">
-        <thead><tr><th style="padding:4px 6px;font-size:9px;font-weight:700;color:#FFFFFF;background:#4D6B15;border:1px solid #3A5010;text-align:left;">Plaga</th>${fecheHds}</tr></thead>
+        <thead><tr>
+          <th style="padding:4px 6px;font-size:9px;font-weight:700;color:#FFFFFF;background:#4D6B15;border:1px solid #3A5010;text-align:left;">Plaga</th>
+          <th style="padding:4px 6px;font-size:9px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:center;">Incidencia</th>
+          <th style="padding:4px 6px;font-size:9px;font-weight:700;color:#FFFFFF;background:#73991C;border:1px solid #5A7A15;text-align:left;">Tendencia</th>
+        </tr></thead>
         <tbody>${rows}</tbody>
       </table>
     </div>`;
@@ -1102,30 +1167,45 @@ function construirSlideMonitoreoPorLote(datos: any): string {
 </div>`;
 }
 
+// ============================================================================
+// SLIDE 3: VISTA POR SUBLOTE (1 slide por lote)
+// ============================================================================
+
 function construirSlideMonitoreoPorSublote(loteVista: any, semana: any): string {
-  if (!loteVista || !loteVista.sublotes || loteVista.sublotes.length === 0) return '';
+  if (!loteVista) return '';
   const loteNombre = loteVista.loteNombre || 'Lote';
 
-  // VistaMonitoreoSublote structure:
-  // - sublotes: string[] (column names)
-  // - plagas: string[] (row names)
-  // - celdas: Record<plaga, Record<sublote, ObservacionFecha[]>>
-  const sublotes = loteVista.sublotes || [];
-  const plagas = loteVista.plagas || [];
+  if (loteVista.sinDatos) {
+    const sublotes = loteVista.sublotes || [];
+    if (sublotes.length === 0) return '';
+    return `<div class="slide page-break">
+    ${slideHeader('MONITOREO', `Sublotes — ${loteNombre}`, semana)}
+    <div style="padding:40px 22px;text-align:center;">
+      <div style="font-size:14px;color:#AAA;font-weight:600;">No se monitoreó este lote</div>
+      <div style="font-size:12px;color:#CCC;margin-top:8px;">Sublotes configurados: ${sublotes.join(', ')}</div>
+    </div>
+  </div>`;
+  }
+
+  const sublotes: string[] = loteVista.sublotes || [];
+  const plagas: string[] = loteVista.plagas || [];
   const celdas = loteVista.celdas || {};
 
-  const subHeaders = sublotes.map((sl: string) => `<th style="padding:7px 8px;font-size:10px;font-weight:700;color:#FFFFFF;background:#4D6B15;border:1px solid #3A5010;text-align:center;min-width:80px;">${sl}</th>`).join('');
+  if (sublotes.length === 0 || plagas.length === 0) return '';
+
+  const subHeaders = sublotes.map((sl: string) =>
+    `<th style="padding:7px 8px;font-size:10px;font-weight:700;color:#FFFFFF;background:#4D6B15;border:1px solid #3A5010;text-align:center;min-width:90px;">${sl}</th>`
+  ).join('');
 
   const bodyRows = plagas.map((plaga: string) => {
     const cells = sublotes.map((sl: string) => {
-      const obs: any[] = celdas[plaga]?.[sl] || [];
-      if (obs.length === 0) return `<td style="padding:6px 8px;text-align:center;background:#F5F5F0;border:1px solid #E8E8E8;font-size:10px;color:#CCC;">—</td>`;
-      // Show up to 3 observations (for the 3 monitoring dates)
-      const chips = obs.slice(0, 3).map((o: any) => {
-        const bg = getIncidenciaColor(o.incidencia);
-        return `<div style="display:inline-block;padding:2px 6px;border-radius:8px;font-size:10px;font-weight:600;background:${bg};color:#4D240F;margin:1px;">${formatNum(o.incidencia, 1)}%</div>`;
-      }).join('');
-      return `<td style="padding:5px 6px;text-align:center;border:1px solid #E8E8E8;">${chips}</td>`;
+      const celda = celdas[plaga]?.[sl];
+      if (!celda || celda.actual === null) {
+        return `<td style="padding:6px 8px;text-align:center;background:#F5F5F0;border:1px solid #E8E8E8;font-size:10px;color:#CCC;">—</td>`;
+      }
+      const bg = getIncidenciaColor(celda.actual);
+      const tendenciaHTML = formatTendenciaCell(celda.actual, celda.anterior, celda.tendencia);
+      return `<td style="padding:5px 6px;text-align:center;border:1px solid #E8E8E8;background:${bg};font-size:10px;">${tendenciaHTML}</td>`;
     }).join('');
     return `<tr><td style="padding:7px 10px;font-size:11px;font-weight:600;color:#4D240F;border:1px solid #E8E8E8;background:#FAFAFA;white-space:nowrap;">${plaga}</td>${cells}</tr>`;
   }).join('');
@@ -1140,13 +1220,7 @@ function construirSlideMonitoreoPorSublote(loteVista: any, semana: any): string 
       </tr></thead>
       <tbody>${bodyRows}</tbody>
     </table>
-    <div style="margin-top:12px;display:flex;gap:8px;align-items:center;">
-      <span style="font-size:10px;color:#888;font-weight:600;">LEYENDA:</span>
-      <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFFFFF;border:1px solid #CCC;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">0%</span></span>
-      <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFF9C4;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">&lt;10% Baja</span></span>
-      <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#FFB74D;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">&lt;20% Media</span></span>
-      <span style="display:inline-flex;align-items:center;gap:4px;"><span style="width:14px;height:14px;background:#EF9A9A;display:inline-block;border-radius:2px;"></span><span style="font-size:10px;color:#555;">≥20% Alta</span></span>
-    </div>
+    ${monitoreoLeyendaHTML()}
   </div>
 </div>`;
 }
@@ -1211,8 +1285,10 @@ function construirHTMLReporte(datos: any, analisis: AnalisisGemini): string {
   const cerradas = aplicaciones?.cerradas || [];
   const planeadas = aplicaciones?.planeadas || [];
 
-  // Build sublote vistas from monitoreo.vistasPorSublote (NOT detallePorLote — different structure)
-  const vistasPorSublote: any[] = monitoreo?.vistasPorSublote || [];
+  // Build sublote vistas — filter out lotes with no sublotes configured
+  const vistasPorSublote: any[] = (monitoreo?.vistasPorSublote || []).filter(
+    (v: any) => v.sublotes && v.sublotes.length > 0
+  );
 
   const temasAd: any[] = temasAdicionales || [];
 

--- a/src/types/reporteSemanal.ts
+++ b/src/types/reporteSemanal.ts
@@ -203,6 +203,8 @@ export interface AplicacionCerrada {
 // SECCIÓN 4: MONITOREO
 // ============================================================================
 
+// --- Legacy types (kept for backward compat, used internally) ---
+
 export interface TendenciaMonitoreo {
   fecha: string;
   plagaNombre: string;
@@ -223,51 +225,82 @@ export interface MonitoreoPorLote {
   sublotes: MonitoreoSublote[];
 }
 
-// Para la vista por lote con 3 observaciones
 export interface ObservacionFecha {
   fecha: string;
   incidencia: number | null;
   gravedad?: 'Baja' | 'Media' | 'Alta' | null;
 }
 
-export interface VistaLotePlaga {
+// --- Nuevos tipos: Comparativo con tendencia ---
+
+/** Dirección de la tendencia entre observación actual y anterior */
+export type TendenciaDir = 'subiendo' | 'bajando' | 'estable' | 'sin_referencia';
+
+/** Celda con valor actual + comparativo respecto a la observación anterior */
+export interface CeldaComparativa {
+  actual: number | null;       // Incidencia del monitoreo más reciente (null = sin datos)
+  anterior: number | null;     // Incidencia del monitoreo de referencia (null = sin ref)
+  tendencia: TendenciaDir;
+}
+
+/** Fila de la tabla resumen general: una plaga con promedio, rango entre lotes, y tendencia */
+export interface ResumenPlagaGlobal {
   plagaNombre: string;
   esPlaga_interes: boolean;
-  observaciones: ObservacionFecha[]; // hasta 3 fechas
+  promedioActual: number | null;
+  minLote: number | null;          // Mínimo entre lotes
+  maxLote: number | null;          // Máximo entre lotes
+  promedioAnterior: number | null; // Promedio de la observación de referencia
+  tendencia: TendenciaDir;
 }
 
-export interface VistaMonitoreoLote {
+/** Vista por lote: cada lote con lista de plagas comparativas */
+export interface VistaLoteComparativa {
   loteId: string;
   loteNombre: string;
-  plagasRows: VistaLotePlaga[];
+  sinDatos: boolean;              // true si no hay monitoreos para este lote
+  plagas: PlagaLoteComparativa[];
 }
 
-// Para la vista por sublote (1 slide por lote)
-export interface ObservacionSublotePlaga {
-  fechas: ObservacionFecha[]; // hasta 3
-}
-
-export interface VistaSubLotePlagaCell {
-  subloteNombre: string;
+export interface PlagaLoteComparativa {
   plagaNombre: string;
-  observaciones: ObservacionFecha[]; // hasta 3
+  esPlaga_interes: boolean;
+  actual: number | null;
+  anterior: number | null;
+  tendencia: TendenciaDir;
 }
 
-export interface VistaMonitoreoSublote {
+/** Vista por sublote: una tabla por lote, cada celda = plaga × sublote con comparativo */
+export interface VistaSubloteComparativa {
   loteId: string;
   loteNombre: string;
-  sublotes: string[];    // nombres de sublotes (columnas)
-  plagas: string[];      // nombres de plagas (filas)
-  celdas: Record<string, Record<string, ObservacionFecha[]>>; // plaga → sublote → [obs]
+  sinDatos: boolean;
+  sublotes: string[];             // Nombres de sublotes (columnas)
+  plagas: string[];               // Nombres de plagas (filas)
+  celdas: Record<string, Record<string, CeldaComparativa>>; // plaga → sublote → celda
 }
 
+/** Contenedor principal de datos de monitoreo para el informe */
 export interface DatosMonitoreo {
-  tendencias: TendenciaMonitoreo[];  // Últimos 3 monitoreos agrupados
-  detallePorLote: MonitoreoPorLote[];
+  // --- Fechas de referencia ---
+  fechaActual: string | null;            // Fecha del monitoreo principal
+  fechaAnterior: string | null;          // Fecha del monitoreo de referencia
+  avisoFechaDesactualizada: string | null; // Aviso si los datos no son de la semana del reporte
+
+  // --- Vistas ---
+  resumenGlobal: ResumenPlagaGlobal[];        // Slide 1: Resumen general
+  vistasPorLote: VistaLoteComparativa[];      // Slide 2: Vista por lote
+  vistasPorSublote: VistaSubloteComparativa[]; // Slide 3: Vista por sublote (1 por lote)
+
+  // --- Análisis ---
   insights: Insight[];
-  fechasMonitoreo: string[];         // Las 3 fechas de monitoreo usadas
-  vistasPorLote: VistaMonitoreoLote[];      // Vista tabla por lote con 3 obs.
-  vistasPorSublote: VistaMonitoreoSublote[]; // Vista por sublote (1 per lote)
+
+  // --- Legacy (backward compat for Gemini prompt) ---
+  tendencias: TendenciaMonitoreo[];
+  detallePorLote: MonitoreoPorLote[];
+  fechasMonitoreo: string[];
+  vistasPorLote_legacy?: unknown[];
+  vistasPorSublote_legacy?: unknown[];
 }
 
 // ============================================================================

--- a/src/utils/fetchDatosReporteSemanal.ts
+++ b/src/utils/fetchDatosReporteSemanal.ts
@@ -25,10 +25,12 @@ import type {
   AplicacionCierreGeneral,
   AplicacionCierreKPILote,
   AplicacionCierreFinancieroLote,
-  VistaMonitoreoLote,
-  VistaLotePlaga,
-  VistaMonitoreoSublote,
-  ObservacionFecha,
+  ResumenPlagaGlobal,
+  VistaLoteComparativa,
+  PlagaLoteComparativa,
+  VistaSubloteComparativa,
+  CeldaComparativa,
+  TendenciaDir,
 } from '../types/reporteSemanal';
 import type { Insight } from '../types/monitoreo';
 
@@ -1034,34 +1036,92 @@ export async function fetchListaAplicacionesCerradas(): Promise<{ id: string; no
  * Obtiene datos de monitoreo: tendencias de los últimos 3 eventos,
  * detalle por lote, vistas por lote con 3 fechas, y vistas por sublote.
  */
-export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
+export async function fetchDatosMonitoreo(semana: RangoSemana): Promise<DatosMonitoreo> {
   const supabase = getSupabase();
 
-  // Get all unique monitoring dates, ascending (oldest first)
-  // Then take the last 3 (most recent) which will be in chronological order
+  // 1. Load ALL lotes and sublotes from the DB (to guarantee all appear even without data)
+  const [
+    { data: todosLotes, error: errLotes },
+    { data: todosSublotes, error: errSub },
+  ] = await Promise.all([
+    supabase.from('lotes').select('id, nombre').order('nombre'),
+    supabase.from('sublotes').select('id, nombre, lote_id').order('nombre'),
+  ]);
+
+  if (errLotes) throw new Error(`Error al cargar lotes: ${errLotes.message}`);
+  if (errSub) throw new Error(`Error al cargar sublotes: ${errSub.message}`);
+
+  const lotesDB = (todosLotes || []) as Array<{ id: string; nombre: string }>;
+  const sublotesDB = (todosSublotes || []) as Array<{ id: string; nombre: string; lote_id: string }>;
+
+  // 2. Find the 2 most relevant monitoring dates relative to the report week
+  //    - fechaActual: most recent observation within the report week, or up to 2 weeks before
+  //    - fechaAnterior: the observation immediately before fechaActual
+  const limiteInferior = restarDias(semana.inicio, 14); // 2 weeks back from start of report week
+
   const { data: fechasRaw, error: errorFechas } = await supabase
     .from('monitoreos')
     .select('fecha_monitoreo')
-    .order('fecha_monitoreo', { ascending: true });
+    .gte('fecha_monitoreo', limiteInferior)
+    .lte('fecha_monitoreo', semana.fin)
+    .order('fecha_monitoreo', { ascending: false });
 
   if (errorFechas) throw new Error(`Error al cargar fechas de monitoreo: ${errorFechas.message}`);
 
-  const fechasUnicas = [...new Set((fechasRaw || []).map(r => r.fecha_monitoreo))];
-  // Take last 3 (most recent) - now in chronological order (oldest→newest)
-  const ultimas3Fechas = fechasUnicas.slice(-3);
+  const fechasUnicasRecientes = [...new Set((fechasRaw || []).map(r => r.fecha_monitoreo))];
+  // fechasUnicasRecientes is sorted DESC (newest first)
 
-  if (ultimas3Fechas.length === 0) {
+  const fechaActual = fechasUnicasRecientes[0] || null;
+  let fechaAnterior: string | null = null;
+
+  if (fechaActual) {
+    // Look for any monitoring date before fechaActual (not limited to the 2-week window)
+    const { data: anteriorRaw } = await supabase
+      .from('monitoreos')
+      .select('fecha_monitoreo')
+      .lt('fecha_monitoreo', fechaActual)
+      .order('fecha_monitoreo', { ascending: false })
+      .limit(1);
+    fechaAnterior = anteriorRaw?.[0]?.fecha_monitoreo || null;
+  }
+
+  // Build aviso if data is from a previous week
+  let avisoFechaDesactualizada: string | null = null;
+  if (fechaActual && fechaActual < semana.inicio) {
+    avisoFechaDesactualizada = `Datos del monitoreo del ${fechaActual}. No se realizó monitoreo en la semana del reporte.`;
+  }
+
+  // Empty result if no monitoring data at all
+  if (!fechaActual) {
     return {
+      fechaActual: null,
+      fechaAnterior: null,
+      avisoFechaDesactualizada: 'No se encontraron monitoreos en las últimas 2 semanas.',
+      resumenGlobal: [],
+      vistasPorLote: lotesDB.map(l => ({
+        loteId: l.id,
+        loteNombre: l.nombre,
+        sinDatos: true,
+        plagas: [],
+      })),
+      vistasPorSublote: lotesDB.map(l => ({
+        loteId: l.id,
+        loteNombre: l.nombre,
+        sinDatos: true,
+        sublotes: sublotesDB.filter(s => s.lote_id === l.id).map(s => s.nombre).sort(),
+        plagas: [],
+        celdas: {},
+      })),
+      insights: [],
       tendencias: [],
       detallePorLote: [],
-      insights: [],
       fechasMonitoreo: [],
-      vistasPorLote: [],
-      vistasPorSublote: [],
     };
   }
 
-  // Load monitoring data for the last 3 dates
+  // 3. Load monitoring records for the 2 relevant dates
+  const fechasQuery = fechaAnterior ? [fechaActual, fechaAnterior] : [fechaActual];
+
   const { data: monitoreos, error: errorMon } = await supabase
     .from('monitoreos')
     .select(`
@@ -1078,18 +1138,195 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
       lotes(id, nombre),
       sublotes(id, nombre)
     `)
-    .in('fecha_monitoreo', ultimas3Fechas)
+    .in('fecha_monitoreo', fechasQuery)
     .order('fecha_monitoreo', { ascending: true });
 
   if (errorMon) throw new Error(`Error al cargar monitoreos: ${errorMon.message}`);
 
-  // --- TENDENCIAS: fecha × plaga → avg incidencia ---
-  const tendenciasMap = new Map<string, Map<string, number[]>>();
+  const registros = monitoreos || [];
+  const regActuales = registros.filter((m: any) => m.fecha_monitoreo === fechaActual);
+  const regAnteriores = registros.filter((m: any) => m.fecha_monitoreo === fechaAnterior);
 
-  (monitoreos || []).forEach((m: any) => {
+  // Collect all unique plaga names from both observations
+  const allPlagas = new Set<string>();
+  registros.forEach((m: any) => {
+    allPlagas.add(m.plagas_enfermedades_catalogo?.nombre || 'Desconocida');
+  });
+  const plagasArr = Array.from(allPlagas);
+
+  // Helper: determine trend direction
+  function calcTendencia(actual: number | null, anterior: number | null): TendenciaDir {
+    if (actual === null || anterior === null) return 'sin_referencia';
+    const diff = actual - anterior;
+    if (Math.abs(diff) < 0.5) return 'estable';
+    return diff > 0 ? 'subiendo' : 'bajando';
+  }
+
+  // Helper: check if plaga is de interés
+  function esPlagaInteres(nombre: string): boolean {
+    return PLAGAS_INTERES.some(p => nombre.toLowerCase().includes(p.toLowerCase()));
+  }
+
+  // Helper: avg of incidencias
+  function promedio(vals: number[]): number {
+    if (vals.length === 0) return 0;
+    return Math.round((vals.reduce((a, b) => a + b, 0) / vals.length) * 10) / 10;
+  }
+
+  // 4. Build RESUMEN GLOBAL (Slide 1)
+  // For each plaga: avg across all lotes (actual), min-max across lotes, and comparison with anterior
+  const resumenGlobal: ResumenPlagaGlobal[] = plagasArr.map(plaga => {
+    // Current: per-lote averages
+    const lotesActuales = new Map<string, number[]>();
+    regActuales.forEach((m: any) => {
+      if ((m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') !== plaga) return;
+      const loteId = m.lote_id;
+      if (!lotesActuales.has(loteId)) lotesActuales.set(loteId, []);
+      lotesActuales.get(loteId)!.push(Number(m.incidencia) || 0);
+    });
+
+    const promediosPorLote = Array.from(lotesActuales.values()).map(vals => promedio(vals));
+    const promedioActual = promediosPorLote.length > 0
+      ? Math.round((promediosPorLote.reduce((a, b) => a + b, 0) / promediosPorLote.length) * 10) / 10
+      : null;
+    const minLote = promediosPorLote.length > 0 ? Math.min(...promediosPorLote) : null;
+    const maxLote = promediosPorLote.length > 0 ? Math.max(...promediosPorLote) : null;
+
+    // Previous: global average
+    const valsAnterior = regAnteriores
+      .filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga)
+      .map((m: any) => Number(m.incidencia) || 0);
+    const promedioAnterior = valsAnterior.length > 0 ? promedio(valsAnterior) : null;
+
+    return {
+      plagaNombre: plaga,
+      esPlaga_interes: esPlagaInteres(plaga),
+      promedioActual,
+      minLote,
+      maxLote,
+      promedioAnterior,
+      tendencia: calcTendencia(promedioActual, promedioAnterior),
+    };
+  });
+
+  // Sort: plagas de interés first, then by incidencia desc
+  resumenGlobal.sort((a, b) => {
+    if (a.esPlaga_interes !== b.esPlaga_interes) return a.esPlaga_interes ? -1 : 1;
+    return (b.promedioActual ?? 0) - (a.promedioActual ?? 0);
+  });
+
+  // 5. Build VISTAS POR LOTE (Slide 2) — ALL lotes, including those without data
+  const vistasPorLote: VistaLoteComparativa[] = lotesDB.map(lote => {
+    const regLoteActual = regActuales.filter((m: any) => m.lote_id === lote.id);
+    const regLoteAnterior = regAnteriores.filter((m: any) => m.lote_id === lote.id);
+
+    if (regLoteActual.length === 0 && regLoteAnterior.length === 0) {
+      return { loteId: lote.id, loteNombre: lote.nombre, sinDatos: true, plagas: [] };
+    }
+
+    // Collect plagas for this lote (from both dates)
+    const plagasLote = new Set<string>();
+    [...regLoteActual, ...regLoteAnterior].forEach((m: any) => {
+      plagasLote.add(m.plagas_enfermedades_catalogo?.nombre || 'Desconocida');
+    });
+
+    const plagas: PlagaLoteComparativa[] = Array.from(plagasLote).map(plaga => {
+      const valsActual = regLoteActual
+        .filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga)
+        .map((m: any) => Number(m.incidencia) || 0);
+      const valsAnteriorLote = regLoteAnterior
+        .filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga)
+        .map((m: any) => Number(m.incidencia) || 0);
+
+      const actual = valsActual.length > 0 ? promedio(valsActual) : null;
+      const anterior = valsAnteriorLote.length > 0 ? promedio(valsAnteriorLote) : null;
+
+      return {
+        plagaNombre: plaga,
+        esPlaga_interes: esPlagaInteres(plaga),
+        actual,
+        anterior,
+        tendencia: calcTendencia(actual, anterior),
+      };
+    });
+
+    // Sort: plagas de interés first, then by incidencia desc
+    plagas.sort((a, b) => {
+      if (a.esPlaga_interes !== b.esPlaga_interes) return a.esPlaga_interes ? -1 : 1;
+      return (b.actual ?? 0) - (a.actual ?? 0);
+    });
+
+    return { loteId: lote.id, loteNombre: lote.nombre, sinDatos: false, plagas };
+  });
+
+  // 6. Build VISTAS POR SUBLOTE (Slide 3) — ALL lotes/sublotes
+  const vistasPorSublote: VistaSubloteComparativa[] = lotesDB.map(lote => {
+    const sublotesLote = sublotesDB.filter(s => s.lote_id === lote.id).map(s => s.nombre).sort();
+    const regLoteActual = regActuales.filter((m: any) => m.lote_id === lote.id);
+    const regLoteAnterior = regAnteriores.filter((m: any) => m.lote_id === lote.id);
+
+    if (regLoteActual.length === 0 && regLoteAnterior.length === 0) {
+      return {
+        loteId: lote.id, loteNombre: lote.nombre, sinDatos: true,
+        sublotes: sublotesLote, plagas: [], celdas: {},
+      };
+    }
+
+    // Collect plagas for this lote
+    const plagasLoteSet = new Set<string>();
+    [...regLoteActual, ...regLoteAnterior].forEach((m: any) => {
+      plagasLoteSet.add(m.plagas_enfermedades_catalogo?.nombre || 'Desconocida');
+    });
+    const plagasLote = Array.from(plagasLoteSet).sort((a, b) => {
+      const aInt = esPlagaInteres(a);
+      const bInt = esPlagaInteres(b);
+      if (aInt !== bInt) return aInt ? -1 : 1;
+      return a.localeCompare(b);
+    });
+
+    // Build celdas: plaga → sublote → CeldaComparativa
+    const celdas: Record<string, Record<string, CeldaComparativa>> = {};
+    plagasLote.forEach(plaga => {
+      celdas[plaga] = {};
+      sublotesLote.forEach(subloteNombre => {
+        const valsActual = regLoteActual
+          .filter((m: any) =>
+            (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga &&
+            (m.sublotes?.nombre || 'Sin sublote') === subloteNombre
+          )
+          .map((m: any) => Number(m.incidencia) || 0);
+        const valsAnteriorSub = regLoteAnterior
+          .filter((m: any) =>
+            (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga &&
+            (m.sublotes?.nombre || 'Sin sublote') === subloteNombre
+          )
+          .map((m: any) => Number(m.incidencia) || 0);
+
+        const actual = valsActual.length > 0 ? promedio(valsActual) : null;
+        const anterior = valsAnteriorSub.length > 0 ? promedio(valsAnteriorSub) : null;
+
+        celdas[plaga][subloteNombre] = {
+          actual,
+          anterior,
+          tendencia: calcTendencia(actual, anterior),
+        };
+      });
+    });
+
+    return {
+      loteId: lote.id, loteNombre: lote.nombre, sinDatos: false,
+      sublotes: sublotesLote, plagas: plagasLote, celdas,
+    };
+  });
+
+  // 7. INSIGHTS (keep existing logic)
+  const insights: Insight[] = generarInsightsBasicos(registros);
+
+  // 8. LEGACY data for Gemini prompt (tendencias + detallePorLote)
+  const tendenciasMap = new Map<string, Map<string, number[]>>();
+  registros.forEach((m: any) => {
     const fecha = m.fecha_monitoreo;
     const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
-
     if (!tendenciasMap.has(fecha)) tendenciasMap.set(fecha, new Map());
     const fechaMap = tendenciasMap.get(fecha)!;
     if (!fechaMap.has(plaga)) fechaMap.set(plaga, []);
@@ -1099,31 +1336,21 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
   const tendencias: TendenciaMonitoreo[] = [];
   tendenciasMap.forEach((plagasMap, fecha) => {
     plagasMap.forEach((incidencias, plagaNombre) => {
-      const promedio = incidencias.reduce((a, b) => a + b, 0) / incidencias.length;
       tendencias.push({
         fecha,
         plagaNombre,
-        incidenciaPromedio: Math.round(promedio * 10) / 10,
+        incidenciaPromedio: promedio(incidencias),
       });
     });
   });
 
-  // --- DETALLE POR LOTE: most recent monitoring ---
-  const fechaMasReciente = ultimas3Fechas[0];
-  const monitoreoReciente = (monitoreos || []).filter(
-    (m: any) => m.fecha_monitoreo === fechaMasReciente
-  );
-
   const detalleLoteMap = new Map<string, MonitoreoSublote[]>();
-  monitoreoReciente.forEach((m: any) => {
+  regActuales.forEach((m: any) => {
     const loteNombre = m.lotes?.nombre || 'Sin lote';
-    const subloteNombre = m.sublotes?.nombre || 'Sin sublote';
-    const plagaNombre = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
-
     if (!detalleLoteMap.has(loteNombre)) detalleLoteMap.set(loteNombre, []);
     detalleLoteMap.get(loteNombre)!.push({
-      subloteNombre,
-      plagaNombre,
+      subloteNombre: m.sublotes?.nombre || 'Sin sublote',
+      plagaNombre: m.plagas_enfermedades_catalogo?.nombre || 'Desconocida',
       incidencia: Number(m.incidencia) || 0,
       gravedad: m.gravedad_texto || 'Baja',
       arboresAfectados: Number(m.arboles_afectados) || 0,
@@ -1135,156 +1362,25 @@ export async function fetchDatosMonitoreo(): Promise<DatosMonitoreo> {
     .map(([loteNombre, sublotes]) => ({ loteNombre, sublotes }))
     .sort((a, b) => a.loteNombre.localeCompare(b.loteNombre));
 
-  // --- INSIGHTS ---
-  const insights: Insight[] = generarInsightsBasicos(monitoreos || []);
-
-  // --- VISTAS POR LOTE (3 fechas per lote × plaga) ---
-  const vistasPorLote = buildVistasPorLote(monitoreos || [], ultimas3Fechas);
-
-  // --- VISTAS POR SUBLOTE (1 per lote: sublotes × plagas grid with 3 obs) ---
-  const vistasPorSublote = buildVistasPorSublote(monitoreos || [], ultimas3Fechas);
-
   return {
-    tendencias,
-    detallePorLote,
-    insights,
-    fechasMonitoreo: ultimas3Fechas,
+    fechaActual,
+    fechaAnterior,
+    avisoFechaDesactualizada,
+    resumenGlobal,
     vistasPorLote,
     vistasPorSublote,
+    insights,
+    tendencias,
+    detallePorLote,
+    fechasMonitoreo: fechasQuery,
   };
 }
 
-function buildVistasPorLote(monitoreos: any[], fechas: string[]): VistaMonitoreoLote[] {
-  // loteId → plagaNombre → fecha → avg incidencia
-  const loteMap = new Map<string, { id: string; nombre: string; plagas: Map<string, Map<string, number[]>> }>();
-
-  monitoreos.forEach((m: any) => {
-    const loteId = m.lote_id;
-    const loteNombre = m.lotes?.nombre || 'Sin lote';
-    const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
-    const fecha = m.fecha_monitoreo;
-    const incidencia = Number(m.incidencia) || 0;
-
-    if (!loteMap.has(loteId)) {
-      loteMap.set(loteId, { id: loteId, nombre: loteNombre, plagas: new Map() });
-    }
-    const loteEntry = loteMap.get(loteId)!;
-    if (!loteEntry.plagas.has(plaga)) loteEntry.plagas.set(plaga, new Map());
-    const plagaEntry = loteEntry.plagas.get(plaga)!;
-    if (!plagaEntry.has(fecha)) plagaEntry.set(fecha, []);
-    plagaEntry.get(fecha)!.push(incidencia);
-  });
-
-  const result: VistaMonitoreoLote[] = [];
-
-  loteMap.forEach(({ id, nombre, plagas }) => {
-    const plagasRows: VistaLotePlaga[] = [];
-
-    plagas.forEach((fechaMap, plagaNombre) => {
-      const esInteres = PLAGAS_INTERES.some(p =>
-        plagaNombre.toLowerCase().includes(p.toLowerCase())
-      );
-
-      const observaciones: ObservacionFecha[] = fechas.map(fecha => {
-        const vals = fechaMap.get(fecha);
-        if (!vals || vals.length === 0) return { fecha, incidencia: null };
-        const avg = vals.reduce((a, b) => a + b, 0) / vals.length;
-        return { fecha, incidencia: Math.round(avg * 10) / 10 };
-      });
-
-      plagasRows.push({ plagaNombre, esPlaga_interes: esInteres, observaciones });
-    });
-
-    // Sort: plagas de interes first, then by latest incidencia desc
-    plagasRows.sort((a, b) => {
-      if (a.esPlaga_interes !== b.esPlaga_interes) return a.esPlaga_interes ? -1 : 1;
-      const aLast = a.observaciones.find(o => o.incidencia != null)?.incidencia || 0;
-      const bLast = b.observaciones.find(o => o.incidencia != null)?.incidencia || 0;
-      return bLast - aLast;
-    });
-
-    result.push({ loteId: id, loteNombre: nombre, plagasRows });
-  });
-
-  return result.sort((a, b) => a.loteNombre.localeCompare(b.loteNombre));
-}
-
-function buildVistasPorSublote(monitoreos: any[], fechas: string[]): VistaMonitoreoSublote[] {
-  // loteId → { sublotes: Set, plagas: Set, celdas: plaga → sublote → fecha → vals[] }
-  type LoteEntry = {
-    id: string;
-    nombre: string;
-    sublotes: Set<string>;
-    plagas: Set<string>;
-    celdas: Map<string, Map<string, Map<string, number[]>>>;
-  };
-
-  const loteMap = new Map<string, LoteEntry>();
-
-  monitoreos.forEach((m: any) => {
-    const loteId = m.lote_id;
-    const loteNombre = m.lotes?.nombre || 'Sin lote';
-    const subloteNombre = m.sublotes?.nombre || 'Sin sublote';
-    const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
-    const fecha = m.fecha_monitoreo;
-    const incidencia = Number(m.incidencia) || 0;
-
-    if (!loteMap.has(loteId)) {
-      loteMap.set(loteId, {
-        id: loteId, nombre: loteNombre,
-        sublotes: new Set(), plagas: new Set(),
-        celdas: new Map(),
-      });
-    }
-
-    const entry = loteMap.get(loteId)!;
-    entry.sublotes.add(subloteNombre);
-    entry.plagas.add(plaga);
-
-    if (!entry.celdas.has(plaga)) entry.celdas.set(plaga, new Map());
-    const plagaMap = entry.celdas.get(plaga)!;
-    if (!plagaMap.has(subloteNombre)) plagaMap.set(subloteNombre, new Map());
-    const subloteMap = plagaMap.get(subloteNombre)!;
-    if (!subloteMap.has(fecha)) subloteMap.set(fecha, []);
-    subloteMap.get(fecha)!.push(incidencia);
-  });
-
-  const result: VistaMonitoreoSublote[] = [];
-
-  loteMap.forEach(({ id, nombre, sublotes, plagas, celdas }) => {
-    const sublotesArr = Array.from(sublotes).sort();
-    const plagasArr = Array.from(plagas).sort((a, b) => {
-      const aInt = PLAGAS_INTERES.some(p => a.toLowerCase().includes(p.toLowerCase()));
-      const bInt = PLAGAS_INTERES.some(p => b.toLowerCase().includes(p.toLowerCase()));
-      if (aInt !== bInt) return aInt ? -1 : 1;
-      return a.localeCompare(b);
-    });
-
-    const celdasObj: Record<string, Record<string, ObservacionFecha[]>> = {};
-
-    plagasArr.forEach(plaga => {
-      celdasObj[plaga] = {};
-      sublotesArr.forEach(sublote => {
-        const fechaMap = celdas.get(plaga)?.get(sublote);
-        celdasObj[plaga][sublote] = fechas.map(fecha => {
-          const vals = fechaMap?.get(fecha);
-          if (!vals || vals.length === 0) return { fecha, incidencia: null };
-          const avg = vals.reduce((a, b) => a + b, 0) / vals.length;
-          return { fecha, incidencia: Math.round(avg * 10) / 10 };
-        });
-      });
-    });
-
-    result.push({
-      loteId: id,
-      loteNombre: nombre,
-      sublotes: sublotesArr,
-      plagas: plagasArr,
-      celdas: celdasObj,
-    });
-  });
-
-  return result.sort((a, b) => a.loteNombre.localeCompare(b.loteNombre));
+/** Resta N días a una fecha ISO y retorna ISO string */
+function restarDias(fechaISO: string, dias: number): string {
+  const d = new Date(fechaISO);
+  d.setDate(d.getDate() - dias);
+  return d.toISOString().split('T')[0];
 }
 
 /**
@@ -1389,7 +1485,7 @@ export async function fetchDatosReporteSemanal(
     fetchAplicacionesPlaneadas(),
     fetchAplicacionesActivas(),
     fetchAplicacionesCerradas(cerradasIds),
-    fetchDatosMonitoreo(),
+    fetchDatosMonitoreo(semana),
   ]);
 
   const jornalesPosibles = personalBase.totalTrabajadores * diasHabiles;

--- a/supabase/functions/make-server-1ccce916/fetch-datos-reporte.ts
+++ b/supabase/functions/make-server-1ccce916/fetch-datos-reporte.ts
@@ -338,125 +338,237 @@ async function fetchAplicacionesActivas(
 // ============================================================================
 
 async function fetchDatosMonitoreo(
-  supabase: ReturnType<typeof createClient>
+  supabase: ReturnType<typeof createClient>,
+  semana: RangoSemana
 ): Promise<any> {
+  const PLAGAS_INTERES = ['Monalonion', 'Ácaro', 'Huevos de Ácaro', 'Ácaro Cristalino', 'Cucarrón marceño', 'Trips'];
+
+  // 1. Load ALL lotes and sublotes
+  const [{ data: todosLotes, error: errLotes }, { data: todosSublotes, error: errSub }] = await Promise.all([
+    supabase.from('lotes').select('id, nombre').order('nombre'),
+    supabase.from('sublotes').select('id, nombre, lote_id').order('nombre'),
+  ]);
+  if (errLotes) throw new Error(`Error al cargar lotes: ${errLotes.message}`);
+  if (errSub) throw new Error(`Error al cargar sublotes: ${errSub.message}`);
+
+  const lotesDB = (todosLotes || []) as Array<{ id: string; nombre: string }>;
+  const sublotesDB = (todosSublotes || []) as Array<{ id: string; nombre: string; lote_id: string }>;
+
+  // 2. Find 2 relevant monitoring dates relative to the report week
+  const limiteInferior = (() => {
+    const d = new Date(semana.inicio);
+    d.setDate(d.getDate() - 14);
+    return d.toISOString().split('T')[0];
+  })();
+
   const { data: fechasRaw, error: errorFechas } = await supabase
     .from('monitoreos')
     .select('fecha_monitoreo')
+    .gte('fecha_monitoreo', limiteInferior)
+    .lte('fecha_monitoreo', semana.fin)
     .order('fecha_monitoreo', { ascending: false });
 
   if (errorFechas) throw new Error(`Error al cargar fechas de monitoreo: ${errorFechas.message}`);
 
   const fechasUnicas = [...new Set((fechasRaw || []).map((r: any) => r.fecha_monitoreo))];
-  const ultimas3Fechas = fechasUnicas.slice(0, 3);
+  const fechaActual = fechasUnicas[0] || null;
+  let fechaAnterior: string | null = null;
 
-  if (ultimas3Fechas.length === 0) {
-    return { tendencias: [], detallePorLote: [], insights: [], fechasMonitoreo: [] };
+  if (fechaActual) {
+    const { data: anteriorRaw } = await supabase
+      .from('monitoreos')
+      .select('fecha_monitoreo')
+      .lt('fecha_monitoreo', fechaActual)
+      .order('fecha_monitoreo', { ascending: false })
+      .limit(1);
+    fechaAnterior = anteriorRaw?.[0]?.fecha_monitoreo || null;
   }
+
+  let avisoFechaDesactualizada: string | null = null;
+  if (fechaActual && fechaActual < semana.inicio) {
+    avisoFechaDesactualizada = `Datos del monitoreo del ${fechaActual}. No se realizó monitoreo en la semana del reporte.`;
+  }
+
+  if (!fechaActual) {
+    return {
+      fechaActual: null, fechaAnterior: null,
+      avisoFechaDesactualizada: 'No se encontraron monitoreos en las últimas 2 semanas.',
+      resumenGlobal: [],
+      vistasPorLote: lotesDB.map((l: any) => ({ loteId: l.id, loteNombre: l.nombre, sinDatos: true, plagas: [] })),
+      vistasPorSublote: lotesDB.map((l: any) => ({
+        loteId: l.id, loteNombre: l.nombre, sinDatos: true,
+        sublotes: sublotesDB.filter((s: any) => s.lote_id === l.id).map((s: any) => s.nombre).sort(),
+        plagas: [], celdas: {},
+      })),
+      insights: [], tendencias: [], detallePorLote: [], fechasMonitoreo: [],
+    };
+  }
+
+  // 3. Load monitoring records for the 2 relevant dates
+  const fechasQuery = fechaAnterior ? [fechaActual, fechaAnterior] : [fechaActual];
 
   const { data: monitoreos, error: errorMon } = await supabase
     .from('monitoreos')
     .select(`
-      id,
-      fecha_monitoreo,
-      lote_id,
-      sublote_id,
-      plaga_enfermedad_id,
-      arboles_monitoreados,
-      arboles_afectados,
-      incidencia,
-      gravedad_texto,
-      plagas_enfermedades_catalogo(nombre),
-      lotes(nombre),
-      sublotes(nombre)
+      id, fecha_monitoreo, lote_id, sublote_id, plaga_enfermedad_id,
+      arboles_monitoreados, arboles_afectados, incidencia, gravedad_texto,
+      plagas_enfermedades_catalogo(nombre), lotes(id, nombre), sublotes(id, nombre)
     `)
-    .in('fecha_monitoreo', ultimas3Fechas)
+    .in('fecha_monitoreo', fechasQuery)
     .order('fecha_monitoreo', { ascending: true });
 
   if (errorMon) throw new Error(`Error al cargar monitoreos: ${errorMon.message}`);
 
-  // Tendencias
-  const tendenciasMap = new Map<string, Map<string, number[]>>();
-  (monitoreos || []).forEach((m: any) => {
-    const fecha = m.fecha_monitoreo;
-    const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
-    if (!tendenciasMap.has(fecha)) tendenciasMap.set(fecha, new Map());
-    const fechaMap = tendenciasMap.get(fecha)!;
-    if (!fechaMap.has(plaga)) fechaMap.set(plaga, []);
-    fechaMap.get(plaga)!.push(Number(m.incidencia) || 0);
-  });
+  const registros = monitoreos || [];
+  const regActuales = registros.filter((m: any) => m.fecha_monitoreo === fechaActual);
+  const regAnteriores = registros.filter((m: any) => m.fecha_monitoreo === fechaAnterior);
 
-  const tendencias: any[] = [];
-  tendenciasMap.forEach((plagasMap, fecha) => {
-    plagasMap.forEach((incidencias, plagaNombre) => {
-      const promedio = incidencias.reduce((a: number, b: number) => a + b, 0) / incidencias.length;
-      tendencias.push({ fecha, plagaNombre, incidenciaPromedio: Math.round(promedio * 10) / 10 });
+  const allPlagas = new Set<string>();
+  registros.forEach((m: any) => allPlagas.add(m.plagas_enfermedades_catalogo?.nombre || 'Desconocida'));
+
+  const esPlagaInteres = (nombre: string) => PLAGAS_INTERES.some(p => nombre.toLowerCase().includes(p.toLowerCase()));
+  const avg = (vals: number[]) => vals.length === 0 ? 0 : Math.round((vals.reduce((a: number, b: number) => a + b, 0) / vals.length) * 10) / 10;
+  const calcTendencia = (act: number | null, ant: number | null) => {
+    if (act === null || ant === null) return 'sin_referencia';
+    const diff = act - ant;
+    if (Math.abs(diff) < 0.5) return 'estable';
+    return diff > 0 ? 'subiendo' : 'bajando';
+  };
+
+  // 4. Build resumenGlobal
+  const resumenGlobal = Array.from(allPlagas).map(plaga => {
+    const lotesActuales = new Map<string, number[]>();
+    regActuales.forEach((m: any) => {
+      if ((m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') !== plaga) return;
+      const lid = m.lote_id;
+      if (!lotesActuales.has(lid)) lotesActuales.set(lid, []);
+      lotesActuales.get(lid)!.push(Number(m.incidencia) || 0);
     });
+    const promediosPorLote = Array.from(lotesActuales.values()).map(v => avg(v));
+    const promedioActual = promediosPorLote.length > 0
+      ? Math.round((promediosPorLote.reduce((a: number, b: number) => a + b, 0) / promediosPorLote.length) * 10) / 10 : null;
+
+    const valsAnt = regAnteriores.filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga).map((m: any) => Number(m.incidencia) || 0);
+    const promedioAnterior = valsAnt.length > 0 ? avg(valsAnt) : null;
+
+    return {
+      plagaNombre: plaga, esPlaga_interes: esPlagaInteres(plaga),
+      promedioActual, minLote: promediosPorLote.length > 0 ? Math.min(...promediosPorLote) : null,
+      maxLote: promediosPorLote.length > 0 ? Math.max(...promediosPorLote) : null,
+      promedioAnterior, tendencia: calcTendencia(promedioActual, promedioAnterior),
+    };
+  }).sort((a: any, b: any) => {
+    if (a.esPlaga_interes !== b.esPlaga_interes) return a.esPlaga_interes ? -1 : 1;
+    return (b.promedioActual ?? 0) - (a.promedioActual ?? 0);
   });
 
-  // Detalle por lote (fecha más reciente)
-  const fechaMasReciente = ultimas3Fechas[0];
-  const monitoreoReciente = (monitoreos || []).filter(
-    (m: any) => m.fecha_monitoreo === fechaMasReciente
-  );
-
-  const detalleLoteMap = new Map<string, any[]>();
-  monitoreoReciente.forEach((m: any) => {
-    const loteNombre = m.lotes?.nombre || 'Sin lote';
-    const subloteNombre = m.sublotes?.nombre || 'Sin sublote';
-    const plagaNombre = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
-    if (!detalleLoteMap.has(loteNombre)) detalleLoteMap.set(loteNombre, []);
-    detalleLoteMap.get(loteNombre)!.push({
-      subloteNombre,
-      plagaNombre,
-      incidencia: Number(m.incidencia) || 0,
-      gravedad: m.gravedad_texto || 'Baja',
-      arboresAfectados: Number(m.arboles_afectados) || 0,
-      arboresMonitoreados: Number(m.arboles_monitoreados) || 0,
+  // 5. Build vistasPorLote
+  const vistasPorLote = lotesDB.map((lote: any) => {
+    const regLA = regActuales.filter((m: any) => m.lote_id === lote.id);
+    const regLAnt = regAnteriores.filter((m: any) => m.lote_id === lote.id);
+    if (regLA.length === 0 && regLAnt.length === 0) return { loteId: lote.id, loteNombre: lote.nombre, sinDatos: true, plagas: [] };
+    const plagasLote = new Set<string>();
+    [...regLA, ...regLAnt].forEach((m: any) => plagasLote.add(m.plagas_enfermedades_catalogo?.nombre || 'Desconocida'));
+    const plagas = Array.from(plagasLote).map(plaga => {
+      const vA = regLA.filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga).map((m: any) => Number(m.incidencia) || 0);
+      const vP = regLAnt.filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga).map((m: any) => Number(m.incidencia) || 0);
+      const actual = vA.length > 0 ? avg(vA) : null;
+      const anterior = vP.length > 0 ? avg(vP) : null;
+      return { plagaNombre: plaga, esPlaga_interes: esPlagaInteres(plaga), actual, anterior, tendencia: calcTendencia(actual, anterior) };
+    }).sort((a: any, b: any) => {
+      if (a.esPlaga_interes !== b.esPlaga_interes) return a.esPlaga_interes ? -1 : 1;
+      return (b.actual ?? 0) - (a.actual ?? 0);
     });
+    return { loteId: lote.id, loteNombre: lote.nombre, sinDatos: false, plagas };
   });
 
-  const detallePorLote = Array.from(detalleLoteMap.entries())
-    .map(([loteNombre, sublotes]) => ({ loteNombre, sublotes }))
-    .sort((a: any, b: any) => a.loteNombre.localeCompare(b.loteNombre));
+  // 6. Build vistasPorSublote
+  const vistasPorSublote = lotesDB.map((lote: any) => {
+    const sublotesLote = sublotesDB.filter((s: any) => s.lote_id === lote.id).map((s: any) => s.nombre).sort();
+    const regLA = regActuales.filter((m: any) => m.lote_id === lote.id);
+    const regLAnt = regAnteriores.filter((m: any) => m.lote_id === lote.id);
+    if (regLA.length === 0 && regLAnt.length === 0) {
+      return { loteId: lote.id, loteNombre: lote.nombre, sinDatos: true, sublotes: sublotesLote, plagas: [], celdas: {} };
+    }
+    const plagasSet = new Set<string>();
+    [...regLA, ...regLAnt].forEach((m: any) => plagasSet.add(m.plagas_enfermedades_catalogo?.nombre || 'Desconocida'));
+    const plagasLote = Array.from(plagasSet).sort((a, b) => {
+      const aI = esPlagaInteres(a); const bI = esPlagaInteres(b);
+      if (aI !== bI) return aI ? -1 : 1;
+      return a.localeCompare(b);
+    });
+    const celdas: Record<string, Record<string, any>> = {};
+    plagasLote.forEach(plaga => {
+      celdas[plaga] = {};
+      sublotesLote.forEach(sub => {
+        const vA = regLA.filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga && (m.sublotes?.nombre || 'Sin sublote') === sub).map((m: any) => Number(m.incidencia) || 0);
+        const vP = regLAnt.filter((m: any) => (m.plagas_enfermedades_catalogo?.nombre || 'Desconocida') === plaga && (m.sublotes?.nombre || 'Sin sublote') === sub).map((m: any) => Number(m.incidencia) || 0);
+        const actual = vA.length > 0 ? avg(vA) : null;
+        const anterior = vP.length > 0 ? avg(vP) : null;
+        celdas[plaga][sub] = { actual, anterior, tendencia: calcTendencia(actual, anterior) };
+      });
+    });
+    return { loteId: lote.id, loteNombre: lote.nombre, sinDatos: false, sublotes: sublotesLote, plagas: plagasLote, celdas };
+  });
 
-  // Insights simples
+  // 7. Insights
   const plagaLoteMap = new Map<string, { incidencias: number[]; plaga: string; lote: string }>();
-  (monitoreos || []).forEach((m: any) => {
+  registros.forEach((m: any) => {
     const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
     const lote = m.lotes?.nombre || 'Sin lote';
     const key = `${plaga}|${lote}`;
     if (!plagaLoteMap.has(key)) plagaLoteMap.set(key, { incidencias: [], plaga, lote });
     plagaLoteMap.get(key)!.incidencias.push(Number(m.incidencia) || 0);
   });
-
   const insights: any[] = [];
   plagaLoteMap.forEach(({ incidencias, plaga, lote }) => {
-    const promedio = incidencias.reduce((a: number, b: number) => a + b, 0) / incidencias.length;
-    if (promedio >= 30) {
-      insights.push({
-        tipo: 'urgente',
-        titulo: `${plaga} crítica en ${lote}`,
-        descripcion: `Incidencia promedio de ${promedio.toFixed(1)}% — requiere atención inmediata`,
-        plaga, lote, incidenciaActual: promedio,
-        accion: 'Evaluar aplicación de tratamiento',
-      });
-    } else if (promedio >= 20) {
-      insights.push({
-        tipo: 'atencion',
-        titulo: `${plaga} elevada en ${lote}`,
-        descripcion: `Incidencia promedio de ${promedio.toFixed(1)}% — monitorear de cerca`,
-        plaga, lote, incidenciaActual: promedio,
-        accion: 'Monitorear de cerca',
-      });
+    const prom = incidencias.reduce((a: number, b: number) => a + b, 0) / incidencias.length;
+    if (prom >= 30) {
+      insights.push({ tipo: 'urgente', titulo: `${plaga} crítica en ${lote}`, descripcion: `Incidencia promedio de ${prom.toFixed(1)}% — requiere atención inmediata`, plaga, lote, incidenciaActual: prom, accion: 'Evaluar aplicación de tratamiento' });
+    } else if (prom >= 20) {
+      insights.push({ tipo: 'atencion', titulo: `${plaga} elevada en ${lote}`, descripcion: `Incidencia promedio de ${prom.toFixed(1)}% — monitorear de cerca`, plaga, lote, incidenciaActual: prom, accion: 'Monitorear de cerca' });
     }
   });
 
+  // 8. Legacy tendencias for Gemini
+  const tendenciasMap = new Map<string, Map<string, number[]>>();
+  registros.forEach((m: any) => {
+    const fecha = m.fecha_monitoreo;
+    const plaga = m.plagas_enfermedades_catalogo?.nombre || 'Desconocida';
+    if (!tendenciasMap.has(fecha)) tendenciasMap.set(fecha, new Map());
+    const fm = tendenciasMap.get(fecha)!;
+    if (!fm.has(plaga)) fm.set(plaga, []);
+    fm.get(plaga)!.push(Number(m.incidencia) || 0);
+  });
+  const tendencias: any[] = [];
+  tendenciasMap.forEach((plagasMap, fecha) => {
+    plagasMap.forEach((incidencias, plagaNombre) => {
+      tendencias.push({ fecha, plagaNombre, incidenciaPromedio: avg(incidencias) });
+    });
+  });
+
+  const detalleLoteMap = new Map<string, any[]>();
+  regActuales.forEach((m: any) => {
+    const ln = m.lotes?.nombre || 'Sin lote';
+    if (!detalleLoteMap.has(ln)) detalleLoteMap.set(ln, []);
+    detalleLoteMap.get(ln)!.push({
+      subloteNombre: m.sublotes?.nombre || 'Sin sublote',
+      plagaNombre: m.plagas_enfermedades_catalogo?.nombre || 'Desconocida',
+      incidencia: Number(m.incidencia) || 0,
+      gravedad: m.gravedad_texto || 'Baja',
+      arboresAfectados: Number(m.arboles_afectados) || 0,
+      arboresMonitoreados: Number(m.arboles_monitoreados) || 0,
+    });
+  });
+  const detallePorLote = Array.from(detalleLoteMap.entries())
+    .map(([loteNombre, sublotes]) => ({ loteNombre, sublotes }))
+    .sort((a: any, b: any) => a.loteNombre.localeCompare(b.loteNombre));
+
   return {
-    tendencias,
-    detallePorLote,
+    fechaActual, fechaAnterior, avisoFechaDesactualizada,
+    resumenGlobal, vistasPorLote, vistasPorSublote,
     insights: insights.sort((a: any, b: any) => (b.incidenciaActual || 0) - (a.incidenciaActual || 0)).slice(0, 5),
-    fechasMonitoreo: ultimas3Fechas,
+    tendencias, detallePorLote, fechasMonitoreo: fechasQuery,
   };
 }
 
@@ -484,7 +596,7 @@ export async function fetchDatosReporteSemanalServidor(
     fetchMatrizJornales(supabase, semana.inicio, semana.fin),
     fetchAplicacionesPlaneadas(supabase),
     fetchAplicacionesActivas(supabase),
-    fetchDatosMonitoreo(supabase),
+    fetchDatosMonitoreo(supabase, semana),
   ]);
 
   return {


### PR DESCRIPTION
## Summary
Refactored the `fetchDatosMonitoreo` function to compare two monitoring observations (current and reference) instead of three, enabling trend analysis and better data visualization. The new structure provides a global summary view, per-lote comparisons, and per-sublote grids with trend indicators.

## Key Changes

### Data Fetching & Structure
- **Modified `fetchDatosMonitoreo` signature**: Now accepts `semana: RangoSemana` parameter to contextualize monitoring dates relative to the report week
- **Two-date comparison model**: 
  - `fechaActual`: Most recent observation within the report week (or up to 2 weeks prior)
  - `fechaAnterior`: The observation immediately before `fechaActual` (unrestricted lookback)
  - Includes `avisoFechaDesactualizada` warning when data is from a previous week
- **Guaranteed data completeness**: Now loads ALL lotes and sublotes from the database upfront, ensuring every lote/sublote appears in results even without monitoring data

### New Type System
- Added `TendenciaDir` type: `'subiendo' | 'bajando' | 'estable' | 'sin_referencia'`
- Added `CeldaComparativa`: Encapsulates actual value, reference value, and trend direction
- Added `ResumenPlagaGlobal`: Global summary row with average incidence, min/max across lotes, and trend
- Added `VistaLoteComparativa` & `PlagaLoteComparativa`: Per-lote view with comparative data
- Added `VistaSubloteComparativa`: Per-sublote grid view with plaga × sublote cells containing trend data

### Report Generation
- **Slide 1 (Resumen General)**: New table showing all pests with current incidence, range across lotes, and trend arrows
- **Slide 2 (Detalle por Lote)**: Updated to show per-lote pest comparisons with trend indicators
- **Slide 3 (Detalle por Sublote)**: Grid-based view with color-coded cells and trend arrows
- Added helper functions for trend visualization: `getTendenciaArrow()`, `getTendenciaColor()`, `formatTendenciaCell()`
- Added legend HTML for incidence color scale and trend indicators

### Backward Compatibility
- Retained legacy `tendencias` and `detallePorLote` fields for Gemini prompt compatibility
- Existing insights generation logic preserved
- Updated test mocks to support new multi-query pattern (lotes, sublotes, fechas, anterior, full monitoreos)

### Edge Function Updates
- Updated Supabase edge function `fetch-datos-reporte.ts` with identical refactoring
- Consistent implementation across client and server environments

## Implementation Details
- Trend calculation: Compares current vs. reference incidence; flags as "estable" if difference < 0.5%
- Pest prioritization: "Plagas de interés" (Monalonion, Ácaro, etc.) sorted first in all views
- Averaging: Incidences averaged per lote/sublote, then aggregated for global summary
- Empty state handling: Returns complete structure with `sinDatos: true` flags for lotes/sublotes without observations

https://claude.ai/code/session_01V2vem3xTQUEPJySFrXqspm