### PR TITLE
fix(esco): repair broken application + inventory queries

### DIFF
--- a/src/supabase/functions/server/chat.tsx
+++ b/src/supabase/functions/server/chat.tsx
@@ -818,10 +818,15 @@ async function execApplicationSummary(args: Record<string, unknown>): Promise<st
   if (application_id) query += `&id=eq.${e(application_id)}`;
   if (date_from) query += `&fecha_inicio_planeada=gte.${e(date_from)}`;
   if (date_to) query += `&fecha_inicio_planeada=lte.${e(date_to)}`;
-  if (type) query += `&tipo_aplicacion=ilike.*${e(type)}*`;
+  // tipo_aplicacion is an enum; PostgREST `ilike` has no operator overload
+  // for enum vs text, so filter client-side after fetch.
 
   const apps = await supabaseQuery('aplicaciones', query);
-  const appsList = apps as Array<Record<string, unknown>>;
+  let appsList = apps as Array<Record<string, unknown>>;
+  if (type) {
+    const t = type.toLowerCase();
+    appsList = appsList.filter((a) => ((a.tipo_aplicacion as string) || '').toLowerCase().includes(t));
+  }
 
   // Batch all sub-queries to avoid N+1
   const enriched: Array<Record<string, unknown>> = [];
@@ -831,7 +836,7 @@ async function execApplicationSummary(args: Record<string, unknown>): Promise<st
     const [allLotes, allLotesPlan, allMezclas, allMovimientos] = await Promise.all([
       supabaseQuery('aplicaciones_lotes', `select=aplicacion_id,lote:lotes(nombre)&aplicacion_id=in.(${appIds})&limit=2000`),
       supabaseQuery('aplicaciones_lotes_planificado', `select=aplicacion_id,lote:lotes(nombre),canecas_planificado,litros_mezcla_planificado&aplicacion_id=in.(${appIds})&limit=2000`),
-      supabaseQuery('aplicaciones_mezclas', `select=aplicacion_id,nombre,aplicaciones_productos(producto:productos(nombre),dosis_por_caneca,cantidad_total_necesaria,unidad_dosis)&aplicacion_id=in.(${appIds})&limit=2000`),
+      supabaseQuery('aplicaciones_mezclas', `select=aplicacion_id,nombre_mezcla,aplicaciones_productos(producto:productos(nombre),dosis_por_caneca,cantidad_total_necesaria,unidad_dosis)&aplicacion_id=in.(${appIds})&limit=2000`),
       supabaseQuery('movimientos_diarios', `select=aplicacion_id,fecha_movimiento,numero_canecas,numero_bultos,lote:lotes(nombre)&aplicacion_id=in.(${appIds})&order=fecha_movimiento.asc&limit=2000`),
     ]);
 
@@ -864,7 +869,7 @@ async function execApplicationSummary(args: Record<string, unknown>): Promise<st
   }
 
   return JSON.stringify({
-    total_aplicaciones: apps.length,
+    total_aplicaciones: appsList.length,
     aplicaciones: enriched,
   });
 }
@@ -1214,7 +1219,8 @@ async function execInventoryMovements(args: Record<string, unknown>): Promise<st
   let movQuery = `select=id,fecha_movimiento,tipo_movimiento,cantidad,unidad,saldo_anterior,saldo_nuevo,valor_movimiento,observaciones,producto:productos(nombre,categoria)&order=fecha_movimiento.desc&limit=2000`;
   if (date_from) movQuery += `&fecha_movimiento=gte.${e(date_from)}`;
   if (date_to) movQuery += `&fecha_movimiento=lte.${e(date_to)}`;
-  if (tipo) movQuery += `&tipo_movimiento=ilike.*${e(tipo)}*`;
+  // tipo_movimiento is an enum; PostgREST `ilike` has no operator overload
+  // for enum vs text, so filter client-side after fetch.
 
   const [movimientos, verificaciones] = await Promise.all([
     supabaseQuery('movimientos_inventario', movQuery),
@@ -1223,6 +1229,10 @@ async function execInventoryMovements(args: Record<string, unknown>): Promise<st
   ]);
 
   let filteredMov = movimientos as Array<Record<string, unknown>>;
