### PR TITLE
Fix fertilizer purchase cost auto-fill and per-lote jornales in application reports

### DIFF
--- a/src/__tests__/calculosCompras.test.ts
+++ b/src/__tests__/calculosCompras.test.ts
@@ -1,0 +1,79 @@
+import { describe, it, expect } from 'vitest';
+import { calcularPrecioAutoFillBulto, calcularTotalesCompra } from '@/utils/calculosCompras';
+
+describe('calcularPrecioAutoFillBulto', () => {
+  it('usa precio_por_presentacion cuando está disponible', () => {
+    const precio = calcularPrecioAutoFillBulto({
+      precio_por_presentacion: 191400,
+      precio_unitario: 3828,
+      presentacion_kg_l: 50,
+    });
+    expect(precio).toBe(191400);
+  });
+
+  it('cae a precio_unitario × presentacion_kg_l cuando falta precio_por_presentacion', () => {
+    const precio = calcularPrecioAutoFillBulto({
+      precio_por_presentacion: null,
+      precio_unitario: 3828,
+      presentacion_kg_l: 50,
+    });
+    expect(precio).toBe(191400);
+  });
+
+  it('regresión: nunca usa precio_unitario ($/kg) directo como precio por bulto en presentaciones > 1', () => {
+    // Caso real que causó el bug: fertilizante en bultos de 50kg con precio_unitario = $/kg
+    const producto = {
+      precio_por_presentacion: null,
+      precio_unitario: 3719.64,
+      presentacion_kg_l: 50,
+    };
+    const precio = calcularPrecioAutoFillBulto(producto);
+    expect(precio).not.toBe(producto.precio_unitario);
+    expect(precio).toBe(185982);
+  });
+
+  it('presentación de 1 (ej. productos líquidos por litro) no distorsiona el precio', () => {
+    const precio = calcularPrecioAutoFillBulto({
+      precio_por_presentacion: null,
+      precio_unitario: 43795,
+      presentacion_kg_l: 1,
+    });
+    expect(precio).toBe(43795);
+  });
+
+  it('retorna 0 sin datos de precio', () => {
+    const precio = calcularPrecioAutoFillBulto({
+      precio_por_presentacion: null,
+      precio_unitario: null,
+      presentacion_kg_l: 50,
+    });
+    expect(precio).toBe(0);
+  });
+});
+
+describe('calcularTotalesCompra', () => {
+  it('calcula cantidad total, costo total y precio unitario real', () => {
+    const totales = calcularTotalesCompra(38, 191400, 50);
+    expect(totales.cantidadTotal).toBe(1900);
+    expect(totales.costoTotal).toBe(7273200);
+    expect(totales.precioUnitarioReal).toBeCloseTo(3828, 2);
+  });
+
+  it('retorna ceros cuando algún input es inválido', () => {
+    expect(calcularTotalesCompra(0, 191400, 50)).toEqual({
+      cantidadTotal: 0,
+      costoTotal: 0,
+      precioUnitarioReal: 0,
+    });
+    expect(calcularTotalesCompra(38, 0, 50)).toEqual({
+      cantidadTotal: 0,
+      costoTotal: 0,
+      precioUnitarioReal: 0,
+    });
+    expect(calcularTotalesCompra(38, 191400, 0)).toEqual({
+      cantidadTotal: 0,
+      costoTotal: 0,
+      precioUnitarioReal: 0,
+    });
+  });
+});

--- a/src/components/inventory/NewPurchase.tsx
+++ b/src/components/inventory/NewPurchase.tsx
@@ -7,6 +7,7 @@ import { ProveedorDialog } from '../shared/ProveedorDialog';
 import { FacturaUploader } from '../shared/FacturaUploader';
 import { useFormDraft } from '@/hooks/useFormDraft';
 import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
