### PR TITLE
Add budget tracking and presupuesto module for Aguacate Hass

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -43,6 +43,7 @@ const GastosView = lazy(() => import('./components/finanzas/GastosView').then(m 
 const IngresosView = lazy(() => import('./components/finanzas/IngresosView').then(m => ({ default: m.IngresosView })));
 const ReportesView = lazy(() => import('./components/finanzas/ReportesView').then(m => ({ default: m.ReportesView })));
 const ConfiguracionFinanzas = lazy(() => import('./components/finanzas/ConfiguracionFinanzas').then(m => ({ default: m.ConfiguracionFinanzas })));
+const PresupuestoView = lazy(() => import('./components/finanzas/presupuesto/PresupuestoView').then(m => ({ default: m.PresupuestoView })));
 const ProduccionDashboard = lazy(() => import('./components/produccion/ProduccionDashboard').then(m => ({ default: m.ProduccionDashboard })));
 const ReportesDashboard = lazy(() => import('./components/reportes/ReportesDashboard').then(m => ({ default: m.ReportesDashboard })));
 const ReporteSemanalWizard = lazy(() => import('./components/reportes/ReporteSemanalWizard').then(m => ({ default: m.ReporteSemanalWizard })));
@@ -125,6 +126,7 @@ function LayoutRoutes() {
             <Route path="gastos" element={<GastosView />} />
             <Route path="ingresos" element={<IngresosView />} />
             <Route path="reportes" element={<ReportesView />} />
+            <Route path="presupuesto" element={<PresupuestoView />} />
             <Route path="configuracion" element={<ConfiguracionFinanzas />} />
           </Route>
 

--- a/src/__tests__/presupuesto.test.ts
+++ b/src/__tests__/presupuesto.test.ts
@@ -1,0 +1,221 @@
+import { describe, it, expect, beforeEach, vi } from 'vitest';
+
+// ── Mock Supabase ──────────────────────────────────────────────
+function createChainableMock(resolvedData: unknown = { data: [], error: null }) {
+  const chain: Record<string, unknown> = {};
+  const methods = ['select', 'eq', 'in', 'gte', 'lte', 'order', 'upsert'];
+  methods.forEach((method) => {
+    chain[method] = vi.fn(() => chain);
+  });
+  Object.defineProperty(chain, 'then', {
+    value: (resolve: (v: unknown) => void, reject: (v: unknown) => void) =>
+      Promise.resolve(resolvedData).then(resolve, reject),
+  });
+  return chain;
+}
+
+const mockFrom = vi.fn();
+const mockSupabase = { from: mockFrom };
+
+vi.mock('../utils/supabase/client', () => ({
+  getSupabase: () => mockSupabase,
+}));
+
+// Import the hook's exported utilities AFTER mocking
+import {
+  getQuarterRange,
+  buildPresupuestoData,
+} from '../components/finanzas/hooks/usePresupuestoData';
+
+import type {
+  PresupuestoRow,
+  PresupuestoCategoriaRow,
+  PresupuestoData,
+} from '../types/finanzas';
+
+// ── Tests ──────────────────────────────────────────────────────
+
+describe('getQuarterRange', () => {
+  it('returns correct date range for Q1', () => {
+    const { desde, hasta } = getQuarterRange(2026, 1);
+    expect(desde).toBe('2026-01-01');
+    expect(hasta).toBe('2026-03-31');
+  });
+
+  it('returns correct date range for Q2', () => {
+    const { desde, hasta } = getQuarterRange(2026, 2);
+    expect(desde).toBe('2026-04-01');
+    expect(hasta).toBe('2026-06-30');
+  });
+
+  it('returns correct date range for Q3', () => {
+    const { desde, hasta } = getQuarterRange(2025, 3);
+    expect(desde).toBe('2025-07-01');
+    expect(hasta).toBe('2025-09-30');
+  });
+
+  it('returns correct date range for Q4', () => {
+    const { desde, hasta } = getQuarterRange(2025, 4);
+    expect(desde).toBe('2025-10-01');
+    expect(hasta).toBe('2025-12-31');
+  });
+});
+
+describe('buildPresupuestoData', () => {
+  const cat1Id = 'cat-1';
+  const cat2Id = 'cat-2';
+  const con1Id = 'con-1';
+  const con2Id = 'con-2';
+  const con3Id = 'con-3'; // actuals only, no budget
+
+  const budgets = [
+    {
+      id: 'p-1',
+      concepto_id: con1Id,
+      categoria_id: cat1Id,
+      monto_anual: 200_000_000,
+      is_principal: true,
+      fin_categorias_gastos: { nombre: 'CONTROL_PLAGAS' },
+      fin_conceptos_gastos: { nombre: 'Insecticidas' },
+    },
+    {
+      id: 'p-2',
+      concepto_id: con2Id,
+      categoria_id: cat1Id,
+      monto_anual: 40_000_000,
+      is_principal: false,
+      fin_categorias_gastos: { nombre: 'CONTROL_PLAGAS' },
+      fin_conceptos_gastos: { nombre: 'Fungicidas' },
+    },
+  ];
+
+  // Actual gastos for selected Q (aggregated by concepto)
+  const actualsQ = [
+    { concepto_id: con1Id, categoria_id: cat1Id, total: 30_000_000 },
+    { concepto_id: con3Id, categoria_id: cat2Id, total: 5_000_000 }, // no budget
+  ];
+
+  // Same Q last year
+  const actualsQAnterior = [
+    { concepto_id: con1Id, categoria_id: cat1Id, total: 25_000_000 },
+  ];
+
+  // Full last year
+  const actualsAnioAnterior = [
+    { concepto_id: con1Id, categoria_id: cat1Id, total: 100_000_000 },
+    { concepto_id: con3Id, categoria_id: cat2Id, total: 20_000_000 },
+  ];
+
+  // concepto_id → categoria name mapping for unbudgeted items
+  const conceptoCatalog = [
+    { id: con3Id, categoria_id: cat2Id, nombre: 'Otros Gastos', fin_categorias_gastos: { nombre: 'OTROS' } },
+  ];
+
+  let result: PresupuestoData;
+
+  beforeEach(() => {
+    result = buildPresupuestoData(
+      budgets,
+      actualsQ,
+      actualsQAnterior,
+      actualsAnioAnterior,
+      conceptoCatalog,
+    );
+  });
+
+  it('creates a category for each unique categoria', () => {
+    expect(result.categorias).toHaveLength(2);
+    const names = result.categorias.map((c) => c.categoria_nombre);
+    expect(names).toContain('CONTROL_PLAGAS');
+    expect(names).toContain('OTROS');
+  });
+
+  it('includes budgeted conceptos even with zero actuals', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    expect(cp.conceptos).toHaveLength(2);
+    const fungicidas = cp.conceptos.find((r) => r.concepto_nombre === 'Fungicidas')!;
+    expect(fungicidas.monto_anual).toBe(40_000_000);
+    expect(fungicidas.actual_q).toBe(0);
+  });
+
+  it('includes unbudgeted conceptos that have actuals', () => {
+    const otros = result.categorias.find((c) => c.categoria_nombre === 'OTROS')!;
+    expect(otros.conceptos).toHaveLength(1);
+    const row = otros.conceptos[0];
+    expect(row.concepto_nombre).toBe('Otros Gastos');
+    expect(row.monto_anual).toBe(0);
+    expect(row.actual_q).toBe(5_000_000);
+  });
+
+  it('computes monto_trimestral as monto_anual / 4', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    const insecticidas = cp.conceptos.find((r) => r.concepto_nombre === 'Insecticidas')!;
+    expect(insecticidas.monto_trimestral).toBe(50_000_000);
+  });
+
+  it('computes ejecucion_vs_q as actual / trimestral', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    const insecticidas = cp.conceptos.find((r) => r.concepto_nombre === 'Insecticidas')!;
+    // 30M / 50M = 0.6 → 60%
+    expect(insecticidas.ejecucion_vs_q).toBe(60);
+  });
+
+  it('returns null ejecucion when budget is zero', () => {
+    const otros = result.categorias.find((c) => c.categoria_nombre === 'OTROS')!;
+    expect(otros.conceptos[0].ejecucion_vs_q).toBeNull();
+  });
+
+  it('computes variacion_yoy correctly', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    const insecticidas = cp.conceptos.find((r) => r.concepto_nombre === 'Insecticidas')!;
+    // (30M - 25M) / 25M = 0.2 → 20%
+    expect(insecticidas.variacion_yoy).toBe(20);
+  });
+
+  it('returns null variacion when Q anterior is zero', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    const fungicidas = cp.conceptos.find((r) => r.concepto_nombre === 'Fungicidas')!;
+    expect(fungicidas.variacion_yoy).toBeNull();
+  });
+
+  it('aggregates category totals from its conceptos', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    expect(cp.monto_anual).toBe(240_000_000); // 200M + 40M
+    expect(cp.monto_trimestral).toBe(60_000_000);
+    expect(cp.actual_q).toBe(30_000_000);
+  });
+
+  it('computes grand totals across all categories', () => {
+    expect(result.totals.monto_anual).toBe(240_000_000);
+    expect(result.totals.actual_q).toBe(35_000_000); // 30M + 5M
+    expect(result.totals.actual_q_anterior).toBe(25_000_000);
+    expect(result.totals.actual_anio_anterior).toBe(120_000_000); // 100M + 20M
+  });
+
+  it('computes pct_presupuesto correctly', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    const insecticidas = cp.conceptos.find((r) => r.concepto_nombre === 'Insecticidas')!;
+    // 200M / 240M total budget * 100 = 83.33
+    expect(insecticidas.pct_presupuesto).toBeCloseTo(83.33, 0);
+  });
+
+  it('computes pct_actual correctly', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    const insecticidas = cp.conceptos.find((r) => r.concepto_nombre === 'Insecticidas')!;
+    // 30M / 35M total actuals * 100 = 85.71
+    expect(insecticidas.pct_actual).toBeCloseTo(85.71, 0);
+  });
+
+  it('marks is_principal from budget data', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    const insecticidas = cp.conceptos.find((r) => r.concepto_nombre === 'Insecticidas')!;
+    const fungicidas = cp.conceptos.find((r) => r.concepto_nombre === 'Fungicidas')!;
+    expect(insecticidas.is_principal).toBe(true);
+    expect(fungicidas.is_principal).toBe(false);
+  });
+
+  it('sorts principal conceptos first within a category', () => {
+    const cp = result.categorias.find((c) => c.categoria_nombre === 'CONTROL_PLAGAS')!;
+    expect(cp.conceptos[0].is_principal).toBe(true);
+  });
+});

