### PR TITLE
fix(finanzas): avocado batch entry + responsive dashboard tables

### DIFF
--- a/src/__tests__/agrupacionIngresos.test.ts
+++ b/src/__tests__/agrupacionIngresos.test.ts
@@ -1,0 +1,124 @@
+import { describe, it, expect } from 'vitest';
+import { agruparPorCosecha, agruparPorQuincena, quincenaDe } from '@/utils/agrupacionIngresos';
+import type { IngresoDetalleRow } from '@/types/finanzas';
+
+function row(overrides: Partial<IngresoDetalleRow>): IngresoDetalleRow {
+  return {
+    fecha: '2025-06-01',
+    tipo_ingreso: 'Venta',
+    cantidad: null,
+    precio_unitario: null,
+    valor: 0,
+    cosecha: null,
+    alianza: null,
+    cliente: null,
+    finca: null,
+    comprador: null,
+    ...overrides,
+  };
+}
+
+describe('quincenaDe', () => {
+  it('day 1 → primera quincena', () => {
+    expect(quincenaDe('2025-01-01').key).toBe('2025-01-1');
+    expect(quincenaDe('2025-01-01').label).toBe('1-15 ene 2025');
+  });
+  it('day 15 → primera quincena (frontera)', () => {
+    expect(quincenaDe('2025-03-15').key).toBe('2025-03-1');
+  });
+  it('day 16 → segunda quincena (frontera)', () => {
+    expect(quincenaDe('2025-03-16').key).toBe('2025-03-2');
+    expect(quincenaDe('2025-03-16').label).toBe('16-fin mar 2025');
+  });
+  it('day 31 → segunda quincena', () => {
+    expect(quincenaDe('2025-01-31').key).toBe('2025-01-2');
+  });
+});
+
+describe('agruparPorCosecha', () => {
+  it('agrupa por cosecha y ordena por fecha más reciente desc', () => {
+    const rows = [
+      row({ cosecha: 'Principal 2025', fecha: '2025-03-01', valor: 100, cantidad: 1000 }),
+      row({ cosecha: 'Traviesa 2025', fecha: '2025-09-01', valor: 200, cantidad: 2000 }),
+      row({ cosecha: 'Principal 2025', fecha: '2025-04-01', valor: 150, cantidad: 1500 }),
+    ];
+    const grupos = agruparPorCosecha(rows);
+    expect(grupos).toHaveLength(2);
+    expect(grupos[0].key).toBe('Traviesa 2025'); // más reciente
+    expect(grupos[1].key).toBe('Principal 2025');
+    expect(grupos[1].valorTotal).toBe(250);
+    expect(grupos[1].cantidad).toBe(2500);
+  });
+
+  it('cosecha nula → grupo Sin cosecha', () => {
+    const grupos = agruparPorCosecha([row({ cosecha: null, valor: 500 })]);
+    expect(grupos[0].key).toBe('Sin cosecha');
+    expect(grupos[0].valorTotal).toBe(500);
+  });
+
+  it('fila sin cantidad: valorTotal incluye la fila, precioPromedio excluye', () => {
+    const rows = [
+      row({ cosecha: 'A', valor: 300, cantidad: 100 }),
+      row({ cosecha: 'A', valor: 100, cantidad: null }), // sin cantidad
+    ];
+    const [g] = agruparPorCosecha(rows);
+    expect(g.valorTotal).toBe(400);           // incluye ambas
+    expect(g.valorConCantidad).toBe(300);     // solo la que tiene cantidad
+    expect(g.cantidad).toBe(100);
+    expect(g.precioPromedio).toBe(3);         // 300 / 100
+  });
+
+  it('sin ninguna cantidad: precioPromedio es 0', () => {
+    const [g] = agruparPorCosecha([row({ cosecha: 'A', valor: 500, cantidad: null })]);
+    expect(g.precioPromedio).toBe(0);
+    expect(g.cantidad).toBe(0);
+    expect(g.valorTotal).toBe(500);
+  });
+
+  it('cantidad 0 no cuenta para precio', () => {
+    const [g] = agruparPorCosecha([row({ cosecha: 'A', valor: 500, cantidad: 0 })]);
+    expect(g.cantidad).toBe(0);
+    expect(g.precioPromedio).toBe(0);
+  });
+
+  it('devuelve arreglo vacío cuando no hay filas', () => {
+    expect(agruparPorCosecha([])).toEqual([]);
+  });
+});
+
+describe('agruparPorQuincena', () => {
+  it('agrupa correctamente por quincena y ordena desc', () => {
+    const rows = [
+      row({ fecha: '2025-01-10', valor: 100, cantidad: 500 }),
+      row({ fecha: '2025-01-20', valor: 200, cantidad: 1000 }),
+      row({ fecha: '2025-02-05', valor: 300, cantidad: 1500 }),
+    ];
+    const grupos = agruparPorQuincena(rows);
+    expect(grupos).toHaveLength(3);
+    expect(grupos[0].key).toBe('2025-02-1'); // más reciente
+    expect(grupos[1].key).toBe('2025-01-2');
+    expect(grupos[2].key).toBe('2025-01-1');
+  });
+
+  it('calcula precioPromedio correctamente (litros)', () => {
+    const rows = [
+      row({ fecha: '2025-05-03', valor: 1000, cantidad: 200 }),
+      row({ fecha: '2025-05-08', valor: 2000, cantidad: 400 }),
+    ];
+    const [g] = agruparPorQuincena(rows);
+    expect(g.cantidad).toBe(600);
+    expect(g.valorConCantidad).toBe(3000);
+    expect(g.precioPromedio).toBeCloseTo(5); // 3000 / 600
+  });
+
+  it('fila sin cantidad incluida en valorTotal pero no en precio', () => {
+    const rows = [
+      row({ fecha: '2025-05-03', valor: 500, cantidad: null }),
+      row({ fecha: '2025-05-10', valor: 1000, cantidad: 200 }),
+    ];
+    const [g] = agruparPorQuincena(rows);
+    expect(g.valorTotal).toBe(1500);
+    expect(g.cantidad).toBe(200);
+    expect(g.precioPromedio).toBe(5); // 1000 / 200
+  });
+});

