### PR TITLE
fix(reportes): source planned jornales from tarea estimate, not canecas

### DIFF
--- a/src/hooks/useReporteAplicacion.ts
+++ b/src/hooks/useReporteAplicacion.ts
@@ -215,6 +215,7 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                 .from('aplicaciones')
                 .select(`
                     *,
+                    tareas ( jornales_estimados ),
                     aplicaciones_cierre(*),
                     aplicaciones_lotes(*, lotes(nombre, total_arboles, arboles_grandes, arboles_medianos, arboles_pequenos, arboles_clonales)),
                     aplicaciones_lotes_planificado(*, lotes(nombre, total_arboles, arboles_grandes, arboles_medianos, arboles_pequenos, arboles_clonales)),
@@ -333,6 +334,20 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
             const totalArbolesApp = lotesSource.reduce((sum: number, l: any) =>
                 sum + (l.total_arboles || l.lotes?.total_arboles || 0), 0) || 0;
 
+            // Planned jornales: canonical source is tareas.jornales_estimados (entered in the
+            // Labores task dialog). It is per-application total; prorate across lotes by tree count.
+            // Fallback to arboles/500 when no task estimate exists.
+            const tareaData = (appData as any).tareas;
+            const tareaJoined = Array.isArray(tareaData) ? tareaData[0] : tareaData;
+            const jornalesEstimadosApp = Number(tareaJoined?.jornales_estimados) || 0;
+            const jornalesPlanLote = (arboles: number) => {
+                const trees = Number(arboles) || 0;
+                if (jornalesEstimadosApp > 0 && totalArbolesApp > 0) {
+                    return jornalesEstimadosApp * (trees / totalArbolesApp);
+                }
+                return trees > 0 ? trees / 500 : 0;
+            };
+
             // Use 'jornales_utilizados' from app for total labor, defaulting to 0
             const cierreData = appData.aplicaciones_cierre as unknown as any[] | undefined;
             const totalJornalesApp = Number(appData.jornales_utilizados || cierreData?.[0]?.jornales_aplicacion || 0);
@@ -443,7 +458,7 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                     lote_id: loteId,
                     canecas_plan: canecas,
                     litros_plan: litros,
-                    jornales_plan: Math.ceil(lp.total_arboles / 500) // Rough estimate if not stored
+                    jornales_plan: jornalesPlanLote(lp.total_arboles)
                 });
 
                 // Products in this mixture
@@ -508,7 +523,7 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                   lote_id: loteId,
                   canecas_plan: bultos,
                   litros_plan: totalKg,
-                  jornales_plan: Math.ceil((al.total_arboles || lote?.total_arboles || 0) / 500),
+                  jornales_plan: jornalesPlanLote(al.total_arboles || lote?.total_arboles || 0),
                 });
 
                 // Compute per-product planned quantity from dosis × trees (not cantidad_total_necesaria)
@@ -550,7 +565,7 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                   lote_id: loteId,
                   canecas_plan: 0,
                   litros_plan: 0,
-                  jornales_plan: Math.ceil(trees / 500),
+                  jornales_plan: jornalesPlanLote(trees),
                 });
               }
             }

--- a/src/utils/fetchDatosReporteSemanal.ts
+++ b/src/utils/fetchDatosReporteSemanal.ts
@@ -701,6 +701,7 @@ export async function fetchAplicacionesCerradas(
           costo_total,
           jornales_utilizados,
           valor_jornal,
+          tareas ( jornales_estimados ),
           aplicaciones_lotes(
             lote_id,
             lotes(id, nombre, total_arboles, arboles_grandes, arboles_medianos, arboles_pequenos, arboles_clonales)
@@ -730,6 +731,13 @@ export async function fetchAplicacionesCerradas(
           pequenos: lote.arboles_pequenos || 0, clonales: lote.arboles_clonales || 0,
         });
       });
+
+      // Planned jornales: canonical source is tareas.jornales_estimados (entered in the Labores
+      // task dialog). It is per-application total; prorate across lotes by tree count.
+      const tareaData = (app as any).tareas;
+      const tareaJoined = Array.isArray(tareaData) ? tareaData[0] : tareaData;
+      const jornalesEstimadosApp = Number(tareaJoined?.jornales_estimados) || 0;
+      const totalArbolesApp = Array.from(lotesMap.values()).reduce((s, l) => s + l.arboles, 0);
 
       // Fetch planned calcs per lote
       const { data: calculos } = await supabase
@@ -925,7 +933,11 @@ export async function fetchAplicacionesCerradas(
         const insumosDesv = insumosPlaneados > 0
           ? ((insumosReales - insumosPlaneados) / insumosPlaneados) * 100 : 0;
 
-        const jornalesPlan = canecasPlan * (esFumigacion ? 1 : 0.5); // Theoretical plan
+        // Planned jornales: prorate task estimate by tree share; fallback arboles/500
+        const arbolRatio = totalArbolesApp > 0 ? arboles / totalArbolesApp : 0;
+        const jornalesPlan = jornalesEstimadosApp > 0
+          ? jornalesEstimadosApp * arbolRatio
+          : (arboles > 0 ? arboles / 500 : 0);
         const jornalesReal = jornales.jornales;
         const jornalesDesv = jornalesPlan > 0 ? ((jornalesReal - jornalesPlan) / jornalesPlan) * 100 : 0;
         


### PR DESCRIPTION
Planned jornales were computed as canecasPlan × (1 for fumigation,
0.5 for fertilization), which made the Jornales Plan column mirror
the Canecas Plan column and produced bogus -40% to -50% deviations.
This also propagated into costoLoteManoObraPlan, contaminating the
financial block of the weekly report.

Read the canonical estimate from tareas.jornales_estimados via the
existing aplicaciones.tarea_id link, then prorate across lotes by
tree count. Fall back to arboles/500 only when the task has no
estimate. Apply the same logic in useReporteAplicacion so the
per-application and weekly reports stay consistent.