--- a/src/components/finanzas/components/FinanzasSubNav.tsx
+++ b/src/components/finanzas/components/FinanzasSubNav.tsx
@@ -4,6 +4,7 @@ import {
   TrendingDown,
   TrendingUp,
   FileBarChart,
+  Target,
   Settings
 } from 'lucide-react';
 
@@ -42,6 +43,13 @@ export function FinanzasSubNav() {
       subtitle: 'P&L y análisis',
       icon: FileBarChart,
       path: '/finanzas/reportes',
+    },
+    {
+      id: 'presupuesto',
+      label: 'Presupuesto',
+      subtitle: 'Control presupuestal',
+      icon: Target,
+      path: '/finanzas/presupuesto',
     },
     {
       id: 'configuracion',

--- a/src/components/finanzas/hooks/usePresupuestoData.ts
+++ b/src/components/finanzas/hooks/usePresupuestoData.ts
@@ -1,0 +1,329 @@
+import { useState } from 'react';
+import { getSupabase } from '@/utils/supabase/client';
+import type {
+  Presupuesto,
+  PresupuestoRow,
+  PresupuestoCategoriaRow,
+  PresupuestoData,
+} from '@/types/finanzas';
+
+// ── Quarter helpers (exported for testing) ─────────────────────
+
+const QUARTER_MONTHS: Record<number, [number, number, number, number]> = {
+  1: [1, 1, 3, 31],
+  2: [4, 1, 6, 30],
+  3: [7, 1, 9, 30],
+  4: [10, 1, 12, 31],
+};
+
+export function getQuarterRange(anio: number, q: number): { desde: string; hasta: string } {
+  const [startM, startD, endM, endD] = QUARTER_MONTHS[q];
+  const pad = (n: number) => String(n).padStart(2, '0');
+  return {
+    desde: `${anio}-${pad(startM)}-${pad(startD)}`,
+    hasta: `${anio}-${pad(endM)}-${pad(endD)}`,
+  };
+}
+
+// ── Pure data builder (exported for testing) ───────────────────
+
+interface RawBudget {
+  id: string;
+  concepto_id: string;
+  categoria_id: string;
+  monto_anual: number;
+  is_principal: boolean;
+  fin_categorias_gastos: { nombre: string };
+  fin_conceptos_gastos: { nombre: string };
+}
+
+interface ActualAggregate {
+  concepto_id: string;
+  categoria_id: string;
+  total: number;
+}
+
+interface ConceptoCatalogEntry {
+  id: string;
+  categoria_id: string;
+  nombre: string;
+  fin_categorias_gastos: { nombre: string };
+}
+
+function variacion(actual: number, anterior: number): number | null {
+  if (anterior === 0) return null;
+  return Math.round(((actual - anterior) / anterior) * 100);
+}
+
+export function buildPresupuestoData(
+  budgets: RawBudget[],
+  actualsQ: ActualAggregate[],
+  actualsQAnterior: ActualAggregate[],
+  actualsAnioAnterior: ActualAggregate[],
+  conceptoCatalog: ConceptoCatalogEntry[],
+): PresupuestoData {
+  // Build maps for fast lookup
+  const actualQMap = new Map(actualsQ.map((a) => [a.concepto_id, a.total]));
+  const actualQAntMap = new Map(actualsQAnterior.map((a) => [a.concepto_id, a.total]));
+  const actualAnioAntMap = new Map(actualsAnioAnterior.map((a) => [a.concepto_id, a.total]));
+
+  // Map concepto_id → PresupuestoRow
+  const rowMap = new Map<string, PresupuestoRow>();
+
+  // 1. Budgeted conceptos
+  for (const b of budgets) {
+    const trimestral = b.monto_anual / 4;
+    const aq = actualQMap.get(b.concepto_id) ?? 0;
+    const aqAnt = actualQAntMap.get(b.concepto_id) ?? 0;
+    const aAnioAnt = actualAnioAntMap.get(b.concepto_id) ?? 0;
+
+    rowMap.set(b.concepto_id, {
+      categoria_id: b.categoria_id,
+      categoria_nombre: b.fin_categorias_gastos.nombre,
+      concepto_id: b.concepto_id,
+      concepto_nombre: b.fin_conceptos_gastos.nombre,
+      is_principal: b.is_principal,
+      presupuesto_id: b.id,
+      monto_anual: b.monto_anual,
+      monto_trimestral: trimestral,
+      pct_presupuesto: 0, // computed after totals
+      actual_q: aq,
+      pct_actual: 0, // computed after totals
+      ejecucion_vs_q: trimestral > 0 ? Math.round((aq / trimestral) * 100) : null,
+      ejecucion_vs_anio: b.monto_anual > 0 ? Math.round((aq / b.monto_anual) * 100) : null,
+      actual_q_anterior: aqAnt,
+      variacion_yoy: variacion(aq, aqAnt),
+      actual_anio_anterior: aAnioAnt,
+    });
+  }
+
+  // 2. Unbudgeted conceptos with actuals
+  const allActualConceptos = new Set([
+    ...actualsQ.map((a) => a.concepto_id),
+    ...actualsQAnterior.map((a) => a.concepto_id),
+    ...actualsAnioAnterior.map((a) => a.concepto_id),
+  ]);
+
+  for (const conceptoId of allActualConceptos) {
+    if (rowMap.has(conceptoId)) continue;
+
+    // Look up concepto in catalog
+    const catalogEntry = conceptoCatalog.find((c) => c.id === conceptoId);
+    if (!catalogEntry) continue;
+
+    // Also check actuals for categoria_id
+    const actualEntry =
+      actualsQ.find((a) => a.concepto_id === conceptoId) ??
+      actualsQAnterior.find((a) => a.concepto_id === conceptoId) ??
+      actualsAnioAnterior.find((a) => a.concepto_id === conceptoId);
+
+    const catId = catalogEntry.categoria_id ?? actualEntry?.categoria_id ?? '';
+    const aq = actualQMap.get(conceptoId) ?? 0;
+    const aqAnt = actualQAntMap.get(conceptoId) ?? 0;
+    const aAnioAnt = actualAnioAntMap.get(conceptoId) ?? 0;
+
+    rowMap.set(conceptoId, {
+      categoria_id: catId,
+      categoria_nombre: catalogEntry.fin_categorias_gastos.nombre,
+      concepto_id: conceptoId,
+      concepto_nombre: catalogEntry.nombre,
+      is_principal: false,
+      monto_anual: 0,
+      monto_trimestral: 0,
+      pct_presupuesto: 0,
+      actual_q: aq,
+      pct_actual: 0,
+      ejecucion_vs_q: null,
+      ejecucion_vs_anio: null,
+      actual_q_anterior: aqAnt,
+      variacion_yoy: variacion(aq, aqAnt),
+      actual_anio_anterior: aAnioAnt,
+    });
+  }
+
+  // 3. Compute grand totals
+  const allRows = Array.from(rowMap.values());
+  const totalBudget = allRows.reduce((s, r) => s + r.monto_anual, 0);
+  const totalActual = allRows.reduce((s, r) => s + r.actual_q, 0);
+
+  // 4. Compute percentages
+  for (const r of allRows) {
+    r.pct_presupuesto = totalBudget > 0 ? (r.monto_anual / totalBudget) * 100 : 0;
+    r.pct_actual = totalActual > 0 ? (r.actual_q / totalActual) * 100 : 0;
+  }
+
+  // 5. Group by categoria
+  const catMap = new Map<string, PresupuestoRow[]>();
+  for (const r of allRows) {
+    const key = r.categoria_id;
+    if (!catMap.has(key)) catMap.set(key, []);
+    catMap.get(key)!.push(r);
+  }
+
+  const categorias: PresupuestoCategoriaRow[] = [];
+  for (const [catId, conceptos] of catMap) {
+    // Sort: principal first, then alphabetically
+    conceptos.sort((a, b) => {
+      if (a.is_principal !== b.is_principal) return a.is_principal ? -1 : 1;
+      return a.concepto_nombre.localeCompare(b.concepto_nombre);
+    });
+
+    const catAnual = conceptos.reduce((s, r) => s + r.monto_anual, 0);
+    const catTrimestral = conceptos.reduce((s, r) => s + r.monto_trimestral, 0);
+    const catActualQ = conceptos.reduce((s, r) => s + r.actual_q, 0);
+    const catActualQAnt = conceptos.reduce((s, r) => s + r.actual_q_anterior, 0);
+    const catActualAnioAnt = conceptos.reduce((s, r) => s + r.actual_anio_anterior, 0);
+
+    categorias.push({
+      categoria_id: catId,
+      categoria_nombre: conceptos[0].categoria_nombre,
+      conceptos,
+      monto_anual: catAnual,
+      monto_trimestral: catTrimestral,
+      actual_q: catActualQ,
+      pct_presupuesto: totalBudget > 0 ? (catAnual / totalBudget) * 100 : 0,
+      pct_actual: totalActual > 0 ? (catActualQ / totalActual) * 100 : 0,
+      ejecucion_vs_q: catTrimestral > 0 ? Math.round((catActualQ / catTrimestral) * 100) : null,
+      ejecucion_vs_anio: catAnual > 0 ? Math.round((catActualQ / catAnual) * 100) : null,
+      actual_q_anterior: catActualQAnt,
+      variacion_yoy: variacion(catActualQ, catActualQAnt),
+      actual_anio_anterior: catActualAnioAnt,
+    });
+  }
+
+  // Sort categories alphabetically
+  categorias.sort((a, b) => a.categoria_nombre.localeCompare(b.categoria_nombre));
+
+  // Grand totals
+  const totalTrimestral = totalBudget / 4;
+  const totalActualQAnt = allRows.reduce((s, r) => s + r.actual_q_anterior, 0);
+  const totalActualAnioAnt = allRows.reduce((s, r) => s + r.actual_anio_anterior, 0);
+
+  return {
+    categorias,
+    totals: {
+      monto_anual: totalBudget,
+      monto_trimestral: totalTrimestral,
+      actual_q: totalActual,
+      ejecucion_vs_q: totalTrimestral > 0 ? Math.round((totalActual / totalTrimestral) * 100) : null,
+      ejecucion_vs_anio: totalBudget > 0 ? Math.round((totalActual / totalBudget) * 100) : null,
+      actual_q_anterior: totalActualQAnt,
+      variacion_yoy: variacion(totalActual, totalActualQAnt),
+      actual_anio_anterior: totalActualAnioAnt,
+    },
+  };
+}
+
+// ── Supabase data fetcher ──────────────────────────────────────
+
+async function aggregateGastos(
+  negocioId: string,
+  desde: string,
+  hasta: string,
+): Promise<ActualAggregate[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('fin_gastos')
+    .select('concepto_id, categoria_id, valor')
+    .eq('negocio_id', negocioId)
+    .eq('estado', 'Confirmado')
+    .gte('fecha', desde)
+    .lte('fecha', hasta);
+
+  if (error || !data) return [];
+
+  // Aggregate by concepto
+  const map = new Map<string, ActualAggregate>();
+  for (const row of data as Array<{ concepto_id: string; categoria_id: string; valor: number }>) {
+    const existing = map.get(row.concepto_id);
+    if (existing) {
+      existing.total += Number(row.valor);
+    } else {
+      map.set(row.concepto_id, {
+        concepto_id: row.concepto_id,
+        categoria_id: row.categoria_id,
+        total: Number(row.valor),
+      });
+    }
+  }
+  return Array.from(map.values());
+}
+
+// ── Main hook ──────────────────────────────────────────────────
+
+export function usePresupuestoData() {
+  const [loading, setLoading] = useState(false);
+
+  async function fetchPresupuesto(
+    anio: number,
+    trimestre: number,
+    negocioId: string,
+  ): Promise<PresupuestoData> {
+    setLoading(true);
+    try {
+      const supabase = getSupabase();
+      const qRange = getQuarterRange(anio, trimestre);
+      const qAntRange = getQuarterRange(anio - 1, trimestre);
+      const anioAntRange = { desde: `${anio - 1}-01-01`, hasta: `${anio - 1}-12-31` };
+
+      // Parallel queries
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- fin_presupuestos not yet in generated DB types
+      const sb = supabase as any;
+      const [budgetsRes, actualsQ, actualsQAnt, actualsAnioAnt, conceptosRes] = await Promise.all([
+        sb
+          .from('fin_presupuestos')
+          .select('id, concepto_id, categoria_id, monto_anual, is_principal, fin_categorias_gastos(nombre), fin_conceptos_gastos(nombre)')
+          .eq('anio', anio)
+          .eq('negocio_id', negocioId),
+        aggregateGastos(negocioId, qRange.desde, qRange.hasta),
+        aggregateGastos(negocioId, qAntRange.desde, qAntRange.hasta),
+        aggregateGastos(negocioId, anioAntRange.desde, anioAntRange.hasta),
+        supabase
+          .from('fin_conceptos_gastos')
+          .select('id, categoria_id, nombre, fin_categorias_gastos(nombre)')
+          .eq('activo', true),
+      ]);
+
+      const budgets = (budgetsRes.data ?? []) as unknown as RawBudget[];
+      const conceptoCatalog = (conceptosRes.data ?? []) as unknown as ConceptoCatalogEntry[];
+
+      return buildPresupuestoData(budgets, actualsQ, actualsQAnt, actualsAnioAnt, conceptoCatalog);
+    } finally {
+      setLoading(false);
+    }
+  }
+
+  async function upsertPresupuesto(data: {
+    anio: number;
+    negocio_id: string;
+    categoria_id: string;
+    concepto_id: string;
+    monto_anual: number;
+    is_principal?: boolean;
+  }): Promise<Presupuesto | null> {
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any -- fin_presupuestos not yet in generated DB types
+    const supabase = getSupabase() as any;
+    const { data: result, error } = await supabase
+      .from('fin_presupuestos')
+      .upsert(
+        {
+          anio: data.anio,
+          negocio_id: data.negocio_id,
+          categoria_id: data.categoria_id,
+          concepto_id: data.concepto_id,
+          monto_anual: data.monto_anual,
+          is_principal: data.is_principal ?? false,
+        },
+        { onConflict: 'anio,negocio_id,concepto_id' },
+      )
+      .select();
+
+    if (error) {
+      console.error('Error upserting presupuesto:', error);
+      return null;
+    }
+    return (result as unknown as Presupuesto[])?.[0] ?? null;
+  }
+
+  return { loading, fetchPresupuesto, upsertPresupuesto };
+}

--- a/src/components/finanzas/presupuesto/EjecucionBadge.tsx
+++ b/src/components/finanzas/presupuesto/EjecucionBadge.tsx
@@ -1,0 +1,49 @@
+import { cn } from '@/components/ui/utils';
+
+interface EjecucionBadgeProps {
+  value: number | null;
+}
+
+export function EjecucionBadge({ value }: EjecucionBadgeProps) {
+  if (value === null || value === undefined) return null;
+
+  const label = `${value}%`;
+  const color =
+    value <= 80
+      ? 'bg-green-100 text-green-700'
+      : value <= 100
+        ? 'bg-yellow-100 text-yellow-700'
+        : 'bg-red-100 text-red-700';
+
+  return (
+    <span className={cn('inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold', color)}>
+      {label}
+    </span>
+  );
+}
+
+export function VariacionBadge({ value }: { value: number | null }) {
+  if (value === null || value === undefined) return null;
+
+  const label = (value > 0 ? '+' : '') + value + '%';
+  const color = value <= 0 ? 'bg-green-100 text-green-700' : 'bg-red-100 text-red-700';
+
+  return (
+    <span className={cn('inline-flex items-center px-2 py-0.5 rounded-full text-xs font-semibold', color)}>
+      {label}
+    </span>
+  );
+}
+
+export function StatusDot({ ejecucion }: { ejecucion: number | null }) {
+  const color =
+    ejecucion === null
+      ? 'bg-gray-300'
+      : ejecucion <= 80
+        ? 'bg-green-500'
+        : ejecucion <= 100
+          ? 'bg-yellow-500'
+          : 'bg-red-500';
+
+  return <span className={cn('inline-block w-2.5 h-2.5 rounded-full', color)} />;
+}

--- a/src/components/finanzas/presupuesto/PresupuestoCategoriaRow.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoCategoriaRow.tsx
@@ -1,0 +1,81 @@
+import { formatCompact } from '@/utils/format';
+import { EjecucionBadge, VariacionBadge, StatusDot } from './EjecucionBadge';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+import type { PresupuestoCategoriaRow as CatRow } from '@/types/finanzas';
+
+interface PresupuestoCategoriaRowProps {
+  categoria: CatRow;
+  expanded: boolean;
+  onToggle: () => void;
+  showPct: boolean;
+}
+
+export function PresupuestoCategoriaRow({ categoria, expanded, onToggle, showPct }: PresupuestoCategoriaRowProps) {
+  const exec = categoria.ejecucion_vs_q;
+  const bgColor =
+    exec === null
+      ? 'bg-green-50/80'
+      : exec <= 80
+        ? 'bg-green-50/80'
+        : exec <= 100
+          ? 'bg-yellow-50/80'
+          : 'bg-red-50/60';
+
+  const fmt = (v: number) => (v > 0 ? '$' + formatCompact(v) : '');
+  const Chevron = expanded ? ChevronDown : ChevronRight;
+
+  return (
+    <tr
+      className={cn('border-b border-gray-200 cursor-pointer text-xs font-semibold', bgColor)}
+      onClick={onToggle}
+    >
+      {/* Status dot */}
+      <td className="px-2 py-2.5 text-center">
+        <StatusDot ejecucion={exec} />
+      </td>
+
+      {/* Categoria name */}
+      <td className="pl-2 pr-3 py-2.5">
+        <div className="flex items-center gap-1.5">
+          <Chevron className="w-3.5 h-3.5 text-gray-500 flex-shrink-0" />
+          <span>{categoria.categoria_nombre}</span>
+        </div>
+      </td>
+
+      {/* Actual Q */}
+      <td className="px-3 py-2.5 text-right tabular-nums">{fmt(categoria.actual_q)}</td>
+
+      {/* Act % */}
+      {showPct && <td className="px-2 py-2.5 text-right text-gray-500 tabular-nums">{categoria.pct_actual > 0 ? Math.round(categoria.pct_actual) + '%' : ''}</td>}
+
+      {/* Ppto Q */}
+      <td className="px-3 py-2.5 text-right border-l border-gray-200/60 tabular-nums">{fmt(categoria.monto_trimestral)}</td>
+
+      {/* Ppto Año */}
+      <td className="px-3 py-2.5 text-right tabular-nums">{fmt(categoria.monto_anual)}</td>
+
+      {/* Ppto % */}
+      {showPct && <td className="px-2 py-2.5 text-right text-gray-500 tabular-nums">{categoria.pct_presupuesto > 0 ? Math.round(categoria.pct_presupuesto) + '%' : ''}</td>}
+
+      {/* Ejecución vs Q */}
+      <td className="px-3 py-2.5 text-center">
+        <EjecucionBadge value={exec} />
+      </td>
+
+      {/* Ejec vs Año */}
+      {showPct && <td className="px-3 py-2.5 text-center"><EjecucionBadge value={categoria.ejecucion_vs_anio} /></td>}
+
+      {/* Q Anterior */}
+      <td className="px-3 py-2.5 text-right border-l border-gray-200/60 tabular-nums">{fmt(categoria.actual_q_anterior)}</td>
+
+      {/* Var YoY */}
+      <td className="px-2 py-2.5 text-center">
+        <VariacionBadge value={categoria.variacion_yoy} />
+      </td>
+
+      {/* Total Anterior */}
+      <td className="px-3 py-2.5 text-right tabular-nums">{fmt(categoria.actual_anio_anterior)}</td>
+    </tr>
+  );
+}

--- a/src/components/finanzas/presupuesto/PresupuestoConceptoRow.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoConceptoRow.tsx
@@ -1,0 +1,105 @@
+import { useState, useRef } from 'react';
+import { formatCompact } from '@/utils/format';
+import { EjecucionBadge, VariacionBadge, StatusDot } from './EjecucionBadge';
+import type { PresupuestoRow } from '@/types/finanzas';
+
+interface PresupuestoConceptoRowProps {
+  row: PresupuestoRow;
+  showPct: boolean;
+  onBudgetChange: (conceptoId: string, categoriaId: string, newAmount: number) => void;
+}
+
+export function PresupuestoConceptoRow({ row, showPct, onBudgetChange }: PresupuestoConceptoRowProps) {
+  const [editing, setEditing] = useState(false);
+  const [editValue, setEditValue] = useState('');
+  const inputRef = useRef<HTMLInputElement>(null);
+
+  const handleStartEdit = () => {
+    setEditValue(row.monto_anual > 0 ? String(row.monto_anual) : '');
+    setEditing(true);
+    setTimeout(() => inputRef.current?.select(), 0);
+  };
+
+  const handleSave = () => {
+    setEditing(false);
+    const val = Number(editValue) || 0;
+    if (val !== row.monto_anual) {
+      onBudgetChange(row.concepto_id, row.categoria_id, val);
+    }
+  };
+
+  const handleKeyDown = (e: React.KeyboardEvent) => {
+    if (e.key === 'Enter') handleSave();
+    if (e.key === 'Escape') setEditing(false);
+  };
+
+  const fmt = (v: number) => (v > 0 ? '$' + formatCompact(v) : '');
+
+  return (
+    <tr className="border-b border-gray-100 hover:bg-gray-50/50 text-xs">
+      {/* Status dot */}
+      <td className="px-2 py-1.5 text-center">
+        <StatusDot ejecucion={row.ejecucion_vs_q} />
+      </td>
+
+      {/* Concepto name */}
+      <td className="pl-7 pr-3 py-1.5">
+        <span className={row.is_principal ? 'font-semibold text-foreground' : 'text-foreground'}>
+          {row.concepto_nombre}
+        </span>
+      </td>
+
+      {/* Actual Q */}
+      <td className="px-3 py-1.5 text-right tabular-nums">{fmt(row.actual_q)}</td>
+
+      {/* Act % (toggleable) */}
+      {showPct && <td className="px-2 py-1.5 text-right text-gray-400 tabular-nums">{row.pct_actual > 0 ? Math.round(row.pct_actual) + '%' : ''}</td>}
+
+      {/* Group separator + Ppto Q */}
+      <td className="px-3 py-1.5 text-right border-l border-gray-100 tabular-nums">{fmt(row.monto_trimestral)}</td>
+
+      {/* Ppto Año (editable) */}
+      <td className="px-2 py-1.5 text-right" onClick={!editing ? handleStartEdit : undefined}>
+        {editing ? (
+          <input
+            ref={inputRef}
+            type="number"
+            value={editValue}
+            onChange={(e) => setEditValue(e.target.value)}
+            onBlur={handleSave}
+            onKeyDown={handleKeyDown}
+            onWheel={(e) => e.currentTarget.blur()}
+            className="w-full text-right text-xs font-medium text-primary bg-green-50 border border-primary/30 rounded px-2 py-1 outline-none focus:ring-1 focus:ring-primary/50"
+            autoFocus
+          />
+        ) : (
+          <span className="inline-flex items-center gap-1 cursor-pointer px-2 py-1 rounded bg-green-50/60 border border-primary/20 text-primary font-medium tabular-nums hover:bg-green-50">
+            {fmt(row.monto_anual) || '—'}
+          </span>
+        )}
+      </td>
+
+      {/* Ppto % (toggleable) */}
+      {showPct && <td className="px-2 py-1.5 text-right text-gray-400 tabular-nums">{row.pct_presupuesto > 0 ? Math.round(row.pct_presupuesto) + '%' : ''}</td>}
+
+      {/* Ejecución vs Q */}
+      <td className="px-3 py-1.5 text-center">
+        <EjecucionBadge value={row.ejecucion_vs_q} />
+      </td>
+
+      {/* Ejec vs Año (toggleable) */}
+      {showPct && <td className="px-3 py-1.5 text-center"><EjecucionBadge value={row.ejecucion_vs_anio} /></td>}
+
+      {/* Group separator + Q Anterior */}
+      <td className="px-3 py-1.5 text-right border-l border-gray-100 tabular-nums">{fmt(row.actual_q_anterior)}</td>
+
+      {/* Var YoY */}
+      <td className="px-2 py-1.5 text-center">
+        <VariacionBadge value={row.variacion_yoy} />
+      </td>
+
+      {/* Total Anterior */}
+      <td className="px-3 py-1.5 text-right tabular-nums">{fmt(row.actual_anio_anterior)}</td>
+    </tr>
+  );
+}

--- a/src/components/finanzas/presupuesto/PresupuestoControls.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoControls.tsx
@@ -1,0 +1,80 @@
+import { cn } from '@/components/ui/utils';
+
+interface PresupuestoControlsProps {
+  anio: number;
+  trimestre: number;
+  onAnioChange: (anio: number) => void;
+  onTrimestreChange: (q: number) => void;
+  showPct: boolean;
+  onTogglePct: () => void;
+}
+
+export function PresupuestoControls({
+  anio,
+  trimestre,
+  onAnioChange,
+  onTrimestreChange,
+  showPct,
+  onTogglePct,
+}: PresupuestoControlsProps) {
+  const currentYear = new Date().getFullYear();
+  const years = [currentYear - 1, currentYear, currentYear + 1];
+
+  return (
+    <div className="flex items-center gap-6 bg-white rounded-lg border border-gray-200 px-4 py-3">
+      {/* Year selector */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-gray-500 font-medium">Año</span>
+        <select
+          value={anio}
+          onChange={(e) => onAnioChange(Number(e.target.value))}
+          className="text-sm font-medium border border-gray-200 rounded-md px-3 py-1.5 bg-white"
+        >
+          {years.map((y) => (
+            <option key={y} value={y}>{y}</option>
+          ))}
+        </select>
+      </div>
+
+      {/* Quarter pills */}
+      <div className="flex items-center gap-2">
+        <span className="text-sm text-gray-500 font-medium">Trimestre</span>
+        <div className="flex gap-1">
+          {[1, 2, 3, 4].map((q) => (
+            <button
+              key={q}
+              onClick={() => onTrimestreChange(q)}
+              className={cn(
+                'px-3.5 py-1.5 rounded-md text-sm font-semibold transition-colors',
+                q === trimestre
+                  ? 'bg-primary text-white'
+                  : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+              )}
+            >
+              Q{q}
+            </button>
+          ))}
+        </div>
+      </div>
+
+      {/* Spacer */}
+      <div className="flex-1" />
+
+      {/* Toggle % columns */}
+      <button
+        onClick={onTogglePct}
+        className={cn(
+          'text-xs font-medium px-3 py-1.5 rounded-md transition-colors',
+          showPct ? 'bg-primary/10 text-primary' : 'bg-gray-100 text-gray-500 hover:bg-gray-200',
+        )}
+      >
+        {showPct ? '− Ocultar %' : '+ Mostrar %'}
+      </button>
+
+      {/* Negocio badge */}
+      <span className="inline-flex items-center gap-1 px-3 py-1 rounded-full bg-green-50 text-primary text-xs font-semibold">
+        Aguacate Hass
+      </span>
+    </div>
+  );
+}

--- a/src/components/finanzas/presupuesto/PresupuestoTable.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoTable.tsx
@@ -1,0 +1,137 @@
+import { useState } from 'react';
+import { formatCompact } from '@/utils/format';
+import { EjecucionBadge, VariacionBadge } from './EjecucionBadge';
+import { PresupuestoCategoriaRow } from './PresupuestoCategoriaRow';
+import { PresupuestoConceptoRow } from './PresupuestoConceptoRow';
+import type { PresupuestoData } from '@/types/finanzas';
+
+interface PresupuestoTableProps {
+  data: PresupuestoData;
+  showPct: boolean;
+  anio: number;
+  trimestre: number;
+  onBudgetChange: (conceptoId: string, categoriaId: string, newAmount: number) => void;
+}
+
+export function PresupuestoTable({ data, showPct, anio, trimestre, onBudgetChange }: PresupuestoTableProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggleCategory = (catId: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(catId)) next.delete(catId);
+      else next.add(catId);
+      return next;
+    });
+  };
+
+  const fmt = (v: number) => (v > 0 ? '$' + formatCompact(v) : '');
+  const t = data.totals;
+
+  // Column count varies with showPct toggle
+  const extraCols = showPct ? 3 : 0; // Act%, Ppto%, EjecAño
+
+  return (
+    <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
+      <table className="w-full text-left">
+        {/* Column group headers */}
+        <thead>
+          <tr className="bg-gray-50/80 text-[10px] font-semibold tracking-wider uppercase">
+            <th colSpan={showPct ? 4 : 3} className="px-3 py-1.5 text-gray-400">
+              Actual
+            </th>
+            <th colSpan={showPct ? 4 : 3} className="px-3 py-1.5 text-primary border-l border-gray-100">
+              Presupuesto
+            </th>
+            <th colSpan={3} className="px-3 py-1.5 text-gray-400 border-l border-gray-100">
+              Comparativo año anterior
+            </th>
+          </tr>
+
+          {/* Column headers */}
+          <tr className="bg-gray-50 text-[11px] font-semibold text-gray-500 border-b border-gray-200">
+            <th className="w-8 px-2 py-2"></th>
+            <th className="px-3 py-2">Concepto</th>
+            <th className="px-3 py-2 text-right">Actual Q{trimestre}</th>
+            {showPct && <th className="px-2 py-2 text-right">Act %</th>}
+            <th className="px-3 py-2 text-right border-l border-gray-100">Ppto Q</th>
+            <th className="px-3 py-2 text-right">Ppto Año ✏️</th>
+            {showPct && <th className="px-2 py-2 text-right">Ppto %</th>}
+            <th className="px-3 py-2 text-center">Ejecución</th>
+            {showPct && <th className="px-3 py-2 text-center">Ejec Año</th>}
+            <th className="px-3 py-2 text-right border-l border-gray-100">Q{trimestre} {anio - 1}</th>
+            <th className="px-2 py-2 text-center">Var YoY</th>
+            <th className="px-3 py-2 text-right">Total {anio - 1}</th>
+          </tr>
+        </thead>
+
+        <tbody>
+          {/* Grand total row */}
+          <tr className="bg-primary text-white text-xs font-semibold">
+            <td className="px-2 py-2.5"></td>
+            <td className="px-3 py-2.5">Suma Total</td>
+            <td className="px-3 py-2.5 text-right tabular-nums">{fmt(t.actual_q)}</td>
+            {showPct && <td className="px-2 py-2.5 text-right">100%</td>}
+            <td className="px-3 py-2.5 text-right tabular-nums">{fmt(t.monto_trimestral)}</td>
+            <td className="px-3 py-2.5 text-right tabular-nums">{fmt(t.monto_anual)}</td>
+            {showPct && <td className="px-2 py-2.5 text-right">100%</td>}
+            <td className="px-3 py-2.5 text-center">{t.ejecucion_vs_q !== null ? t.ejecucion_vs_q + '%' : ''}</td>
+            {showPct && <td className="px-3 py-2.5 text-center">{t.ejecucion_vs_anio !== null ? t.ejecucion_vs_anio + '%' : ''}</td>}
+            <td className="px-3 py-2.5 text-right tabular-nums">{fmt(t.actual_q_anterior)}</td>
+            <td className="px-2 py-2.5 text-center">{t.variacion_yoy !== null ? (t.variacion_yoy > 0 ? '+' : '') + t.variacion_yoy + '%' : ''}</td>
+            <td className="px-3 py-2.5 text-right tabular-nums">{fmt(t.actual_anio_anterior)}</td>
+          </tr>
+
+          {/* Categories + conceptos */}
+          {data.categorias.map((cat) => {
+            const isExpanded = expanded.has(cat.categoria_id);
+            return (
+              <PresupuestoCategoryGroup
+                key={cat.categoria_id}
+                categoria={cat}
+                expanded={isExpanded}
+                onToggle={() => toggleCategory(cat.categoria_id)}
+                showPct={showPct}
+                onBudgetChange={onBudgetChange}
+              />
+            );
+          })}
+        </tbody>
+      </table>
+    </div>
+  );
+}
+
+function PresupuestoCategoryGroup({
+  categoria,
+  expanded,
+  onToggle,
+  showPct,
+  onBudgetChange,
+}: {
+  categoria: PresupuestoData['categorias'][0];
+  expanded: boolean;
+  onToggle: () => void;
+  showPct: boolean;
+  onBudgetChange: (conceptoId: string, categoriaId: string, newAmount: number) => void;
+}) {
+  return (
+    <>
+      <PresupuestoCategoriaRow
+        categoria={categoria}
+        expanded={expanded}
+        onToggle={onToggle}
+        showPct={showPct}
+      />
+      {expanded &&
+        categoria.conceptos.map((row) => (
+          <PresupuestoConceptoRow
+            key={row.concepto_id}
+            row={row}
+            showPct={showPct}
+            onBudgetChange={onBudgetChange}
+          />
+        ))}
+    </>
+  );
+}