--- a/src/components/finanzas/components/FinanzasSubNav.tsx
+++ b/src/components/finanzas/components/FinanzasSubNav.tsx
@@ -69,7 +69,7 @@ export function FinanzasSubNav() {
 
   return (
     <div className="bg-white/80 backdrop-blur-xl border-b border-primary/10 mb-6 -mx-4 lg:-mx-8 px-4 lg:px-8">
-      <div className="flex gap-2 overflow-x-auto scrollbar-hide">
+      <div className="flex flex-wrap gap-x-2 gap-y-0">
         {tabs.map((tab) => {
           const Icon = tab.icon;
           const active = isActive(tab.path);
@@ -78,7 +78,7 @@ export function FinanzasSubNav() {
             <button
               key={tab.id}
               onClick={() => navigate(tab.path)}
-              className={`flex items-center gap-2 px-3 lg:px-4 py-3 lg:py-4 border-b-2 transition-all whitespace-nowrap ${
+              className={`flex items-center gap-2 px-2 lg:px-4 py-2 lg:py-4 border-b-2 transition-all whitespace-nowrap ${
                 active
                   ? 'border-primary text-foreground'
                   : 'border-transparent text-brand-brown/60 hover:text-foreground hover:border-primary/30'

--- a/src/components/finanzas/components/IngresosBatchRow.tsx
+++ b/src/components/finanzas/components/IngresosBatchRow.tsx
@@ -2,6 +2,7 @@ import { useRef } from 'react';
 import { Upload, CheckCircle, X } from 'lucide-react';
 import type { BatchRowDataIngreso } from '@/types/finanzas';
 import type { IngresosCatalogs } from '../hooks/useIngresosCatalogs';
+import { formatCurrency } from '@/utils/format';
 
 interface IngresosBatchRowProps {
   row: BatchRowDataIngreso;
@@ -25,163 +26,276 @@ export function IngresosBatchRow({ row, index, catalogs, errors, onChange, onRem
     ? catalogs.getCategoriasPorNegocio(row.negocio_id)
     : [];
 
+  // Determinar si el negocio seleccionado requiere campos de cantidad
+  const negocio = catalogs.negocios.find((n) => n.id === row.negocio_id);
+  const negocioNombre = negocio?.nombre ?? '';
+  const esAguacate = negocioNombre.toLowerCase().includes('aguacate');
+  const esHatoLechero =
+    negocioNombre.toLowerCase().includes('hato') ||
+    negocioNombre.toLowerCase().includes('lechero');
+  const mostrarCantidad = esAguacate || esHatoLechero;
+  const labelCantidad = esHatoLechero ? 'Cantidad (litros)' : 'Cantidad (kg)';
+  const labelPrecio = esHatoLechero ? 'Precio / litro' : 'Precio / kg';
+  const unidad = esHatoLechero ? 'L' : 'kg';
+
+  // Auto-calcular precio unitario
+  const cantidadNum = row.cantidad ? Number(row.cantidad) : 0;
+  const valorNum = row.valor ? Number(row.valor) : 0;
+  const precioComputado =
+    cantidadNum > 0 && valorNum > 0 ? valorNum / cantidadNum : null;
+
   const cls = (field: string) => (errors[field] ? inputErr : inputOk);
 
+  // Número total de columnas de la tabla (debe coincidir con COLUMN_HEADERS en IngresosBatchTable)
+  const totalColumnas = 11;
+
   return (
-    <tr className="border-b border-primary/5 hover:bg-muted/30 transition-colors">
-      <td className={cellClass}>
-        <input
-          type="date"
-          value={row.fecha}
-          onChange={(e) => onChange(index, 'fecha', e.target.value)}
-          className={cls('fecha')}
-          style={{ minWidth: 130 }}
-        />
-      </td>
-      <td className={cellClass}>
-        <input
-          type="text"
-          value={row.nombre}
-          onChange={(e) => onChange(index, 'nombre', e.target.value)}
-          className={cls('nombre')}
-          placeholder="Nombre del ingreso"
-          style={{ minWidth: 160 }}
-        />
-      </td>
-      <td className={cellClass}>
-        <input
-          type="number"
-          value={row.valor}
-          onChange={(e) => onChange(index, 'valor', e.target.value)}
-          className={cls('valor')}
-          placeholder="0"
-          min="0"
-          style={{ minWidth: 110 }}
-        />
-      </td>
-      <td className={cellClass}>
-        <select
-          value={row.negocio_id}
-          onChange={(e) => {
-            onChange(index, 'negocio_id', e.target.value);
-            onChange(index, 'categoria_id', '');
-          }}
-          className={cls('negocio_id')}
-          style={{ minWidth: 130 }}
-        >
-          <option value="">Seleccionar</option>
-          {catalogs.negocios.map((n) => (
-            <option key={n.id} value={n.id}>{n.nombre}</option>
-          ))}
-        </select>
-      </td>
-      <td className={cellClass}>
-        <select
-          value={row.region_id}
-          onChange={(e) => onChange(index, 'region_id', e.target.value)}
-          className={cls('region_id')}
-          style={{ minWidth: 120 }}
-        >
-          <option value="">Seleccionar</option>
-          {catalogs.regiones.map((r) => (
-            <option key={r.id} value={r.id}>{r.nombre}</option>
-          ))}
-        </select>
-      </td>
-      <td className={cellClass}>
-        <select
-          value={row.categoria_id}
-          onChange={(e) => onChange(index, 'categoria_id', e.target.value)}
-          className={cls('categoria_id')}
-          disabled={!row.negocio_id}
-          style={{ minWidth: 130 }}
-        >
-          <option value="">{row.negocio_id ? 'Seleccionar' : 'Elija negocio'}</option>
-          {categoriasFiltradas.map((c) => (
-            <option key={c.id} value={c.id}>{c.nombre}</option>
-          ))}
-        </select>
-      </td>
-      <td className={cellClass}>
-        <div className="flex items-center gap-1">
+    <>
+      <tr className="border-b border-primary/5 hover:bg-muted/30 transition-colors">
+        <td className={cellClass}>
+          <input
+            type="date"
+            value={row.fecha}
+            onChange={(e) => onChange(index, 'fecha', e.target.value)}
+            className={cls('fecha')}
+            style={{ minWidth: 130 }}
+          />
+        </td>
+        <td className={cellClass}>
+          <input
+            type="text"
+            value={row.nombre}
+            onChange={(e) => onChange(index, 'nombre', e.target.value)}
+            className={cls('nombre')}
+            placeholder="Nombre del ingreso"
+            style={{ minWidth: 160 }}
+          />
+        </td>
+        <td className={cellClass}>
+          <input
+            type="number"
+            value={row.valor}
+            onChange={(e) => onChange(index, 'valor', e.target.value)}
+            onWheel={(e) => e.currentTarget.blur()}
+            className={cls('valor')}
+            placeholder="0"
+            min="0"
+            style={{ minWidth: 110 }}
+          />
+        </td>
+        <td className={cellClass}>
           <select
-            value={row.comprador_id}
+            value={row.negocio_id}
             onChange={(e) => {
-              if (e.target.value === '__CREATE__') {
-                onCreateComprador();
-                return;
-              }
-              onChange(index, 'comprador_id', e.target.value);
+              onChange(index, 'negocio_id', e.target.value);
+              onChange(index, 'categoria_id', '');
+              // Limpiar cantidad al cambiar negocio
+              onChange(index, 'cantidad', '');
             }}
-            className={inputOk}
+            className={cls('negocio_id')}
+            style={{ minWidth: 130 }}
+          >
+            <option value="">Seleccionar</option>
+            {catalogs.negocios.map((n) => (
+              <option key={n.id} value={n.id}>{n.nombre}</option>
+            ))}
+          </select>
+        </td>
+        <td className={cellClass}>
+          <select
+            value={row.region_id}
+            onChange={(e) => onChange(index, 'region_id', e.target.value)}
+            className={cls('region_id')}
             style={{ minWidth: 120 }}
           >
-            <option value="">Opcional</option>
-            {catalogs.compradores.map((c) => (
+            <option value="">Seleccionar</option>
+            {catalogs.regiones.map((r) => (
+              <option key={r.id} value={r.id}>{r.nombre}</option>
+            ))}
+          </select>
+        </td>
+        <td className={cellClass}>
+          <select
+            value={row.categoria_id}
+            onChange={(e) => onChange(index, 'categoria_id', e.target.value)}
+            className={cls('categoria_id')}
+            disabled={!row.negocio_id}
+            style={{ minWidth: 130 }}
+          >
+            <option value="">{row.negocio_id ? 'Seleccionar' : 'Elija negocio'}</option>
+            {categoriasFiltradas.map((c) => (
               <option key={c.id} value={c.id}>{c.nombre}</option>
             ))}
-            <option value="__CREATE__">+ Crear nuevo</option>
           </select>
-        </div>
-      </td>
-      <td className={cellClass}>
-        <select
-          value={row.medio_pago_id}
-          onChange={(e) => onChange(index, 'medio_pago_id', e.target.value)}
-          className={cls('medio_pago_id')}
-          style={{ minWidth: 120 }}
-        >
-          <option value="">Seleccionar</option>
-          {catalogs.mediosPago.map((m) => (
-            <option key={m.id} value={m.id}>{m.nombre}</option>
-          ))}
-        </select>
-      </td>
-      <td className={cellClass}>
-        <input
-          type="text"
-          value={row.observaciones}
-          onChange={(e) => onChange(index, 'observaciones', e.target.value)}
-          className={inputOk}
-          placeholder="Notas"
-          style={{ minWidth: 140 }}
-        />
-      </td>
-      <td className={`${cellClass} text-center`}>
-        <input
-          ref={fileRef}
-          type="file"
-          accept="image/*,.pdf"
-          className="hidden"
-          onChange={(e) => {
-            const file = e.target.files?.[0] || null;
-            onChange(index, 'factura_file', file);
-            if (fileRef.current) fileRef.current.value = '';
-          }}
-        />
-        <button
-          type="button"
-          onClick={() => fileRef.current?.click()}
-          className="p-2 rounded-xl hover:bg-muted/50 transition-colors"
-          title={row.factura_file ? row.factura_file.name : 'Subir factura'}
-        >
-          {row.factura_file ? (
-            <CheckCircle className="w-4 h-4 text-green-600" />
-          ) : (
-            <Upload className="w-4 h-4 text-brand-brown/40" />
-          )}
-        </button>
-      </td>
-      <td className={`${cellClass} text-center`}>
-        <button
-          type="button"
-          onClick={() => onRemove(index)}
-          className="p-2 rounded-xl hover:bg-destructive/10 text-brand-brown/40 hover:text-destructive transition-colors"
-          title="Eliminar fila"
-        >
-          <X className="w-4 h-4" />
-        </button>
-      </td>
-    </tr>
+        </td>
+        <td className={cellClass}>
+          <div className="flex items-center gap-1">
+            <select
+              value={row.comprador_id}
+              onChange={(e) => {
+                if (e.target.value === '__CREATE__') {
+                  onCreateComprador();
+                  return;
+                }
+                onChange(index, 'comprador_id', e.target.value);
+              }}
+              className={inputOk}
+              style={{ minWidth: 120 }}
+            >
+              <option value="">Opcional</option>
+              {catalogs.compradores.map((c) => (
+                <option key={c.id} value={c.id}>{c.nombre}</option>
+              ))}
+              <option value="__CREATE__">+ Crear nuevo</option>
+            </select>
+          </div>
+        </td>
+        <td className={cellClass}>
+          <select
+            value={row.medio_pago_id}
+            onChange={(e) => onChange(index, 'medio_pago_id', e.target.value)}
+            className={cls('medio_pago_id')}
+            style={{ minWidth: 120 }}
+          >
+            <option value="">Seleccionar</option>
+            {catalogs.mediosPago.map((m) => (
+              <option key={m.id} value={m.id}>{m.nombre}</option>
+            ))}
+          </select>
+        </td>
+        <td className={cellClass}>
+          <input
+            type="text"
+            value={row.observaciones}
+            onChange={(e) => onChange(index, 'observaciones', e.target.value)}
+            className={inputOk}
+            placeholder="Notas"
+            style={{ minWidth: 140 }}
+          />
+        </td>
+        <td className={`${cellClass} text-center`}>
+          <input
+            ref={fileRef}
+            type="file"
+            accept="image/*,.pdf"
+            className="hidden"
+            onChange={(e) => {
+              const file = e.target.files?.[0] || null;
+              onChange(index, 'factura_file', file);
+              if (fileRef.current) fileRef.current.value = '';
+            }}
+          />
+          <button
+            type="button"
+            onClick={() => fileRef.current?.click()}
+            className="p-2 rounded-xl hover:bg-muted/50 transition-colors"
+            title={row.factura_file ? row.factura_file.name : 'Subir factura'}
+          >
+            {row.factura_file ? (
+              <CheckCircle className="w-4 h-4 text-green-600" />
+            ) : (
+              <Upload className="w-4 h-4 text-brand-brown/40" />
+            )}
+          </button>
+        </td>
+        <td className={`${cellClass} text-center`}>
+          <button
+            type="button"
+            onClick={() => onRemove(index)}
+            className="p-2 rounded-xl hover:bg-destructive/10 text-brand-brown/40 hover:text-destructive transition-colors"
+            title="Eliminar fila"
+          >
+            <X className="w-4 h-4" />
+          </button>
+        </td>
+      </tr>
+
+      {/* Sub-fila de cantidad y precio — solo visible para Aguacate Hass y Hato Lechero */}
+      {mostrarCantidad && (
+        <tr className="border-b border-primary/5 bg-muted/20">
+          <td colSpan={totalColumnas} className="px-3 py-2">
+            <div
+              style={{
+                display: 'flex',
+                alignItems: 'center',
+                gap: '16px',
+                flexWrap: 'wrap',
+              }}
+            >
+              {/* Etiqueta del negocio */}
+              <span
+                style={{
+                  fontSize: '0.75rem',
+                  fontWeight: 600,
+                  color: 'var(--color-primary)',
+                  textTransform: 'uppercase',
+                  letterSpacing: '0.05em',
+                  whiteSpace: 'nowrap',
+                }}
+              >
+                {negocioNombre}
+              </span>
+
+              {/* Campo cantidad */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                <label
+                  style={{
+                    fontSize: '0.75rem',
+                    color: 'var(--color-muted-foreground)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {labelCantidad}
+                </label>
+                <input
+                  type="number"
+                  value={row.cantidad}
+                  onChange={(e) => onChange(index, 'cantidad', e.target.value)}
+                  onWheel={(e) => e.currentTarget.blur()}
+                  placeholder="0"
+                  min="0"
+                  step="0.1"
+                  style={{
+                    width: 100,
+                    padding: '4px 8px',
+                    fontSize: '0.875rem',
+                    border: '1px solid var(--color-border)',
+                    borderRadius: '0.5rem',
+                    background: 'white',
+                    outline: 'none',
+                  }}
+                  aria-label={`${labelCantidad} fila ${index + 1}`}
+                />
+                <span style={{ fontSize: '0.75rem', color: 'var(--color-muted-foreground)' }}>
+                  {unidad}
+                </span>
+              </div>
+
+              {/* Precio unitario calculado (solo lectura) */}
+              <div style={{ display: 'flex', alignItems: 'center', gap: '6px' }}>
+                <span
+                  style={{
+                    fontSize: '0.75rem',
+                    color: 'var(--color-muted-foreground)',
+                    whiteSpace: 'nowrap',
+                  }}
+                >
+                  {labelPrecio} (calculado):
+                </span>
+                <span
+                  style={{
+                    fontSize: '0.875rem',
+                    fontWeight: 500,
+                    color: precioComputado != null ? 'var(--color-foreground)' : 'var(--color-muted-foreground)',
+                  }}
+                >
+                  {precioComputado != null ? formatCurrency(Math.round(precioComputado)) : '—'}
+                </span>
+              </div>
+            </div>
+          </td>
+        </tr>
+      )}
+    </>
   );
 }

--- a/src/components/finanzas/components/IngresosBatchTable.tsx
+++ b/src/components/finanzas/components/IngresosBatchTable.tsx
@@ -29,6 +29,7 @@ function createEmptyRow(): BatchRowDataIngreso {
     observaciones: '',
     factura_file: null,
     factura_uploaded: false,
+    cantidad: '',
   };
 }
 
@@ -45,7 +46,12 @@ function serializeRows(rows: BatchRowDataIngreso[]): DraftData {
 }
 
 function deserializeRows(draft: DraftData): BatchRowDataIngreso[] {
-  return draft.rows.map((r) => ({ ...r, factura_file: null }));
+  return draft.rows.map((r) => {
+    const row = { ...r, factura_file: null } as BatchRowDataIngreso;
+    // Compatibilidad con borradores guardados antes de que se agregara el campo cantidad
+    if (!row.cantidad) row.cantidad = '';
+    return row;
+  });
 }
 
 const REQUIRED_FIELDS = ['fecha', 'nombre', 'valor', 'negocio_id', 'region_id', 'categoria_id', 'medio_pago_id'] as const;
@@ -201,18 +207,33 @@ export function IngresosBatchTable({ catalogs, onSaved }: IngresosBatchTableProp
         }
       }
 
-      const payload = rows.map((row, i) => ({
-        fecha: row.fecha,
-        nombre: row.nombre.trim(),
-        valor: Number(row.valor),
-        negocio_id: row.negocio_id,
-        region_id: row.region_id,
-        categoria_id: row.categoria_id,
-        comprador_id: row.comprador_id || null,
-        medio_pago_id: row.medio_pago_id,
-        observaciones: row.observaciones.trim() || null,
-        url_factura: facturaUrls[i] || null,
-      }));
+      const payload = rows.map((row, i) => {
+        const negocio = catalogs.negocios.find((n) => n.id === row.negocio_id);
+        const negocioNombre = negocio?.nombre ?? '';
+        const mostrarCantidad =
+          negocioNombre.toLowerCase().includes('aguacate') ||
+          negocioNombre.toLowerCase().includes('hato') ||
+          negocioNombre.toLowerCase().includes('lechero');
+        const cantidadNum = mostrarCantidad && row.cantidad ? Number(row.cantidad) : null;
+        const valorNum = Number(row.valor);
+        const precioUnitario =
+          cantidadNum && cantidadNum > 0 && valorNum > 0 ? valorNum / cantidadNum : null;
+
+        return {
+          fecha: row.fecha,
+          nombre: row.nombre.trim(),
+          valor: valorNum,
+          negocio_id: row.negocio_id,
+          region_id: row.region_id,
+          categoria_id: row.categoria_id,
+          comprador_id: row.comprador_id || null,
+          medio_pago_id: row.medio_pago_id,
+          observaciones: row.observaciones.trim() || null,
+          url_factura: facturaUrls[i] || null,
+          cantidad: cantidadNum,
+          precio_unitario: precioUnitario,
+        };
+      });
 
       const { error } = await supabase.from('fin_ingresos').insert(payload);
       if (error) throw error;

--- a/src/components/finanzas/components/IngresosList.tsx
+++ b/src/components/finanzas/components/IngresosList.tsx
@@ -317,7 +317,7 @@ export function IngresosList({ onEdit }: IngresosListProps) {
       </div>
 
       {/* Compact income list */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <div className="bg-white rounded-xl border border-gray-200">
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="w-6 h-6 text-primary animate-spin" />

--- a/src/components/finanzas/dashboard/DashboardGeneral.tsx
+++ b/src/components/finanzas/dashboard/DashboardGeneral.tsx
@@ -50,8 +50,8 @@ export function DashboardGeneral() {
         />
       )}
 
-      {/* Pivot + Trimestre chart */}
-      <div className="grid grid-cols-1 lg:grid-cols-2 gap-6">
+      {/* Pivot + Trimestre chart: stack until xl, so the 7-col pivot table gets full width at tablet */}
+      <div className="grid grid-cols-1 xl:grid-cols-2 gap-6">
         <PivotTableGastos data={pivotData} loading={loading} />
         <GastosPorTrimestreChart
           data={trimestreData.data}

--- a/src/components/finanzas/dashboard/DashboardSubNav.tsx
+++ b/src/components/finanzas/dashboard/DashboardSubNav.tsx
@@ -18,13 +18,13 @@ export function DashboardSubNav({ activeTab }: DashboardSubNavProps) {
   const navigate = useNavigate();
 
   return (
-    <div className="border-b border-primary/10 overflow-x-auto scrollbar-hide">
-      <div className="flex gap-1 min-w-max">
+    <div className="border-b border-primary/10">
+      <div className="flex flex-wrap gap-x-1 gap-y-0">
         {TABS.map((tab) => (
           <button
             key={tab.id}
             onClick={() => navigate(tab.path)}
-            className={`px-4 py-2.5 text-sm font-medium whitespace-nowrap border-b-2 transition-all ${
+            className={`px-3 lg:px-4 py-2 lg:py-2.5 text-sm font-medium whitespace-nowrap border-b-2 transition-all ${
               activeTab === tab.id
                 ? 'border-primary text-foreground'
                 : 'border-transparent text-brand-brown/50 hover:text-foreground hover:border-primary/20'

--- a/src/components/finanzas/dashboard/components/CosechaTable.tsx
+++ b/src/components/finanzas/dashboard/components/CosechaTable.tsx
@@ -66,7 +66,7 @@ export function CosechaTable({ rows, emptyMessage = 'Sin ingresos registrados' }
   }
 
   return (
-    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+    <div className="rounded-xl border border-primary/10 bg-white">
       <div className="overflow-auto" style={{ maxHeight: '28rem' }}>
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-green-600 text-white">

--- a/src/components/finanzas/dashboard/components/CosechaTable.tsx
+++ b/src/components/finanzas/dashboard/components/CosechaTable.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { formatCurrency, formatNumber } from '@/utils/format';
-import { formatearFecha } from '@/utils/fechas';
+import { useMemo } from 'react';
+import { formatNumber } from '@/utils/format';
+import { agruparPorCosecha } from '@/utils/agrupacionIngresos';
+import { GrupoIngresosTable } from './GrupoIngresosTable';
+import type { GrupoIngresosTableConfig } from './GrupoIngresosTable';
 import type { IngresoDetalleRow } from '@/types/finanzas';
 
 interface CosechaTableProps {
@@ -9,145 +10,16 @@ interface CosechaTableProps {
   emptyMessage?: string;
 }
 
-interface GrupoCosecha {
-  cosecha: string;
-  rows: IngresoDetalleRow[];
-  kilos: number;
-  valorTotal: number;
-  valorConKilos: number;
-  maxFecha: string;
-}
+const CONFIG: GrupoIngresosTableConfig = {
+  cantidadHeader: 'Toneladas',
+  formatCantidad: (kg) => `${formatNumber(kg / 1000, 1)} ton`,
+  precioHeader: 'Precio Prom. $/kg',
+  detalleCol2Header: 'Comprador',
+  detalleCol2Value: (r) => r.comprador || '',
+  detalleCantidadFormat: (kg) => `${formatNumber(kg / 1000, 1)} ton`,
+};
 
-const SIN_COSECHA = 'Sin cosecha';
-
-/**
- * Tabla de ingresos de aguacate agrupada por cosecha.
- * Cada cosecha es una fila colapsada (toneladas, precio promedio $/kg,
- * ingreso total) que se expande al detalle de registros individuales.
- * `cantidad` se asume en kilos.
- */
-export function CosechaTable({ rows, emptyMessage = 'Sin ingresos registrados' }: CosechaTableProps) {
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-
-  const grupos = useMemo<GrupoCosecha[]>(() => {
-    const map = new Map<string, GrupoCosecha>();
-    rows.forEach((r) => {
-      const key = r.cosecha || SIN_COSECHA;
-      if (!map.has(key)) {
-        map.set(key, { cosecha: key, rows: [], kilos: 0, valorTotal: 0, valorConKilos: 0, maxFecha: '' });
-      }
-      const g = map.get(key)!;
-      g.rows.push(r);
-      g.valorTotal += r.valor || 0;
-      if (r.cantidad != null && r.cantidad > 0) {
-        g.kilos += r.cantidad;
-        g.valorConKilos += r.valor || 0;
-      }
-      if (r.fecha > g.maxFecha) g.maxFecha = r.fecha;
-    });
-    return Array.from(map.values()).sort((a, b) => b.maxFecha.localeCompare(a.maxFecha));
-  }, [rows]);
-
-  const toggle = (cosecha: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(cosecha)) next.delete(cosecha);
-      else next.add(cosecha);
-      return next;
-    });
-  };
-
-  if (rows.length === 0) {
-    return (
-      <div className="rounded-xl border border-primary/10 bg-white p-8 text-center">
-        <p className="text-sm text-brand-brown/50">{emptyMessage}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
-      <div className="lg:overflow-y-scroll lg:overscroll-contain lg:touch-pan-y lg:max-h-[28rem]">
-        <table className="w-full text-sm">
-          <thead className="sticky top-0 bg-green-600 text-white">
-            <tr>
-              <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Cosecha</th>
-              <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Toneladas</th>
-              <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Precio Prom. $/kg</th>
-              <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Ingreso Total</th>
-            </tr>
-          </thead>
-          <tbody>
-            {grupos.map((g) => {
-              const isOpen = expanded.has(g.cosecha);
-              const precioPromedio = g.kilos > 0 ? g.valorConKilos / g.kilos : 0;
-              return (
-                <GrupoRows
-                  key={g.cosecha}
-                  grupo={g}
-                  isOpen={isOpen}
-                  precioPromedio={precioPromedio}
-                  onToggle={() => toggle(g.cosecha)}
-                />
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function GrupoRows({ grupo, isOpen, precioPromedio, onToggle }: {
-  grupo: GrupoCosecha;
-  isOpen: boolean;
-  precioPromedio: number;
-  onToggle: () => void;
-}) {
-  return (
-    <>
-      <tr
-        className="border-t border-primary/5 bg-green-50/60 hover:bg-green-50 cursor-pointer select-none font-medium"
-        onClick={onToggle}
-      >
-        <td className="px-3 py-2.5 whitespace-nowrap">
-          <div className="flex items-center gap-1.5">
-            {isOpen ? <ChevronDown className="w-4 h-4 text-green-700" /> : <ChevronRight className="w-4 h-4 text-green-700" />}
-            {grupo.cosecha}
-          </div>
-        </td>
-        <td className="px-3 py-2.5 text-right whitespace-nowrap">{formatNumber(grupo.kilos / 1000, 1)} ton</td>
-        <td className="px-3 py-2.5 text-right whitespace-nowrap">{precioPromedio > 0 ? `$${formatNumber(precioPromedio)}` : '-'}</td>
-        <td className="px-3 py-2.5 text-right whitespace-nowrap">{formatCurrency(grupo.valorTotal)}</td>
-      </tr>
-      {isOpen && (
-        <tr className="border-t border-primary/5">
-          <td colSpan={4} className="px-0 py-0 bg-gray-50/30">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-brand-brown/60 uppercase tracking-wide">
-                  <td className="px-3 py-1.5 pl-9">Fecha</td>
-                  <td className="px-3 py-1.5">Comprador</td>
-                  <td className="px-3 py-1.5 text-right">Cantidad</td>
-                  <td className="px-3 py-1.5 text-right">Precio $/kg</td>
-                  <td className="px-3 py-1.5 text-right">Valor</td>
-                </tr>
-              </thead>
-              <tbody>
-                {grupo.rows.map((r, i) => (
-                  <tr key={i} className={`border-t border-primary/5 ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'}`}>
-                    <td className="px-3 py-2 pl-9 whitespace-nowrap">{formatearFecha(r.fecha)}</td>
-                    <td className="px-3 py-2 whitespace-nowrap">{r.comprador || '-'}</td>
-                    <td className="px-3 py-2 text-right whitespace-nowrap">{r.cantidad != null ? `${formatNumber(r.cantidad / 1000, 1)} ton` : '-'}</td>
-                    <td className="px-3 py-2 text-right whitespace-nowrap">{r.precio_unitario != null ? `$${formatNumber(r.precio_unitario)}` : '-'}</td>
-                    <td className="px-3 py-2 text-right whitespace-nowrap">{formatCurrency(r.valor)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </td>
-        </tr>
-      )}
-    </>
-  );
+export function CosechaTable({ rows, emptyMessage }: CosechaTableProps) {
+  const grupos = useMemo(() => agruparPorCosecha(rows), [rows]);
+  return <GrupoIngresosTable grupos={grupos} config={CONFIG} emptyMessage={emptyMessage} />;
 }

--- a/src/components/finanzas/dashboard/components/CosechaTable.tsx
+++ b/src/components/finanzas/dashboard/components/CosechaTable.tsx
@@ -66,8 +66,8 @@ export function CosechaTable({ rows, emptyMessage = 'Sin ingresos registrados' }
   }
 
   return (
-    <div className="rounded-xl border border-primary/10 bg-white">
-      <div className="overflow-auto" style={{ maxHeight: '28rem' }}>
+    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+      <div className="lg:overflow-auto lg:max-h-[28rem]">
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-green-600 text-white">
             <tr>

--- a/src/components/finanzas/dashboard/components/CosechaTable.tsx
+++ b/src/components/finanzas/dashboard/components/CosechaTable.tsx
@@ -67,7 +67,7 @@ export function CosechaTable({ rows, emptyMessage = 'Sin ingresos registrados' }
 
   return (
     <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
-      <div className="lg:overflow-auto lg:max-h-[28rem]">
+      <div className="lg:overflow-y-scroll lg:overscroll-contain lg:touch-pan-y lg:max-h-[28rem]">
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-green-600 text-white">
             <tr>

--- a/src/components/finanzas/dashboard/components/DataTable.tsx
+++ b/src/components/finanzas/dashboard/components/DataTable.tsx
@@ -67,7 +67,7 @@ export function DataTable({ data, columns, maxHeight = '24rem', headerColor = 'd
   }
 
   return (
-    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+    <div className="rounded-xl border border-primary/10 bg-white">
       <div className="overflow-auto" style={{ maxHeight }}>
         <table className="w-full text-sm">
           <thead className={`sticky top-0 ${headerBg}`}>

--- a/src/components/finanzas/dashboard/components/DataTable.tsx
+++ b/src/components/finanzas/dashboard/components/DataTable.tsx
@@ -3,16 +3,17 @@ import { ArrowUpDown, ArrowUp, ArrowDown } from 'lucide-react';
 import { formatCurrency, formatNumber } from '@/utils/format';
 import { formatearFecha } from '@/utils/fechas';
 import type { ColumnDef } from '@/types/finanzas';
+import './dashboardTables.css';
 
 interface DataTableProps {
   data: Record<string, unknown>[];
   columns: ColumnDef[];
-  maxHeight?: string;    // kept for API compat; applies at lg+
+  maxHeight?: string;    // kept for API compat (no longer used; tables grow naturally)
   headerColor?: 'green' | 'red' | 'default';
   emptyMessage?: string;
 }
 
-export function DataTable({ data, columns, maxHeight: _maxHeight = '24rem', headerColor = 'default', emptyMessage = 'Sin datos' }: DataTableProps) {
+export function DataTable({ data, columns, maxHeight: _maxHeight, headerColor = 'default', emptyMessage = 'Sin datos' }: DataTableProps) {
   const [sortKey, setSortKey] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
@@ -52,62 +53,50 @@ export function DataTable({ data, columns, maxHeight: _maxHeight = '24rem', head
     }
   };
 
-  const headerBg = headerColor === 'green'
-    ? 'bg-green-600 text-white'
-    : headerColor === 'red'
-      ? 'bg-red-600 text-white'
-      : 'bg-gray-100 text-foreground';
-
-  // CSS grid: equal-width columns; last col right-aligned for currency/number
+  // CSS grid: equal-width columns (aplicado solo en escritorio vía media query).
   const gridCols = `repeat(${columns.length}, minmax(0, 1fr))`;
 
   if (data.length === 0) {
     return (
-      <div className="rounded-xl border border-primary/10 bg-white p-8 text-center">
-        <p className="text-sm text-brand-brown/50">{emptyMessage}</p>
+      <div className="dtbl">
+        <p className="dtbl-empty">{emptyMessage}</p>
       </div>
     );
   }
 
   return (
-    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
-      {/* Encabezado sticky — solo escritorio */}
-      <div
-        className={`hidden lg:grid items-center gap-2 px-3 py-2.5 text-xs font-semibold uppercase tracking-wide sticky top-0 z-10 ${headerBg}`}
-        style={{ gridTemplateColumns: gridCols }}
-      >
-        {columns.map((col) => (
-          <button
-            key={col.key}
-            type="button"
-            className={`flex items-center gap-1 text-left ${col.sortable !== false ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}`}
-            onClick={() => col.sortable !== false && handleSort(col.key)}
-          >
-            {col.label}
-            {col.sortable !== false && (
-              sortKey === col.key
-                ? sortDir === 'asc' ? <ArrowUp className="w-3 h-3" /> : <ArrowDown className="w-3 h-3" />
-                : <ArrowUpDown className="w-3 h-3 opacity-40" />
-            )}
-          </button>
-        ))}
+    <div className="dtbl">
+      {/* Encabezado — solo escritorio */}
+      <div className={`dtbl-head dtbl-head--${headerColor}`} style={{ gridTemplateColumns: gridCols }}>
+        {columns.map((col) => {
+          const sortable = col.sortable !== false;
+          return (
+            <button
+              key={col.key}
+              type="button"
+              className={`dtbl-th ${sortable ? '' : 'dtbl-th--static'}`}
+              onClick={() => sortable && handleSort(col.key)}
+            >
+              {col.label}
+              {sortable && (
+                sortKey === col.key
+                  ? sortDir === 'asc' ? <ArrowUp className="w-3 h-3" /> : <ArrowDown className="w-3 h-3" />
+                  : <ArrowUpDown className="w-3 h-3 opacity-40" />
+              )}
+            </button>
+          );
+        })}
       </div>
 
-      {/* Zona scrollable solo en escritorio */}
-      <div className="divide-y divide-primary/5 lg:overflow-y-auto lg:max-h-96 lg:overscroll-contain">
+      <div>
         {sortedData.map((row, i) => (
-          <div
-            key={i}
-            className={`px-3 py-2.5 lg:grid lg:gap-2 lg:items-center ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/40'}`}
-            style={{ gridTemplateColumns: gridCols }}
-          >
-            {columns.map((col, ci) => {
+          <div key={i} className="dtbl-row" style={{ gridTemplateColumns: gridCols }}>
+            {columns.map((col) => {
               const formatted = formatCell(row[col.key], col.format);
               const isNumeric = col.format === 'currency' || col.format === 'number';
               return (
-                <span key={col.key} className={`flex items-baseline gap-1 lg:block text-sm ${isNumeric ? 'lg:text-right tabular-nums' : ''} ${ci > 0 ? '' : ''}`}>
-                  <span className="text-[11px] text-brand-brown/40 lg:hidden shrink-0">{col.label}:</span>
-                  <span className={isNumeric && ci === columns.length - 1 ? 'font-medium' : ''}>{formatted}</span>
+                <span key={col.key} className={`dtbl-cell ${isNumeric ? 'dtbl-cell--num' : ''}`} data-label={col.label}>
+                  <span className="dtbl-val">{formatted}</span>
                 </span>
               );
             })}

--- a/src/components/finanzas/dashboard/components/DataTable.tsx
+++ b/src/components/finanzas/dashboard/components/DataTable.tsx
@@ -12,7 +12,7 @@ interface DataTableProps {
   emptyMessage?: string;
 }
 
-export function DataTable({ data, columns, maxHeight = '24rem', headerColor = 'default', emptyMessage = 'Sin datos' }: DataTableProps) {
+export function DataTable({ data, columns, maxHeight: _maxHeight = '24rem', headerColor = 'default', emptyMessage = 'Sin datos' }: DataTableProps) {
   const [sortKey, setSortKey] = useState<string | null>(null);
   const [sortDir, setSortDir] = useState<'asc' | 'desc'>('desc');
 
@@ -67,8 +67,8 @@ export function DataTable({ data, columns, maxHeight = '24rem', headerColor = 'd
   }
 
   return (
-    <div className="rounded-xl border border-primary/10 bg-white">
-      <div className="overflow-auto" style={{ maxHeight }}>
+    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+      <div className="lg:overflow-auto lg:max-h-96">
         <table className="w-full text-sm">
           <thead className={`sticky top-0 ${headerBg}`}>
             <tr>

--- a/src/components/finanzas/dashboard/components/DataTable.tsx
+++ b/src/components/finanzas/dashboard/components/DataTable.tsx
@@ -68,7 +68,7 @@ export function DataTable({ data, columns, maxHeight: _maxHeight = '24rem', head
 
   return (
     <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
-      <div className="lg:overflow-auto lg:max-h-96">
+      <div className="lg:overflow-y-scroll lg:overscroll-contain lg:touch-pan-y lg:max-h-96">
         <table className="w-full text-sm">
           <thead className={`sticky top-0 ${headerBg}`}>
             <tr>

--- a/src/components/finanzas/dashboard/components/DataTable.tsx
+++ b/src/components/finanzas/dashboard/components/DataTable.tsx
@@ -7,7 +7,7 @@ import type { ColumnDef } from '@/types/finanzas';
 interface DataTableProps {
   data: Record<string, unknown>[];
   columns: ColumnDef[];
-  maxHeight?: string;
+  maxHeight?: string;    // kept for API compat; applies at lg+
   headerColor?: 'green' | 'red' | 'default';
   emptyMessage?: string;
 }
@@ -43,12 +43,12 @@ export function DataTable({ data, columns, maxHeight: _maxHeight = '24rem', head
   }, [data, sortKey, sortDir]);
 
   const formatCell = (value: unknown, format?: ColumnDef['format']) => {
-    if (value == null || value === '') return '-';
+    if (value == null || value === '') return '—';
     switch (format) {
       case 'currency': return formatCurrency(Number(value));
-      case 'number': return formatNumber(Number(value));
-      case 'date': return formatearFecha(String(value));
-      default: return String(value);
+      case 'number':   return formatNumber(Number(value));
+      case 'date':     return formatearFecha(String(value));
+      default:         return String(value);
     }
   };
 
@@ -57,6 +57,9 @@ export function DataTable({ data, columns, maxHeight: _maxHeight = '24rem', head
     : headerColor === 'red'
       ? 'bg-red-600 text-white'
       : 'bg-gray-100 text-foreground';
+
+  // CSS grid: equal-width columns; last col right-aligned for currency/number
+  const gridCols = `repeat(${columns.length}, minmax(0, 1fr))`;
 
   if (data.length === 0) {
     return (
@@ -68,42 +71,48 @@ export function DataTable({ data, columns, maxHeight: _maxHeight = '24rem', head
 
   return (
     <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
-      <div className="lg:overflow-y-scroll lg:overscroll-contain lg:touch-pan-y lg:max-h-96">
-        <table className="w-full text-sm">
-          <thead className={`sticky top-0 ${headerBg}`}>
-            <tr>
-              {columns.map((col) => (
-                <th
-                  key={col.key}
-                  className={`px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wide whitespace-nowrap ${
-                    col.sortable !== false ? 'cursor-pointer select-none hover:opacity-80' : ''
-                  }`}
-                  onClick={() => col.sortable !== false && handleSort(col.key)}
-                >
-                  <div className="flex items-center gap-1">
-                    {col.label}
-                    {col.sortable !== false && (
-                      sortKey === col.key
-                        ? sortDir === 'asc' ? <ArrowUp className="w-3 h-3" /> : <ArrowDown className="w-3 h-3" />
-                        : <ArrowUpDown className="w-3 h-3 opacity-40" />
-                    )}
-                  </div>
-                </th>
-              ))}
-            </tr>
-          </thead>
-          <tbody>
-            {sortedData.map((row, i) => (
-              <tr key={i} className={`border-t border-primary/5 ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'}`}>
-                {columns.map((col) => (
-                  <td key={col.key} className="px-3 py-2 whitespace-nowrap">
-                    {formatCell(row[col.key], col.format)}
-                  </td>
-                ))}
-              </tr>
-            ))}
-          </tbody>
-        </table>
+      {/* Encabezado sticky — solo escritorio */}
+      <div
+        className={`hidden lg:grid items-center gap-2 px-3 py-2.5 text-xs font-semibold uppercase tracking-wide sticky top-0 z-10 ${headerBg}`}
+        style={{ gridTemplateColumns: gridCols }}
+      >
+        {columns.map((col) => (
+          <button
+            key={col.key}
+            type="button"
+            className={`flex items-center gap-1 text-left ${col.sortable !== false ? 'cursor-pointer hover:opacity-80' : 'cursor-default'}`}
+            onClick={() => col.sortable !== false && handleSort(col.key)}
+          >
+            {col.label}
+            {col.sortable !== false && (
+              sortKey === col.key
+                ? sortDir === 'asc' ? <ArrowUp className="w-3 h-3" /> : <ArrowDown className="w-3 h-3" />
+                : <ArrowUpDown className="w-3 h-3 opacity-40" />
+            )}
+          </button>
+        ))}
+      </div>
+
+      {/* Zona scrollable solo en escritorio */}
+      <div className="divide-y divide-primary/5 lg:overflow-y-auto lg:max-h-96 lg:overscroll-contain">
+        {sortedData.map((row, i) => (
+          <div
+            key={i}
+            className={`px-3 py-2.5 lg:grid lg:gap-2 lg:items-center ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/40'}`}
+            style={{ gridTemplateColumns: gridCols }}
+          >
+            {columns.map((col, ci) => {
+              const formatted = formatCell(row[col.key], col.format);
+              const isNumeric = col.format === 'currency' || col.format === 'number';
+              return (
+                <span key={col.key} className={`flex items-baseline gap-1 lg:block text-sm ${isNumeric ? 'lg:text-right tabular-nums' : ''} ${ci > 0 ? '' : ''}`}>
+                  <span className="text-[11px] text-brand-brown/40 lg:hidden shrink-0">{col.label}:</span>
+                  <span className={isNumeric && ci === columns.length - 1 ? 'font-medium' : ''}>{formatted}</span>
+                </span>
+              );
+            })}
+          </div>
+        ))}
       </div>
     </div>
   );

--- a/src/components/finanzas/dashboard/components/DetalleGastosExpandible.tsx
+++ b/src/components/finanzas/dashboard/components/DetalleGastosExpandible.tsx
@@ -1,8 +1,9 @@
 import { useState, Fragment } from 'react';
-import { ChevronDown, ChevronRight, TrendingUp, TrendingDown } from 'lucide-react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
 import { formatCompact } from '@/utils/format';
 import type { PivotRow } from '@/types/finanzas';
 import { GastosDetalleDialog } from './GastosDetalleDialog';
+import './dashboardTables.css';
 
 const formatPivot = (v: number) => `$${formatCompact(v)}`;
 const cellClickable = "cursor-pointer hover:bg-primary/10 rounded transition-colors";
@@ -10,17 +11,12 @@ const cellClickable = "cursor-pointer hover:bg-primary/10 rounded transition-col
 function VariacionBadge({ actual, anterior }: { actual: number; anterior: number }) {
   if (anterior === 0 && actual === 0) return null;
   const pct = anterior === 0 ? 100 : ((actual - anterior) / anterior) * 100;
+  if (pct === 0) return null;
   const isUp = pct > 0;
-  const isNeutral = pct === 0;
-
-  if (isNeutral) return null;
 
   // For gastos: up = bad (red), down = good (green)
   return (
-    <span className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-medium ${
-      isUp ? 'bg-red-50 text-red-600' : 'bg-green-50 text-green-600'
-    }`}>
-      {isUp ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+    <span className={`pivot-var ${isUp ? 'pivot-var--up' : 'pivot-var--down'}`}>
       {isUp ? '+' : ''}{pct.toFixed(0)}%
     </span>
   );
@@ -128,7 +124,7 @@ export function DetalleGastosExpandible({ data, loading }: DetalleGastosExpandib
         <div className="px-4 py-3 border-b border-primary/10">
           <h3 className="text-sm font-semibold text-foreground">Detalle de Gastos por Negocio y Categoria</h3>
         </div>
-        <div className="overflow-x-auto">
+        <div className="pivot-scroll">
           <table className="w-full text-sm table-fixed">
             <colgroup>
               <col className="w-[16%]" />
@@ -164,14 +160,14 @@ export function DetalleGastosExpandible({ data, loading }: DetalleGastosExpandib
                   total_n2: data.reduce((s, r) => s + r.total_n2, 0),
                 };
                 return (
-                  <tr className="border-t-2 border-foreground/20 bg-gray-100 font-bold">
+                  <tr className="pivot-total border-t-2 border-foreground/20 bg-gray-100 font-bold">
                     <td className="px-3 py-2 text-foreground">TOTAL</td>
-                    <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.ytd_actual)}</td>
-                    <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.ytd_anterior)}</td>
-                    <td className="px-3 py-2 text-right"><VariacionBadge actual={grandTotal.ytd_actual} anterior={grandTotal.ytd_anterior} /></td>
-                    <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.total_anterior)}</td>
-                    <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.total_n2)}</td>
-                    <td className="px-3 py-2 text-right"><VariacionBadge actual={grandTotal.total_anterior} anterior={grandTotal.total_n2} /></td>
+                    <td className="px-3 py-2 text-right tabular-nums" data-label={`YTD ${currentYear}`}>{formatPivot(grandTotal.ytd_actual)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums" data-label={`YTD ${currentYear - 1}`}>{formatPivot(grandTotal.ytd_anterior)}</td>
+                    <td className="px-3 py-2 text-right" data-label="Var YoY (YTD)"><VariacionBadge actual={grandTotal.ytd_actual} anterior={grandTotal.ytd_anterior} /></td>
+                    <td className="px-3 py-2 text-right tabular-nums" data-label={`Total ${currentYear - 1}`}>{formatPivot(grandTotal.total_anterior)}</td>
+                    <td className="px-3 py-2 text-right tabular-nums" data-label={`Total ${currentYear - 2}`}>{formatPivot(grandTotal.total_n2)}</td>
+                    <td className="px-3 py-2 text-right" data-label="Var YoY (Total)"><VariacionBadge actual={grandTotal.total_anterior} anterior={grandTotal.total_n2} /></td>
                   </tr>
                 );
               })()}
@@ -195,12 +191,12 @@ export function DetalleGastosExpandible({ data, loading }: DetalleGastosExpandib
                           {row.negocio}
                         </div>
                       </td>
-                      <td className="px-3 py-2 text-right tabular-nums font-medium">{formatPivot(row.ytd_actual)}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{formatPivot(row.ytd_anterior)}</td>
-                      <td className="px-3 py-2 text-right"><VariacionBadge actual={row.ytd_actual} anterior={row.ytd_anterior} /></td>
-                      <td className="px-3 py-2 text-right tabular-nums font-medium">{formatPivot(row.total_anterior)}</td>
-                      <td className="px-3 py-2 text-right tabular-nums">{formatPivot(row.total_n2)}</td>
-                      <td className="px-3 py-2 text-right"><VariacionBadge actual={row.total_anterior} anterior={row.total_n2} /></td>
+                      <td className="px-3 py-2 text-right tabular-nums font-medium" data-label={`YTD ${currentYear}`}>{formatPivot(row.ytd_actual)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums" data-label={`YTD ${currentYear - 1}`}>{formatPivot(row.ytd_anterior)}</td>
+                      <td className="px-3 py-2 text-right" data-label="Var YoY (YTD)"><VariacionBadge actual={row.ytd_actual} anterior={row.ytd_anterior} /></td>
+                      <td className="px-3 py-2 text-right tabular-nums font-medium" data-label={`Total ${currentYear - 1}`}>{formatPivot(row.total_anterior)}</td>
+                      <td className="px-3 py-2 text-right tabular-nums" data-label={`Total ${currentYear - 2}`}>{formatPivot(row.total_n2)}</td>
+                      <td className="px-3 py-2 text-right" data-label="Var YoY (Total)"><VariacionBadge actual={row.total_anterior} anterior={row.total_n2} /></td>
                     </tr>
                     {isExpanded && row.categorias?.map((cat) => {
                       const catKey = `${row.negocio_id}::${cat.negocio_id}`;
@@ -225,25 +221,29 @@ export function DetalleGastosExpandible({ data, loading }: DetalleGastosExpandib
                             </td>
                             <td
                               className={`px-3 py-2 text-right tabular-nums text-sm ${cellClickable}`}
+                              data-label={`YTD ${currentYear}`}
                               onClick={(e) => handleCellClick(row, cat.negocio, 'ytd_actual', e)}
                             >
                               {formatPivot(cat.ytd_actual)}
                             </td>
                             <td
                               className={`px-3 py-2 text-right tabular-nums text-sm ${cellClickable}`}
+                              data-label={`YTD ${currentYear - 1}`}
                               onClick={(e) => handleCellClick(row, cat.negocio, 'ytd_anterior', e)}
                             >
                               {formatPivot(cat.ytd_anterior)}
                             </td>
-                            <td className="px-3 py-2 text-right"><VariacionBadge actual={cat.ytd_actual} anterior={cat.ytd_anterior} /></td>
+                            <td className="px-3 py-2 text-right" data-label="Var YoY (YTD)"><VariacionBadge actual={cat.ytd_actual} anterior={cat.ytd_anterior} /></td>
                             <td
                               className={`px-3 py-2 text-right tabular-nums text-sm ${cellClickable}`}
+                              data-label={`Total ${currentYear - 1}`}
                               onClick={(e) => handleCellClick(row, cat.negocio, 'total_anterior', e)}
                             >
                               {formatPivot(cat.total_anterior)}
                             </td>
                             <td
                               className={`px-3 py-2 text-right tabular-nums text-sm ${cellClickable}`}
+                              data-label={`Total ${currentYear - 2}`}
                               onClick={(e) => handleCellClick(row, cat.negocio, 'total_n2', e)}
                             >
                               {formatPivot(cat.total_n2)}
@@ -253,12 +253,12 @@ export function DetalleGastosExpandible({ data, loading }: DetalleGastosExpandib
                           {isCatExpanded && cat.categorias?.map((concepto) => (
                             <tr key={concepto.negocio_id} className="bg-primary/[0.01] border-t border-primary/5 hover:bg-green-50/50 transition-colors">
                               <td className="px-3 py-1.5 pl-16 text-brand-brown/50 text-xs">{concepto.negocio}</td>
-                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60">{formatPivot(concepto.ytd_actual)}</td>
-                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60">{formatPivot(concepto.ytd_anterior)}</td>
-                              <td className="px-3 py-1.5 text-right"><VariacionBadge actual={concepto.ytd_actual} anterior={concepto.ytd_anterior} /></td>
-                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60">{formatPivot(concepto.total_anterior)}</td>
-                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60">{formatPivot(concepto.total_n2)}</td>
-                              <td className="px-3 py-1.5 text-right"><VariacionBadge actual={concepto.total_anterior} anterior={concepto.total_n2} /></td>
+                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60" data-label={`YTD ${currentYear}`}>{formatPivot(concepto.ytd_actual)}</td>
+                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60" data-label={`YTD ${currentYear - 1}`}>{formatPivot(concepto.ytd_anterior)}</td>
+                              <td className="px-3 py-1.5 text-right" data-label="Var YoY (YTD)"><VariacionBadge actual={concepto.ytd_actual} anterior={concepto.ytd_anterior} /></td>
+                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60" data-label={`Total ${currentYear - 1}`}>{formatPivot(concepto.total_anterior)}</td>
+                              <td className="px-3 py-1.5 text-right tabular-nums text-xs text-brand-brown/60" data-label={`Total ${currentYear - 2}`}>{formatPivot(concepto.total_n2)}</td>
+                              <td className="px-3 py-1.5 text-right" data-label="Var YoY (Total)"><VariacionBadge actual={concepto.total_anterior} anterior={concepto.total_n2} /></td>
                             </tr>
                           ))}
                         </Fragment>

--- a/src/components/finanzas/dashboard/components/GrupoIngresosTable.tsx
+++ b/src/components/finanzas/dashboard/components/GrupoIngresosTable.tsx
@@ -1,0 +1,178 @@
+import { useState } from 'react';
+import { ChevronDown, ChevronRight } from 'lucide-react';
+import { formatCurrency, formatNumber } from '@/utils/format';
+import { formatearFecha } from '@/utils/fechas';
+import type { GrupoIngresos } from '@/utils/agrupacionIngresos';
+import type { IngresoDetalleRow } from '@/types/finanzas';
+
+export interface GrupoIngresosTableConfig {
+  cantidadHeader: string;
+  formatCantidad: (n: number) => string;
+  precioHeader: string;
+  detalleCol2Header: string;
+  detalleCol2Value: (r: IngresoDetalleRow) => string;
+  detalleCantidadFormat: (n: number) => string;
+}
+
+interface GrupoIngresosTableProps {
+  grupos: GrupoIngresos[];
+  config: GrupoIngresosTableConfig;
+  emptyMessage?: string;
+}
+
+// Grid classes shared between header and rows
+const GRID = 'lg:grid lg:grid-cols-[1fr_9rem_9rem_10rem]';
+
+export function GrupoIngresosTable({ grupos, config, emptyMessage = 'Sin ingresos registrados' }: GrupoIngresosTableProps) {
+  const [expanded, setExpanded] = useState<Set<string>>(new Set());
+
+  const toggle = (key: string) => {
+    setExpanded((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key); else next.add(key);
+      return next;
+    });
+  };
+
+  if (grupos.length === 0) {
+    return (
+      <div className="rounded-xl border border-primary/10 bg-white p-8 text-center">
+        <p className="text-sm text-brand-brown/50">{emptyMessage}</p>
+      </div>
+    );
+  }
+
+  return (
+    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+      {/* Encabezado — solo escritorio */}
+      <div className={`hidden ${GRID} items-center gap-3 px-3 py-2.5 bg-green-600 text-white text-xs font-semibold uppercase tracking-wide sticky top-0 z-10`}>
+        <span>Cosecha / Período</span>
+        <span className="text-right">{config.cantidadHeader}</span>
+        <span className="text-right">{config.precioHeader}</span>
+        <span className="text-right">Ingreso Total</span>
+      </div>
+
+      {/* Zona scrollable solo en escritorio */}
+      <div className="lg:overflow-y-auto lg:max-h-[28rem] lg:overscroll-contain">
+        {grupos.map((g) => {
+          const isOpen = expanded.has(g.key);
+          return (
+            <div key={g.key} className="border-t border-primary/5 first:border-t-0">
+              {/* Fila resumen / toggle */}
+              <button
+                type="button"
+                onClick={() => toggle(g.key)}
+                className={`w-full text-left px-3 py-2.5 bg-green-50/60 hover:bg-green-50 transition-colors select-none ${GRID} gap-3 items-center`}
+              >
+                {/* Columna 1: chevron + label */}
+                <span className="flex items-start gap-1.5 font-medium text-sm">
+                  {isOpen
+                    ? <ChevronDown className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />
+                    : <ChevronRight className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />}
+                  <span>{g.label}</span>
+                </span>
+
+                {/* Métricas — en móvil como fila wrap, en escritorio como celdas alineadas */}
+                <span className="col-span-3 lg:contents">
+                  <span className="hidden lg:block" /> {/* placeholder para que contents funcione */}
+                  <MetricaResumen
+                    label={config.cantidadHeader}
+                    valor={g.cantidad > 0 ? config.formatCantidad(g.cantidad) : '—'}
+                  />
+                  <MetricaResumen
+                    label={config.precioHeader}
+                    valor={g.precioPromedio > 0 ? `$${formatNumber(g.precioPromedio)}` : '—'}
+                  />
+                  <MetricaResumen
+                    label="Ingreso Total"
+                    valor={formatCurrency(g.valorTotal)}
+                    valorClass="text-green-700 font-semibold"
+                  />
+                </span>
+              </button>
+
+              {/* Detalle expandido */}
+              {isOpen && (
+                <div className="border-t border-primary/5 bg-gray-50/40 divide-y divide-primary/5">
+                  {/* Sub-encabezado — solo escritorio */}
+                  <div className={`hidden lg:grid lg:grid-cols-[2rem_1fr_1fr_7rem_7rem_8rem] gap-2 px-3 py-1.5 text-[11px] text-brand-brown/50 uppercase tracking-wide font-medium`}>
+                    <span />
+                    <span>Fecha</span>
+                    <span>{config.detalleCol2Header}</span>
+                    <span className="text-right">{config.cantidadHeader}</span>
+                    <span className="text-right">{config.precioHeader.replace('Prom. ', '')}</span>
+                    <span className="text-right">Valor</span>
+                  </div>
+
+                  {g.rows.map((r, i) => (
+                    <DetalleRow key={i} row={r} config={config} />
+                  ))}
+                </div>
+              )}
+            </div>
+          );
+        })}
+      </div>
+    </div>
+  );
+}
+
+function MetricaResumen({ label, valor, valorClass = 'text-sm tabular-nums' }: {
+  label: string;
+  valor: string;
+  valorClass?: string;
+}) {
+  return (
+    <span className="flex items-baseline gap-1 lg:justify-end lg:block">
+      <span className="text-xs text-brand-brown/50 lg:hidden">{label}:</span>
+      <span className={valorClass}>{valor}</span>
+    </span>
+  );
+}
+
+function DetalleRow({ row: r, config }: { row: IngresoDetalleRow; config: GrupoIngresosTableConfig }) {
+  return (
+    <div className="px-3 py-2 lg:grid lg:grid-cols-[2rem_1fr_1fr_7rem_7rem_8rem] lg:gap-2 lg:items-center">
+      {/* Indent — solo escritorio */}
+      <span className="hidden lg:block" />
+
+      {/* Fecha */}
+      <span className="text-sm text-brand-brown/70 lg:text-xs">{formatearFecha(r.fecha)}</span>
+
+      {/* Col2: comprador / tipo */}
+      <span className="text-sm font-medium lg:text-xs lg:font-normal lg:text-brand-brown/80">
+        {config.detalleCol2Value(r) || '—'}
+      </span>
+
+      {/* Métricas: en móvil como flex-wrap con etiquetas, en escritorio celdas alineadas */}
+      <span className="flex flex-wrap gap-x-4 gap-y-0.5 mt-1 lg:contents">
+        <MiniMetrica
+          label={config.cantidadHeader}
+          valor={r.cantidad != null && r.cantidad > 0 ? config.detalleCantidadFormat(r.cantidad) : '—'}
+        />
+        <MiniMetrica
+          label="Precio"
+          valor={r.precio_unitario != null ? `$${formatNumber(r.precio_unitario)}` : '—'}
+        />
+        <MiniMetrica
+          label="Valor"
+          valor={formatCurrency(r.valor)}
+          valorClass="font-semibold text-green-700"
+        />
+      </span>
+    </div>
+  );
+}
+
+function MiniMetrica({ label, valor, valorClass = 'tabular-nums' }: {
+  label: string;
+  valor: string;
+  valorClass?: string;
+}) {
+  return (
+    <span className="flex items-baseline gap-1 text-xs lg:justify-end lg:block">
+      <span className="text-brand-brown/40 lg:hidden">{label}:</span>
+      <span className={valorClass}>{valor}</span>
+    </span>
+  );
+}

--- a/src/components/finanzas/dashboard/components/GrupoIngresosTable.tsx
+++ b/src/components/finanzas/dashboard/components/GrupoIngresosTable.tsx
@@ -4,6 +4,7 @@ import { formatCurrency, formatNumber } from '@/utils/format';
 import { formatearFecha } from '@/utils/fechas';
 import type { GrupoIngresos } from '@/utils/agrupacionIngresos';
 import type { IngresoDetalleRow } from '@/types/finanzas';
+import './dashboardTables.css';
 
 export interface GrupoIngresosTableConfig {
   cantidadHeader: string;
@@ -20,9 +21,6 @@ interface GrupoIngresosTableProps {
   emptyMessage?: string;
 }
 
-// Grid classes shared between header and rows
-const GRID = 'lg:grid lg:grid-cols-[1fr_9rem_9rem_10rem]';
-
 export function GrupoIngresosTable({ grupos, config, emptyMessage = 'Sin ingresos registrados' }: GrupoIngresosTableProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
 
@@ -36,72 +34,55 @@ export function GrupoIngresosTable({ grupos, config, emptyMessage = 'Sin ingreso
 
   if (grupos.length === 0) {
     return (
-      <div className="rounded-xl border border-primary/10 bg-white p-8 text-center">
-        <p className="text-sm text-brand-brown/50">{emptyMessage}</p>
+      <div className="dtab">
+        <p className="dtab-empty">{emptyMessage}</p>
       </div>
     );
   }
 
+  const precioCortoHeader = config.precioHeader.replace('Prom. ', '');
+
   return (
-    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+    <div className="dtab">
       {/* Encabezado — solo escritorio */}
-      <div className={`hidden ${GRID} items-center gap-3 px-3 py-2.5 bg-green-600 text-white text-xs font-semibold uppercase tracking-wide sticky top-0 z-10`}>
+      <div className="dtab-head dtab-head--green">
         <span>Cosecha / Período</span>
-        <span className="text-right">{config.cantidadHeader}</span>
-        <span className="text-right">{config.precioHeader}</span>
-        <span className="text-right">Ingreso Total</span>
+        <span className="r">{config.cantidadHeader}</span>
+        <span className="r">{config.precioHeader}</span>
+        <span className="r">Ingreso Total</span>
       </div>
 
-      {/* Zona scrollable solo en escritorio */}
-      <div className="lg:overflow-y-auto lg:max-h-[28rem] lg:overscroll-contain">
+      <div>
         {grupos.map((g) => {
           const isOpen = expanded.has(g.key);
           return (
-            <div key={g.key} className="border-t border-primary/5 first:border-t-0">
+            <div key={g.key} className="dtab-group">
               {/* Fila resumen / toggle */}
-              <button
-                type="button"
-                onClick={() => toggle(g.key)}
-                className={`w-full text-left px-3 py-2.5 bg-green-50/60 hover:bg-green-50 transition-colors select-none ${GRID} gap-3 items-center`}
-              >
-                {/* Columna 1: chevron + label */}
-                <span className="flex items-start gap-1.5 font-medium text-sm">
-                  {isOpen
-                    ? <ChevronDown className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />
-                    : <ChevronRight className="w-4 h-4 text-green-700 mt-0.5 flex-shrink-0" />}
+              <button type="button" onClick={() => toggle(g.key)} className="dtab-summary">
+                <span className="dtab-summary-label">
+                  {isOpen ? <ChevronDown className="w-4 h-4" /> : <ChevronRight className="w-4 h-4" />}
                   <span>{g.label}</span>
                 </span>
-
-                {/* Métricas — en móvil como fila wrap, en escritorio como celdas alineadas */}
-                <span className="col-span-3 lg:contents">
-                  <span className="hidden lg:block" /> {/* placeholder para que contents funcione */}
-                  <MetricaResumen
-                    label={config.cantidadHeader}
-                    valor={g.cantidad > 0 ? config.formatCantidad(g.cantidad) : '—'}
-                  />
-                  <MetricaResumen
-                    label={config.precioHeader}
-                    valor={g.precioPromedio > 0 ? `$${formatNumber(g.precioPromedio)}` : '—'}
-                  />
-                  <MetricaResumen
-                    label="Ingreso Total"
-                    valor={formatCurrency(g.valorTotal)}
-                    valorClass="text-green-700 font-semibold"
-                  />
+                <span className="dtab-cell" data-label={config.cantidadHeader}>
+                  {g.cantidad > 0 ? config.formatCantidad(g.cantidad) : '—'}
+                </span>
+                <span className="dtab-cell" data-label={config.precioHeader}>
+                  {g.precioPromedio > 0 ? `$${formatNumber(g.precioPromedio)}` : '—'}
+                </span>
+                <span className="dtab-cell dtab-cell--total" data-label="Ingreso Total">
+                  {formatCurrency(g.valorTotal)}
                 </span>
               </button>
 
               {/* Detalle expandido */}
               {isOpen && (
-                <div className="border-t border-primary/5 bg-gray-50/40 divide-y divide-primary/5">
-                  {/* Sub-encabezado — solo escritorio */}
-                  <div className={`hidden lg:grid lg:grid-cols-[2rem_1fr_1fr_7rem_7rem_8rem] gap-2 px-3 py-1.5 text-[11px] text-brand-brown/50 uppercase tracking-wide font-medium`}>
-                    <span />
+                <div className="dtab-detail">
+                  <div className="dtab-detail-head">
                     <span>Fecha</span>
                     <span>{config.detalleCol2Header}</span>
-                    <span className="text-right">{config.cantidadHeader}</span>
-                    <span className="text-right">{config.precioHeader.replace('Prom. ', '')}</span>
-                    <span className="text-right">Valor</span>
+                    <span className="r">{config.cantidadHeader}</span>
+                    <span className="r">{precioCortoHeader}</span>
+                    <span className="r">Valor</span>
                   </div>
 
                   {g.rows.map((r, i) => (
@@ -117,62 +98,22 @@ export function GrupoIngresosTable({ grupos, config, emptyMessage = 'Sin ingreso
   );
 }
 
-function MetricaResumen({ label, valor, valorClass = 'text-sm tabular-nums' }: {
-  label: string;
-  valor: string;
-  valorClass?: string;
-}) {
-  return (
-    <span className="flex items-baseline gap-1 lg:justify-end lg:block">
-      <span className="text-xs text-brand-brown/50 lg:hidden">{label}:</span>
-      <span className={valorClass}>{valor}</span>
-    </span>
-  );
-}
-
 function DetalleRow({ row: r, config }: { row: IngresoDetalleRow; config: GrupoIngresosTableConfig }) {
   return (
-    <div className="px-3 py-2 lg:grid lg:grid-cols-[2rem_1fr_1fr_7rem_7rem_8rem] lg:gap-2 lg:items-center">
-      {/* Indent — solo escritorio */}
-      <span className="hidden lg:block" />
-
-      {/* Fecha */}
-      <span className="text-sm text-brand-brown/70 lg:text-xs">{formatearFecha(r.fecha)}</span>
-
-      {/* Col2: comprador / tipo */}
-      <span className="text-sm font-medium lg:text-xs lg:font-normal lg:text-brand-brown/80">
-        {config.detalleCol2Value(r) || '—'}
-      </span>
-
-      {/* Métricas: en móvil como flex-wrap con etiquetas, en escritorio celdas alineadas */}
-      <span className="flex flex-wrap gap-x-4 gap-y-0.5 mt-1 lg:contents">
-        <MiniMetrica
-          label={config.cantidadHeader}
-          valor={r.cantidad != null && r.cantidad > 0 ? config.detalleCantidadFormat(r.cantidad) : '—'}
-        />
-        <MiniMetrica
-          label="Precio"
-          valor={r.precio_unitario != null ? `$${formatNumber(r.precio_unitario)}` : '—'}
-        />
-        <MiniMetrica
-          label="Valor"
-          valor={formatCurrency(r.valor)}
-          valorClass="font-semibold text-green-700"
-        />
+    <div className="dtab-detail-row">
+      <span className="dtab-detail-fecha">{formatearFecha(r.fecha)}</span>
+      <span className="dtab-detail-col2">{config.detalleCol2Value(r) || '—'}</span>
+      <span className="dtab-detail-meta">
+        <span className="dtab-dcell" data-label={config.cantidadHeader}>
+          {r.cantidad != null && r.cantidad > 0 ? config.detalleCantidadFormat(r.cantidad) : '—'}
+        </span>
+        <span className="dtab-dcell" data-label="Precio">
+          {r.precio_unitario != null ? `$${formatNumber(r.precio_unitario)}` : '—'}
+        </span>
+        <span className="dtab-dcell dtab-dcell--valor" data-label="Valor">
+          {formatCurrency(r.valor)}
+        </span>
       </span>
     </div>
-  );
-}
-
-function MiniMetrica({ label, valor, valorClass = 'tabular-nums' }: {
-  label: string;
-  valor: string;
-  valorClass?: string;
-}) {
-  return (
-    <span className="flex items-baseline gap-1 text-xs lg:justify-end lg:block">
-      <span className="text-brand-brown/40 lg:hidden">{label}:</span>
-      <span className={valorClass}>{valor}</span>
-    </span>
   );
 }

--- a/src/components/finanzas/dashboard/components/PivotTableGastos.tsx
+++ b/src/components/finanzas/dashboard/components/PivotTableGastos.tsx
@@ -1,20 +1,17 @@
-import { TrendingUp, TrendingDown } from 'lucide-react';
 import { formatCompact } from '@/utils/format';
 import type { PivotRow } from '@/types/finanzas';
+import './dashboardTables.css';
 
 const formatPivot = (v: number) => `$${formatCompact(v)}`;
 
 function VariacionBadge({ actual, anterior }: { actual: number; anterior: number }) {
   if (anterior === 0 && actual === 0) return null;
   const pct = anterior === 0 ? 100 : ((actual - anterior) / anterior) * 100;
-  const isUp = pct > 0;
   if (pct === 0) return null;
+  const isUp = pct > 0;
 
   return (
-    <span className={`inline-flex items-center gap-0.5 rounded-full px-1.5 py-0.5 text-xs font-medium ${
-      isUp ? 'bg-red-50 text-red-600' : 'bg-green-50 text-green-600'
-    }`}>
-      {isUp ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
+    <span className={`pivot-var ${isUp ? 'pivot-var--up' : 'pivot-var--down'}`}>
       {isUp ? '+' : ''}{pct.toFixed(0)}%
     </span>
   );
@@ -62,7 +59,7 @@ export function PivotTableGastos({ data, loading }: PivotTableGastosProps) {
       <div className="px-4 py-3 border-b border-primary/10">
         <h3 className="text-sm font-semibold text-foreground">Gastos Acumulados por Negocio</h3>
       </div>
-      <div className="overflow-x-auto">
+      <div className="pivot-scroll">
         <table className="w-full text-sm table-fixed">
           <colgroup>
             <col className="w-[16%]" />
@@ -93,22 +90,22 @@ export function PivotTableGastos({ data, loading }: PivotTableGastosProps) {
             {data.map((row, i) => (
               <tr key={row.negocio_id} className={`border-t border-primary/5 ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'}`}>
                 <td className="px-3 py-2 font-medium text-foreground">{row.negocio}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatPivot(row.ytd_actual)}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatPivot(row.ytd_anterior)}</td>
-                <td className="px-3 py-2 text-right"><VariacionBadge actual={row.ytd_actual} anterior={row.ytd_anterior} /></td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatPivot(row.total_anterior)}</td>
-                <td className="px-3 py-2 text-right tabular-nums">{formatPivot(row.total_n2)}</td>
-                <td className="px-3 py-2 text-right"><VariacionBadge actual={row.total_anterior} anterior={row.total_n2} /></td>
+                <td className="px-3 py-2 text-right tabular-nums" data-label={`YTD ${currentYear}`}>{formatPivot(row.ytd_actual)}</td>
+                <td className="px-3 py-2 text-right tabular-nums" data-label={`YTD ${currentYear - 1}`}>{formatPivot(row.ytd_anterior)}</td>
+                <td className="px-3 py-2 text-right" data-label="Var YoY (YTD)"><VariacionBadge actual={row.ytd_actual} anterior={row.ytd_anterior} /></td>
+                <td className="px-3 py-2 text-right tabular-nums" data-label={`Total ${currentYear - 1}`}>{formatPivot(row.total_anterior)}</td>
+                <td className="px-3 py-2 text-right tabular-nums" data-label={`Total ${currentYear - 2}`}>{formatPivot(row.total_n2)}</td>
+                <td className="px-3 py-2 text-right" data-label="Var YoY (Total)"><VariacionBadge actual={row.total_anterior} anterior={row.total_n2} /></td>
               </tr>
             ))}
-            <tr className="border-t-2 border-foreground/20 bg-gray-100 font-bold">
+            <tr className="pivot-total border-t-2 border-foreground/20 bg-gray-100 font-bold">
               <td className="px-3 py-2 text-foreground">{grandTotal.negocio}</td>
-              <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.ytd_actual)}</td>
-              <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.ytd_anterior)}</td>
-              <td className="px-3 py-2 text-right"><VariacionBadge actual={grandTotal.ytd_actual} anterior={grandTotal.ytd_anterior} /></td>
-              <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.total_anterior)}</td>
-              <td className="px-3 py-2 text-right tabular-nums">{formatPivot(grandTotal.total_n2)}</td>
-              <td className="px-3 py-2 text-right"><VariacionBadge actual={grandTotal.total_anterior} anterior={grandTotal.total_n2} /></td>
+              <td className="px-3 py-2 text-right tabular-nums" data-label={`YTD ${currentYear}`}>{formatPivot(grandTotal.ytd_actual)}</td>
+              <td className="px-3 py-2 text-right tabular-nums" data-label={`YTD ${currentYear - 1}`}>{formatPivot(grandTotal.ytd_anterior)}</td>
+              <td className="px-3 py-2 text-right" data-label="Var YoY (YTD)"><VariacionBadge actual={grandTotal.ytd_actual} anterior={grandTotal.ytd_anterior} /></td>
+              <td className="px-3 py-2 text-right tabular-nums" data-label={`Total ${currentYear - 1}`}>{formatPivot(grandTotal.total_anterior)}</td>
+              <td className="px-3 py-2 text-right tabular-nums" data-label={`Total ${currentYear - 2}`}>{formatPivot(grandTotal.total_n2)}</td>
+              <td className="px-3 py-2 text-right" data-label="Var YoY (Total)"><VariacionBadge actual={grandTotal.total_anterior} anterior={grandTotal.total_n2} /></td>
             </tr>
           </tbody>
         </table>

--- a/src/components/finanzas/dashboard/components/QuincenaTable.tsx
+++ b/src/components/finanzas/dashboard/components/QuincenaTable.tsx
@@ -76,8 +76,8 @@ export function QuincenaTable({ rows, emptyMessage = 'Sin ingresos registrados' 
   }
 
   return (
-    <div className="rounded-xl border border-primary/10 bg-white">
-      <div className="overflow-auto" style={{ maxHeight: '28rem' }}>
+    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+      <div className="lg:overflow-auto lg:max-h-[28rem]">
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-green-600 text-white">
             <tr>

--- a/src/components/finanzas/dashboard/components/QuincenaTable.tsx
+++ b/src/components/finanzas/dashboard/components/QuincenaTable.tsx
@@ -77,7 +77,7 @@ export function QuincenaTable({ rows, emptyMessage = 'Sin ingresos registrados' 
 
   return (
     <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
-      <div className="lg:overflow-auto lg:max-h-[28rem]">
+      <div className="lg:overflow-y-scroll lg:overscroll-contain lg:touch-pan-y lg:max-h-[28rem]">
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-green-600 text-white">
             <tr>

--- a/src/components/finanzas/dashboard/components/QuincenaTable.tsx
+++ b/src/components/finanzas/dashboard/components/QuincenaTable.tsx
@@ -1,7 +1,8 @@
-import { useState, useMemo } from 'react';
-import { ChevronDown, ChevronRight } from 'lucide-react';
-import { formatCurrency, formatNumber } from '@/utils/format';
-import { formatearFecha } from '@/utils/fechas';
+import { useMemo } from 'react';
+import { formatNumber } from '@/utils/format';
+import { agruparPorQuincena } from '@/utils/agrupacionIngresos';
+import { GrupoIngresosTable } from './GrupoIngresosTable';
+import type { GrupoIngresosTableConfig } from './GrupoIngresosTable';
 import type { IngresoDetalleRow } from '@/types/finanzas';
 
 interface QuincenaTableProps {
@@ -9,155 +10,16 @@ interface QuincenaTableProps {
   emptyMessage?: string;
 }
 
-interface GrupoQuincena {
-  key: string; // "YYYY-MM-1" | "YYYY-MM-2" — ordenable lexicograficamente
-  label: string;
-  rows: IngresoDetalleRow[];
-  litros: number;
-  valorTotal: number;
-  valorConLitros: number;
-}
+const CONFIG: GrupoIngresosTableConfig = {
+  cantidadHeader: 'Litros',
+  formatCantidad: (l) => `${formatNumber(l)} L`,
+  precioHeader: 'Precio Prom. $/L',
+  detalleCol2Header: 'Tipo ingreso',
+  detalleCol2Value: (r) => r.tipo_ingreso || '',
+  detalleCantidadFormat: (l) => `${formatNumber(l)} L`,
+};
 
-const MESES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
-
-function quincenaDe(fecha: string): { key: string; label: string } {
-  const year = fecha.substring(0, 4);
-  const monthIdx = parseInt(fecha.substring(5, 7), 10) - 1;
-  const day = parseInt(fecha.substring(8, 10), 10);
-  const q = day <= 15 ? 1 : 2;
-  const mes = MESES[monthIdx] || '';
-  return {
-    key: `${fecha.substring(0, 7)}-${q}`,
-    label: q === 1 ? `1-15 ${mes} ${year}` : `16-fin ${mes} ${year}`,
-  };
-}
-
-/**
- * Tabla de ingresos del Hato Lechero agrupada por quincena (1-15 y 16-fin de mes).
- * Litros y precio promedio $/L se calculan solo con las filas que tienen
- * cantidad registrada (leche); el ingreso total incluye todas las filas.
- */
-export function QuincenaTable({ rows, emptyMessage = 'Sin ingresos registrados' }: QuincenaTableProps) {
-  const [expanded, setExpanded] = useState<Set<string>>(new Set());
-
-  const grupos = useMemo<GrupoQuincena[]>(() => {
-    const map = new Map<string, GrupoQuincena>();
-    rows.forEach((r) => {
-      const { key, label } = quincenaDe(r.fecha);
-      if (!map.has(key)) {
-        map.set(key, { key, label, rows: [], litros: 0, valorTotal: 0, valorConLitros: 0 });
-      }
-      const g = map.get(key)!;
-      g.rows.push(r);
-      g.valorTotal += r.valor || 0;
-      if (r.cantidad != null && r.cantidad > 0) {
-        g.litros += r.cantidad;
-        g.valorConLitros += r.valor || 0;
-      }
-    });
-    return Array.from(map.values()).sort((a, b) => b.key.localeCompare(a.key));
-  }, [rows]);
-
-  const toggle = (key: string) => {
-    setExpanded((prev) => {
-      const next = new Set(prev);
-      if (next.has(key)) next.delete(key);
-      else next.add(key);
-      return next;
-    });
-  };
-
-  if (rows.length === 0) {
-    return (
-      <div className="rounded-xl border border-primary/10 bg-white p-8 text-center">
-        <p className="text-sm text-brand-brown/50">{emptyMessage}</p>
-      </div>
-    );
-  }
-
-  return (
-    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
-      <div className="lg:overflow-y-scroll lg:overscroll-contain lg:touch-pan-y lg:max-h-[28rem]">
-        <table className="w-full text-sm">
-          <thead className="sticky top-0 bg-green-600 text-white">
-            <tr>
-              <th className="px-3 py-2.5 text-left text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Quincena</th>
-              <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Litros</th>
-              <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Precio Prom. $/L</th>
-              <th className="px-3 py-2.5 text-right text-xs font-semibold uppercase tracking-wide whitespace-nowrap">Ingreso Total</th>
-            </tr>
-          </thead>
-          <tbody>
-            {grupos.map((g) => {
-              const isOpen = expanded.has(g.key);
-              const precioPromedio = g.litros > 0 ? g.valorConLitros / g.litros : 0;
-              return (
-                <GrupoQuincenaRows
-                  key={g.key}
-                  grupo={g}
-                  isOpen={isOpen}
-                  precioPromedio={precioPromedio}
-                  onToggle={() => toggle(g.key)}
-                />
-              );
-            })}
-          </tbody>
-        </table>
-      </div>
-    </div>
-  );
-}
-
-function GrupoQuincenaRows({ grupo, isOpen, precioPromedio, onToggle }: {
-  grupo: GrupoQuincena;
-  isOpen: boolean;
-  precioPromedio: number;
-  onToggle: () => void;
-}) {
-  return (
-    <>
-      <tr
-        className="border-t border-primary/5 bg-green-50/60 hover:bg-green-50 cursor-pointer select-none font-medium"
-        onClick={onToggle}
-      >
-        <td className="px-3 py-2.5 whitespace-nowrap">
-          <div className="flex items-center gap-1.5">
-            {isOpen ? <ChevronDown className="w-4 h-4 text-green-700" /> : <ChevronRight className="w-4 h-4 text-green-700" />}
-            {grupo.label}
-          </div>
-        </td>
-        <td className="px-3 py-2.5 text-right whitespace-nowrap">{grupo.litros > 0 ? `${formatNumber(grupo.litros)} L` : '-'}</td>
-        <td className="px-3 py-2.5 text-right whitespace-nowrap">{precioPromedio > 0 ? `$${formatNumber(precioPromedio)}` : '-'}</td>
-        <td className="px-3 py-2.5 text-right whitespace-nowrap">{formatCurrency(grupo.valorTotal)}</td>
-      </tr>
-      {isOpen && (
-        <tr className="border-t border-primary/5">
-          <td colSpan={4} className="px-0 py-0 bg-gray-50/30">
-            <table className="w-full text-sm">
-              <thead>
-                <tr className="text-xs text-brand-brown/60 uppercase tracking-wide">
-                  <td className="px-3 py-1.5 pl-9">Fecha</td>
-                  <td className="px-3 py-1.5">Tipo ingreso</td>
-                  <td className="px-3 py-1.5 text-right">Litros</td>
-                  <td className="px-3 py-1.5 text-right">Precio $/L</td>
-                  <td className="px-3 py-1.5 text-right">Valor</td>
-                </tr>
-              </thead>
-              <tbody>
-                {grupo.rows.map((r, i) => (
-                  <tr key={i} className={`border-t border-primary/5 ${i % 2 === 0 ? 'bg-white' : 'bg-gray-50/50'}`}>
-                    <td className="px-3 py-2 pl-9 whitespace-nowrap">{formatearFecha(r.fecha)}</td>
-                    <td className="px-3 py-2 whitespace-nowrap">{r.tipo_ingreso || '-'}</td>
-                    <td className="px-3 py-2 text-right whitespace-nowrap">{r.cantidad != null ? `${formatNumber(r.cantidad)} L` : '-'}</td>
-                    <td className="px-3 py-2 text-right whitespace-nowrap">{r.precio_unitario != null ? `$${formatNumber(r.precio_unitario)}` : '-'}</td>
-                    <td className="px-3 py-2 text-right whitespace-nowrap">{formatCurrency(r.valor)}</td>
-                  </tr>
-                ))}
-              </tbody>
-            </table>
-          </td>
-        </tr>
-      )}
-    </>
-  );
+export function QuincenaTable({ rows, emptyMessage }: QuincenaTableProps) {
+  const grupos = useMemo(() => agruparPorQuincena(rows), [rows]);
+  return <GrupoIngresosTable grupos={grupos} config={CONFIG} emptyMessage={emptyMessage} />;
 }

--- a/src/components/finanzas/dashboard/components/QuincenaTable.tsx
+++ b/src/components/finanzas/dashboard/components/QuincenaTable.tsx
@@ -76,7 +76,7 @@ export function QuincenaTable({ rows, emptyMessage = 'Sin ingresos registrados' 
   }
 
   return (
-    <div className="rounded-xl border border-primary/10 bg-white overflow-hidden">
+    <div className="rounded-xl border border-primary/10 bg-white">
       <div className="overflow-auto" style={{ maxHeight: '28rem' }}>
         <table className="w-full text-sm">
           <thead className="sticky top-0 bg-green-600 text-white">

--- a/src/components/finanzas/dashboard/components/dashboardTables.css
+++ b/src/components/finanzas/dashboard/components/dashboardTables.css
@@ -1,0 +1,320 @@
+/*
+ * Estilos responsive para las tablas de detalle del dashboard de finanzas
+ * (Ingresos por Cosecha / Quincena y Detalle Gastos).
+ *
+ * IMPORTANTE: este proyecto compila Tailwind a un index.css ESTÁTICO; no hay
+ * JIT, así que clases utilitarias nuevas (grid-cols arbitrarios, max-h, etc.)
+ * NO se generan y quedan inertes. Por eso el layout de estas tablas vive aquí
+ * como CSS plano con media queries reales: garantiza que el contenido se vea
+ * completo en móvil, tablet y escritorio, sin recortes ni scroll interno.
+ *
+ * Patrón: tarjetas apiladas en móvil/tablet (< 1024px), grid alineado tipo
+ * tabla en escritorio (>= 1024px). Sin alto máximo: la tabla crece y la página
+ * hace scroll.
+ */
+
+/* ---- Contenedor ---- */
+.dtab {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: #fff;
+  overflow: hidden;
+}
+
+/* ---- Encabezado (oculto en móvil, visible en escritorio) ---- */
+.dtab-head {
+  display: none;
+}
+
+/* ---- Estado vacío ---- */
+.dtab-empty {
+  padding: 2rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: rgba(77, 36, 15, 0.5);
+}
+
+/* =======================================================================
+   TABLA DE GRUPOS (Cosecha / Quincena)
+   ======================================================================= */
+
+.dtab-group + .dtab-group {
+  border-top: 1px solid var(--border);
+}
+
+/* Fila resumen / botón de expandir */
+.dtab-summary {
+  width: 100%;
+  text-align: left;
+  cursor: pointer;
+  border: 0;
+  border-top: 1px solid var(--border);
+  background: rgba(115, 153, 28, 0.06);
+  padding: 0.625rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  transition: background-color 0.15s ease;
+}
+.dtab-group:first-child .dtab-summary {
+  border-top: 0;
+}
+.dtab-summary:hover {
+  background: rgba(115, 153, 28, 0.12);
+}
+
+.dtab-summary-label {
+  display: flex;
+  align-items: flex-start;
+  gap: 0.375rem;
+  font-weight: 600;
+  font-size: 0.875rem;
+  color: var(--foreground);
+}
+.dtab-summary-label svg {
+  flex-shrink: 0;
+  margin-top: 0.125rem;
+  color: #15803d;
+}
+
+/* Celda métrica (resumen) */
+.dtab-cell {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  font-size: 0.8125rem;
+  font-variant-numeric: tabular-nums;
+}
+.dtab-cell::before {
+  content: attr(data-label) ": ";
+  color: rgba(77, 36, 15, 0.5);
+  font-size: 0.75rem;
+}
+.dtab-cell--total {
+  color: #15803d;
+  font-weight: 600;
+}
+
+/* ---- Detalle expandido ---- */
+.dtab-detail {
+  background: rgba(0, 0, 0, 0.02);
+  border-top: 1px solid var(--border);
+}
+.dtab-detail-head {
+  display: none;
+}
+.dtab-detail-row {
+  padding: 0.5rem 0.75rem;
+  display: flex;
+  flex-direction: column;
+  gap: 0.125rem;
+}
+.dtab-detail-row + .dtab-detail-row {
+  border-top: 1px solid var(--border);
+}
+.dtab-detail-fecha {
+  font-size: 0.875rem;
+  color: rgba(77, 36, 15, 0.7);
+}
+.dtab-detail-col2 {
+  font-size: 0.875rem;
+  font-weight: 500;
+  color: var(--foreground);
+}
+.dtab-detail-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.125rem 1rem;
+  margin-top: 0.125rem;
+}
+.dtab-dcell {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  font-size: 0.75rem;
+  font-variant-numeric: tabular-nums;
+}
+.dtab-dcell::before {
+  content: attr(data-label) ": ";
+  color: rgba(77, 36, 15, 0.4);
+}
+.dtab-dcell--valor {
+  color: #15803d;
+  font-weight: 600;
+}
+
+/* =======================================================================
+   TABLA SIMPLE (DataTable: Detalle Gastos / Ingresos genéricos)
+   ======================================================================= */
+
+.dtbl {
+  border-radius: 0.75rem;
+  border: 1px solid var(--border);
+  background: #fff;
+  overflow: hidden;
+}
+.dtbl-head {
+  display: none;
+}
+.dtbl-row {
+  display: flex;
+  flex-direction: column;
+  gap: 0.25rem;
+  padding: 0.625rem 0.75rem;
+}
+.dtbl-row:nth-child(even) {
+  background: rgba(0, 0, 0, 0.015);
+}
+.dtbl-cell {
+  display: flex;
+  align-items: baseline;
+  gap: 0.375rem;
+  font-size: 0.875rem;
+  font-variant-numeric: tabular-nums;
+}
+.dtbl-cell::before {
+  content: attr(data-label) ": ";
+  color: rgba(77, 36, 15, 0.4);
+  font-size: 0.6875rem;
+  flex-shrink: 0;
+}
+.dtbl-cell--num .dtbl-val {
+  font-weight: 500;
+}
+.dtbl-empty {
+  padding: 2rem;
+  text-align: center;
+  font-size: 0.875rem;
+  color: rgba(77, 36, 15, 0.5);
+}
+
+/* =======================================================================
+   ESCRITORIO (>= 1024px): grids alineados tipo tabla
+   ======================================================================= */
+@media (min-width: 1024px) {
+  /* --- Tabla de grupos --- */
+  .dtab-head {
+    display: grid;
+    grid-template-columns: 1fr 9rem 9rem 10rem;
+    gap: 0.75rem;
+    align-items: center;
+    padding: 0.625rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+    color: #fff;
+  }
+  .dtab-head--green {
+    background: #16a34a;
+  }
+  .dtab-head .r {
+    text-align: right;
+  }
+
+  .dtab-summary {
+    display: grid;
+    grid-template-columns: 1fr 9rem 9rem 10rem;
+    gap: 0.75rem;
+    align-items: center;
+  }
+  .dtab-cell {
+    justify-content: flex-end;
+    font-size: 0.875rem;
+  }
+  .dtab-cell::before {
+    content: none;
+  }
+
+  .dtab-detail-head {
+    display: grid;
+    grid-template-columns: 1fr 1fr 7rem 7rem 8rem;
+    gap: 0.5rem;
+    padding: 0.375rem 0.75rem;
+    font-size: 0.6875rem;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    color: rgba(77, 36, 15, 0.5);
+    font-weight: 500;
+  }
+  .dtab-detail-head .r {
+    text-align: right;
+  }
+  .dtab-detail-row {
+    display: grid;
+    grid-template-columns: 1fr 1fr 7rem 7rem 8rem;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .dtab-detail-fecha,
+  .dtab-detail-col2 {
+    font-size: 0.8125rem;
+    font-weight: 400;
+    color: rgba(77, 36, 15, 0.8);
+  }
+  .dtab-detail-meta {
+    display: contents;
+  }
+  .dtab-dcell {
+    justify-content: flex-end;
+  }
+  .dtab-dcell::before {
+    content: none;
+  }
+
+  /* --- Tabla simple --- */
+  .dtbl-head {
+    display: grid;
+    gap: 0.5rem;
+    align-items: center;
+    padding: 0.625rem 0.75rem;
+    font-size: 0.75rem;
+    font-weight: 600;
+    text-transform: uppercase;
+    letter-spacing: 0.05em;
+  }
+  .dtbl-head--green {
+    background: #16a34a;
+    color: #fff;
+  }
+  .dtbl-head--red {
+    background: #dc2626;
+    color: #fff;
+  }
+  .dtbl-head--default {
+    background: #f3f4f6;
+    color: var(--foreground);
+  }
+  .dtbl-th {
+    display: flex;
+    align-items: center;
+    gap: 0.25rem;
+    text-align: left;
+    background: none;
+    border: 0;
+    color: inherit;
+    font: inherit;
+    text-transform: inherit;
+    letter-spacing: inherit;
+    padding: 0;
+    cursor: pointer;
+  }
+  .dtbl-th--static {
+    cursor: default;
+  }
+  .dtbl-row {
+    display: grid;
+    gap: 0.5rem;
+    align-items: center;
+  }
+  .dtbl-cell {
+    font-size: 0.875rem;
+  }
+  .dtbl-cell::before {
+    content: none;
+  }
+  .dtbl-cell--num {
+    justify-content: flex-end;
+    text-align: right;
+  }
+}

--- a/src/components/finanzas/dashboard/components/dashboardTables.css
+++ b/src/components/finanzas/dashboard/components/dashboardTables.css
@@ -195,8 +195,8 @@
   /* --- Tabla de grupos --- */
   .dtab-head {
     display: grid;
-    grid-template-columns: 1fr 9rem 9rem 10rem;
-    gap: 0.75rem;
+    grid-template-columns: minmax(8rem, 1fr) minmax(5rem, 7rem) minmax(5.5rem, 7.5rem) minmax(7rem, 9rem);
+    gap: 0.5rem;
     align-items: center;
     padding: 0.625rem 0.75rem;
     font-size: 0.75rem;
@@ -214,8 +214,8 @@
 
   .dtab-summary {
     display: grid;
-    grid-template-columns: 1fr 9rem 9rem 10rem;
-    gap: 0.75rem;
+    grid-template-columns: minmax(8rem, 1fr) minmax(5rem, 7rem) minmax(5.5rem, 7.5rem) minmax(7rem, 9rem);
+    gap: 0.5rem;
     align-items: center;
   }
   .dtab-cell {
@@ -316,5 +316,84 @@
   .dtbl-cell--num {
     justify-content: flex-end;
     text-align: right;
+  }
+}
+
+/* =======================================================================
+   TABLA PIVOT (General → Gastos Acumulados / Detalle por Negocio y Categoría)
+   Mantiene <table> markup pero le añade:
+   - iOS touch-safe scroll horizontal (no atrapa el scroll vertical)
+   - Vista de tarjetas en móvil/tablet usando data-label en cada celda
+   ======================================================================= */
+.pivot-scroll {
+  overflow-x: auto;
+  touch-action: pan-y;
+  overscroll-behavior-x: contain;
+  -webkit-overflow-scrolling: touch;
+}
+
+/* Insignia compacta de variación (Var YoY) */
+.pivot-var {
+  display: inline-flex;
+  align-items: center;
+  gap: 0.0625rem;
+  border-radius: 9999px;
+  padding: 0.125rem 0.25rem;
+  font-size: 0.6875rem;
+  font-weight: 500;
+  white-space: nowrap;
+  line-height: 1;
+  font-variant-numeric: tabular-nums;
+}
+.pivot-var--up   { background: rgba(254, 226, 226, 1); color: rgb(220, 38, 38); }
+.pivot-var--down { background: rgba(220, 252, 231, 1); color: rgb(22, 163, 74); }
+.pivot-var svg { width: 0.5625rem; height: 0.5625rem; flex-shrink: 0; }
+
+/* Móvil (< 768px): convertimos las filas en tarjetas apiladas.
+   En tablet la tabla cabe a ancho completo porque DashboardGeneral usa xl:grid-cols-2. */
+@media (max-width: 767.98px) {
+  .pivot-scroll { overflow-x: visible; }
+  .pivot-scroll table,
+  .pivot-scroll thead,
+  .pivot-scroll tbody,
+  .pivot-scroll tr,
+  .pivot-scroll td,
+  .pivot-scroll th { display: block; }
+  .pivot-scroll colgroup { display: none; }
+  .pivot-scroll thead { display: none; }      /* labels viven en data-label */
+  .pivot-scroll tr {
+    border-top: 1px solid var(--border);
+    padding: 0.625rem 0.75rem;
+  }
+  .pivot-scroll tr:first-child { border-top: 0; }
+  .pivot-scroll td {
+    padding: 0.25rem 0 !important;
+    text-align: left !important;
+    display: flex;
+    align-items: baseline;
+    gap: 0.5rem;
+  }
+  .pivot-scroll td:first-child {
+    font-weight: 600;
+    font-size: 0.9375rem;
+    padding-bottom: 0.375rem !important;
+    border-bottom: 1px dashed var(--border);
+    margin-bottom: 0.25rem;
+  }
+  .pivot-scroll td[data-label]::before {
+    content: attr(data-label);
+    color: rgba(77, 36, 15, 0.55);
+    font-size: 0.6875rem;
+    font-weight: 500;
+    text-transform: uppercase;
+    letter-spacing: 0.03em;
+    flex: 0 0 auto;
+    min-width: 7.5rem;
+  }
+  /* La fila TOTAL gana borde superior fuerte */
+  .pivot-scroll tr.pivot-total {
+    border-top: 2px solid rgba(0, 0, 0, 0.15);
+    background: rgba(0, 0, 0, 0.025);
+    font-weight: 600;
   }
 }

--- a/src/types/finanzas.ts
+++ b/src/types/finanzas.ts
@@ -378,6 +378,8 @@ export interface BatchRowDataIngreso {
   observaciones: string;
   factura_file: File | null;
   factura_uploaded: boolean;
+  /** Cantidad (kg para Aguacate Hass, litros para Hato Lechero). Null para otros negocios. */
+  cantidad: string;
 }
 
 // ── Budget (Presupuesto) ─────────────────────────────────────────

--- a/src/utils/agrupacionIngresos.ts
+++ b/src/utils/agrupacionIngresos.ts
@@ -1,0 +1,71 @@
+import type { IngresoDetalleRow } from '@/types/finanzas';
+
+export interface GrupoIngresos {
+  key: string;
+  label: string;
+  rows: IngresoDetalleRow[];
+  cantidad: number;          // suma de cantidad para filas CON cantidad (kg o litros)
+  valorTotal: number;        // suma de TODAS las filas
+  valorConCantidad: number;  // suma de valor solo para filas con cantidad (para precio prom.)
+  precioPromedio: number;    // valorConCantidad / cantidad, 0 si no hay cantidad
+  maxFecha: string;          // fecha más reciente del grupo (para ordenar cosechas)
+}
+
+const MESES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+
+export function quincenaDe(fecha: string): { key: string; label: string } {
+  const year = fecha.substring(0, 4);
+  const monthIdx = parseInt(fecha.substring(5, 7), 10) - 1;
+  const day = parseInt(fecha.substring(8, 10), 10);
+  const q = day <= 15 ? 1 : 2;
+  const mes = MESES[monthIdx] ?? '';
+  return {
+    key: `${fecha.substring(0, 7)}-${q}`,
+    label: q === 1 ? `1-15 ${mes} ${year}` : `16-fin ${mes} ${year}`,
+  };
+}
+
+function acumular(g: GrupoIngresos, r: IngresoDetalleRow) {
+  g.rows.push(r);
+  g.valorTotal += r.valor || 0;
+  if (r.cantidad != null && r.cantidad > 0) {
+    g.cantidad += r.cantidad;
+    g.valorConCantidad += r.valor || 0;
+  }
+  if (r.fecha > g.maxFecha) g.maxFecha = r.fecha;
+}
+
+function nuevaGrupo(key: string, label: string): GrupoIngresos {
+  return { key, label, rows: [], cantidad: 0, valorTotal: 0, valorConCantidad: 0, precioPromedio: 0, maxFecha: '' };
+}
+
+function conPrecio(grupos: GrupoIngresos[]): GrupoIngresos[] {
+  return grupos.map((g) => ({
+    ...g,
+    precioPromedio: g.cantidad > 0 ? g.valorConCantidad / g.cantidad : 0,
+  }));
+}
+
+export function agruparPorCosecha(rows: IngresoDetalleRow[]): GrupoIngresos[] {
+  const map = new Map<string, GrupoIngresos>();
+  rows.forEach((r) => {
+    const key = r.cosecha || 'Sin cosecha';
+    if (!map.has(key)) map.set(key, nuevaGrupo(key, key));
+    acumular(map.get(key)!, r);
+  });
+  return conPrecio(
+    Array.from(map.values()).sort((a, b) => b.maxFecha.localeCompare(a.maxFecha))
+  );
+}
+
+export function agruparPorQuincena(rows: IngresoDetalleRow[]): GrupoIngresos[] {
+  const map = new Map<string, GrupoIngresos>();
+  rows.forEach((r) => {
+    const { key, label } = quincenaDe(r.fecha);
+    if (!map.has(key)) map.set(key, nuevaGrupo(key, label));
+    acumular(map.get(key)!, r);
+  });
+  return conPrecio(
+    Array.from(map.values()).sort((a, b) => b.key.localeCompare(a.key))
+  );
+}

--- a/src/utils/format.ts
+++ b/src/utils/format.ts
@@ -9,15 +9,14 @@
  */
 
 /**
- * Formatea un número como moneda colombiana (COP)
- * 
- * @param value - Valor numérico a formatear
- * @returns String formateado como "$X,XXX,XXX COP"
- * 
+ * Formatea un número como moneda colombiana.
+ *
+ * No anexa "COP": la moneda es implícita en la UI (regla de CLAUDE.md).
+ *
  * @example
- * formatCurrency(4250000) // "$4,250,000 COP"
- * formatCurrency(1500000) // "$1,500,000 COP"
- * formatCurrency(0) // "$0 COP"
+ * formatCurrency(4250000) // "$4.250.000"
+ * formatCurrency(1500000) // "$1.500.000"
+ * formatCurrency(0) // "$0"
  */
 export function formatCurrency(value: number): string {
   const formatted = new Intl.NumberFormat('es-CO', {
@@ -25,8 +24,8 @@ export function formatCurrency(value: number): string {
     minimumFractionDigits: 0,
     maximumFractionDigits: 0,
   }).format(value);
-  
-  return `$${formatted} COP`;
+
+  return `$${formatted}`;
 }
 
 /**


### PR DESCRIPTION
## Summary

Two related finanzas fixes from a single session:

- **`IngresosBatchTable` — avocado/dairy entry fix**. Commit `88aff93` added conditional Cantidad (kg/L) + auto-computed Precio/kg fields to the `IngresoForm` edit dialog, but the new "Registrar" tab uses the inline `IngresosBatchTable` grid which never got those fields. Operators were encoding kg into the nombre as a workaround (e.g. `"John Vela > 90 g x 551 kg"`). Now the grid renders a secondary sub-row when the row's negocio is Aguacate Hass or Hato Lechero, with a kg/L input and read-only `Precio / kg (calculado)`. Payload builder resolves the negocio name and persists `cantidad` + `precio_unitario` to `fin_ingresos`.
- **Dashboard tables — fully usable across viewports**. Browser audit across all 6 negocio tabs at 1440 / 1024 / 390 px surfaced truncated mini-tables, columns hidden offscreen, the iOS scroll-trap risk on raw `<table>`s, sub-nav strips cut mid-word, and the `formatCurrency` `COP` suffix violating the CLAUDE.md UI rule. Fixed all of it: stripped `COP`, added `.pivot-scroll` (iOS-safe touch scroll + mobile card-stack layout via `data-label`), tightened `.dtab` desktop grid, compacted the Var YoY badge, switched sub-nav strips to `flex-wrap`, and stacked the General-tab grid so the 7-column pivot gets full width.

## Commits

- `dc85030` fix(finanzas): make dashboard tables fully usable across desktop/tablet/mobile
- `d61ecbc` fix(finanzas): add cantidad/precio per kg fields to IngresosBatchTable inline grid

## Test plan

- [x] **Avocado entry end-to-end**: on `/finanzas/ingresos` Registrar tab, pick Aguacate Hass → sub-row appears; valor=1.000.000 + cantidad=500 → precio auto-computes to \$2.000; save → "1 ingreso guardado exitosamente"; switch to Historial → row appears with right values; reopen via Edit → cantidad=500 and precio=\$2.000 loaded from the DB.
- [x] **Dashboard tables at desktop 1440 px**: General mini-table fits, all 7 columns visible, Var YoY badges compact; Aguacate dtab fits; Ganado dtbl fits.
- [x] **Dashboard tables at tablet 1024 px**: General mini-table goes full width (chart stacks below); Aguacate dtab keeps all 4 columns visible; sub-nav wraps "Configuración" to row 2.
- [x] **Dashboard tables at mobile 390 px**: tables collapse to label/value card stacks; no horizontal overflow; touch scroll behaves; tab strips wrap gracefully.
- [ ] iOS Safari touch verification on real device (recommended before merge).
- [ ] Spot-check `formatCurrency` usages outside `/finanzas` (it's used in 107 call sites) — `COP` suffix gone everywhere, e.g. PDF reports, Esco chat responses, weekly report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)