+import { calcularPrecioAutoFillBulto, calcularTotalesCompra } from '@/utils/calculosCompras';
 import {
   Package,
   Search,
@@ -49,6 +50,7 @@ interface Producto {
   unidad_medida: string;
   categoria: string;
   precio_unitario: number | null;
+  precio_por_presentacion: number | null;
   cantidad_actual: number | null;
   activo: boolean | null;
 }
@@ -137,7 +139,7 @@ export function NewPurchase({ onSuccess }: { onSuccess?: () => void }) {
     try {
       const { data, error } = await getSupabase()
         .from('productos')
-        .select('id, nombre, presentacion_kg_l, unidad_medida, categoria, precio_unitario, cantidad_actual, activo')
+        .select('id, nombre, presentacion_kg_l, unidad_medida, categoria, precio_unitario, precio_por_presentacion, cantidad_actual, activo')
         .eq('activo', true)
         .order('nombre');
 
@@ -222,7 +224,7 @@ export function NewPurchase({ onSuccess }: { onSuccess?: () => void }) {
         // Auto-rellenar con datos del producto
         const presentacionCantidad = productoSeleccionado.presentacion_kg_l || 1;
         const presentacionUnidad = productoSeleccionado.unidad_medida || 'Kilos';
-        const precioPorBulto = productoSeleccionado.precio_unitario || 0;
+        const precioPorBulto = calcularPrecioAutoFillBulto(productoSeleccionado);
 
         return {
           ...item,
@@ -266,24 +268,11 @@ export function NewPurchase({ onSuccess }: { onSuccess?: () => void }) {
         const precioPorBulto = Number(item.precio_por_bulto) || 0;
         const presentacionCantidad = Number(item.presentacion_cantidad) || 0;
 
-        // Validar valores
-        if (cantidadBultos <= 0 || precioPorBulto <= 0 || presentacionCantidad <= 0) {
-          return {
-            ...item,
-            cantidad_total: 0,
-            costo_total: 0,
-            precio_unitario_real: 0,
-          };
-        }
-
-        // CÁLCULO 1: Total kg/L = cantidad_bultos × presentacion_cantidad
-        const cantidadTotal = cantidadBultos * presentacionCantidad;
-
-        // CÁLCULO 2: Costo Total = cantidad_bultos × precio_por_bulto
-        const costoTotal = cantidadBultos * precioPorBulto;
-
-        // CÁLCULO 3: Precio Unitario Real = costo_total ÷ cantidad_total
-        const precioUnitarioReal = costoTotal / cantidadTotal;
+        const { cantidadTotal, costoTotal, precioUnitarioReal } = calcularTotalesCompra(
+          cantidadBultos,
+          precioPorBulto,
+          presentacionCantidad
+        );
 
         return {
           ...item,
@@ -424,7 +413,7 @@ export function NewPurchase({ onSuccess }: { onSuccess?: () => void }) {
               saldo_nuevo: cantidadNueva,
               valor_movimiento: item.costo_total,
               responsable: user?.email || null,
-              observaciones: `Compra - Factura: ${datosCompra.numero_factura} - Proveedor: ${proveedorNombre} - ${item.cantidad_bultos} bultos de ${item.presentacion_cantidad} ${item.presentacion_unidad}`,
+              observaciones: `Compra - Factura: ${datosCompra.numero_factura} - Proveedor: ${proveedorNombre} - ${item.cantidad_bultos} bultos de ${item.presentacion_cantidad} ${item.presentacion_unidad} a ${formatearPesos(item.precio_por_bulto)}/bulto`,
               provisional: false,
             } as any);
 

--- a/src/hooks/useReporteAplicacion.ts
+++ b/src/hooks/useReporteAplicacion.ts
@@ -323,6 +323,32 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                 }
             }
 
+            // Fetch Real Labor Data (registros_trabajo — same source as the Historial de
+            // Trabajo labor log) so per-lote jornales reflect actual worker assignments
+            // instead of a tree-count proration of a single application-wide total.
+            const jornalesPorLoteReal = new Map<string, { jornales: number; costo: number; lote_nombre?: string; total_arboles?: number }>();
+            if (appData.tarea_id) {
+                const { data: registrosTrabajo } = await supabase
+                    .from('registros_trabajo')
+                    .select('lote_id, fraccion_jornal, costo_jornal, lotes(nombre, total_arboles)')
+                    .eq('tarea_id', appData.tarea_id);
+
+                (registrosTrabajo || []).forEach((r: any) => {
+                    if (!r.lote_id) return;
+                    const existing = jornalesPorLoteReal.get(r.lote_id) || {
+                        jornales: 0,
+                        costo: 0,
+                        lote_nombre: r.lotes?.nombre,
+                        total_arboles: r.lotes?.total_arboles,
+                    };
+                    existing.jornales += Number(r.fraccion_jornal) || 0;
+                    existing.costo += Number(r.costo_jornal) || 0;
+                    jornalesPorLoteReal.set(r.lote_id, existing);
+                });
+            }
+            const totalJornalesRegistros = Array.from(jornalesPorLoteReal.values())
+                .reduce((sum, v) => sum + v.jornales, 0);
+
             // 2. AGGREGATE DATA
             // ----------------------------------------------------------------
 
@@ -348,9 +374,13 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                 return trees > 0 ? trees / 500 : 0;
             };
 
-            // Use 'jornales_utilizados' from app for total labor, defaulting to 0
+            // Prefer the live sum of registros_trabajo (ground truth, matches the labor log);
+            // fall back to the 'jornales_utilizados' snapshot taken at cierre time when the
+            // application has no linked tarea or no work has been logged yet.
             const cierreData = appData.aplicaciones_cierre as unknown as any[] | undefined;
-            const totalJornalesApp = Number(appData.jornales_utilizados || cierreData?.[0]?.jornales_aplicacion || 0);
+            const totalJornalesApp = totalJornalesRegistros > 0
+                ? totalJornalesRegistros
+                : Number(appData.jornales_utilizados || cierreData?.[0]?.jornales_aplicacion || 0);
             const valorJornal = Number(appData.valor_jornal || cierreData?.[0]?.valor_jornal || 0);
 
             // --- Real Data Processing ---
@@ -412,11 +442,36 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                 }
             });
 