--- a/src/components/finanzas/presupuesto/PresupuestoView.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoView.tsx
@@ -1,0 +1,151 @@
+import { useState, useEffect, useCallback } from 'react';
+import { RoleGuard } from '@/components/auth/RoleGuard';
+import { FinanzasSubNav } from '@/components/finanzas/components/FinanzasSubNav';
+import { PresupuestoControls } from './PresupuestoControls';
+import { PresupuestoTable } from './PresupuestoTable';
+import { StatusDot } from './EjecucionBadge';
+import { usePresupuestoData } from '@/components/finanzas/hooks/usePresupuestoData';
+import { getSupabase } from '@/utils/supabase/client';
+import { Loader2 } from 'lucide-react';
+import { toast } from 'sonner';
+import type { PresupuestoData } from '@/types/finanzas';
+
+function getCurrentQuarter(): number {
+  return Math.ceil((new Date().getMonth() + 1) / 3);
+}
+
+export function PresupuestoView() {
+  const currentYear = new Date().getFullYear();
+  const [anio, setAnio] = useState(currentYear);
+  const [trimestre, setTrimestre] = useState(getCurrentQuarter());
+  const [showPct, setShowPct] = useState(false);
+  const [negocioId, setNegocioId] = useState<string | null>(null);
+  const [data, setData] = useState<PresupuestoData | null>(null);
+
+  const { loading, fetchPresupuesto, upsertPresupuesto } = usePresupuestoData();
+
+  // Resolve Aguacate Hass negocio_id on mount
+  useEffect(() => {
+    async function resolveNegocio() {
+      const supabase = getSupabase();
+      const { data } = await supabase
+        .from('fin_negocios')
+        .select('id')
+        .eq('nombre', 'Aguacate Hass')
+        .eq('activo', true);
+      if (data && data.length > 0) {
+        setNegocioId((data as Array<{ id: string }>)[0].id);
+      }
+    }
+    resolveNegocio();
+  }, []);
+
+  // Fetch data when params change
+  const loadData = useCallback(async () => {
+    if (!negocioId) return;
+    const result = await fetchPresupuesto(anio, trimestre, negocioId);
+    setData(result);
+  }, [anio, trimestre, negocioId, fetchPresupuesto]);
+
+  useEffect(() => {
+    loadData();
+  }, [loadData]);
+
+  const handleBudgetChange = async (conceptoId: string, categoriaId: string, newAmount: number) => {
+    if (!negocioId) return;
+
+    // Optimistic update
+    if (data) {
+      setData((prev) => {
+        if (!prev) return prev;
+        // Deep clone and update
+        const next = JSON.parse(JSON.stringify(prev)) as PresupuestoData;
+        for (const cat of next.categorias) {
+          for (const row of cat.conceptos) {
+            if (row.concepto_id === conceptoId) {
+              row.monto_anual = newAmount;
+              row.monto_trimestral = newAmount / 4;
+              row.ejecucion_vs_q = newAmount > 0 ? Math.round((row.actual_q / (newAmount / 4)) * 100) : null;
+              row.ejecucion_vs_anio = newAmount > 0 ? Math.round((row.actual_q / newAmount) * 100) : null;
+            }
+          }
+        }
+        return next;
+      });
+    }
+
+    const result = await upsertPresupuesto({
+      anio,
+      negocio_id: negocioId,
+      categoria_id: categoriaId,
+      concepto_id: conceptoId,
+      monto_anual: newAmount,
+    });
+
+    if (result) {
+      toast.success('Presupuesto actualizado');
+    } else {
+      toast.error('Error al guardar presupuesto');
+      loadData(); // Revert on failure
+    }
+  };
+
+  return (
+    <RoleGuard allowedRoles={['Gerencia']}>
+      <FinanzasSubNav />
+
+      <div className="space-y-5">
+        {/* Header */}
+        <div>
+          <h1 className="text-2xl font-bold text-foreground">Presupuesto</h1>
+          <p className="text-sm text-gray-500">
+            Aguacate Hass — Control presupuestal por categoría y concepto
+          </p>
+        </div>
+
+        {/* Controls */}
+        <PresupuestoControls
+          anio={anio}
+          trimestre={trimestre}
+          onAnioChange={setAnio}
+          onTrimestreChange={setTrimestre}
+          showPct={showPct}
+          onTogglePct={() => setShowPct((v) => !v)}
+        />
+
+        {/* Table */}
+        {loading && !data ? (
+          <div className="flex items-center justify-center py-20">
+            <Loader2 className="w-6 h-6 animate-spin text-primary" />
+            <span className="ml-2 text-sm text-gray-500">Cargando presupuesto...</span>
+          </div>
+        ) : data ? (
+          <PresupuestoTable
+            data={data}
+            showPct={showPct}
+            anio={anio}
+            trimestre={trimestre}
+            onBudgetChange={handleBudgetChange}
+          />
+        ) : (
+          <div className="text-center py-20 text-gray-400 text-sm">
+            No se encontró el negocio Aguacate Hass
+          </div>
+        )}
+
+        {/* Legend */}
+        <div className="flex items-center gap-6 text-xs text-gray-400">
+          <div className="flex items-center gap-4">
+            <div className="flex items-center gap-1.5"><StatusDot ejecucion={50} /> <span>≤80%</span></div>
+            <div className="flex items-center gap-1.5"><StatusDot ejecucion={90} /> <span>80-100%</span></div>
+            <div className="flex items-center gap-1.5"><StatusDot ejecucion={120} /> <span>&gt;100%</span></div>
+          </div>
+          <div className="flex items-center gap-1.5">
+            <span className="inline-block w-3 h-3 rounded-sm bg-green-50 border border-primary/20" />
+            <span>Celda editable</span>
+          </div>
+        </div>
+      </div>
+    </RoleGuard>
+  );
+}