+  if (tipo) {
+    const t = tipo.toLowerCase();
+    filteredMov = filteredMov.filter((r) => ((r.tipo_movimiento as string) || '').toLowerCase().includes(t));
+  }
   if (product_name) {
     const pn = product_name.toLowerCase();
     filteredMov = filteredMov.filter((r) => ((r.producto as Record<string, unknown>)?.nombre as string || '').toLowerCase().includes(pn));

--- a/supabase/functions/make-server-1ccce916/chat.tsx
+++ b/supabase/functions/make-server-1ccce916/chat.tsx
@@ -818,10 +818,15 @@ async function execApplicationSummary(args: Record<string, unknown>): Promise<st
   if (application_id) query += `&id=eq.${e(application_id)}`;
   if (date_from) query += `&fecha_inicio_planeada=gte.${e(date_from)}`;
   if (date_to) query += `&fecha_inicio_planeada=lte.${e(date_to)}`;
-  if (type) query += `&tipo_aplicacion=ilike.*${e(type)}*`;
+  // tipo_aplicacion is an enum; PostgREST `ilike` has no operator overload
+  // for enum vs text, so filter client-side after fetch.
 
   const apps = await supabaseQuery('aplicaciones', query);
-  const appsList = apps as Array<Record<string, unknown>>;
+  let appsList = apps as Array<Record<string, unknown>>;
+  if (type) {
+    const t = type.toLowerCase();
+    appsList = appsList.filter((a) => ((a.tipo_aplicacion as string) || '').toLowerCase().includes(t));
+  }
 
   // Batch all sub-queries to avoid N+1
   const enriched: Array<Record<string, unknown>> = [];
@@ -831,7 +836,7 @@ async function execApplicationSummary(args: Record<string, unknown>): Promise<st
     const [allLotes, allLotesPlan, allMezclas, allMovimientos] = await Promise.all([
       supabaseQuery('aplicaciones_lotes', `select=aplicacion_id,lote:lotes(nombre)&aplicacion_id=in.(${appIds})&limit=2000`),
       supabaseQuery('aplicaciones_lotes_planificado', `select=aplicacion_id,lote:lotes(nombre),canecas_planificado,litros_mezcla_planificado&aplicacion_id=in.(${appIds})&limit=2000`),
-      supabaseQuery('aplicaciones_mezclas', `select=aplicacion_id,nombre,aplicaciones_productos(producto:productos(nombre),dosis_por_caneca,cantidad_total_necesaria,unidad_dosis)&aplicacion_id=in.(${appIds})&limit=2000`),
+      supabaseQuery('aplicaciones_mezclas', `select=aplicacion_id,nombre_mezcla,aplicaciones_productos(producto:productos(nombre),dosis_por_caneca,cantidad_total_necesaria,unidad_dosis)&aplicacion_id=in.(${appIds})&limit=2000`),
       supabaseQuery('movimientos_diarios', `select=aplicacion_id,fecha_movimiento,numero_canecas,numero_bultos,lote:lotes(nombre)&aplicacion_id=in.(${appIds})&order=fecha_movimiento.asc&limit=2000`),
     ]);
 
@@ -864,7 +869,7 @@ async function execApplicationSummary(args: Record<string, unknown>): Promise<st
   }
 
   return JSON.stringify({
-    total_aplicaciones: apps.length,
+    total_aplicaciones: appsList.length,
     aplicaciones: enriched,
   });
 }
@@ -1214,7 +1219,8 @@ async function execInventoryMovements(args: Record<string, unknown>): Promise<st
   let movQuery = `select=id,fecha_movimiento,tipo_movimiento,cantidad,unidad,saldo_anterior,saldo_nuevo,valor_movimiento,observaciones,producto:productos(nombre,categoria)&order=fecha_movimiento.desc&limit=2000`;
   if (date_from) movQuery += `&fecha_movimiento=gte.${e(date_from)}`;
   if (date_to) movQuery += `&fecha_movimiento=lte.${e(date_to)}`;
