### PR TITLE
fix(monitoreo): repair broken JSX blocking production deploys

### DIFF
--- a/src/components/monitoreo/PriorizacionScoutingView.tsx
+++ b/src/components/monitoreo/PriorizacionScoutingView.tsx
@@ -434,18 +434,12 @@ function FilaFoco({
                 </span>
               ) : null}
             </span>
-            <span className="min-w-0 flex-1 truncate text-sm font-medium text-foreground">{entry.pest_nombre}</span>
-            <span className="flex shrink-0 flex-col items-end gap-0.5">
-              <span className="text-sm font-semibold tabular-nums text-foreground">
-                {formatPercentage(entry.incidenciaActual, 0)}
-              </span>
-              <TrendBadge tendencia={entry.tendencia} numRondas={entry.numRondas} />
           </span>
-          <span className="flex shrink-0 flex-col items-end" style={{ gap: '0.125rem' }}>
-            <span className="text-sm font-semibold text-foreground" style={{ fontVariantNumeric: 'tabular-nums' }}>
+          <span className="flex shrink-0 flex-col items-end gap-0.5">
+            <span className="text-sm font-semibold tabular-nums text-foreground">
               {formatPercentage(entry.incidenciaActual, 0)}
             </span>
-            <TrendBadge tendencia={entry.tendencia} />
+            <TrendBadge tendencia={entry.tendencia} numRondas={entry.numRondas} />
           </span>
         </button>
       </PopoverTrigger>
@@ -493,7 +487,7 @@ function FilaLoteExpandible({
             <span className="text-sm font-semibold text-foreground" style={{ fontVariantNumeric: 'tabular-nums' }}>
               {formatPercentage(peor.incidenciaActual, 0)}
             </span>
-            <TrendBadge tendencia={peor.tendencia} />
+            <TrendBadge tendencia={peor.tendencia} numRondas={peor.numRondas} />
           </span>
         </button>
       </CollapsibleTrigger>


### PR DESCRIPTION
## Why

Production still shows the pre-#65 monitoreo behavior (all heatmap values, marceño 40%+ in La Vega) because **every Vercel build of `main` since #65 merged has been failing**, so prod kept serving the last good deployment. The build log shows esbuild dying on `PriorizacionScoutingView.tsx` with mismatched JSX tag errors.

## Root cause

The `ce62b6b` merge of `main` into the #65 branch mangled `FilaFoco`:
- left a stray `pest_nombre` line from the old pre-hierarchy layout
- duplicated the right-hand %/trend column (the old copy called `TrendBadge` without the now-required `numRondas` prop)
- dropped the closing tag of the `min-w-0 flex-1` span

## Fix

- Removed the leftover markup and closed the span, keeping the hierarchy-layout version with `numRondas`
- Passed `numRondas` to the remaining `TrendBadge` call in `FilaLoteExpandible`

## Verification

- `npm run build` ✓ (this is what Vercel runs — it was the failing step)
- `npm run typecheck` — no errors in this file (the `PurchaseHistory.tsx` RPC-typing error is pre-existing and does not affect the Vite build)
- `npx eslint` on the file ✓

🤖 Generated with [Claude Code](https://claude.com/claude-code)