--- a/src/sql/migrations/034_create_fin_presupuestos.sql
+++ b/src/sql/migrations/034_create_fin_presupuestos.sql
@@ -1,0 +1,37 @@
+-- Migration 034: Create fin_presupuestos table for budget tracking
+-- One budget row per year + negocio + concepto
+
+CREATE TABLE IF NOT EXISTS fin_presupuestos (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  anio INTEGER NOT NULL,
+  negocio_id UUID NOT NULL REFERENCES fin_negocios(id),
+  categoria_id UUID NOT NULL REFERENCES fin_categorias_gastos(id),
+  concepto_id UUID NOT NULL REFERENCES fin_conceptos_gastos(id),
+  monto_anual NUMERIC(15,2) NOT NULL DEFAULT 0,
+  is_principal BOOLEAN NOT NULL DEFAULT false,
+  created_at TIMESTAMPTZ DEFAULT NOW(),
+  updated_at TIMESTAMPTZ DEFAULT NOW(),
+  created_by UUID REFERENCES auth.users(id),
+  updated_by UUID REFERENCES auth.users(id),
+  CONSTRAINT fin_presupuestos_unique UNIQUE (anio, negocio_id, concepto_id)
+);
+
+CREATE INDEX idx_fin_presupuestos_anio_negocio ON fin_presupuestos(anio, negocio_id);
+CREATE INDEX idx_fin_presupuestos_concepto ON fin_presupuestos(concepto_id);
+
+-- Trigger for updated_at (reuse existing function)
+CREATE TRIGGER update_fin_presupuestos_updated_at
+  BEFORE UPDATE ON fin_presupuestos
+  FOR EACH ROW EXECUTE FUNCTION update_updated_at_column();
+
+-- RLS (Gerencia only, same pattern as fin_transacciones_ganado)
+ALTER TABLE fin_presupuestos ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY fin_presupuestos_select ON fin_presupuestos FOR SELECT
+  USING (EXISTS (SELECT 1 FROM usuarios u WHERE u.id = auth.uid() AND u.rol = 'Gerencia'::rol_usuario));
+CREATE POLICY fin_presupuestos_insert ON fin_presupuestos FOR INSERT
+  WITH CHECK (EXISTS (SELECT 1 FROM usuarios u WHERE u.id = auth.uid() AND u.rol = 'Gerencia'::rol_usuario));
+CREATE POLICY fin_presupuestos_update ON fin_presupuestos FOR UPDATE
+  USING (EXISTS (SELECT 1 FROM usuarios u WHERE u.id = auth.uid() AND u.rol = 'Gerencia'::rol_usuario));
+CREATE POLICY fin_presupuestos_delete ON fin_presupuestos FOR DELETE
+  USING (EXISTS (SELECT 1 FROM usuarios u WHERE u.id = auth.uid() AND u.rol = 'Gerencia'::rol_usuario));

