### PR TITLE
Fix lot cost calculation to use canonical assignment table

### DIFF
--- a/src/__tests__/esco-evals.test.ts
+++ b/src/__tests__/esco-evals.test.ts
@@ -204,8 +204,12 @@ describe('Phase 1B — execApplicationCostByLote (executor)', () => {
     expect(r).toMatch(/tarea_id=eq\./);
   });
 
-  it('queries aplicaciones_lotes_planificado for tree counts per lote', () => {
-    expect(region()).toContain('aplicaciones_lotes_planificado');
+  it('queries aplicaciones_lotes for tree counts per lote (canonical assignment table)', () => {
+    const r = region();
+    // Must read from aplicaciones_lotes, not the planning-only aplicaciones_lotes_planificado
+    // (which is empty for ad-hoc apps like drench / focos / edáficas registradas direct).
+    expect(r).toMatch(/'aplicaciones_lotes'/);
+    expect(r).not.toMatch(/'aplicaciones_lotes_planificado'/);
   });
 
   it('uses pure aggregation helpers from cost-aggregation module', () => {

--- a/src/supabase/functions/server/chat.tsx
+++ b/src/supabase/functions/server/chat.tsx
@@ -1421,13 +1421,15 @@ async function fetchPerLoteCostsForApplication(app: AplicacionRow) {
     )) as typeof registros;
   }
 
-  // Tree counts per lote (planned)
-  const lotesPlan = (await supabaseQuery(
-    'aplicaciones_lotes_planificado',
+  // Tree counts per lote — read the canonical lot-assignment table (aplicaciones_lotes).
+  // aplicaciones_lotes_planificado is only populated when the planning Calculadora is used,
+  // so ad-hoc apps (drench, focos, edáficas registradas direct) end up with zero rows there.
+  const lotesAsignados = (await supabaseQuery(
+    'aplicaciones_lotes',
     `select=lote_id,total_arboles,lote:lotes(id,nombre,total_arboles)&aplicacion_id=eq.${e(app.id)}&limit=200`,
   )) as Array<{ lote_id: string; total_arboles: number | string; lote: { id: string; nombre: string; total_arboles: number | string } | null }>;
 
-  const lotesInfo = lotesPlan
+  const lotesInfo = lotesAsignados
     .filter((row) => row.lote_id)
     .map((row) => ({
       id: row.lote_id,
@@ -1437,6 +1439,22 @@ async function fetchPerLoteCostsForApplication(app: AplicacionRow) {
 
   const insumosByLote = aggregateInsumosPorLote(movimientos, movProductos, precios);
   const jornalesByLote = aggregateJornalesPorLote(registros);
+
+  // Fallback: any lote that shows up only in movimientos / registros (e.g. focos applied
+  // to a lote not formally assigned) gets its name + tree count from the lotes master.
+  const knownIds = new Set(lotesInfo.map((l) => l.id));
+  const orphanIds = [...new Set([...insumosByLote.keys(), ...jornalesByLote.keys()])]
+    .filter((id) => !knownIds.has(id));
+  if (orphanIds.length) {
+    const orphans = (await supabaseQuery(
+      'lotes',
+      `select=id,nombre,total_arboles&id=in.(${orphanIds.join(',')})`,
+    )) as Array<{ id: string; nombre: string; total_arboles: number | string }>;
+    for (const o of orphans) {
+      lotesInfo.push({ id: o.id, nombre: o.nombre, total_arboles: Number(o.total_arboles) || 0 });
+    }
+  }
+
   return combineCostosPorLote(insumosByLote, jornalesByLote, lotesInfo);
 }
 

--- a/supabase/functions/make-server-1ccce916/chat.tsx
+++ b/supabase/functions/make-server-1ccce916/chat.tsx
@@ -1421,13 +1421,15 @@ async function fetchPerLoteCostsForApplication(app: AplicacionRow) {
     )) as typeof registros;
   }
 
-  // Tree counts per lote (planned)
-  const lotesPlan = (await supabaseQuery(
-    'aplicaciones_lotes_planificado',
+  // Tree counts per lote — read the canonical lot-assignment table (aplicaciones_lotes).
+  // aplicaciones_lotes_planificado is only populated when the planning Calculadora is used,
+  // so ad-hoc apps (drench, focos, edáficas registradas direct) end up with zero rows there.
+  const lotesAsignados = (await supabaseQuery(
+    'aplicaciones_lotes',
     `select=lote_id,total_arboles,lote:lotes(id,nombre,total_arboles)&aplicacion_id=eq.${e(app.id)}&limit=200`,
   )) as Array<{ lote_id: string; total_arboles: number | string; lote: { id: string; nombre: string; total_arboles: number | string } | null }>;
 
-  const lotesInfo = lotesPlan
+  const lotesInfo = lotesAsignados
     .filter((row) => row.lote_id)
     .map((row) => ({
       id: row.lote_id,
@@ -1437,6 +1439,22 @@ async function fetchPerLoteCostsForApplication(app: AplicacionRow) {
 
   const insumosByLote = aggregateInsumosPorLote(movimientos, movProductos, precios);
   const jornalesByLote = aggregateJornalesPorLote(registros);
+
+  // Fallback: any lote that shows up only in movimientos / registros (e.g. focos applied
+  // to a lote not formally assigned) gets its name + tree count from the lotes master.
+  const knownIds = new Set(lotesInfo.map((l) => l.id));
+  const orphanIds = [...new Set([...insumosByLote.keys(), ...jornalesByLote.keys()])]
+    .filter((id) => !knownIds.has(id));
+  if (orphanIds.length) {
+    const orphans = (await supabaseQuery(
+      'lotes',
+      `select=id,nombre,total_arboles&id=in.(${orphanIds.join(',')})`,
+    )) as Array<{ id: string; nombre: string; total_arboles: number | string }>;
+    for (const o of orphans) {
+      lotesInfo.push({ id: o.id, nombre: o.nombre, total_arboles: Number(o.total_arboles) || 0 });
+    }
+  }
+
   return combineCostosPorLote(insumosByLote, jornalesByLote, lotesInfo);
 }
 


### PR DESCRIPTION
## Summary
Fixed a bug in per-lot cost calculation where the function was querying the wrong database table, causing ad-hoc applications (drench, focos, edáficas registradas direct) to have missing lot information.

## Key Changes
- **Changed data source**: Switched from `aplicaciones_lotes_planificado` (planning-only table) to `aplicaciones_lotes` (canonical lot-assignment table)
  - `aplicaciones_lotes_planificado` is only populated when the planning Calculadora is used
  - Ad-hoc applications end up with zero rows in the planning table, breaking cost calculations
  
- **Added fallback logic**: Implemented orphan lot detection and resolution
  - Identifies lots that appear in cost/labor records but aren't in the formal assignment table
  - Fetches missing lot metadata (name, tree count) from the `lotes` master table
  - Ensures complete lot information even for informally-assigned lots

- **Updated test expectations**: Modified test to verify the correct table is queried and the planning table is not used

## Implementation Details
The fallback mechanism works by:
1. Tracking which lot IDs are known from the canonical assignment table
2. Finding any additional lot IDs that appear in aggregated costs or labor records
3. Querying the master `lotes` table for metadata on those orphan lots
4. Adding them to the lot info collection before final cost aggregation

This ensures cost calculations work correctly for all application types, not just planned applications.

https://claude.ai/code/session_015VbP4S4KXJXTXBugaYFLuN