-            // Distribute Labor (Proportional to trees)
+            // Ensure lots with logged labor but no movement/plan entry (rare) still appear
+            jornalesPorLoteReal.forEach((real, loteId) => {
+                if (!lotesRealMap.has(loteId)) {
+                    lotesRealMap.set(loteId, {
+                        lote_id: loteId,
+                        lote_nombre: real.lote_nombre || 'Unknown',
+                        total_arboles: real.total_arboles || 0,
+                        canecas_200l: 0,
+                        litros_total: 0,
+                        jornales: 0,
+                        costo_mano_obra: 0
+                    });
+                }
+            });
+
+            // Distribute Labor: when the application has any registros_trabajo, they are
+            // ground truth (matches the Historial de Trabajo labor log exactly) — a lot with
+            // no logged rows genuinely got 0 jornales, it must NOT receive a tree-count share
+            // of jornales actually worked on other lots. Only fall back to proration when the
+            // application has no registros_trabajo at all (e.g. no linked tarea).
             lotesRealMap.forEach((lote) => {
-                const share = safeDivide(lote.total_arboles, totalArbolesApp);
-                lote.jornales = totalJornalesApp * share;
-                lote.costo_mano_obra = lote.jornales * valorJornal;
+                if (totalJornalesRegistros > 0) {
+                    const real = jornalesPorLoteReal.get(lote.lote_id);
+                    lote.jornales = real?.jornales || 0;
+                    lote.costo_mano_obra = real?.costo || (lote.jornales * valorJornal);
+                } else {
+                    const share = safeDivide(lote.total_arboles, totalArbolesApp);
+                    lote.jornales = totalJornalesApp * share;
+                    lote.costo_mano_obra = lote.jornales * valorJornal;
+                }
             });
 
             // Aggregate Real Products
@@ -574,7 +629,11 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
             // ----------------------------------------------------------------
 
             // Totals
-            const totalCostoManoObraReal = totalJornalesApp * valorJornal;
+            // Prefer the sum of actual per-worker costo_jornal from registros_trabajo (accounts
+            // for each worker's real rate); fall back to average valorJornal × jornales otherwise.
+            const totalCostoManoObraReal = totalJornalesRegistros > 0
+                ? Array.from(jornalesPorLoteReal.values()).reduce((sum, v) => sum + v.costo, 0)
+                : totalJornalesApp * valorJornal;
             const totalCostoProductosReal = Array.from(productosRealMap.values()).reduce((sum: number, p: any) => sum + p.costo, 0);
             const totalCostoReal = totalCostoManoObraReal + totalCostoProductosReal; // Ignore app.costo_total to force recalc
 