--- a/src/types/finanzas.ts
+++ b/src/types/finanzas.ts
@@ -356,3 +356,72 @@ export interface BatchRowDataIngreso {
   factura_file: File | null;
   factura_uploaded: boolean;
 }
+
+// ── Budget (Presupuesto) ─────────────────────────────────────────
+
+/** DB row in fin_presupuestos */
+export interface Presupuesto {
+  id: string;
+  anio: number;
+  negocio_id: string;
+  categoria_id: string;
+  concepto_id: string;
+  monto_anual: number;
+  is_principal: boolean;
+  created_at: string;
+  updated_at: string;
+  created_by?: string;
+  updated_by?: string;
+}
+
+/** Concepto-level row in the budget comparison table */
+export interface PresupuestoRow {
+  categoria_id: string;
+  categoria_nombre: string;
+  concepto_id: string;
+  concepto_nombre: string;
+  is_principal: boolean;
+  presupuesto_id?: string;
+  monto_anual: number;
+  monto_trimestral: number;
+  pct_presupuesto: number;
+  actual_q: number;
+  pct_actual: number;
+  ejecucion_vs_q: number | null;
+  ejecucion_vs_anio: number | null;
+  actual_q_anterior: number;
+  variacion_yoy: number | null;
+  actual_anio_anterior: number;
+}
+
+/** Category aggregate row */
+export interface PresupuestoCategoriaRow {
+  categoria_id: string;
+  categoria_nombre: string;
+  conceptos: PresupuestoRow[];
+  monto_anual: number;
+  monto_trimestral: number;
+  actual_q: number;
+  pct_presupuesto: number;
+  pct_actual: number;
+  ejecucion_vs_q: number | null;
+  ejecucion_vs_anio: number | null;
+  actual_q_anterior: number;
+  variacion_yoy: number | null;
+  actual_anio_anterior: number;
+}
+
+/** Full page data returned by usePresupuestoData */
+export interface PresupuestoData {
+  categorias: PresupuestoCategoriaRow[];
+  totals: {
+    monto_anual: number;
+    monto_trimestral: number;
+    actual_q: number;
+    ejecucion_vs_q: number | null;
+    ejecucion_vs_anio: number | null;
+    actual_q_anterior: number;
+    variacion_yoy: number | null;
+    actual_anio_anterior: number;
+  };
+}


