### PR TITLE
feat(reportes): separate own vs. contractor jornales in weekly report (#46)

### DIFF
--- a/src/__tests__/generarReporteSemanal.test.ts
+++ b/src/__tests__/generarReporteSemanal.test.ts
@@ -47,6 +47,11 @@ const MOCK_DATOS_COMPLETOS = {
   },
   jornales: {
     actividades: ['Fumigación', 'Fertilización', 'Poda'],
+    filas: [
+      { nombre: 'Fertilización', tipo: 'Fertilización' },
+      { nombre: 'Fumigación', tipo: 'Fumigación' },
+      { nombre: 'Poda', tipo: 'Poda' },
+    ],
     lotes: ['Lote PP', 'Lote ST', 'Lote AU'],
     datos: {
       'Fumigación': {
@@ -72,6 +77,92 @@ const MOCK_DATOS_COMPLETOS = {
       'Lote AU': { jornales: 2.5, costo: 137500 },
     },
     totalGeneral: { jornales: 10.5, costo: 547500 },
+  },
+  labores: {
+    programadas: [],
+    matrizJornales: {
+      actividades: ['Fumigación', 'Fertilización', 'Poda'],
+      filas: [
+        { nombre: 'Fertilización', tipo: 'Fertilización' },
+        { nombre: 'Fumigación', tipo: 'Fumigación' },
+        { nombre: 'Poda', tipo: 'Poda' },
+      ],
+      lotes: ['Lote PP', 'Lote ST', 'Lote AU'],
+      datos: {
+        'Fumigación': {
+          'Lote PP': { jornales: 3.5, costo: 175000 },
+          'Lote ST': { jornales: 2.0, costo: 100000 },
+        },
+        'Fertilización': {
+          'Lote PP': { jornales: 1.0, costo: 60000 },
+          'Lote AU': { jornales: 2.5, costo: 137500 },
+        },
+        'Poda': {
+          'Lote ST': { jornales: 1.5, costo: 75000 },
+        },
+      },
+      totalesPorActividad: {
+        'Fumigación': { jornales: 5.5, costo: 275000 },
+        'Fertilización': { jornales: 3.5, costo: 197500 },
+        'Poda': { jornales: 1.5, costo: 75000 },
+      },
+      totalesPorLote: {
+        'Lote PP': { jornales: 4.5, costo: 235000 },
+        'Lote ST': { jornales: 3.5, costo: 175000 },
+        'Lote AU': { jornales: 2.5, costo: 137500 },
+      },
+      totalGeneral: { jornales: 10.5, costo: 547500 },
+    },
+    matrizJornalesPropios: {
+      actividades: ['Fumigación', 'Fertilización', 'Poda'],
+      filas: [
+        { nombre: 'Fertilización', tipo: 'Fertilización' },
+        { nombre: 'Fumigación', tipo: 'Fumigación' },
+        { nombre: 'Poda', tipo: 'Poda' },
+      ],
+      lotes: ['Lote PP', 'Lote ST', 'Lote AU'],
+      datos: {
+        'Fumigación': {
+          'Lote PP': { jornales: 3.5, costo: 175000 },
+          'Lote ST': { jornales: 2.0, costo: 100000 },
+        },
+        'Poda': {
+          'Lote ST': { jornales: 1.5, costo: 75000 },
+        },
+      },
+      totalesPorActividad: {
+        'Fumigación': { jornales: 5.5, costo: 275000 },
+        'Poda': { jornales: 1.5, costo: 75000 },
+      },
+      totalesPorLote: {
+        'Lote PP': { jornales: 3.5, costo: 175000 },
+        'Lote ST': { jornales: 3.5, costo: 175000 },
+      },
+      totalGeneral: { jornales: 7.0, costo: 350000 },
+    },
+    matrizJornalesContrato: {
+      actividades: ['Fumigación', 'Fertilización', 'Poda'],
+      filas: [
+        { nombre: 'Fertilización', tipo: 'Fertilización' },
+        { nombre: 'Fumigación', tipo: 'Fumigación' },
+        { nombre: 'Poda', tipo: 'Poda' },
+      ],
+      lotes: ['Lote PP', 'Lote ST', 'Lote AU'],
+      datos: {
+        'Fertilización': {
+          'Lote PP': { jornales: 1.0, costo: 60000 },
+          'Lote AU': { jornales: 2.5, costo: 137500 },
+        },
+      },
+      totalesPorActividad: {
+        'Fertilización': { jornales: 3.5, costo: 197500 },
+      },
+      totalesPorLote: {
+        'Lote PP': { jornales: 1.0, costo: 60000 },
+        'Lote AU': { jornales: 2.5, costo: 137500 },
+      },
+      totalGeneral: { jornales: 3.5, costo: 197500 },
+    },
   },
   aplicaciones: {
     planeadas: [
@@ -400,14 +491,35 @@ describe('Edge Function: generarReporteSemanal', () => {
 
       const resultado = await generarReporteSemanal({ datos: MOCK_DATOS_COMPLETOS });
 
-      // Slide uses section header "LABORES" with heatmap table inside
-      expect(resultado.html).toContain('LABORES');
+      // Slide uses section header "JORNALES" with heatmap table inside
+      expect(resultado.html).toContain('JORNALES');
       expect(resultado.html).toContain('Fumigación');
       expect(resultado.html).toContain('Fertilización');
       expect(resultado.html).toContain('Poda');
       expect(resultado.html).toContain('Lote PP');
       expect(resultado.html).toContain('Lote ST');
       expect(resultado.html).toContain('Lote AU');
+    });
+
+    it('renderiza dos tablas independientes (propios + contrato) con barras apiladas y leyenda', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(MOCK_OPENROUTER_RESPONSE),
+      });
+
+      const resultado = await generarReporteSemanal({ datos: MOCK_DATOS_COMPLETOS });
+
+      // Both channel headings appear
+      expect(resultado.html).toContain('JORNALES PROPIOS');
+      expect(resultado.html).toContain('JORNALES POR CONTRATO');
+
+      // Stacked-bar colors (propio = #73991C, contrato = #B8D47F) are both present
+      expect(resultado.html).toContain('#73991C');
+      expect(resultado.html).toContain('#B8D47F');
+
+      // Legend labels are present
+      expect(resultado.html).toContain('Propios');
+      expect(resultado.html).toContain('Contrato');
     });
 
     it('incluye aplicaciones con barras de progreso', async () => {

--- a/src/__tests__/generarReporteSemanal.test.ts
+++ b/src/__tests__/generarReporteSemanal.test.ts
@@ -114,13 +114,13 @@ const MOCK_DATOS_COMPLETOS = {
       totalGeneral: { jornales: 10.5, costo: 547500 },
     },
     matrizJornalesPropios: {
-      actividades: ['Fumigación', 'Fertilización', 'Poda'],
+      // After per-channel filtering: only Fumigación and Poda have own-labor rows.
+      actividades: ['Fumigación', 'Poda'],
       filas: [
-        { nombre: 'Fertilización', tipo: 'Fertilización' },
         { nombre: 'Fumigación', tipo: 'Fumigación' },
         { nombre: 'Poda', tipo: 'Poda' },
       ],
-      lotes: ['Lote PP', 'Lote ST', 'Lote AU'],
+      lotes: ['Lote PP', 'Lote ST'],
       datos: {
         'Fumigación': {
           'Lote PP': { jornales: 3.5, costo: 175000 },
@@ -141,13 +141,12 @@ const MOCK_DATOS_COMPLETOS = {
       totalGeneral: { jornales: 7.0, costo: 350000 },
     },
     matrizJornalesContrato: {
-      actividades: ['Fumigación', 'Fertilización', 'Poda'],
+      // After per-channel filtering: only Fertilización has contractor rows.
+      actividades: ['Fertilización'],
       filas: [
         { nombre: 'Fertilización', tipo: 'Fertilización' },
-        { nombre: 'Fumigación', tipo: 'Fumigación' },
-        { nombre: 'Poda', tipo: 'Poda' },
       ],
-      lotes: ['Lote PP', 'Lote ST', 'Lote AU'],
+      lotes: ['Lote PP', 'Lote AU'],
       datos: {
         'Fertilización': {
           'Lote PP': { jornales: 1.0, costo: 60000 },
@@ -520,6 +519,39 @@ describe('Edge Function: generarReporteSemanal', () => {
       // Legend labels are present
       expect(resultado.html).toContain('Propios');
       expect(resultado.html).toContain('Contrato');
+    });
+
+    it('colapsa la seccion de contrato cuando no hay jornales por contrato', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: () => Promise.resolve(MOCK_OPENROUTER_RESPONSE),
+      });
+
+      const datosSinContrato = {
+        ...MOCK_DATOS_COMPLETOS,
+        labores: {
+          ...MOCK_DATOS_COMPLETOS.labores,
+          matrizJornalesContrato: {
+            actividades: [],
+            filas: [],
+            lotes: [],
+            datos: {},
+            totalesPorActividad: {},
+            totalesPorLote: {},
+            totalGeneral: { jornales: 0, costo: 0 },
+          },
+        },
+      };
+
+      const resultado = await generarReporteSemanal({ datos: datosSinContrato });
+
+      // Propios sigue presente y las gráficas también (siempre se renderizan)
+      expect(resultado.html).toContain('JORNALES PROPIOS');
+      expect(resultado.html).toContain('POR TAREA');
+      expect(resultado.html).toContain('POR LOTE');
+
+      // La tabla de contrato queda omitida (no aparece el heading dentro de un table block)
+      expect(resultado.html).not.toContain('JORNALES POR CONTRATO');
     });
 
     it('incluye aplicaciones con barras de progreso', async () => {

--- a/src/__tests__/reporteSemanal.test.ts
+++ b/src/__tests__/reporteSemanal.test.ts
@@ -553,15 +553,24 @@ describe('fetchMatrizJornales', () => {
     expect(propios.totalGeneral.costo + contrato.totalGeneral.costo).toBeCloseTo(combinado.totalGeneral.costo);
   });
 
-  it('matrices propio y contrato comparten el mismo orden de filas y lotes que combinado', async () => {
+  it('cada canal expone solo actividades y lotes con datos reales (subconjunto del combinado)', async () => {
     setupMocks();
 
     const { propios, contrato, combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
 
-    expect(propios.actividades).toEqual(combinado.actividades);
-    expect(contrato.actividades).toEqual(combinado.actividades);
-    expect(propios.lotes).toEqual(combinado.lotes);
-    expect(contrato.lotes).toEqual(combinado.lotes);
+    // Propios: solo Fumigación (no Fertilización), solo lotes con propios (PP, ST — no AU)
+    expect(propios.actividades).toEqual(['Fumigación']);
+    expect(propios.lotes.sort()).toEqual(['Lote PP', 'Lote ST']);
+
+    // Contrato: solo Fertilización, solo lotes con contrato (PP, AU — no ST)
+    expect(contrato.actividades).toEqual(['Fertilización']);
+    expect(contrato.lotes.sort()).toEqual(['Lote AU', 'Lote PP']);
+
+    // Subset del combinado en ambos casos
+    expect(propios.actividades.every(a => combinado.actividades.includes(a))).toBe(true);
+    expect(contrato.actividades.every(a => combinado.actividades.includes(a))).toBe(true);
+    expect(propios.lotes.every(l => combinado.lotes.includes(l))).toBe(true);
+    expect(contrato.lotes.every(l => combinado.lotes.includes(l))).toBe(true);
   });
 
   it('canal vacio: solo contrato registrado deja propios vacio y combinado igual a contrato', async () => {

--- a/src/__tests__/reporteSemanal.test.ts
+++ b/src/__tests__/reporteSemanal.test.ts
@@ -433,151 +433,150 @@ describe('fetchMatrizJornales', () => {
     vi.clearAllMocks();
   });
 
-  it('construye correctamente la matriz actividad × lote', async () => {
-    // Primera llamada: tipos_tareas
+  const setupMocks = (registros: any[] = MOCK_REGISTROS_TRABAJO) => {
     const tiposChain = createChainableMock({ data: MOCK_TIPOS_TAREAS, error: null });
-    // Segunda llamada: registros_trabajo
-    const registrosChain = createChainableMock({ data: MOCK_REGISTROS_TRABAJO, error: null });
-
-    let callCount = 0;
+    const registrosChain = createChainableMock({ data: registros, error: null });
     mockFrom.mockImplementation((table: string) => {
-      callCount++;
       if (table === 'tipos_tareas') return tiposChain;
       return registrosChain;
     });
+  };
 
-    const resultado = await fetchMatrizJornales('2026-02-09', '2026-02-15');
+  it('construye correctamente la matriz actividad × lote (combinado)', async () => {
+    setupMocks();
 
-    // Debe tener 2 actividades: Fumigación y Fertilización
-    expect(resultado.actividades).toContain('Fumigación');
-    expect(resultado.actividades).toContain('Fertilización');
-    expect(resultado.actividades.length).toBe(2);
+    const { combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
 
-    // Debe tener 3 lotes: PP, ST, AU
-    expect(resultado.lotes).toContain('Lote PP');
-    expect(resultado.lotes).toContain('Lote ST');
-    expect(resultado.lotes).toContain('Lote AU');
-    expect(resultado.lotes.length).toBe(3);
+    expect(combinado.actividades).toContain('Fumigación');
+    expect(combinado.actividades).toContain('Fertilización');
+    expect(combinado.actividades.length).toBe(2);
+
+    expect(combinado.lotes).toContain('Lote PP');
+    expect(combinado.lotes).toContain('Lote ST');
+    expect(combinado.lotes).toContain('Lote AU');
+    expect(combinado.lotes.length).toBe(3);
   });
 
-  it('calcula totales por actividad correctamente', async () => {
-    const tiposChain = createChainableMock({ data: MOCK_TIPOS_TAREAS, error: null });
-    const registrosChain = createChainableMock({ data: MOCK_REGISTROS_TRABAJO, error: null });
+  it('calcula totales por actividad correctamente (combinado)', async () => {
+    setupMocks();
 
-    mockFrom.mockImplementation((table: string) => {
-      if (table === 'tipos_tareas') return tiposChain;
-      return registrosChain;
-    });
-
-    const resultado = await fetchMatrizJornales('2026-02-09', '2026-02-15');
+    const { combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
 
     // Fumigación: emp-1(1.0) + emp-1(0.5) + emp-2(0.75) = 2.25
-    expect(resultado.totalesPorActividad['Fumigación'].jornales).toBeCloseTo(2.25);
-
+    expect(combinado.totalesPorActividad['Fumigación'].jornales).toBeCloseTo(2.25);
     // Fertilización: con-1(1.0) + con-2(1.0) = 2.0
-    expect(resultado.totalesPorActividad['Fertilización'].jornales).toBeCloseTo(2.0);
+    expect(combinado.totalesPorActividad['Fertilización'].jornales).toBeCloseTo(2.0);
   });
 
-  it('calcula totales por lote correctamente', async () => {
-    const tiposChain = createChainableMock({ data: MOCK_TIPOS_TAREAS, error: null });
-    const registrosChain = createChainableMock({ data: MOCK_REGISTROS_TRABAJO, error: null });
+  it('calcula totales por lote correctamente (combinado)', async () => {
+    setupMocks();
 
-    mockFrom.mockImplementation((table: string) => {
-      if (table === 'tipos_tareas') return tiposChain;
-      return registrosChain;
-    });
+    const { combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
 
-    const resultado = await fetchMatrizJornales('2026-02-09', '2026-02-15');
-
-    // Lote PP: emp-1(1.0, Fumigación) + con-1(1.0, Fertilización) + emp-2(0.75, Fumigación) = 2.75
-    expect(resultado.totalesPorLote['Lote PP'].jornales).toBeCloseTo(2.75);
-
-    // Lote ST: emp-1(0.5, Fumigación) = 0.5
-    expect(resultado.totalesPorLote['Lote ST'].jornales).toBeCloseTo(0.5);
-
-    // Lote AU: con-2(1.0, Fertilización) = 1.0
-    expect(resultado.totalesPorLote['Lote AU'].jornales).toBeCloseTo(1.0);
+    expect(combinado.totalesPorLote['Lote PP'].jornales).toBeCloseTo(2.75);
+    expect(combinado.totalesPorLote['Lote ST'].jornales).toBeCloseTo(0.5);
+    expect(combinado.totalesPorLote['Lote AU'].jornales).toBeCloseTo(1.0);
   });
 
-  it('calcula el total general correctamente', async () => {
-    const tiposChain = createChainableMock({ data: MOCK_TIPOS_TAREAS, error: null });
-    const registrosChain = createChainableMock({ data: MOCK_REGISTROS_TRABAJO, error: null });
+  it('calcula el total general correctamente (combinado)', async () => {
+    setupMocks();
 
-    mockFrom.mockImplementation((table: string) => {
-      if (table === 'tipos_tareas') return tiposChain;
-      return registrosChain;
-    });
+    const { combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
 
-    const resultado = await fetchMatrizJornales('2026-02-09', '2026-02-15');
-
-    // Total: 1.0 + 0.5 + 1.0 + 0.75 + 1.0 = 4.25
-    expect(resultado.totalGeneral.jornales).toBeCloseTo(4.25);
-
-    // Costo total: 50000 + 25000 + 60000 + 37500 + 55000 = 227500
-    expect(resultado.totalGeneral.costo).toBeCloseTo(227500);
+    expect(combinado.totalGeneral.jornales).toBeCloseTo(4.25);
+    expect(combinado.totalGeneral.costo).toBeCloseTo(227500);
   });
 
-  it('calcula celdas individuales de la matriz correctamente', async () => {
-    const tiposChain = createChainableMock({ data: MOCK_TIPOS_TAREAS, error: null });
-    const registrosChain = createChainableMock({ data: MOCK_REGISTROS_TRABAJO, error: null });
+  it('calcula celdas individuales de la matriz correctamente (combinado)', async () => {
+    setupMocks();
 
-    mockFrom.mockImplementation((table: string) => {
-      if (table === 'tipos_tareas') return tiposChain;
-      return registrosChain;
-    });
+    const { combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
 
-    const resultado = await fetchMatrizJornales('2026-02-09', '2026-02-15');
-
-    // Fumigación × Lote PP: emp-1(1.0) + emp-2(0.75) = 1.75
-    expect(resultado.datos['Fumigación']['Lote PP'].jornales).toBeCloseTo(1.75);
-
-    // Fumigación × Lote ST: emp-1(0.5)
-    expect(resultado.datos['Fumigación']['Lote ST'].jornales).toBeCloseTo(0.5);
-
-    // Fertilización × Lote PP: con-1(1.0)
-    expect(resultado.datos['Fertilización']['Lote PP'].jornales).toBeCloseTo(1.0);
-
-    // Fertilización × Lote AU: con-2(1.0)
-    expect(resultado.datos['Fertilización']['Lote AU'].jornales).toBeCloseTo(1.0);
+    expect(combinado.datos['Fumigación']['Lote PP'].jornales).toBeCloseTo(1.75);
+    expect(combinado.datos['Fumigación']['Lote ST'].jornales).toBeCloseTo(0.5);
+    expect(combinado.datos['Fertilización']['Lote PP'].jornales).toBeCloseTo(1.0);
+    expect(combinado.datos['Fertilización']['Lote AU'].jornales).toBeCloseTo(1.0);
   });
 
   it('maneja registros sin tipo de tarea como "Sin tipo"', async () => {
     const registrosSinTipo = [
       {
+        empleado_id: 'emp-99',
+        contratista_id: null,
         fraccion_jornal: 1.0,
         costo_jornal: 40000,
         tareas: { tipo_tarea_id: null },
         lote: { nombre: 'Lote PP' },
       },
     ];
-    const tiposChain = createChainableMock({ data: MOCK_TIPOS_TAREAS, error: null });
-    const registrosChain = createChainableMock({ data: registrosSinTipo, error: null });
+    setupMocks(registrosSinTipo);
 
-    mockFrom.mockImplementation((table: string) => {
-      if (table === 'tipos_tareas') return tiposChain;
-      return registrosChain;
-    });
+    const { combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
 
-    const resultado = await fetchMatrizJornales('2026-02-09', '2026-02-15');
-
-    expect(resultado.actividades).toContain('Sin tipo');
+    expect(combinado.actividades).toContain('Sin tipo');
   });
 
-  it('retorna matriz vacía cuando no hay registros', async () => {
-    const tiposChain = createChainableMock({ data: MOCK_TIPOS_TAREAS, error: null });
-    const registrosChain = createChainableMock({ data: [], error: null });
+  it('retorna matrices vacías cuando no hay registros', async () => {
+    setupMocks([]);
 
-    mockFrom.mockImplementation((table: string) => {
-      if (table === 'tipos_tareas') return tiposChain;
-      return registrosChain;
-    });
+    const { propios, contrato, combinado } = await fetchMatrizJornales('2026-03-01', '2026-03-07');
 
-    const resultado = await fetchMatrizJornales('2026-03-01', '2026-03-07');
+    for (const matriz of [propios, contrato, combinado]) {
+      expect(matriz.actividades.length).toBe(0);
+      expect(matriz.lotes.length).toBe(0);
+      expect(matriz.totalGeneral.jornales).toBe(0);
+      expect(matriz.totalGeneral.costo).toBe(0);
+    }
+  });
 
-    expect(resultado.actividades.length).toBe(0);
-    expect(resultado.lotes.length).toBe(0);
-    expect(resultado.totalGeneral.jornales).toBe(0);
-    expect(resultado.totalGeneral.costo).toBe(0);
+  it('separa propios y contrato segun empleado_id / contratista_id', async () => {
+    setupMocks();
+
+    const { propios, contrato, combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
+
+    // Propios: 3 registros Fumigación = 2.25 jornales (todos en Lote PP/ST)
+    expect(propios.totalGeneral.jornales).toBeCloseTo(2.25);
+    expect(propios.totalesPorActividad['Fumigación']?.jornales).toBeCloseTo(2.25);
+    expect(propios.totalesPorActividad['Fertilización']).toBeUndefined();
+    expect(propios.datos['Fumigación']?.['Lote PP']?.jornales).toBeCloseTo(1.75);
+    expect(propios.datos['Fumigación']?.['Lote ST']?.jornales).toBeCloseTo(0.5);
+
+    // Contrato: 2 registros Fertilización = 2.0 jornales (PP + AU)
+    expect(contrato.totalGeneral.jornales).toBeCloseTo(2.0);
+    expect(contrato.totalesPorActividad['Fertilización']?.jornales).toBeCloseTo(2.0);
+    expect(contrato.totalesPorActividad['Fumigación']).toBeUndefined();
+    expect(contrato.datos['Fertilización']?.['Lote PP']?.jornales).toBeCloseTo(1.0);
+    expect(contrato.datos['Fertilización']?.['Lote AU']?.jornales).toBeCloseTo(1.0);
+
+    // Suma de canales debe igualar el combinado
+    expect(propios.totalGeneral.jornales + contrato.totalGeneral.jornales).toBeCloseTo(combinado.totalGeneral.jornales);
+    expect(propios.totalGeneral.costo + contrato.totalGeneral.costo).toBeCloseTo(combinado.totalGeneral.costo);
+  });
+
+  it('matrices propio y contrato comparten el mismo orden de filas y lotes que combinado', async () => {
+    setupMocks();
+
+    const { propios, contrato, combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
+
+    expect(propios.actividades).toEqual(combinado.actividades);
+    expect(contrato.actividades).toEqual(combinado.actividades);
+    expect(propios.lotes).toEqual(combinado.lotes);
+    expect(contrato.lotes).toEqual(combinado.lotes);
+  });
+
+  it('canal vacio: solo contrato registrado deja propios vacio y combinado igual a contrato', async () => {
+    const soloContrato = MOCK_REGISTROS_TRABAJO.filter(r => r.contratista_id);
+    setupMocks(soloContrato);
+
+    const { propios, contrato, combinado } = await fetchMatrizJornales('2026-02-09', '2026-02-15');
+
+    // Propios queda sin actividades reales y total cero
+    expect(propios.totalGeneral.jornales).toBe(0);
+    expect(Object.keys(propios.totalesPorActividad).length).toBe(0);
+
+    // Contrato y combinado son idénticos en totales
+    expect(contrato.totalGeneral.jornales).toBeCloseTo(combinado.totalGeneral.jornales);
+    expect(contrato.totalGeneral.costo).toBeCloseTo(combinado.totalGeneral.costo);
   });
 });
 

--- a/src/components/reportes/ReporteSemanalWizard.tsx
+++ b/src/components/reportes/ReporteSemanalWizard.tsx
@@ -59,6 +59,7 @@ import type {
   BloqueImagenConTexto,
   DetalleFallaPermiso,
   SeccionesReporte,
+  MatrizJornales,
 } from '../../types/reporteSemanal';
 import { SECCIONES_DEFAULT } from '../../types/reporteSemanal';
 import { formatearFechaCorta } from '../../utils/fechas';
@@ -84,6 +85,75 @@ function formatFecha(iso: string): string {
   if (!iso) return '—';
   try { return new Date(iso + 'T00:00:00').toLocaleDateString('es-CO', { day: '2-digit', month: 'short', year: 'numeric' }); }
   catch { return iso; }
+}
+
+interface MatrizJornalesCardProps {
+  titulo: string;
+  matriz: MatrizJornales;
+  emptyText: string;
+}
+
+function MatrizJornalesCard({ titulo, matriz, emptyText }: MatrizJornalesCardProps) {
+  return (
+    <Card className="rounded-xl">
+      <CardHeader className="pb-2">
+        <CardTitle className="text-foreground text-lg">
+          {titulo}
+          <Badge variant="secondary" className="ml-2">
+            {matriz.totalGeneral.jornales.toFixed(2)} jornales
+          </Badge>
+        </CardTitle>
+      </CardHeader>
+      <CardContent>
+        {matriz.actividades.length === 0 ? (
+          <p className="text-gray-400 text-center py-4">{emptyText}</p>
+        ) : (
+          <div className="overflow-x-auto rounded-lg border border-gray-200">
+            <Table>
+              <TableHeader>
+                <TableRow className="bg-gray-50">
+                  <TableHead className="font-semibold text-left px-4 py-3">Actividad</TableHead>
+                  {matriz.lotes.map(lote => (
+                    <TableHead key={lote} className="text-center px-3 py-3 font-medium">{lote}</TableHead>
+                  ))}
+                  <TableHead className="text-center font-bold px-4 py-3 bg-primary/5">Total</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {matriz.actividades.map((actividad, idx) => (
+                  <TableRow key={actividad} className={idx % 2 === 1 ? 'bg-gray-50/50' : ''}>
+                    <TableCell className="font-medium px-4 py-3">{actividad}</TableCell>
+                    {matriz.lotes.map(lote => {
+                      const celda = matriz.datos[actividad]?.[lote];
+                      return (
+                        <TableCell key={lote} className="text-center px-3 py-3 text-sm">
+                          {celda ? celda.jornales.toFixed(2) : '-'}
+                        </TableCell>
+                      );
+                    })}
+                    <TableCell className="text-center font-semibold px-4 py-3 bg-primary/5">
+                      {(matriz.totalesPorActividad[actividad]?.jornales || 0).toFixed(2)}
+                    </TableCell>
+                  </TableRow>
+                ))}
+                <TableRow className="bg-primary/10 font-bold border-t-2 border-primary/20">
+                  <TableCell className="px-4 py-3">Total</TableCell>
+                  {matriz.lotes.map(lote => (
+                    <TableCell key={lote} className="text-center px-3 py-3">
+                      {(matriz.totalesPorLote[lote]?.jornales || 0).toFixed(2)}
+                    </TableCell>
+                  ))}
+                  <TableCell className="text-center px-4 py-3 bg-primary/20">
+                    {matriz.totalGeneral.jornales.toFixed(2)}
+                  </TableCell>
+                </TableRow>
+              </TableBody>
+            </Table>
+          </div>
+        )}
+      </CardContent>
+    </Card>
+  );
 }
 
 // ============================================================================
@@ -822,65 +892,23 @@ export function ReporteSemanalWizard() {
           </Card>
         )}
 
-        {/* Jornales matrix */}
-        <Card className="rounded-xl">
-          <CardHeader className="pb-2">
-            <CardTitle className="text-foreground text-lg">
-              Distribución de Jornales
-              <Badge variant="secondary" className="ml-2">
-                {datosReporte.labores.matrizJornales.totalGeneral.jornales.toFixed(2)} jornales
-              </Badge>
-            </CardTitle>
-          </CardHeader>
-          <CardContent>
-            {datosReporte.labores.matrizJornales.actividades.length === 0 ? (
-              <p className="text-gray-400 text-center py-4">No hay registros de trabajo en esta semana</p>
-            ) : (
-              <div className="overflow-x-auto rounded-lg border border-gray-200">
-                <Table>
-                  <TableHeader>
-                    <TableRow className="bg-gray-50">
-                      <TableHead className="font-semibold text-left px-4 py-3">Actividad</TableHead>
-                      {datosReporte.labores.matrizJornales.lotes.map(lote => (
-                        <TableHead key={lote} className="text-center px-3 py-3 font-medium">{lote}</TableHead>
-                      ))}
-                      <TableHead className="text-center font-bold px-4 py-3 bg-primary/5">Total</TableHead>
-                    </TableRow>
-                  </TableHeader>
-                  <TableBody>
-                    {datosReporte.labores.matrizJornales.actividades.map((actividad, idx) => (
-                      <TableRow key={actividad} className={idx % 2 === 1 ? 'bg-gray-50/50' : ''}>
-                        <TableCell className="font-medium px-4 py-3">{actividad}</TableCell>
-                        {datosReporte.labores.matrizJornales.lotes.map(lote => {
-                          const celda = datosReporte.labores.matrizJornales.datos[actividad]?.[lote];
-                          return (
-                            <TableCell key={lote} className="text-center px-3 py-3 text-sm">
-                              {celda ? celda.jornales.toFixed(2) : '-'}
-                            </TableCell>
-                          );
-                        })}
-                        <TableCell className="text-center font-semibold px-4 py-3 bg-primary/5">
-                          {(datosReporte.labores.matrizJornales.totalesPorActividad[actividad]?.jornales || 0).toFixed(2)}
-                        </TableCell>
-                      </TableRow>
-                    ))}
-                    <TableRow className="bg-primary/10 font-bold border-t-2 border-primary/20">
-                      <TableCell className="px-4 py-3">Total</TableCell>
-                      {datosReporte.labores.matrizJornales.lotes.map(lote => (
-                        <TableCell key={lote} className="text-center px-3 py-3">
-                          {(datosReporte.labores.matrizJornales.totalesPorLote[lote]?.jornales || 0).toFixed(2)}
-                        </TableCell>
-                      ))}
-                      <TableCell className="text-center px-4 py-3 bg-primary/20">
-                        {datosReporte.labores.matrizJornales.totalGeneral.jornales.toFixed(2)}
-                      </TableCell>
-                    </TableRow>
-                  </TableBody>
-                </Table>
-              </div>
-            )}
-          </CardContent>
-        </Card>
+        {/* Jornales matrix: propios + contrato como tablas independientes */}
+        <MatrizJornalesCard
+          titulo="Jornales Propios"
+          matriz={datosReporte.labores.matrizJornalesPropios}
+          emptyText="Sin jornales propios en la semana"
+        />
+        <MatrizJornalesCard
+          titulo="Jornales por Contrato"
+          matriz={datosReporte.labores.matrizJornalesContrato}
+          emptyText="Sin jornales por contrato en la semana"
+        />
+        <div className="rounded-xl border border-primary/20 bg-primary/5 px-4 py-3 flex items-center justify-between">
+          <span className="text-sm font-medium text-foreground">Gran Total combinado (propios + contrato)</span>
+          <span className="text-sm font-bold text-foreground">
+            {datosReporte.labores.matrizJornales.totalGeneral.jornales.toFixed(2)} jornales
+          </span>
+        </div>
 
         {/* Aplicaciones cerradas */}
         {datosReporte.aplicaciones.cerradas.length > 0 && (

--- a/src/supabase/functions/server/generar-reporte-semanal.tsx
+++ b/src/supabase/functions/server/generar-reporte-semanal.tsx
@@ -1022,19 +1022,14 @@ function construirSlideLaboresProgramadas(datos: any, analisis: AnalisisGemini):
 const COLOR_PROPIO = '#73991C';
 const COLOR_CONTRATO = '#B8D47F';
 
-function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: string): string {
-  if (!matriz || !matriz.actividades || matriz.actividades.length === 0) {
-    return `<div style="border-radius:8px;border:1px solid #E7EDDD;background:#F8FAF5;padding:14px 16px;">
-      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
-      <div style="font-size:12px;color:#9ca3af;font-style:italic;">${emptyText}</div>
-    </div>`;
-  }
-
-  const { actividades, filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = matriz;
+function renderMatrizJornalesTable(matriz: any, titulo: string): string {
+  // Caller is responsible for skipping empty channels — when a channel has no data,
+  // we omit its section entirely so propios + contrato + charts redistribute the space.
+  const { filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = matriz;
 
   const rows: Array<{ nombre: string; tipo: string }> = filas && filas.length > 0
     ? filas
-    : actividades.map((a: string) => ({ nombre: a, tipo: '' }));
+    : (matriz.actividades || []).map((a: string) => ({ nombre: a, tipo: '' }));
 
   let mx = 0;
   for (const row of rows) for (const lote of lotes) {
@@ -1050,35 +1045,35 @@ function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: strin
   for (const row of rows) {
     let cells = '';
     const tipoCell = hasTipo
-      ? `<td style="padding:6px 8px;font-size:11px;color:#6b7280;border-bottom:1px solid #E7EDDD;background:#F8FAF5;white-space:nowrap;${row.tipo !== prevTipo ? 'border-top:1px solid #BFD97D;' : ''}">${row.tipo !== prevTipo ? row.tipo : ''}</td>`
+      ? `<td style="padding:3px 6px;font-size:10px;color:#6b7280;border-bottom:1px solid #E7EDDD;background:#F8FAF5;white-space:nowrap;${row.tipo !== prevTipo ? 'border-top:1px solid #BFD97D;' : ''}">${row.tipo !== prevTipo ? row.tipo : ''}</td>`
       : '';
     prevTipo = row.tipo;
 
     for (const lote of lotes) {
       const v = md[row.nombre]?.[lote]?.jornales || 0;
-      cells += `<td style="padding:5px 6px;text-align:center;font-size:12px;font-weight:${v > 0 ? '600' : '400'};background:${hmBg(v, mx)};color:${hmTx(v, mx)};border-bottom:1px solid #E7EDDD;">${v > 0 ? fmtN(v) : '—'}</td>`;
+      cells += `<td style="padding:3px 6px;text-align:center;font-size:11px;font-weight:${v > 0 ? '600' : '400'};background:${hmBg(v, mx)};color:${hmTx(v, mx)};border-bottom:1px solid #E7EDDD;">${v > 0 ? fmtN(v) : '—'}</td>`;
     }
     const tot = totalesPorActividad[row.nombre]?.jornales || 0;
-    cells += `<td style="padding:5px 6px;text-align:center;font-size:12px;font-weight:700;background:#f0fdf4;color:#172E08;border-bottom:1px solid #E7EDDD;">${fmtN(tot)}</td>`;
+    cells += `<td style="padding:3px 6px;text-align:center;font-size:11px;font-weight:700;background:#f0fdf4;color:#172E08;border-bottom:1px solid #E7EDDD;">${fmtN(tot)}</td>`;
     const nombreTrunc = row.nombre.length > 26 ? row.nombre.slice(0, 25) + '…' : row.nombre;
-    bodyRows += `<tr>${tipoCell}<td style="padding:5px 8px;font-size:12px;font-weight:600;color:#172E08;border-bottom:1px solid #E7EDDD;white-space:nowrap;">${nombreTrunc}</td>${cells}</tr>`;
+    bodyRows += `<tr>${tipoCell}<td style="padding:3px 8px;font-size:11px;font-weight:600;color:#172E08;border-bottom:1px solid #E7EDDD;white-space:nowrap;">${nombreTrunc}</td>${cells}</tr>`;
   }
 
   let totCells = '';
-  if (hasTipo) totCells += `<td style="padding:5px 8px;background:#E7EDDD;border-top:2px solid #73991C;"></td>`;
+  if (hasTipo) totCells += `<td style="padding:3px 8px;background:#E7EDDD;border-top:2px solid #73991C;"></td>`;
   for (const lote of lotes) {
     const v = totalesPorLote[lote]?.jornales || 0;
-    totCells += `<td style="padding:5px 6px;text-align:center;font-size:12px;font-weight:700;background:#E7EDDD;color:#172E08;border-top:2px solid #73991C;">${fmtN(v)}</td>`;
+    totCells += `<td style="padding:3px 6px;text-align:center;font-size:11px;font-weight:700;background:#E7EDDD;color:#172E08;border-top:2px solid #73991C;">${fmtN(v)}</td>`;
   }
-  totCells += `<td style="padding:5px 6px;text-align:center;font-size:14px;font-weight:900;background:#73991C;color:#ffffff;border-top:2px solid #5f7d17;">${fmtN(totalGeneral.jornales)}</td>`;
-  bodyRows += `<tr><td style="padding:5px 8px;font-size:12px;font-weight:800;color:#73991C;background:#E7EDDD;border-top:2px solid #73991C;">TOTAL</td>${totCells}</tr>`;
+  totCells += `<td style="padding:3px 6px;text-align:center;font-size:12px;font-weight:900;background:#73991C;color:#ffffff;border-top:2px solid #5f7d17;">${fmtN(totalGeneral.jornales)}</td>`;
+  bodyRows += `<tr><td style="padding:3px 8px;font-size:11px;font-weight:800;color:#73991C;background:#E7EDDD;border-top:2px solid #73991C;">TOTAL</td>${totCells}</tr>`;
 
   const thTipo = hasTipo ? `<th style="${CSS.thGreen}min-width:90px;">Tipo</th>` : '';
 
   return `
-    <div>
-      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
-      <div style="border-radius:8px;border:1px solid #E7EDDD;overflow:hidden;">
+    <div style="display:flex;flex-direction:column;flex:1 1 0;min-height:0;overflow:hidden;">
+      <div style="font-size:10px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:3px;">${titulo}</div>
+      <div style="flex:1;min-height:0;overflow:hidden;border-radius:8px;border:1px solid #E7EDDD;">
         <table style="width:100%;border-collapse:collapse;">
           <thead><tr>${thTipo}<th style="${CSS.thGreen}">Nombre</th>${hCells}<th style="${CSS.thGreenC}background:#5f7d17;">Total</th></tr></thead>
           <tbody>${bodyRows}</tbody>
@@ -1088,9 +1083,9 @@ function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: strin
 }
 
 function legendHTML(): string {
-  return `<div style="display:flex;gap:18px;align-items:center;margin-bottom:8px;font-size:11px;color:#4D240F;">
-    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_PROPIO};border-radius:2px;"></span>Propios</span>
-    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_CONTRATO};border-radius:2px;"></span>Contrato</span>
+  return `<div style="display:flex;gap:18px;align-items:center;margin-bottom:6px;font-size:10px;color:#4D240F;">
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:10px;height:10px;background:${COLOR_PROPIO};border-radius:2px;"></span>Propios</span>
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:10px;height:10px;background:${COLOR_CONTRATO};border-radius:2px;"></span>Contrato</span>
   </div>`;
 }
 
@@ -1098,19 +1093,12 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
   const combinado = datos.jornales || datos.labores?.matrizJornales;
   if (!combinado || !combinado.actividades || combinado.actividades.length === 0) return [];
 
-  const propios = datos.labores?.matrizJornalesPropios || emptyMatrizFallback(combinado);
-  const contrato = datos.labores?.matrizJornalesContrato || emptyMatrizFallback(combinado);
+  const propios = datos.labores?.matrizJornalesPropios;
+  const contrato = datos.labores?.matrizJornalesContrato;
 
   const { semana } = datos;
-
-  const tableHTMLPropios = renderMatrizJornalesTable(propios, 'JORNALES PROPIOS', 'Sin jornales propios en la semana');
-  const tableHTMLContrato = renderMatrizJornalesTable(contrato, 'JORNALES POR CONTRATO', 'Sin jornales por contrato en la semana');
-
-  const MAX_ROWS_WITH_CHARTS = 8;
-  const chartsSeparate = Math.max(
-    (propios.actividades?.length || 0),
-    (contrato.actividades?.length || 0)
-  ) > MAX_ROWS_WITH_CHARTS;
+  const hasPropios = (propios?.actividades?.length || 0) > 0;
+  const hasContrato = (contrato?.actividades?.length || 0) > 0;
 
   // Stacked bar charts ordered by combined totals so propios + contrato segments line up.
   const nameOrd = [...combinado.actividades].sort((a: string, b: string) =>
@@ -1130,84 +1118,60 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
     getContrato: (k: string) => number,
     maxV: number,
   ) =>
-    items.slice(0, 8).map((k: string) => {
+    items.slice(0, 6).map((k: string) => {
       const own = getPropio(k);
       const ctr = getContrato(k);
       const total = own + ctr;
       const ownPct = (own / maxV) * 100;
       const ctrPct = (ctr / maxV) * 100;
       const totalPct = (total / maxV) * 100;
-      const label = truncLabel(k, 24);
-      return `<div style="display:flex;align-items:center;margin-bottom:8px;">
-        <div style="width:180px;font-size:11px;font-weight:500;color:#4D240F;text-align:right;padding-right:10px;flex-shrink:0;white-space:nowrap;">${label}</div>
-        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:22px;position:relative;overflow:hidden;display:flex;">
+      const label = truncLabel(k, 22);
+      return `<div style="display:flex;align-items:center;margin-bottom:5px;">
+        <div style="width:150px;font-size:10px;font-weight:500;color:#4D240F;text-align:right;padding-right:8px;flex-shrink:0;white-space:nowrap;">${label}</div>
+        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:18px;position:relative;overflow:hidden;display:flex;">
           <div style="background:${COLOR_PROPIO};height:100%;width:${ownPct}%;"></div>
           <div style="background:${COLOR_CONTRATO};height:100%;width:${ctrPct}%;"></div>
-          <span style="position:absolute;left:6px;top:2px;font-size:11px;font-weight:600;color:${totalPct > 35 ? '#fff' : '#4D240F'};">${fmtN(total, 1)}</span>
+          <span style="position:absolute;left:6px;top:1px;font-size:10px;font-weight:600;color:${totalPct > 35 ? '#fff' : '#4D240F'};">${fmtN(total, 1)}</span>
         </div>
       </div>`;
     }).join('');
 
   const chartsHTML = `
-    ${legendHTML()}
-    <div style="display:flex;gap:32px;flex:1;">
-      <div style="flex:1;">
-        <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR TAREA</div>
-        ${stackedBar(
-          nameOrd,
-          (a: string) => propios.totalesPorActividad?.[a]?.jornales || 0,
-          (a: string) => contrato.totalesPorActividad?.[a]?.jornales || 0,
-          mxN,
-        )}
-      </div>
-      <div style="flex:1;">
-        <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR LOTE</div>
-        ${stackedBar(
-          loteOrd,
-          (l: string) => propios.totalesPorLote?.[l]?.jornales || 0,
-          (l: string) => contrato.totalesPorLote?.[l]?.jornales || 0,
-          mxL,
-        )}
+    <div style="flex:0 0 auto;display:flex;flex-direction:column;">
+      ${legendHTML()}
+      <div style="display:flex;gap:24px;">
+        <div style="flex:1;">
+          <div style="font-size:10px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">POR TAREA</div>
+          ${stackedBar(
+            nameOrd,
+            (a: string) => propios?.totalesPorActividad?.[a]?.jornales || 0,
+            (a: string) => contrato?.totalesPorActividad?.[a]?.jornales || 0,
+            mxN,
+          )}
+        </div>
+        <div style="flex:1;">
+          <div style="font-size:10px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">POR LOTE</div>
+          ${stackedBar(
+            loteOrd,
+            (l: string) => propios?.totalesPorLote?.[l]?.jornales || 0,
+            (l: string) => contrato?.totalesPorLote?.[l]?.jornales || 0,
+            mxL,
+          )}
+        </div>
       </div>
     </div>`;
 
-  const slides: string[] = [];
+  const sections: string[] = [];
+  if (hasPropios) sections.push(renderMatrizJornalesTable(propios, 'JORNALES PROPIOS'));
+  if (hasContrato) sections.push(renderMatrizJornalesTable(contrato, 'JORNALES POR CONTRATO'));
+  sections.push(chartsHTML);
 
-  if (chartsSeparate) {
-    slides.push(slide('JORNALES — MATRIZ', semana, `
-      ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
-        ${tableHTMLPropios}
-        ${tableHTMLContrato}
-      </div>
-    `));
-    slides.push(slide('JORNALES — DISTRIBUCIÓN', semana, `
-      <div style="flex:1;display:flex;flex-direction:column;justify-content:center;">${chartsHTML}</div>
-    `));
-  } else {
-    slides.push(slide('JORNALES', semana, `
-      ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
-        ${tableHTMLPropios}
-        ${tableHTMLContrato}
-        ${chartsHTML}
-      </div>
-    `));
-  }
-
-  return slides;
-}
-
-function emptyMatrizFallback(reference: any): any {
-  return {
-    actividades: [],
-    filas: [],
-    lotes: reference?.lotes || [],
-    datos: {},
-    totalesPorActividad: {},
-    totalesPorLote: {},
-    totalGeneral: { jornales: 0, costo: 0 },
-  };
+  return [slide('JORNALES', semana, `
+    ${headline(analisis.titulares.jornales)}
+    <div style="flex:1;display:flex;flex-direction:column;gap:10px;min-height:0;overflow:hidden;">
+      ${sections.join('')}
+    </div>
+  `)];
 }
 
 // ============================================================================

--- a/src/supabase/functions/server/generar-reporte-semanal.tsx
+++ b/src/supabase/functions/server/generar-reporte-semanal.tsx
@@ -100,7 +100,8 @@ Ejemplo MALO personal: "Resumen del personal de esta semana"
 Ejemplo BUENO monitoreo: "Alerta critica: Cucarron marceno al 35% en Salto de Tequendama"
 Ejemplo MALO monitoreo: "Estado fitosanitario de los lotes monitoreados"
 
-Ejemplo BUENO jornales: "54.5 jornales — La Vega concentra 55% del esfuerzo semanal"
+Ejemplo BUENO jornales (canal mixto): "54.5 jornales: 32 propios + 22.5 contrato — contrato concentrado en poda en La Vega"
+Ejemplo BUENO jornales (un solo canal material): "54.5 jornales propios — La Vega concentra 55% del esfuerzo semanal"
 Ejemplo MALO jornales: "Distribucion de jornales por lote y actividad"
 
 Ejemplo BUENO labores: "8 labores activas, ninguna completada — zanjas llevan 7 semanas"
@@ -393,27 +394,50 @@ function formatearDatosParaPrompt(datos: any, historicoCtx = '', notionCtx = '')
   }
 
   if (datos.jornales) {
-    const { actividades, totalesPorActividad, totalesPorLote, totalGeneral } = datos.jornales;
+    const combinado = datos.jornales;
+    const propios = datos.labores?.matrizJornalesPropios;
+    const contrato = datos.labores?.matrizJornalesContrato;
 
-    // Top 5 actividades y lotes por jornales para reducir prompt
-    const topActividades = actividades
-      .map((act: string) => ({ nombre: act, jornales: totalesPorActividad[act]?.jornales || 0 }))
-      .sort((a: any, b: any) => b.jornales - a.jornales)
-      .slice(0, 5);
+    const topByChannel = (matriz: any, field: 'totalesPorActividad' | 'totalesPorLote') => {
+      if (!matriz) return [] as Array<{ nombre: string; jornales: number }>;
+      return Object.entries(matriz[field] as Record<string, { jornales: number }>)
+        .map(([nombre, v]) => ({ nombre, jornales: v.jornales || 0 }))
+        .filter(x => x.jornales > 0)
+        .sort((a, b) => b.jornales - a.jornales)
+        .slice(0, 5);
+    };
 
-    const topLotes = Object.entries(totalesPorLote as Record<string, { jornales: number }>)
-      .map(([nombre, v]) => ({ nombre, jornales: v.jornales || 0 }))
-      .sort((a, b) => b.jornales - a.jornales)
-      .slice(0, 5);
+    const topActividadesPropios = topByChannel(propios, 'totalesPorActividad');
+    const topActividadesContrato = topByChannel(contrato, 'totalesPorActividad');
+    const topLotesPropios = topByChannel(propios, 'totalesPorLote');
+    const topLotesContrato = topByChannel(contrato, 'totalesPorLote');
+
+    const fmtTop = (items: Array<{ nombre: string; jornales: number }>) =>
+      items.length === 0 ? '  - (sin registros)' : items.map(a => `  - ${a.nombre}: ${a.jornales.toFixed(2)}`).join('\n');
+
+    const totPropios = propios?.totalGeneral?.jornales || 0;
+    const totContrato = contrato?.totalGeneral?.jornales || 0;
+    const totCombinado = combinado.totalGeneral.jornales;
+    const pctContrato = totCombinado > 0 ? (totContrato / totCombinado) * 100 : 0;
+    const pctPropios = totCombinado > 0 ? (totPropios / totCombinado) * 100 : 0;
 
     partes.push(`## DISTRIBUCION DE JORNALES
-Total general: ${totalGeneral.jornales.toFixed(2)} jornales ($${Math.round(totalGeneral.costo).toLocaleString('es-CO')} COP)
+Total general: ${totCombinado.toFixed(2)} jornales ($${Math.round(combinado.totalGeneral.costo).toLocaleString('es-CO')} COP)
+Desglose por canal: ${totPropios.toFixed(2)} propios (${pctPropios.toFixed(0)}%) + ${totContrato.toFixed(2)} contrato (${pctContrato.toFixed(0)}%)
 
-### Top tareas por jornales
-${topActividades.map((a: any) => `  - ${a.nombre}: ${a.jornales.toFixed(2)}`).join('\n')}
+### Top tareas propios
+${fmtTop(topActividadesPropios)}
 
-### Top lotes por jornales
-${topLotes.map((l: any) => `  - ${l.nombre}: ${l.jornales.toFixed(2)}`).join('\n')}`);
+### Top tareas contrato
+${fmtTop(topActividadesContrato)}
+
+### Top lotes propios
+${fmtTop(topLotesPropios)}
+
+### Top lotes contrato
+${fmtTop(topLotesContrato)}
+
+NOTA: Si un canal (propios o contrato) representa menos del 5% del total combinado, omitelo del titular para no agregar ruido.`);
   }
 
   if (datos.labores?.programadas?.length > 0) {
@@ -994,13 +1018,20 @@ function construirSlideLaboresProgramadas(datos: any, analisis: AnalisisGemini):
   `);
 }
 
-function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): string[] {
-  const jornales = datos.jornales;
-  if (!jornales || !jornales.actividades || jornales.actividades.length === 0) return [];
-  const { semana } = datos;
-  const { actividades, filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = jornales;
+// Colors for the propio/contrato split (issue #46)
+const COLOR_PROPIO = '#73991C';
+const COLOR_CONTRATO = '#B8D47F';
 
-  // Use filas (nombre+tipo) if available, fall back to actividades-only for backward compat
+function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: string): string {
+  if (!matriz || !matriz.actividades || matriz.actividades.length === 0) {
+    return `<div style="border-radius:8px;border:1px solid #E7EDDD;background:#F8FAF5;padding:14px 16px;">
+      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
+      <div style="font-size:12px;color:#9ca3af;font-style:italic;">${emptyText}</div>
+    </div>`;
+  }
+
+  const { actividades, filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = matriz;
+
   const rows: Array<{ nombre: string; tipo: string }> = filas && filas.length > 0
     ? filas
     : actividades.map((a: string) => ({ nombre: a, tipo: '' }));
@@ -1011,20 +1042,13 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
     if (v > mx) mx = v;
   }
 
-  // Determine if charts fit on same slide (≤8 rows) or need their own slide
-  const MAX_ROWS_WITH_CHARTS = 8;
-  const chartsSeparate = rows.length > MAX_ROWS_WITH_CHARTS;
-
-  // Build table header
-  const hasTipo = rows.some(r => r.tipo && r.tipo !== r.nombre);
+  const hasTipo = rows.some((r: any) => r.tipo && r.tipo !== r.nombre);
   const hCells = lotes.map((l: string) => `<th style="${CSS.thGreenC}min-width:55px;">${l}</th>`).join('');
 
-  // Build table body rows
   let bodyRows = '';
   let prevTipo = '';
   for (const row of rows) {
     let cells = '';
-    // Show tipo column with rowspan-like visual grouping
     const tipoCell = hasTipo
       ? `<td style="padding:6px 8px;font-size:11px;color:#6b7280;border-bottom:1px solid #E7EDDD;background:#F8FAF5;white-space:nowrap;${row.tipo !== prevTipo ? 'border-top:1px solid #BFD97D;' : ''}">${row.tipo !== prevTipo ? row.tipo : ''}</td>`
       : '';
@@ -1040,7 +1064,6 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
     bodyRows += `<tr>${tipoCell}<td style="padding:5px 8px;font-size:12px;font-weight:600;color:#172E08;border-bottom:1px solid #E7EDDD;white-space:nowrap;">${nombreTrunc}</td>${cells}</tr>`;
   }
 
-  // Total row
   let totCells = '';
   if (hasTipo) totCells += `<td style="padding:5px 8px;background:#E7EDDD;border-top:2px solid #73991C;"></td>`;
   for (const lote of lotes) {
@@ -1050,75 +1073,141 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
   totCells += `<td style="padding:5px 6px;text-align:center;font-size:14px;font-weight:900;background:#73991C;color:#ffffff;border-top:2px solid #5f7d17;">${fmtN(totalGeneral.jornales)}</td>`;
   bodyRows += `<tr><td style="padding:5px 8px;font-size:12px;font-weight:800;color:#73991C;background:#E7EDDD;border-top:2px solid #73991C;">TOTAL</td>${totCells}</tr>`;
 
-  // Table header row
   const thTipo = hasTipo ? `<th style="${CSS.thGreen}min-width:90px;">Tipo</th>` : '';
 
-  const tableHTML = `
-    <div style="border-radius:8px;border:1px solid #E7EDDD;overflow:hidden;">
-      <table style="width:100%;border-collapse:collapse;">
-        <thead><tr>${thTipo}<th style="${CSS.thGreen}">Nombre</th>${hCells}<th style="${CSS.thGreenC}background:#5f7d17;">Total</th></tr></thead>
-        <tbody>${bodyRows}</tbody>
-      </table>
+  return `
+    <div>
+      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
+      <div style="border-radius:8px;border:1px solid #E7EDDD;overflow:hidden;">
+        <table style="width:100%;border-collapse:collapse;">
+          <thead><tr>${thTipo}<th style="${CSS.thGreen}">Nombre</th>${hCells}<th style="${CSS.thGreenC}background:#5f7d17;">Total</th></tr></thead>
+          <tbody>${bodyRows}</tbody>
+        </table>
+      </div>
     </div>`;
+}
 
-  // Bar charts
-  const nameOrd = [...actividades].sort((a: string, b: string) => (totalesPorActividad[b]?.jornales || 0) - (totalesPorActividad[a]?.jornales || 0));
-  const loteOrd = [...lotes].sort((a: string, b: string) => (totalesPorLote[b]?.jornales || 0) - (totalesPorLote[a]?.jornales || 0));
-  const mxN = Math.max(...nameOrd.map((a: string) => totalesPorActividad[a]?.jornales || 0), 1);
-  const mxL = Math.max(...loteOrd.map((l: string) => totalesPorLote[l]?.jornales || 0), 1);
+function legendHTML(): string {
+  return `<div style="display:flex;gap:18px;align-items:center;margin-bottom:8px;font-size:11px;color:#4D240F;">
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_PROPIO};border-radius:2px;"></span>Propios</span>
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_CONTRATO};border-radius:2px;"></span>Contrato</span>
+  </div>`;
+}
+
+function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): string[] {
+  const combinado = datos.jornales || datos.labores?.matrizJornales;
+  if (!combinado || !combinado.actividades || combinado.actividades.length === 0) return [];
+
+  const propios = datos.labores?.matrizJornalesPropios || emptyMatrizFallback(combinado);
+  const contrato = datos.labores?.matrizJornalesContrato || emptyMatrizFallback(combinado);
+
+  const { semana } = datos;
+
+  const tableHTMLPropios = renderMatrizJornalesTable(propios, 'JORNALES PROPIOS', 'Sin jornales propios en la semana');
+  const tableHTMLContrato = renderMatrizJornalesTable(contrato, 'JORNALES POR CONTRATO', 'Sin jornales por contrato en la semana');
+
+  const MAX_ROWS_WITH_CHARTS = 8;
+  const chartsSeparate = Math.max(
+    (propios.actividades?.length || 0),
+    (contrato.actividades?.length || 0)
+  ) > MAX_ROWS_WITH_CHARTS;
+
+  // Stacked bar charts ordered by combined totals so propios + contrato segments line up.
+  const nameOrd = [...combinado.actividades].sort((a: string, b: string) =>
+    (combinado.totalesPorActividad[b]?.jornales || 0) - (combinado.totalesPorActividad[a]?.jornales || 0)
+  );
+  const loteOrd = [...combinado.lotes].sort((a: string, b: string) =>
+    (combinado.totalesPorLote[b]?.jornales || 0) - (combinado.totalesPorLote[a]?.jornales || 0)
+  );
+  const mxN = Math.max(...nameOrd.map((a: string) => combinado.totalesPorActividad[a]?.jornales || 0), 1);
+  const mxL = Math.max(...loteOrd.map((l: string) => combinado.totalesPorLote[l]?.jornales || 0), 1);
 
   const truncLabel = (s: string, max: number) => s.length > max ? s.slice(0, max - 1) + '…' : s;
 
-  const bar = (items: string[], getData: (k: string) => number, maxV: number, color: string) =>
+  const stackedBar = (
+    items: string[],
+    getPropio: (k: string) => number,
+    getContrato: (k: string) => number,
+    maxV: number,
+  ) =>
     items.slice(0, 8).map((k: string) => {
-      const v = getData(k);
-      const pct = (v / maxV) * 100;
+      const own = getPropio(k);
+      const ctr = getContrato(k);
+      const total = own + ctr;
+      const ownPct = (own / maxV) * 100;
+      const ctrPct = (ctr / maxV) * 100;
+      const totalPct = (total / maxV) * 100;
       const label = truncLabel(k, 24);
       return `<div style="display:flex;align-items:center;margin-bottom:8px;">
         <div style="width:180px;font-size:11px;font-weight:500;color:#4D240F;text-align:right;padding-right:10px;flex-shrink:0;white-space:nowrap;">${label}</div>
-        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:22px;position:relative;overflow:hidden;">
-          <div style="background:${color};height:100%;border-radius:3px;width:${Math.max(pct, 2)}%;"></div>
-          <span style="position:absolute;left:6px;top:2px;font-size:11px;font-weight:600;color:${pct > 35 ? '#fff' : '#4D240F'};">${fmtN(v, 1)}</span>
+        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:22px;position:relative;overflow:hidden;display:flex;">
+          <div style="background:${COLOR_PROPIO};height:100%;width:${ownPct}%;"></div>
+          <div style="background:${COLOR_CONTRATO};height:100%;width:${ctrPct}%;"></div>
+          <span style="position:absolute;left:6px;top:2px;font-size:11px;font-weight:600;color:${totalPct > 35 ? '#fff' : '#4D240F'};">${fmtN(total, 1)}</span>
         </div>
       </div>`;
     }).join('');
 
   const chartsHTML = `
+    ${legendHTML()}
     <div style="display:flex;gap:32px;flex:1;">
       <div style="flex:1;">
         <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR TAREA</div>
-        ${bar(nameOrd, (a: string) => totalesPorActividad[a]?.jornales || 0, mxN, '#73991C')}
+        ${stackedBar(
+          nameOrd,
+          (a: string) => propios.totalesPorActividad?.[a]?.jornales || 0,
+          (a: string) => contrato.totalesPorActividad?.[a]?.jornales || 0,
+          mxN,
+        )}
       </div>
       <div style="flex:1;">
         <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR LOTE</div>
-        ${bar(loteOrd, (l: string) => totalesPorLote[l]?.jornales || 0, mxL, '#73991C')}
+        ${stackedBar(
+          loteOrd,
+          (l: string) => propios.totalesPorLote?.[l]?.jornales || 0,
+          (l: string) => contrato.totalesPorLote?.[l]?.jornales || 0,
+          mxL,
+        )}
       </div>
     </div>`;
 
   const slides: string[] = [];
 
   if (chartsSeparate) {
-    // Slide 1: Table only
     slides.push(slide('JORNALES — MATRIZ', semana, `
       ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;overflow:hidden;">${tableHTML}</div>
+      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
+        ${tableHTMLPropios}
+        ${tableHTMLContrato}
+      </div>
     `));
-    // Slide 2: Charts only
     slides.push(slide('JORNALES — DISTRIBUCIÓN', semana, `
       <div style="flex:1;display:flex;flex-direction:column;justify-content:center;">${chartsHTML}</div>
     `));
   } else {
-    // Single slide: table + charts
     slides.push(slide('JORNALES', semana, `
       ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;display:flex;flex-direction:column;gap:16px;overflow:hidden;">
-        ${tableHTML}
+      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
+        ${tableHTMLPropios}
+        ${tableHTMLContrato}
         ${chartsHTML}
       </div>
     `));
   }
 
   return slides;
+}
+
+function emptyMatrizFallback(reference: any): any {
+  return {
+    actividades: [],
+    filas: [],
+    lotes: reference?.lotes || [],
+    datos: {},
+    totalesPorActividad: {},
+    totalesPorLote: {},
+    totalGeneral: { jornales: 0, costo: 0 },
+  };
 }
 
 // ============================================================================

--- a/src/types/reporteSemanal.ts
+++ b/src/types/reporteSemanal.ts
@@ -478,7 +478,10 @@ export interface DatosReporteSemanal {
   personal: DatosPersonal;
   labores: {
     programadas: LaborSemanal[];
+    /** Legacy combined view; equals matrizJornalesPropios + matrizJornalesContrato. */
     matrizJornales: MatrizJornales;
+    matrizJornalesPropios: MatrizJornales;
+    matrizJornalesContrato: MatrizJornales;
   };
   // Legacy top-level jornales (kept for backward compatibility)
   jornales: MatrizJornales;

--- a/src/utils/fetchDatosReporteSemanal.ts
+++ b/src/utils/fetchDatosReporteSemanal.ts
@@ -252,10 +252,16 @@ export async function fetchLaboresSemanales(
 /**
  * Obtiene la matriz de jornales: actividades (filas) × lotes (columnas)
  */
+export interface MatricesJornales {
+  propios: MatrizJornales;
+  contrato: MatrizJornales;
+  combinado: MatrizJornales;
+}
+
 export async function fetchMatrizJornales(
   inicio: string,
   fin: string
-): Promise<MatrizJornales> {
+): Promise<MatricesJornales> {
   const supabase = getSupabase();
 
   const { data: tiposTareas, error: errorTipos } = await supabase
@@ -271,6 +277,8 @@ export async function fetchMatrizJornales(
     .select(`
       fraccion_jornal,
       costo_jornal,
+      empleado_id,
+      contratista_id,
       tareas!inner(nombre, tipo_tarea_id),
       lote:lotes!lote_id(nombre)
     `)
@@ -279,13 +287,44 @@ export async function fetchMatrizJornales(
 
   if (errorRegistros) throw new Error(`Error al cargar registros: ${errorRegistros.message}`);
 
-  const datos: Record<string, Record<string, CeldaMatrizJornales>> = {};
-  const totalesPorActividad: Record<string, CeldaMatrizJornales> = {};
-  const totalesPorLote: Record<string, CeldaMatrizJornales> = {};
+  type Acc = {
+    datos: Record<string, Record<string, CeldaMatrizJornales>>;
+    totalesPorActividad: Record<string, CeldaMatrizJornales>;
+    totalesPorLote: Record<string, CeldaMatrizJornales>;
+    totalJornales: number;
+    totalCosto: number;
+  };
+  const makeAcc = (): Acc => ({
+    datos: {},
+    totalesPorActividad: {},
+    totalesPorLote: {},
+    totalJornales: 0,
+    totalCosto: 0,
+  });
+  const propiosAcc = makeAcc();
+  const contratoAcc = makeAcc();
+  const combinadoAcc = makeAcc();
+
   const lotesSet = new Set<string>();
   const filasMap = new Map<string, string>(); // nombre → tipo
-  let totalGeneralJornales = 0;
-  let totalGeneralCosto = 0;
+
+  const apply = (acc: Acc, nombre: string, lote: string, jornales: number, costo: number) => {
+    if (!acc.datos[nombre]) acc.datos[nombre] = {};
+    if (!acc.datos[nombre][lote]) acc.datos[nombre][lote] = { jornales: 0, costo: 0 };
+    acc.datos[nombre][lote].jornales += jornales;
+    acc.datos[nombre][lote].costo += costo;
+
+    if (!acc.totalesPorActividad[nombre]) acc.totalesPorActividad[nombre] = { jornales: 0, costo: 0 };
+    acc.totalesPorActividad[nombre].jornales += jornales;
+    acc.totalesPorActividad[nombre].costo += costo;
+
+    if (!acc.totalesPorLote[lote]) acc.totalesPorLote[lote] = { jornales: 0, costo: 0 };
+    acc.totalesPorLote[lote].jornales += jornales;
+    acc.totalesPorLote[lote].costo += costo;
+
+    acc.totalJornales += jornales;
+    acc.totalCosto += costo;
+  };
 
   (registros || []).forEach((registro: any) => {
     const tipoTareaId = registro.tareas?.tipo_tarea_id;
@@ -298,36 +337,34 @@ export async function fetchMatrizJornales(
     filasMap.set(nombre, tipo);
     lotesSet.add(lote);
 
-    if (!datos[nombre]) datos[nombre] = {};
-    if (!datos[nombre][lote]) datos[nombre][lote] = { jornales: 0, costo: 0 };
-    datos[nombre][lote].jornales += jornales;
-    datos[nombre][lote].costo += costo;
-
-    if (!totalesPorActividad[nombre]) totalesPorActividad[nombre] = { jornales: 0, costo: 0 };
-    totalesPorActividad[nombre].jornales += jornales;
-    totalesPorActividad[nombre].costo += costo;
-
-    if (!totalesPorLote[lote]) totalesPorLote[lote] = { jornales: 0, costo: 0 };
-    totalesPorLote[lote].jornales += jornales;
-    totalesPorLote[lote].costo += costo;
-
-    totalGeneralJornales += jornales;
-    totalGeneralCosto += costo;
+    // CHECK constraint on registros_trabajo guarantees exactly one of empleado_id / contratista_id
+    // is set. If both/neither are present (shouldn't happen), classify defensively as propios.
+    const channel: Acc = registro.contratista_id && !registro.empleado_id ? contratoAcc : propiosAcc;
+    apply(channel, nombre, lote, jornales, costo);
+    apply(combinadoAcc, nombre, lote, jornales, costo);
   });
 
-  // Build filas sorted by tipo then nombre
+  // Build filas sorted by tipo then nombre — shared across all three matrices so row order matches.
   const filas = Array.from(filasMap.entries())
     .map(([nombre, tipo]) => ({ nombre, tipo }))
     .sort((a, b) => a.tipo.localeCompare(b.tipo) || a.nombre.localeCompare(b.nombre));
+  const actividades = filas.map(f => f.nombre);
+  const lotes = Array.from(lotesSet).sort();
+
+  const toMatriz = (acc: Acc): MatrizJornales => ({
+    actividades,
+    filas,
+    lotes,
+    datos: acc.datos,
+    totalesPorActividad: acc.totalesPorActividad,
+    totalesPorLote: acc.totalesPorLote,
+    totalGeneral: { jornales: acc.totalJornales, costo: acc.totalCosto },
+  });
 
   return {
-    actividades: filas.map(f => f.nombre),
-    filas,
-    lotes: Array.from(lotesSet).sort(),
-    datos,
-    totalesPorActividad,
-    totalesPorLote,
-    totalGeneral: { jornales: totalGeneralJornales, costo: totalGeneralCosto },
+    propios: toMatriz(propiosAcc),
+    contrato: toMatriz(contratoAcc),
+    combinado: toMatriz(combinadoAcc),
   };
 }
 
@@ -2162,7 +2199,7 @@ export async function fetchDatosReporteSemanal(
   const [
     personalBase,
     laboresProgramadas,
-    matrizJornales,
+    matricesJornales,
     aplicacionesPlaneadas,
     aplicacionesActivas,
     aplicacionesCerradas,
@@ -2208,9 +2245,11 @@ export async function fetchDatosReporteSemanal(
     },
     labores: {
       programadas: laboresProgramadas,
-      matrizJornales,
+      matrizJornales: matricesJornales.combinado,
+      matrizJornalesPropios: matricesJornales.propios,
+      matrizJornalesContrato: matricesJornales.contrato,
     },
-    jornales: matrizJornales, // legacy
+    jornales: matricesJornales.combinado, // legacy
     aplicaciones: {
       planeadas: aplicacionesPlaneadas,
       activas: aplicacionesActivas,

--- a/src/utils/fetchDatosReporteSemanal.ts
+++ b/src/utils/fetchDatosReporteSemanal.ts
@@ -344,27 +344,36 @@ export async function fetchMatrizJornales(
     apply(combinadoAcc, nombre, lote, jornales, costo);
   });
 
-  // Build filas sorted by tipo then nombre — shared across all three matrices so row order matches.
-  const filas = Array.from(filasMap.entries())
+  // Combined matrix keeps the full union of activities and lots so KPI cross-checks
+  // stay valid. Each channel matrix is filtered to its own non-zero rows/columns —
+  // that way the wizard and PDF only render data that actually exists per channel.
+  const allFilas = Array.from(filasMap.entries())
     .map(([nombre, tipo]) => ({ nombre, tipo }))
     .sort((a, b) => a.tipo.localeCompare(b.tipo) || a.nombre.localeCompare(b.nombre));
-  const actividades = filas.map(f => f.nombre);
-  const lotes = Array.from(lotesSet).sort();
+  const allLotes = Array.from(lotesSet).sort();
 
-  const toMatriz = (acc: Acc): MatrizJornales => ({
-    actividades,
-    filas,
-    lotes,
-    datos: acc.datos,
-    totalesPorActividad: acc.totalesPorActividad,
-    totalesPorLote: acc.totalesPorLote,
-    totalGeneral: { jornales: acc.totalJornales, costo: acc.totalCosto },
-  });
+  const toMatriz = (acc: Acc, scoped: boolean): MatrizJornales => {
+    const filas = scoped
+      ? allFilas.filter(f => (acc.totalesPorActividad[f.nombre]?.jornales || 0) > 0)
+      : allFilas;
+    const lotes = scoped
+      ? allLotes.filter(l => (acc.totalesPorLote[l]?.jornales || 0) > 0)
+      : allLotes;
+    return {
+      actividades: filas.map(f => f.nombre),
+      filas,
+      lotes,
+      datos: acc.datos,
+      totalesPorActividad: acc.totalesPorActividad,
+      totalesPorLote: acc.totalesPorLote,
+      totalGeneral: { jornales: acc.totalJornales, costo: acc.totalCosto },
+    };
+  };
 
   return {
-    propios: toMatriz(propiosAcc),
-    contrato: toMatriz(contratoAcc),
-    combinado: toMatriz(combinadoAcc),
+    propios: toMatriz(propiosAcc, true),
+    contrato: toMatriz(contratoAcc, true),
+    combinado: toMatriz(combinadoAcc, false),
   };
 }
 

--- a/supabase/functions/make-server-1ccce916/generar-reporte-semanal.tsx
+++ b/supabase/functions/make-server-1ccce916/generar-reporte-semanal.tsx
@@ -1022,19 +1022,14 @@ function construirSlideLaboresProgramadas(datos: any, analisis: AnalisisGemini):
 const COLOR_PROPIO = '#73991C';
 const COLOR_CONTRATO = '#B8D47F';
 
-function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: string): string {
-  if (!matriz || !matriz.actividades || matriz.actividades.length === 0) {
-    return `<div style="border-radius:8px;border:1px solid #E7EDDD;background:#F8FAF5;padding:14px 16px;">
-      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
-      <div style="font-size:12px;color:#9ca3af;font-style:italic;">${emptyText}</div>
-    </div>`;
-  }
-
-  const { actividades, filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = matriz;
+function renderMatrizJornalesTable(matriz: any, titulo: string): string {
+  // Caller is responsible for skipping empty channels — when a channel has no data,
+  // we omit its section entirely so propios + contrato + charts redistribute the space.
+  const { filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = matriz;
 
   const rows: Array<{ nombre: string; tipo: string }> = filas && filas.length > 0
     ? filas
-    : actividades.map((a: string) => ({ nombre: a, tipo: '' }));
+    : (matriz.actividades || []).map((a: string) => ({ nombre: a, tipo: '' }));
 
   let mx = 0;
   for (const row of rows) for (const lote of lotes) {
@@ -1050,35 +1045,35 @@ function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: strin
   for (const row of rows) {
     let cells = '';
     const tipoCell = hasTipo
-      ? `<td style="padding:6px 8px;font-size:11px;color:#6b7280;border-bottom:1px solid #E7EDDD;background:#F8FAF5;white-space:nowrap;${row.tipo !== prevTipo ? 'border-top:1px solid #BFD97D;' : ''}">${row.tipo !== prevTipo ? row.tipo : ''}</td>`
+      ? `<td style="padding:3px 6px;font-size:10px;color:#6b7280;border-bottom:1px solid #E7EDDD;background:#F8FAF5;white-space:nowrap;${row.tipo !== prevTipo ? 'border-top:1px solid #BFD97D;' : ''}">${row.tipo !== prevTipo ? row.tipo : ''}</td>`
       : '';
     prevTipo = row.tipo;
 
     for (const lote of lotes) {
       const v = md[row.nombre]?.[lote]?.jornales || 0;
-      cells += `<td style="padding:5px 6px;text-align:center;font-size:12px;font-weight:${v > 0 ? '600' : '400'};background:${hmBg(v, mx)};color:${hmTx(v, mx)};border-bottom:1px solid #E7EDDD;">${v > 0 ? fmtN(v) : '—'}</td>`;
+      cells += `<td style="padding:3px 6px;text-align:center;font-size:11px;font-weight:${v > 0 ? '600' : '400'};background:${hmBg(v, mx)};color:${hmTx(v, mx)};border-bottom:1px solid #E7EDDD;">${v > 0 ? fmtN(v) : '—'}</td>`;
     }
     const tot = totalesPorActividad[row.nombre]?.jornales || 0;
-    cells += `<td style="padding:5px 6px;text-align:center;font-size:12px;font-weight:700;background:#f0fdf4;color:#172E08;border-bottom:1px solid #E7EDDD;">${fmtN(tot)}</td>`;
+    cells += `<td style="padding:3px 6px;text-align:center;font-size:11px;font-weight:700;background:#f0fdf4;color:#172E08;border-bottom:1px solid #E7EDDD;">${fmtN(tot)}</td>`;
     const nombreTrunc = row.nombre.length > 26 ? row.nombre.slice(0, 25) + '…' : row.nombre;
-    bodyRows += `<tr>${tipoCell}<td style="padding:5px 8px;font-size:12px;font-weight:600;color:#172E08;border-bottom:1px solid #E7EDDD;white-space:nowrap;">${nombreTrunc}</td>${cells}</tr>`;
+    bodyRows += `<tr>${tipoCell}<td style="padding:3px 8px;font-size:11px;font-weight:600;color:#172E08;border-bottom:1px solid #E7EDDD;white-space:nowrap;">${nombreTrunc}</td>${cells}</tr>`;
   }
 
   let totCells = '';
-  if (hasTipo) totCells += `<td style="padding:5px 8px;background:#E7EDDD;border-top:2px solid #73991C;"></td>`;
+  if (hasTipo) totCells += `<td style="padding:3px 8px;background:#E7EDDD;border-top:2px solid #73991C;"></td>`;
   for (const lote of lotes) {
     const v = totalesPorLote[lote]?.jornales || 0;
-    totCells += `<td style="padding:5px 6px;text-align:center;font-size:12px;font-weight:700;background:#E7EDDD;color:#172E08;border-top:2px solid #73991C;">${fmtN(v)}</td>`;
+    totCells += `<td style="padding:3px 6px;text-align:center;font-size:11px;font-weight:700;background:#E7EDDD;color:#172E08;border-top:2px solid #73991C;">${fmtN(v)}</td>`;
   }
-  totCells += `<td style="padding:5px 6px;text-align:center;font-size:14px;font-weight:900;background:#73991C;color:#ffffff;border-top:2px solid #5f7d17;">${fmtN(totalGeneral.jornales)}</td>`;
-  bodyRows += `<tr><td style="padding:5px 8px;font-size:12px;font-weight:800;color:#73991C;background:#E7EDDD;border-top:2px solid #73991C;">TOTAL</td>${totCells}</tr>`;
+  totCells += `<td style="padding:3px 6px;text-align:center;font-size:12px;font-weight:900;background:#73991C;color:#ffffff;border-top:2px solid #5f7d17;">${fmtN(totalGeneral.jornales)}</td>`;
+  bodyRows += `<tr><td style="padding:3px 8px;font-size:11px;font-weight:800;color:#73991C;background:#E7EDDD;border-top:2px solid #73991C;">TOTAL</td>${totCells}</tr>`;
 
   const thTipo = hasTipo ? `<th style="${CSS.thGreen}min-width:90px;">Tipo</th>` : '';
 
   return `
-    <div>
-      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
-      <div style="border-radius:8px;border:1px solid #E7EDDD;overflow:hidden;">
+    <div style="display:flex;flex-direction:column;flex:1 1 0;min-height:0;overflow:hidden;">
+      <div style="font-size:10px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:3px;">${titulo}</div>
+      <div style="flex:1;min-height:0;overflow:hidden;border-radius:8px;border:1px solid #E7EDDD;">
         <table style="width:100%;border-collapse:collapse;">
           <thead><tr>${thTipo}<th style="${CSS.thGreen}">Nombre</th>${hCells}<th style="${CSS.thGreenC}background:#5f7d17;">Total</th></tr></thead>
           <tbody>${bodyRows}</tbody>
@@ -1088,9 +1083,9 @@ function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: strin
 }
 
 function legendHTML(): string {
-  return `<div style="display:flex;gap:18px;align-items:center;margin-bottom:8px;font-size:11px;color:#4D240F;">
-    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_PROPIO};border-radius:2px;"></span>Propios</span>
-    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_CONTRATO};border-radius:2px;"></span>Contrato</span>
+  return `<div style="display:flex;gap:18px;align-items:center;margin-bottom:6px;font-size:10px;color:#4D240F;">
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:10px;height:10px;background:${COLOR_PROPIO};border-radius:2px;"></span>Propios</span>
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:10px;height:10px;background:${COLOR_CONTRATO};border-radius:2px;"></span>Contrato</span>
   </div>`;
 }
 
@@ -1098,19 +1093,12 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
   const combinado = datos.jornales || datos.labores?.matrizJornales;
   if (!combinado || !combinado.actividades || combinado.actividades.length === 0) return [];
 
-  const propios = datos.labores?.matrizJornalesPropios || emptyMatrizFallback(combinado);
-  const contrato = datos.labores?.matrizJornalesContrato || emptyMatrizFallback(combinado);
+  const propios = datos.labores?.matrizJornalesPropios;
+  const contrato = datos.labores?.matrizJornalesContrato;
 
   const { semana } = datos;
-
-  const tableHTMLPropios = renderMatrizJornalesTable(propios, 'JORNALES PROPIOS', 'Sin jornales propios en la semana');
-  const tableHTMLContrato = renderMatrizJornalesTable(contrato, 'JORNALES POR CONTRATO', 'Sin jornales por contrato en la semana');
-
-  const MAX_ROWS_WITH_CHARTS = 8;
-  const chartsSeparate = Math.max(
-    (propios.actividades?.length || 0),
-    (contrato.actividades?.length || 0)
-  ) > MAX_ROWS_WITH_CHARTS;
+  const hasPropios = (propios?.actividades?.length || 0) > 0;
+  const hasContrato = (contrato?.actividades?.length || 0) > 0;
 
   // Stacked bar charts ordered by combined totals so propios + contrato segments line up.
   const nameOrd = [...combinado.actividades].sort((a: string, b: string) =>
@@ -1130,84 +1118,60 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
     getContrato: (k: string) => number,
     maxV: number,
   ) =>
-    items.slice(0, 8).map((k: string) => {
+    items.slice(0, 6).map((k: string) => {
       const own = getPropio(k);
       const ctr = getContrato(k);
       const total = own + ctr;
       const ownPct = (own / maxV) * 100;
       const ctrPct = (ctr / maxV) * 100;
       const totalPct = (total / maxV) * 100;
-      const label = truncLabel(k, 24);
-      return `<div style="display:flex;align-items:center;margin-bottom:8px;">
-        <div style="width:180px;font-size:11px;font-weight:500;color:#4D240F;text-align:right;padding-right:10px;flex-shrink:0;white-space:nowrap;">${label}</div>
-        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:22px;position:relative;overflow:hidden;display:flex;">
+      const label = truncLabel(k, 22);
+      return `<div style="display:flex;align-items:center;margin-bottom:5px;">
+        <div style="width:150px;font-size:10px;font-weight:500;color:#4D240F;text-align:right;padding-right:8px;flex-shrink:0;white-space:nowrap;">${label}</div>
+        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:18px;position:relative;overflow:hidden;display:flex;">
           <div style="background:${COLOR_PROPIO};height:100%;width:${ownPct}%;"></div>
           <div style="background:${COLOR_CONTRATO};height:100%;width:${ctrPct}%;"></div>
-          <span style="position:absolute;left:6px;top:2px;font-size:11px;font-weight:600;color:${totalPct > 35 ? '#fff' : '#4D240F'};">${fmtN(total, 1)}</span>
+          <span style="position:absolute;left:6px;top:1px;font-size:10px;font-weight:600;color:${totalPct > 35 ? '#fff' : '#4D240F'};">${fmtN(total, 1)}</span>
         </div>
       </div>`;
     }).join('');
 
   const chartsHTML = `
-    ${legendHTML()}
-    <div style="display:flex;gap:32px;flex:1;">
-      <div style="flex:1;">
-        <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR TAREA</div>
-        ${stackedBar(
-          nameOrd,
-          (a: string) => propios.totalesPorActividad?.[a]?.jornales || 0,
-          (a: string) => contrato.totalesPorActividad?.[a]?.jornales || 0,
-          mxN,
-        )}
-      </div>
-      <div style="flex:1;">
-        <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR LOTE</div>
-        ${stackedBar(
-          loteOrd,
-          (l: string) => propios.totalesPorLote?.[l]?.jornales || 0,
-          (l: string) => contrato.totalesPorLote?.[l]?.jornales || 0,
-          mxL,
-        )}
+    <div style="flex:0 0 auto;display:flex;flex-direction:column;">
+      ${legendHTML()}
+      <div style="display:flex;gap:24px;">
+        <div style="flex:1;">
+          <div style="font-size:10px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">POR TAREA</div>
+          ${stackedBar(
+            nameOrd,
+            (a: string) => propios?.totalesPorActividad?.[a]?.jornales || 0,
+            (a: string) => contrato?.totalesPorActividad?.[a]?.jornales || 0,
+            mxN,
+          )}
+        </div>
+        <div style="flex:1;">
+          <div style="font-size:10px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">POR LOTE</div>
+          ${stackedBar(
+            loteOrd,
+            (l: string) => propios?.totalesPorLote?.[l]?.jornales || 0,
+            (l: string) => contrato?.totalesPorLote?.[l]?.jornales || 0,
+            mxL,
+          )}
+        </div>
       </div>
     </div>`;
 
-  const slides: string[] = [];
+  const sections: string[] = [];
+  if (hasPropios) sections.push(renderMatrizJornalesTable(propios, 'JORNALES PROPIOS'));
+  if (hasContrato) sections.push(renderMatrizJornalesTable(contrato, 'JORNALES POR CONTRATO'));
+  sections.push(chartsHTML);
 
-  if (chartsSeparate) {
-    slides.push(slide('JORNALES — MATRIZ', semana, `
-      ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
-        ${tableHTMLPropios}
-        ${tableHTMLContrato}
-      </div>
-    `));
-    slides.push(slide('JORNALES — DISTRIBUCIÓN', semana, `
-      <div style="flex:1;display:flex;flex-direction:column;justify-content:center;">${chartsHTML}</div>
-    `));
-  } else {
-    slides.push(slide('JORNALES', semana, `
-      ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
-        ${tableHTMLPropios}
-        ${tableHTMLContrato}
-        ${chartsHTML}
-      </div>
-    `));
-  }
-
-  return slides;
-}
-
-function emptyMatrizFallback(reference: any): any {
-  return {
-    actividades: [],
-    filas: [],
-    lotes: reference?.lotes || [],
-    datos: {},
-    totalesPorActividad: {},
-    totalesPorLote: {},
-    totalGeneral: { jornales: 0, costo: 0 },
-  };
+  return [slide('JORNALES', semana, `
+    ${headline(analisis.titulares.jornales)}
+    <div style="flex:1;display:flex;flex-direction:column;gap:10px;min-height:0;overflow:hidden;">
+      ${sections.join('')}
+    </div>
+  `)];
 }
 
 // ============================================================================

--- a/supabase/functions/make-server-1ccce916/generar-reporte-semanal.tsx
+++ b/supabase/functions/make-server-1ccce916/generar-reporte-semanal.tsx
@@ -100,7 +100,8 @@ Ejemplo MALO personal: "Resumen del personal de esta semana"
 Ejemplo BUENO monitoreo: "Alerta critica: Cucarron marceno al 35% en Salto de Tequendama"
 Ejemplo MALO monitoreo: "Estado fitosanitario de los lotes monitoreados"
 
-Ejemplo BUENO jornales: "54.5 jornales — La Vega concentra 55% del esfuerzo semanal"
+Ejemplo BUENO jornales (canal mixto): "54.5 jornales: 32 propios + 22.5 contrato — contrato concentrado en poda en La Vega"
+Ejemplo BUENO jornales (un solo canal material): "54.5 jornales propios — La Vega concentra 55% del esfuerzo semanal"
 Ejemplo MALO jornales: "Distribucion de jornales por lote y actividad"
 
 Ejemplo BUENO labores: "8 labores activas, ninguna completada — zanjas llevan 7 semanas"
@@ -393,27 +394,50 @@ function formatearDatosParaPrompt(datos: any, historicoCtx = '', notionCtx = '')
   }
 
   if (datos.jornales) {
-    const { actividades, totalesPorActividad, totalesPorLote, totalGeneral } = datos.jornales;
+    const combinado = datos.jornales;
+    const propios = datos.labores?.matrizJornalesPropios;
+    const contrato = datos.labores?.matrizJornalesContrato;
 
-    // Top 5 actividades y lotes por jornales para reducir prompt
-    const topActividades = actividades
-      .map((act: string) => ({ nombre: act, jornales: totalesPorActividad[act]?.jornales || 0 }))
-      .sort((a: any, b: any) => b.jornales - a.jornales)
-      .slice(0, 5);
+    const topByChannel = (matriz: any, field: 'totalesPorActividad' | 'totalesPorLote') => {
+      if (!matriz) return [] as Array<{ nombre: string; jornales: number }>;
+      return Object.entries(matriz[field] as Record<string, { jornales: number }>)
+        .map(([nombre, v]) => ({ nombre, jornales: v.jornales || 0 }))
+        .filter(x => x.jornales > 0)
+        .sort((a, b) => b.jornales - a.jornales)
+        .slice(0, 5);
+    };
 
-    const topLotes = Object.entries(totalesPorLote as Record<string, { jornales: number }>)
-      .map(([nombre, v]) => ({ nombre, jornales: v.jornales || 0 }))
-      .sort((a, b) => b.jornales - a.jornales)
-      .slice(0, 5);
+    const topActividadesPropios = topByChannel(propios, 'totalesPorActividad');
+    const topActividadesContrato = topByChannel(contrato, 'totalesPorActividad');
+    const topLotesPropios = topByChannel(propios, 'totalesPorLote');
+    const topLotesContrato = topByChannel(contrato, 'totalesPorLote');
+
+    const fmtTop = (items: Array<{ nombre: string; jornales: number }>) =>
+      items.length === 0 ? '  - (sin registros)' : items.map(a => `  - ${a.nombre}: ${a.jornales.toFixed(2)}`).join('\n');
+
+    const totPropios = propios?.totalGeneral?.jornales || 0;
+    const totContrato = contrato?.totalGeneral?.jornales || 0;
+    const totCombinado = combinado.totalGeneral.jornales;
+    const pctContrato = totCombinado > 0 ? (totContrato / totCombinado) * 100 : 0;
+    const pctPropios = totCombinado > 0 ? (totPropios / totCombinado) * 100 : 0;
 
     partes.push(`## DISTRIBUCION DE JORNALES
-Total general: ${totalGeneral.jornales.toFixed(2)} jornales ($${Math.round(totalGeneral.costo).toLocaleString('es-CO')} COP)
+Total general: ${totCombinado.toFixed(2)} jornales ($${Math.round(combinado.totalGeneral.costo).toLocaleString('es-CO')} COP)
+Desglose por canal: ${totPropios.toFixed(2)} propios (${pctPropios.toFixed(0)}%) + ${totContrato.toFixed(2)} contrato (${pctContrato.toFixed(0)}%)
 
-### Top tareas por jornales
-${topActividades.map((a: any) => `  - ${a.nombre}: ${a.jornales.toFixed(2)}`).join('\n')}
+### Top tareas propios
+${fmtTop(topActividadesPropios)}
 
-### Top lotes por jornales
-${topLotes.map((l: any) => `  - ${l.nombre}: ${l.jornales.toFixed(2)}`).join('\n')}`);
+### Top tareas contrato
+${fmtTop(topActividadesContrato)}
+
+### Top lotes propios
+${fmtTop(topLotesPropios)}
+
+### Top lotes contrato
+${fmtTop(topLotesContrato)}
+
+NOTA: Si un canal (propios o contrato) representa menos del 5% del total combinado, omitelo del titular para no agregar ruido.`);
   }
 
   if (datos.labores?.programadas?.length > 0) {
@@ -994,13 +1018,20 @@ function construirSlideLaboresProgramadas(datos: any, analisis: AnalisisGemini):
   `);
 }
 
-function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): string[] {
-  const jornales = datos.jornales;
-  if (!jornales || !jornales.actividades || jornales.actividades.length === 0) return [];
-  const { semana } = datos;
-  const { actividades, filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = jornales;
+// Colors for the propio/contrato split (issue #46)
+const COLOR_PROPIO = '#73991C';
+const COLOR_CONTRATO = '#B8D47F';
 
-  // Use filas (nombre+tipo) if available, fall back to actividades-only for backward compat
+function renderMatrizJornalesTable(matriz: any, titulo: string, emptyText: string): string {
+  if (!matriz || !matriz.actividades || matriz.actividades.length === 0) {
+    return `<div style="border-radius:8px;border:1px solid #E7EDDD;background:#F8FAF5;padding:14px 16px;">
+      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
+      <div style="font-size:12px;color:#9ca3af;font-style:italic;">${emptyText}</div>
+    </div>`;
+  }
+
+  const { actividades, filas, lotes, datos: md, totalesPorActividad, totalesPorLote, totalGeneral } = matriz;
+
   const rows: Array<{ nombre: string; tipo: string }> = filas && filas.length > 0
     ? filas
     : actividades.map((a: string) => ({ nombre: a, tipo: '' }));
@@ -1011,20 +1042,13 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
     if (v > mx) mx = v;
   }
 
-  // Determine if charts fit on same slide (≤8 rows) or need their own slide
-  const MAX_ROWS_WITH_CHARTS = 8;
-  const chartsSeparate = rows.length > MAX_ROWS_WITH_CHARTS;
-
-  // Build table header
-  const hasTipo = rows.some(r => r.tipo && r.tipo !== r.nombre);
+  const hasTipo = rows.some((r: any) => r.tipo && r.tipo !== r.nombre);
   const hCells = lotes.map((l: string) => `<th style="${CSS.thGreenC}min-width:55px;">${l}</th>`).join('');
 
-  // Build table body rows
   let bodyRows = '';
   let prevTipo = '';
   for (const row of rows) {
     let cells = '';
-    // Show tipo column with rowspan-like visual grouping
     const tipoCell = hasTipo
       ? `<td style="padding:6px 8px;font-size:11px;color:#6b7280;border-bottom:1px solid #E7EDDD;background:#F8FAF5;white-space:nowrap;${row.tipo !== prevTipo ? 'border-top:1px solid #BFD97D;' : ''}">${row.tipo !== prevTipo ? row.tipo : ''}</td>`
       : '';
@@ -1040,7 +1064,6 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
     bodyRows += `<tr>${tipoCell}<td style="padding:5px 8px;font-size:12px;font-weight:600;color:#172E08;border-bottom:1px solid #E7EDDD;white-space:nowrap;">${nombreTrunc}</td>${cells}</tr>`;
   }
 
-  // Total row
   let totCells = '';
   if (hasTipo) totCells += `<td style="padding:5px 8px;background:#E7EDDD;border-top:2px solid #73991C;"></td>`;
   for (const lote of lotes) {
@@ -1050,75 +1073,141 @@ function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): str
   totCells += `<td style="padding:5px 6px;text-align:center;font-size:14px;font-weight:900;background:#73991C;color:#ffffff;border-top:2px solid #5f7d17;">${fmtN(totalGeneral.jornales)}</td>`;
   bodyRows += `<tr><td style="padding:5px 8px;font-size:12px;font-weight:800;color:#73991C;background:#E7EDDD;border-top:2px solid #73991C;">TOTAL</td>${totCells}</tr>`;
 
-  // Table header row
   const thTipo = hasTipo ? `<th style="${CSS.thGreen}min-width:90px;">Tipo</th>` : '';
 
-  const tableHTML = `
-    <div style="border-radius:8px;border:1px solid #E7EDDD;overflow:hidden;">
-      <table style="width:100%;border-collapse:collapse;">
-        <thead><tr>${thTipo}<th style="${CSS.thGreen}">Nombre</th>${hCells}<th style="${CSS.thGreenC}background:#5f7d17;">Total</th></tr></thead>
-        <tbody>${bodyRows}</tbody>
-      </table>
+  return `
+    <div>
+      <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:4px;">${titulo}</div>
+      <div style="border-radius:8px;border:1px solid #E7EDDD;overflow:hidden;">
+        <table style="width:100%;border-collapse:collapse;">
+          <thead><tr>${thTipo}<th style="${CSS.thGreen}">Nombre</th>${hCells}<th style="${CSS.thGreenC}background:#5f7d17;">Total</th></tr></thead>
+          <tbody>${bodyRows}</tbody>
+        </table>
+      </div>
     </div>`;
+}
 
-  // Bar charts
-  const nameOrd = [...actividades].sort((a: string, b: string) => (totalesPorActividad[b]?.jornales || 0) - (totalesPorActividad[a]?.jornales || 0));
-  const loteOrd = [...lotes].sort((a: string, b: string) => (totalesPorLote[b]?.jornales || 0) - (totalesPorLote[a]?.jornales || 0));
-  const mxN = Math.max(...nameOrd.map((a: string) => totalesPorActividad[a]?.jornales || 0), 1);
-  const mxL = Math.max(...loteOrd.map((l: string) => totalesPorLote[l]?.jornales || 0), 1);
+function legendHTML(): string {
+  return `<div style="display:flex;gap:18px;align-items:center;margin-bottom:8px;font-size:11px;color:#4D240F;">
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_PROPIO};border-radius:2px;"></span>Propios</span>
+    <span style="display:inline-flex;align-items:center;gap:6px;"><span style="display:inline-block;width:12px;height:12px;background:${COLOR_CONTRATO};border-radius:2px;"></span>Contrato</span>
+  </div>`;
+}
+
+function construirSlidesLaboresMatriz(datos: any, analisis: AnalisisGemini): string[] {
+  const combinado = datos.jornales || datos.labores?.matrizJornales;
+  if (!combinado || !combinado.actividades || combinado.actividades.length === 0) return [];
+
+  const propios = datos.labores?.matrizJornalesPropios || emptyMatrizFallback(combinado);
+  const contrato = datos.labores?.matrizJornalesContrato || emptyMatrizFallback(combinado);
+
+  const { semana } = datos;
+
+  const tableHTMLPropios = renderMatrizJornalesTable(propios, 'JORNALES PROPIOS', 'Sin jornales propios en la semana');
+  const tableHTMLContrato = renderMatrizJornalesTable(contrato, 'JORNALES POR CONTRATO', 'Sin jornales por contrato en la semana');
+
+  const MAX_ROWS_WITH_CHARTS = 8;
+  const chartsSeparate = Math.max(
+    (propios.actividades?.length || 0),
+    (contrato.actividades?.length || 0)
+  ) > MAX_ROWS_WITH_CHARTS;
+
+  // Stacked bar charts ordered by combined totals so propios + contrato segments line up.
+  const nameOrd = [...combinado.actividades].sort((a: string, b: string) =>
+    (combinado.totalesPorActividad[b]?.jornales || 0) - (combinado.totalesPorActividad[a]?.jornales || 0)
+  );
+  const loteOrd = [...combinado.lotes].sort((a: string, b: string) =>
+    (combinado.totalesPorLote[b]?.jornales || 0) - (combinado.totalesPorLote[a]?.jornales || 0)
+  );
+  const mxN = Math.max(...nameOrd.map((a: string) => combinado.totalesPorActividad[a]?.jornales || 0), 1);
+  const mxL = Math.max(...loteOrd.map((l: string) => combinado.totalesPorLote[l]?.jornales || 0), 1);
 
   const truncLabel = (s: string, max: number) => s.length > max ? s.slice(0, max - 1) + '…' : s;
 
-  const bar = (items: string[], getData: (k: string) => number, maxV: number, color: string) =>
+  const stackedBar = (
+    items: string[],
+    getPropio: (k: string) => number,
+    getContrato: (k: string) => number,
+    maxV: number,
+  ) =>
     items.slice(0, 8).map((k: string) => {
-      const v = getData(k);
-      const pct = (v / maxV) * 100;
+      const own = getPropio(k);
+      const ctr = getContrato(k);
+      const total = own + ctr;
+      const ownPct = (own / maxV) * 100;
+      const ctrPct = (ctr / maxV) * 100;
+      const totalPct = (total / maxV) * 100;
       const label = truncLabel(k, 24);
       return `<div style="display:flex;align-items:center;margin-bottom:8px;">
         <div style="width:180px;font-size:11px;font-weight:500;color:#4D240F;text-align:right;padding-right:10px;flex-shrink:0;white-space:nowrap;">${label}</div>
-        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:22px;position:relative;overflow:hidden;">
-          <div style="background:${color};height:100%;border-radius:3px;width:${Math.max(pct, 2)}%;"></div>
-          <span style="position:absolute;left:6px;top:2px;font-size:11px;font-weight:600;color:${pct > 35 ? '#fff' : '#4D240F'};">${fmtN(v, 1)}</span>
+        <div style="flex:1;background:#E7EDDD;border-radius:3px;height:22px;position:relative;overflow:hidden;display:flex;">
+          <div style="background:${COLOR_PROPIO};height:100%;width:${ownPct}%;"></div>
+          <div style="background:${COLOR_CONTRATO};height:100%;width:${ctrPct}%;"></div>
+          <span style="position:absolute;left:6px;top:2px;font-size:11px;font-weight:600;color:${totalPct > 35 ? '#fff' : '#4D240F'};">${fmtN(total, 1)}</span>
         </div>
       </div>`;
     }).join('');
 
   const chartsHTML = `
+    ${legendHTML()}
     <div style="display:flex;gap:32px;flex:1;">
       <div style="flex:1;">
         <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR TAREA</div>
-        ${bar(nameOrd, (a: string) => totalesPorActividad[a]?.jornales || 0, mxN, '#73991C')}
+        ${stackedBar(
+          nameOrd,
+          (a: string) => propios.totalesPorActividad?.[a]?.jornales || 0,
+          (a: string) => contrato.totalesPorActividad?.[a]?.jornales || 0,
+          mxN,
+        )}
       </div>
       <div style="flex:1;">
         <div style="font-size:11px;font-weight:700;color:#4D240F;letter-spacing:1px;margin-bottom:6px;">POR LOTE</div>
-        ${bar(loteOrd, (l: string) => totalesPorLote[l]?.jornales || 0, mxL, '#73991C')}
+        ${stackedBar(
+          loteOrd,
+          (l: string) => propios.totalesPorLote?.[l]?.jornales || 0,
+          (l: string) => contrato.totalesPorLote?.[l]?.jornales || 0,
+          mxL,
+        )}
       </div>
     </div>`;
 
   const slides: string[] = [];
 
   if (chartsSeparate) {
-    // Slide 1: Table only
     slides.push(slide('JORNALES — MATRIZ', semana, `
       ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;overflow:hidden;">${tableHTML}</div>
+      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
+        ${tableHTMLPropios}
+        ${tableHTMLContrato}
+      </div>
     `));
-    // Slide 2: Charts only
     slides.push(slide('JORNALES — DISTRIBUCIÓN', semana, `
       <div style="flex:1;display:flex;flex-direction:column;justify-content:center;">${chartsHTML}</div>
     `));
   } else {
-    // Single slide: table + charts
     slides.push(slide('JORNALES', semana, `
       ${headline(analisis.titulares.jornales)}
-      <div style="flex:1;display:flex;flex-direction:column;gap:16px;overflow:hidden;">
-        ${tableHTML}
+      <div style="flex:1;display:flex;flex-direction:column;gap:12px;overflow:hidden;">
+        ${tableHTMLPropios}
+        ${tableHTMLContrato}
         ${chartsHTML}
       </div>
     `));
   }
 
   return slides;
+}
+
+function emptyMatrizFallback(reference: any): any {
+  return {
+    actividades: [],
+    filas: [],
+    lotes: reference?.lotes || [],
+    datos: {},
+    totalesPorActividad: {},
+    totalesPorLote: {},
+    totalGeneral: { jornales: 0, costo: 0 },
+  };
 }
 
 // ============================================================================


### PR DESCRIPTION
Splits the weekly jornales matrix into two independent flows — own employees
(empleado_id) and contractors (contratista_id) — so management can analyze
each labor channel separately while keeping the combined view for KPI cross-
checks.

- fetchMatrizJornales now returns { propios, contrato, combinado } from a
  single registros_trabajo query, with all three matrices sharing row/column
  ordering for visual consistency.
- DatosLabores gains matrizJornalesPropios and matrizJornalesContrato as
  siblings; matrizJornales remains as a combined alias for backwards compat.
- Wizard step 3 renders two independent matrix Cards plus a combined gran
  total footer; empty channels show a friendly empty state.
- PDF edge function renders two heat-map tables (Propios / Contrato) and
  stacked-bar charts (Por Tarea / Por Lote) with a Propios/Contrato legend.
  chartsSeparate is now driven by max(rowsPropios, rowsContrato) > 8 so the
  layout stays readable.
- Gemini prompt receives per-channel top tareas/lotes plus the combined total
  and an explicit instruction to omit a channel from the headline when it is
  ≤5% of the combined volume.
- Tests cover the propio/contrato split, channel-empty edge case, and the
  PDF rendering of both headings, stacked-bar colors, and legend.

https://claude.ai/code/session_01D7CvaiHc3bvg2RQxPKcc5X