--- a/src/utils/calculosCompras.ts
+++ b/src/utils/calculosCompras.ts
@@ -1,0 +1,37 @@
+export interface ProductoParaAutoFill {
+  precio_por_presentacion: number | null;
+  precio_unitario: number | null;
+  presentacion_kg_l: number | null;
+}
+
+export interface TotalesCompra {
+  cantidadTotal: number;
+  costoTotal: number;
+  precioUnitarioReal: number;
+}
+
+// precio_unitario es $/kg-L (derivado en ProductForm de precio_por_presentacion / presentacion_kg_l); nunca usarlo directo como precio por bulto
+export function calcularPrecioAutoFillBulto(producto: ProductoParaAutoFill): number {
+  if (producto.precio_por_presentacion && producto.precio_por_presentacion > 0) {
+    return producto.precio_por_presentacion;
+  }
+
+  const presentacion = producto.presentacion_kg_l || 1;
+  return (producto.precio_unitario || 0) * presentacion;
+}
+
+export function calcularTotalesCompra(
+  cantidadBultos: number,
+  precioPorBulto: number,
+  presentacionCantidad: number
+): TotalesCompra {
+  if (cantidadBultos <= 0 || precioPorBulto <= 0 || presentacionCantidad <= 0) {
+    return { cantidadTotal: 0, costoTotal: 0, precioUnitarioReal: 0 };
+  }
+
+  const cantidadTotal = cantidadBultos * presentacionCantidad;
+  const costoTotal = cantidadBultos * precioPorBulto;
+  const precioUnitarioReal = costoTotal / cantidadTotal;
+
+  return { cantidadTotal, costoTotal, precioUnitarioReal };
+}


### PR DESCRIPTION
## Summary

Two unrelated fixes bundled into one PR:

**1. Fertilizer purchase cost corruption (`src/components/inventory/NewPurchase.tsx`, `src/utils/calculosCompras.ts`)**
- The "Precio por bulto/tarro" field on the compra form auto-filled from `productos.precio_unitario` (a derived $/kg-L price), instead of `productos.precio_por_presentacion` (the real per-bag price). For any multi-kg bulto product — fertilizantes especially, sold in ~50kg bags — this silently understated `costo_total` by roughly the bag-weight factor, and self-reinforced because the corrupted result was written back into `productos.precio_unitario` on save, seeding the same error on the next purchase.
- Extracted the auto-fill and totals math into `src/utils/calculosCompras.ts` (pure, tested) so the form's auto-fill and its recalculation share one implementation.
- `movimientos_inventario.observaciones` now also records the price-per-bulto entered, so raw invoice inputs behind a compra are recoverable for future audits.
- Added `src/__tests__/calculosCompras.test.ts`, including a regression test pinned to the exact bug scenario (50kg bulto, $/kg price mistakenly used as $/bulto).

**2. Per-lote jornales in application reports (`src/hooks/useReporteAplicacion.ts`)**
- The "Detalle Técnico por Lote" jornales tab prorated a single application-wide total (`aplicaciones.jornales_utilizados`, a snapshot taken once at cierre time) across lotes by tree-count share, which never matched the actual per-lote labor log and made Árboles/Jornal collapse to one constant value across every lote.
- Now queries `registros_trabajo` directly (grouped by `lote_id`, via the application's linked `tarea_id`) as ground truth, falling back to the old tree-count proration only when no work has been logged yet for that application.

## Test plan

- [x] `npm test` — 477/478 passing; the 1 failure (`reporteSemanal.test.ts`) is pre-existing and unrelated, confirmed via `git stash` against the pre-change tree
- [x] `npm run typecheck` — one pre-existing unrelated error in `PurchaseHistory.tsx` (confirmed present before these changes), no new errors
- [x] `npx eslint` on changed files — only pre-existing warnings, nothing introduced
- [ ] Manual verification of the compra form and the application report jornales tab against real data (not run in this session — no live DB access)


---
_Generated by [Claude Code](https://claude.ai/code/session_015EbfjSUnb6KHBmNfCZZwGe)_