-  if (tipo) movQuery += `&tipo_movimiento=ilike.*${e(tipo)}*`;
+  // tipo_movimiento is an enum; PostgREST `ilike` has no operator overload
+  // for enum vs text, so filter client-side after fetch.
 
   const [movimientos, verificaciones] = await Promise.all([
     supabaseQuery('movimientos_inventario', movQuery),
@@ -1223,6 +1229,10 @@ async function execInventoryMovements(args: Record<string, unknown>): Promise<st
   ]);
 
   let filteredMov = movimientos as Array<Record<string, unknown>>;
+  if (tipo) {
+    const t = tipo.toLowerCase();
+    filteredMov = filteredMov.filter((r) => ((r.tipo_movimiento as string) || '').toLowerCase().includes(t));
+  }
   if (product_name) {
     const pn = product_name.toLowerCase();
     filteredMov = filteredMov.filter((r) => ((r.producto as Record<string, unknown>)?.nombre as string || '').toLowerCase().includes(pn));


### PR DESCRIPTION
## Summary

Esco (the chat agent) was effectively "down" in both the web app and the Telegram bot. The HTTP layer was fine (edge-function logs showed 200s), but the LLM tool loop was failing on the two most-used tools because two schema/operator bugs in `chat.tsx` were silently producing PostgREST errors.

Postgres logs caught the actual culprits, aligned in time with recent `/chat/message` invocations:

- `column aplicaciones_mezclas.nombre does not exist`
- `operator does not exist: tipo_aplicacion ~~* unknown`

### Root cause

- `aplicaciones_mezclas.nombre` — the real column is `nombre_mezcla`. The embedded sub-query in `get_application_summary` always runs, so **every** call was failing with "column does not exist" regardless of args.
- `tipo_aplicacion` and `tipo_movimiento` are PostgreSQL enums. PostgREST's `ilike` (`~~*`) has no operator overload for `enum vs text`, raising "operator does not exist". This broke `get_application_summary` (when `type` arg was provided) and latently `get_inventory_movements` (same bug on `tipo_movimiento`).

`executeTool` catches the throw and returns `{"error": ...}` to the model, but with `maxRounds = 3` and `tool_choice: 'required'` on round 0, the LLM tends to keep retrying the broken tool and ends up with no useful answer — that's the "down" symptom users saw on both surfaces.

### Fix

In `src/supabase/functions/server/chat.tsx` (and mirrored to the deployed copy):

- `aplicaciones_mezclas` select → `nombre_mezcla`.
- Dropped the `tipo_aplicacion=ilike.*X*` and `tipo_movimiento=ilike.*X*` URL filters; switched to client-side case-insensitive `.includes()` filtering after fetch. Pattern already used in `execLaborSummary` for employee/lote name filtering, so consistent with the file.
- Adjusted `total_aplicaciones` to count post-filter.

No model change, no schema migration — purely a chat query fix.

## Test plan

- [ ] Redeploy `make-server-1ccce916` (`npx supabase functions deploy make-server-1ccce916` or MCP deploy).
- [ ] Web Esco: ask "Resume las aplicaciones del último mes" → should return real data, not an empty/error response.
- [ ] Web Esco: ask "Resume las fumigaciones del último mes" (exercises the `type` filter path).
- [ ] Telegram bot: same two prompts.
- [ ] Inventory tool: "qué movimientos de inventario tipo entrada hubo esta semana" — should return data, not error.
- [ ] Re-check postgres logs after a few minutes of traffic — the `aplicaciones_mezclas.nombre does not exist` and `tipo_aplicacion ~~* unknown` errors should no longer appear.

https://claude.ai/code/session_01F9kKZszbEL4dU1JkeCs6DD

---
_Generated by [Claude Code](https://claude.ai/code/session_01F9kKZszbEL4dU1JkeCs6DD)_