### PR DESCRIPTION
## Summary
Implements a complete budget (presupuesto) tracking system for the Aguacate Hass business unit, enabling quarterly budget planning, execution monitoring, and year-over-year comparisons.

## Key Changes

### Data Layer
- **New hook `usePresupuestoData`**: Fetches and aggregates budget data from Supabase, combining:
  - Budget allocations from `fin_presupuestos` table
  - Actual expenses from `fin_gastos` for current quarter, prior quarter, and prior year
  - Concept catalog for unbudgeted items with actuals
- **Pure data builder `buildPresupuestoData`**: Transforms raw data into hierarchical structure with computed metrics (execution %, YoY variation, percentages)
- **Quarter range helper `getQuarterRange`**: Calculates date ranges for quarters across years
- **Database migration**: Creates `fin_presupuestos` table with unique constraint on (year, business, concept) and RLS policies for Gerencia role

### UI Components
- **`PresupuestoView`**: Main page with role-based access (Gerencia only), year/quarter selection, and data loading
- **`PresupuestoTable`**: Expandable category-level table with grand totals row
- **`PresupuestoCategoriaRow`**: Category aggregate row with chevron toggle and color-coded execution status
- **`PresupuestoConceptoRow`**: Concept-level row with inline editing for annual budget amounts
- **`PresupuestoControls`**: Year selector, quarter pills, percentage toggle, and business badge
- **`EjecucionBadge`, `VariacionBadge`, `StatusDot`**: Reusable badge components for execution %, YoY variation, and status indicators

### Features
- **Editable budgets**: Click to edit annual budget amounts with optimistic UI updates
- **Execution tracking**: Displays execution % vs quarterly budget and annual budget
- **YoY comparison**: Shows actual spending vs same quarter/period last year with variation %
- **Unbudgeted items**: Automatically includes concepts with actuals but no budget allocation
- **Toggleable columns**: Show/hide percentage columns for cleaner view
- **Color-coded status**: Green (≤80%), yellow (80-100%), red (>100%) execution levels
- **Hierarchical sorting**: Principal concepts first, then alphabetical within categories

### Testing
- Comprehensive test suite covering:
  - Quarter range calculations for all quarters
  - Data aggregation and transformation logic
  - Percentage and variation calculations
  - Category and concept grouping
  - Principal concept sorting

### Type Definitions
- Added `Presupuesto`, `PresupuestoRow`, `PresupuestoCategoriaRow`, and `PresupuestoData` types to finanzas module

### Navigation
- Added Presupuesto link to FinanzasSubNav with Target icon
- Integrated route in App.tsx

https://claude.ai/code/session_01ApNcfbkRNC4MmnGBGBcpRB