### PR TITLE
fix(ui): restaurar scroll en 9 diálogos que recortaban su contenido

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -483,12 +483,13 @@ npm test             # Single run
 npm run test:watch   # Watch mode
 ```
 
-Current test files:
+Selected test files (the directory holds ~25 — run `ls src/__tests__/` for the full set):
 - `aplicacionesReales.test.ts` — Real applications data handling
 - `generarReporteSemanal.test.ts` — Report generation logic
 - `laborImprovements.test.ts` — Labor module improvements
 - `laborRegistration.test.ts` — Labor registration & DB trigger shapes
 - `reporteSemanal.test.ts` — Weekly report logic
+- `dialogScrollContract.test.ts` — Static guard: every `DialogContent` must scroll (see Dialog Size System)
 
 When adding new tests, place them in `src/__tests__/` and follow existing patterns for mocking Supabase.
 
@@ -579,6 +580,17 @@ See `src/guidelines/Guidelines.md` for the full design system.
 
 ### Dialog Size System (`src/components/ui/dialog.tsx`)
 All dialogs use a fixed-size tier via the `size` prop on `DialogContent`: `sm` (448×384px), `md` (576×512px), `lg` (768×640px), `xl` (1024×704px). These are max dimensions in rem — they never fill the screen. The base `DialogContent` enforces `overflow-hidden`, so scrollable content MUST go inside `<DialogBody>`. Never put `overflow-y-auto` on `DialogContent` directly. `StandardDialog` was removed — use `Dialog` + `DialogContent` + `DialogHeader` + `DialogBody` + `DialogFooter` directly.
+
+**When a `<form>` wraps the dialog content**, it becomes the flex child and must be able to shrink, or it clips the panel exactly as if `DialogBody` were absent:
+
+```tsx
+<form onSubmit={…} className="flex flex-col flex-1 min-h-0 gap-4">
+  <DialogBody className="space-y-4">{/* fields */}</DialogBody>
+  <DialogFooter className="gap-3">{/* buttons */}</DialogFooter>
+</form>
+```
+
+`src/__tests__/dialogScrollContract.test.ts` enforces both rules across the codebase. See `docs/bugs/2026-07-21-dialog-sin-scroll-usuarios.md`.
 
 ---
 

--- a/docs/bugs/2026-07-21-dialog-sin-scroll-usuarios.md
+++ b/docs/bugs/2026-07-21-dialog-sin-scroll-usuarios.md
@@ -1,0 +1,144 @@
+# Bug: El diálogo "Editar Usuario" recorta su contenido y no permite scroll
+
+**Date:** 2026-07-21
+**Severity:** High — bloquea completamente la edición de usuarios (los botones Guardar/Cancelar son inalcanzables)
+**Status:** Fixed
+
+## Symptom
+
+En Configuración → Usuarios, al abrir el modal "Nuevo Usuario" o "Editar Usuario":
+
+- El panel del diálogo se dibuja con una altura fija y el contenido del formulario se corta a media fila ("Usuario activo" queda partido por la mitad).
+- No aparece barra de scroll y la rueda del mouse / trackpad no desplaza el contenido.
+- La fila de botones (Cancelar / Guardar Cambios) queda fuera del área visible, por lo que **el formulario no se puede enviar con el mouse**. La única salida es la X de cerrar.
+
+No es un problema de datos ni de red: el formulario se renderiza correctamente, simplemente está clipeado.
+
+## Reproduction path
+
+1. Login como Gerencia → `/configuracion` → pestaña **Usuarios**.
+2. Click en el botón editar de cualquier usuario (o "Nuevo Usuario").
+3. `UsuariosConfig.tsx:367` monta `<Dialog>` → `<DialogContent size="md">` (línea 368).
+4. `DialogContent` (`src/components/ui/dialog.tsx:74-89`) aplica `flex flex-col` + `overflow-hidden` + la clase de tier `dialog-md`.
+5. `.dialog-md` (`src/styles/globals.css:285`) fija `max-height: min(32rem, calc(100dvh - 2rem))` → **512 px** en desktop.
+6. El hijo directo es `<form className="space-y-4">` (línea 381), un flex item sin `flex-1`, sin `min-h-0` y sin `overflow-y-auto`.
+
+**Altura requerida vs. disponible** (modo editar, desktop):
+
+| Bloque | Alto aprox. |
+|---|---|
+| padding `p-6` (arriba + abajo) | 48 px |
+| `DialogHeader` (título + descripción) | 48 px |
+| `gap-4` header↔form | 16 px |
+| Nombre Completo | 56 px |
+| Email (+ nota "El email no se puede modificar") | 76 px |
+| Rol | 60 px |
+| **Módulos de acceso (4 checkboxes)** | **132 px** |
+| Clave | 56 px |
+| Usuario activo | 20 px |
+| Botones (`pt-4` + fila) | 52 px |
+| 6 × `space-y-4` | 96 px |
+| **Total** | **≈ 660 px** |
+
+660 px de contenido dentro de un contenedor de 512 px con `overflow-hidden` ⇒ ~148 px recortados, exactamente donde el screenshot corta.
+
+## Hypotheses evaluated
+
+| Hypothesis | Status | Evidence |
+|---|---|---|
+| El contenido del formulario no está envuelto en `DialogBody`, así que no hay región scrolleable y `overflow-hidden` del padre lo recorta | **Confirmed root cause** | `UsuariosConfig.tsx:381` usa `<form className="space-y-4">` como hijo directo; `grep 'overflow-y-auto'` dentro del bloque 368–533 → 0 coincidencias. `DialogContent` fuerza `overflow-hidden` (`dialog.tsx:77`). Contradice la regla explícita de CLAUDE.md ("scrollable content MUST go inside `<DialogBody>`") |
+| El flex item podría encogerse y mostrar scroll propio | **Ruled out** | En `flex-direction: column` los ítems tienen `min-height: auto` por defecto: el `<form>` no puede encogerse por debajo de su altura de contenido. Sin `min-h-0` no cede, y sin `overflow-y-auto` no scrollea |
+| Tier de tamaño mal elegido (`md` demasiado pequeño) | **Contributing, not root** | Subir a `lg` (640 px) daría margen hoy pero volvería a romperse con un campo más o en pantallas bajas; `dialog-viewport-cap` reduce la altura aún más en viewports pequeños. No corrige la falta de scroll |
+| Regresión introducida por el bloque "Módulos de acceso" | **Confirmed trigger** | `git log` → `4690945 feat(nav): grouped sidebar + per-user module access control` agregó los 4 checkboxes (~132 px). El defecto estructural ya existía desde `385c30f` ("Enforce fixed-size dialog tiers"), pero antes el contenido cabía por poco |
+| Overlay de Radix bloqueando el scroll (scroll-lock del body) | **Ruled out** | El scroll-lock de Radix afecta al `body`, no al panel. El panel simplemente no tiene región scrolleable propia |
+| `DialogPrimitive.Close` absoluto tapando el contenido | **Ruled out** | Es `position: absolute`, fuera del flujo; no afecta el cálculo de altura |
+| Bug exclusivo de este diálogo | **Ruled out — el defecto es sistémico** | 8 diálogos en 6 archivos tienen la misma estructura (hijo directo `space-y-4` sin `DialogBody` ni scroll propio). Ver Impact |
+
+## Root cause
+
+`UsuariosConfig` monta el `<form>` como hijo directo de `DialogContent`. `DialogContent` es un contenedor `flex flex-col` con `overflow-hidden` y altura máxima fija por tier (512 px para `md`). El formulario, al no estar envuelto en `DialogBody` (que aporta `flex-1 overflow-y-auto min-h-0`), conserva su altura natural (~660 px), desborda el contenedor y es recortado sin barra de scroll. El bloque "Módulos de acceso" añadido en `4690945` fue lo que empujó el formulario por encima del límite y volvió visible un defecto estructural preexistente.
+
+## Impact
+
+**Diálogos con el mismo defecto** (hijo directo `space-y-4`, sin `DialogBody` ni región scrolleable):
+
+| Archivo | Líneas | Tier | Riesgo |
+|---|---|---|---|
+| `src/components/configuracion/UsuariosConfig.tsx` | 368–533 | `md` (512 px) | **Roto — reportado** |
+| `src/components/configuracion/TelegramConfig.tsx` (crear/editar) | 433–552 | `sm` (384 px) | **Roto** — formulario largo en el tier más pequeño |
+| `src/components/finanzas/components/ProveedoresConfig.tsx` | 356–439 | `sm` | **Roto probable** |
+| `src/components/finanzas/components/CompradoresConfig.tsx` | 347–420 | `sm` | **Roto probable** |
+| `src/components/monitoreo/RegistroColmenas.tsx` | 128–247 | `sm` | **Roto probable** |
+| `src/components/finanzas/components/MediosPagoConfig.tsx` | 331–393 | `sm` | En el límite |
+| `src/components/configuracion/TelegramConfig.tsx` (código acceso) | 557–593 | `sm` | En el límite |
+| `src/components/monitoreo/ConfigApiarios.tsx` | 236–290 | `sm` | En el límite |
+
+**No afectados:** `RegistroConductividad.tsx` (tiene su propia región `flex-1 overflow-y-auto min-h-0`) y `ui/command.tsx` (cmdk gestiona su propio scroll).
+
+**Riesgo de regresión del fix:**
+- Mover los botones a `DialogFooter` cambia el layout de `flex gap-3` a `flex-col-reverse … sm:flex-row sm:justify-end`. Para conservar los botones al 50/50 hay que pasar `className` explícito al footer.
+- `DialogBody` aplica `-mx-6 px-6` para compensar el padding del padre. Si el `<form>` queda entre `DialogContent` y `DialogBody`, el form no debe introducir padding propio, o la compensación se desalinea.
+- El `<form>` debe seguir envolviendo **ambos** (campos y botones) para que `type="submit"` siga disparando `onSubmit`.
+- `DialogTitle` / `DialogDescription` de Radix se comunican por contexto, no por posición en el DOM, así que reordenar no rompe la accesibilidad.
+
+## Fix plan
+
+**1. Reestructurar el diálogo de `UsuariosConfig` según el contrato de CLAUDE.md**
+
+```tsx
+<DialogContent size="md">
+  <DialogHeader>…</DialogHeader>
+
+  <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 gap-4">
+    <DialogBody className="space-y-4">
+      {/* FormDraftBanner + Nombre + Email + Rol + Módulos + Clave + Activo */}
+    </DialogBody>
+
+    <DialogFooter className="flex-row gap-3">
+      <Button type="button" variant="outline" className="flex-1">Cancelar</Button>
+      <Button type="submit" className="flex-1 …">Guardar Cambios</Button>
+    </DialogFooter>
+  </form>
+</DialogContent>
+```
+
+- El `<form>` toma `flex-1 min-h-0` para ceder altura; `DialogBody` scrollea; `DialogFooter` queda anclado y siempre visible.
+- Se quita el `pt-4` del contenedor de botones (el `gap-4` del form ya lo cubre).
+
+**2. Aplicar la misma reestructuración a los 7 diálogos restantes de la tabla de Impact.**
+
+**3. Guard de regresión** — test en `src/__tests__/dialogBodyUsage.test.ts` que lee los fuentes `.tsx` y falla si un `<DialogContent>` contiene contenido sin `DialogBody` ni una región `overflow-y-auto` propia (allowlist explícita para `ui/command.tsx` y `RegistroConductividad.tsx`). Evita que el defecto vuelva a colarse — es exactamente el patrón que ya se documentó en CLAUDE.md pero que nada verificaba.
+
+## Hallazgo durante la implementación: `min-h-0` era una clase muerta
+
+`src/index.css` es un build de Tailwind congelado y **`.min-h-0` no existe en él** — cualquier
+`className="min-h-0"` del código era un no-op silencioso (igual que `flex-row` sin prefijo; solo
+existen `sm:flex-row` / `md:flex-row`).
+
+Esto importa porque envolver los campos en `DialogBody` **no basta por sí solo** cuando hay un
+`<form>` intermedio: sin `min-height: 0` el form conserva su altura de contenido y el panel lo
+recorta igual. Medido en un harness con el CSS real del repo, panel fijado a 512 px:
+
+| Estructura | `scrollHeight` del body | Borde inferior del botón Guardar | ¿Visible? |
+|---|---|---|---|
+| Antes (form hijo directo) | — (form de 574 px, no scrollea) | 671 px | **No** — 159 px fuera del panel |
+| DialogBody **sin** `.min-h-0` | — | 653 px | **No** — el fix no surte efecto |
+| DialogBody **con** `.min-h-0` | 500 px vs 280 px visibles → scrollea | 433 px | **Sí** |
+| DialogBody hijo directo (sin form) | 500 px vs 280 px visibles → scrollea | 433 px | **Sí** |
+
+Por eso se agregó `.min-h-0 { min-height: 0 }` como regla real en `globals.css`. Las otras 5
+apariciones de la clase en el código están sobre contenedores que ya son scroll containers
+(`overflow-y-auto`), donde el mínimo automático ya resuelve a 0 — para ellas la regla es un no-op,
+así que no hay riesgo de regresión.
+
+## Tests
+
+- [x] Guard estático: ningún `<DialogContent>` sin `DialogBody` ni scroll propio (salvo allowlist) — `src/__tests__/dialogScrollContract.test.ts`, 3/3 en verde. **Detectó un 9º diálogo** (`IngresoForm.tsx` #2) que el escaneo manual a nivel de archivo había pasado por alto
+- [x] Guard estático: todo `<form>` que envuelve `DialogBody` declara `flex-1 min-h-0`
+- [x] `npm run typecheck` — sin errores nuevos (queda 1 preexistente en `PurchaseHistory.tsx:354`, verificado también en `main`)
+- [x] `npm run lint` — sin errores nuevos (los 6 `no-useless-catch` son preexistentes, en `useProduccionData.ts`)
+- [x] `npm test` — 486/487. El único fallo (`reporteSemanal.test.ts:785`) es preexistente, confirmado ejecutando la suite con los cambios stasheados
+- [x] Verificación del mecanismo CSS en navegador con `index.css` + `globals.css` reales (tabla de arriba)
+- [ ] Manual en la app: Configuración → Usuarios → Editar — no ejecutable en este entorno (falta `.env.local`, la app lanza al arrancar sin las vars de Supabase)
+- [ ] Manual en la app (regresión): Configuración → Telegram, Finanzas → Proveedores / Compradores / Medios de Pago / Ingresos, Monitoreo → Colmenas / Apiarios
+- [ ] Manual: viewport móvil — en `flex-col-reverse` el botón de submit queda arriba; confirmar que es el orden deseado

--- a/src/__tests__/dialogScrollContract.test.ts
+++ b/src/__tests__/dialogScrollContract.test.ts
@@ -1,0 +1,110 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * Guard del contrato de scroll de los diálogos.
+ *
+ * `DialogContent` es un contenedor `flex flex-col` con `overflow-hidden` y una
+ * altura máxima fija por tier (ver `.dialog-sm/md/lg/xl` en globals.css). Si el
+ * contenido se monta como hijo directo sin `DialogBody` (que aporta
+ * `flex-1 overflow-y-auto`) ni una región scrolleable propia, el panel recorta
+ * el contenido en seco: sin barra de scroll y con los botones de acción
+ * inalcanzables.
+ *
+ * Ver docs/bugs/2026-07-21-dialog-sin-scroll-usuarios.md
+ */
+
+const SRC = join(__dirname, '..');
+
+/** Diálogos que gestionan su propio scroll y no necesitan `DialogBody`. */
+const ALLOWLIST = new Set([
+  // cmdk renderiza su propia lista scrolleable (`CommandList`).
+  'components/ui/command.tsx',
+  // Layout hecho a mano con `flex-1 overflow-y-auto min-h-0` entre header y footer sticky.
+  'components/monitoreo/RegistroConductividad.tsx',
+]);
+
+function collectTsx(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      if (entry === 'supabase' || entry === '__tests__') continue;
+      collectTsx(full, out);
+    } else if (entry.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** Extrae cada bloque `<DialogContent ...>…</DialogContent>` de un archivo. */
+function extractDialogContentBlocks(source: string): string[] {
+  const blocks: string[] = [];
+  const open = /<DialogContent[\s>]/g;
+  let m: RegExpExecArray | null;
+  while ((m = open.exec(source)) !== null) {
+    const end = source.indexOf('</DialogContent>', m.index);
+    if (end === -1) continue;
+    blocks.push(source.slice(m.index, end));
+  }
+  return blocks;
+}
+
+describe('contrato de scroll de DialogContent', () => {
+  const files = collectTsx(SRC).filter((f) => /<DialogContent[\s>]/.test(readFileSync(f, 'utf-8')));
+
+  it('encuentra diálogos para auditar', () => {
+    expect(files.length).toBeGreaterThan(5);
+  });
+
+  it('todo DialogContent con contenido usa DialogBody o una región scrolleable propia', () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(SRC, file).replace(/\\/g, '/');
+      if (ALLOWLIST.has(rel)) continue;
+
+      extractDialogContentBlocks(readFileSync(file, 'utf-8')).forEach((block, i) => {
+        const hasBody = block.includes('<DialogBody');
+        const hasOwnScroll = /overflow-y-auto|overflow-auto/.test(block);
+        if (!hasBody && !hasOwnScroll) {
+          offenders.push(`${rel} (diálogo #${i + 1})`);
+        }
+      });
+    }
+
+    expect(
+      offenders,
+      `Estos DialogContent recortan su contenido sin permitir scroll. ` +
+        `Envuelve los campos en <DialogBody> y ancla los botones en <DialogFooter>:\n  ` +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('DialogBody nunca es hermano de un contenedor que no puede encogerse', () => {
+    // Un <form> que envuelve DialogBody debe poder ceder altura: sin `flex-1
+    // min-h-0` conserva su altura de contenido y vuelve a desbordar el panel.
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(SRC, file).replace(/\\/g, '/');
+      const source = readFileSync(file, 'utf-8');
+
+      const formWithBody = /<form[^>]*className="([^"]*)"[^>]*>\s*\n\s*<DialogBody/g;
+      let m: RegExpExecArray | null;
+      while ((m = formWithBody.exec(source)) !== null) {
+        const cls = m[1];
+        if (!cls.includes('flex-1') || !cls.includes('min-h-0')) {
+          offenders.push(`${rel}: <form className="${cls}">`);
+        }
+      }
+    }
+
+    expect(
+      offenders,
+      `Un <form> que envuelve <DialogBody> necesita "flex flex-col flex-1 min-h-0":\n  ` +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+});

--- a/src/__tests__/reporteSemanal.test.ts
+++ b/src/__tests__/reporteSemanal.test.ts
@@ -697,26 +697,35 @@ describe('fetchDatosMonitoreo', () => {
   // Helper to set up mocks for fetchDatosMonitoreo which queries:
   // 1. lotes + sublotes (in parallel), 2. monitoreos (fechas per lote),
   // 3. monitoreos (per-lote anterior, only if needed), 4. monitoreos (full data)
+  /**
+   * `fetchDatosMonitoreo` consulta `monitoreos` en este orden:
+   *   1. actividad de los últimos 30 días (`select('lote_id')`) → decide qué lotes
+   *      siguen activos; un lote sin actividad se excluye del informe por completo.
+   *   2. fechas dentro de la ventana de 2 semanas (`select('lote_id, fecha_monitoreo')`).
+   *   3. datos completos (y, si hace falta, una consulta `anterior` por lote).
+   * Cada escalón se mockea por separado: mezclarlos hace que los tests pasen por
+   * coincidencia y oculta cuál de los tres filtros es el que realmente actúa.
+   */
   function setupMonitoreoMocks(opts: {
+    actividad30d?: any[];
     fechas?: any[];
     monitoreos?: any[];
   } = {}) {
     const lotesChain = createChainableMock({ data: MOCK_LOTES, error: null });
     const sublotesChain = createChainableMock({ data: MOCK_SUBLOTES, error: null });
+    const actividadChain = createChainableMock({ data: opts.actividad30d ?? MOCK_MONITOREOS_FECHAS, error: null });
     const fechasChain = createChainableMock({ data: opts.fechas ?? MOCK_MONITOREOS_FECHAS, error: null });
     const monChain = createChainableMock({ data: opts.monitoreos ?? MOCK_MONITOREOS, error: null });
 
-    // Track monitoreos calls: 1st = fechas, subsequent = full data
-    // (With default fixtures, all lotes have both fechaActual and fechaAnterior
-    //  from the fechas query, so no per-lote anterior queries are needed.)
     let monitoreoCallCount = 0;
     mockFrom.mockImplementation((table: string) => {
       if (table === 'lotes') return lotesChain;
       if (table === 'sublotes') return sublotesChain;
       if (table === 'monitoreos') {
         monitoreoCallCount++;
-        if (monitoreoCallCount === 1) return fechasChain;    // fechas query
-        return monChain;                                       // full data query
+        if (monitoreoCallCount === 1) return actividadChain; // actividad 30 días
+        if (monitoreoCallCount === 2) return fechasChain;    // fechas ventana 2 semanas
+        return monChain;                                     // datos completos / anterior
       }
       return createChainableMock({ data: [], error: null });
     });
@@ -772,7 +781,9 @@ describe('fetchDatosMonitoreo', () => {
     expect(lotePP!.sublotes.length).toBe(2); // Sublote A y B
   });
 
-  it('retorna datos vacíos cuando no hay monitoreos', async () => {
+  it('sin datos en la ventana de 2 semanas: los lotes activos aparecen marcados sinDatos', async () => {
+    // Hay actividad en los últimos 30 días (los lotes siguen vivos), pero ninguna
+    // medición cae dentro de la ventana del informe.
     setupMonitoreoMocks({ fechas: [], monitoreos: [] });
 
     const resultado = await fetchDatosMonitoreo(MOCK_SEMANA_MONITOREO);
@@ -781,9 +792,20 @@ describe('fetchDatosMonitoreo', () => {
     expect(resultado.detallePorLote.length).toBe(0);
     expect(resultado.insights.length).toBe(0);
     expect(resultado.fechaActual).toBeNull();
-    // Should still have lotes in vistasPorLote (all sinDatos)
     expect(resultado.vistasPorLote.length).toBe(2);
-    expect(resultado.vistasPorLote[0].sinDatos).toBe(true);
+    expect(resultado.vistasPorLote.every((l: any) => l.sinDatos)).toBe(true);
+  });
+
+  it('sin actividad en 30 días: los lotes se excluyen por completo del informe', async () => {
+    // Regla introducida en 1753706: un lote erradicado o sin monitoreo en 30 días
+    // no debe aparecer en el informe, ni siquiera como fila "sin datos".
+    setupMonitoreoMocks({ actividad30d: [], fechas: [], monitoreos: [] });
+
+    const resultado = await fetchDatosMonitoreo(MOCK_SEMANA_MONITOREO);
+
+    expect(resultado.fechaActual).toBeNull();
+    expect(resultado.vistasPorLote.length).toBe(0);
+    expect(resultado.vistasPorSublote.length).toBe(0);
   });
 });
 

--- a/src/components/configuracion/TelegramConfig.tsx
+++ b/src/components/configuracion/TelegramConfig.tsx
@@ -3,7 +3,7 @@ import { Card } from '../ui/card';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '../ui/dialog';
+import { Dialog, DialogBody, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { toast } from 'sonner';
 import { useAuth } from '../../contexts/AuthContext';
@@ -442,101 +442,103 @@ export function TelegramConfig() {
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            {/* Usuario vinculado */}
-            <div>
-              <Label htmlFor="usuario-vinculado">Usuario vinculado</Label>
-              <select
-                id="usuario-vinculado"
-                value={usuarioVinculadoId ?? ''}
-                onChange={(e) => {
-                  const id = e.target.value || null;
-                  setUsuarioVinculadoId(id);
-                  if (id) {
-                    const usr = usuariosSistema.find((u) => u.id === id);
-                    if (usr?.nombre_completo) setNombreDisplay(usr.nombre_completo);
-                  }
-                }}
-                className="w-full mt-1 px-3 py-2 border border-secondary/30 rounded-lg bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-              >
-                <option value="">— Sin vincular —</option>
-                {usuariosSistema.map((usr) => (
-                  <option key={usr.id} value={usr.id}>
-                    {usr.nombre_completo ?? usr.email} ({usr.rol})
-                  </option>
-                ))}
-              </select>
-              <p className="text-xs text-brand-brown/50 mt-1">
-                Seleccionar un usuario auto-completa el nombre.
-              </p>
-            </div>
-
-            {/* Nombre */}
-            <div>
-              <Label htmlFor="nombre">Nombre completo *</Label>
-              <Input
-                id="nombre"
-                placeholder="Ej: Carlos Mendoza"
-                value={nombreDisplay}
-                onChange={(e) => setNombreDisplay(e.target.value)}
-                className="mt-1"
-              />
-            </div>
-
-            {/* Rol */}
-            <div>
-              <Label htmlFor="rol">Rol en el bot</Label>
-              <select
-                id="rol"
-                value={rolBot}
-                onChange={(e) => {
-                  const val = e.target.value;
-                  if (ROLES_BOT.some((r) => r.key === val)) {
-                    setRolBot(val as RolBot);
-                  }
-                }}
-                className="w-full mt-1 px-3 py-2 border border-secondary/30 rounded-lg bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
-              >
-                {ROLES_BOT.map((r) => (
-                  <option key={r.key} value={r.key}>{r.label}</option>
-                ))}
-              </select>
-            </div>
-
-            {/* Modules */}
-            <div>
-              <Label>Módulos permitidos</Label>
-              <div className="mt-2 space-y-2">
-                {TELEGRAM_MODULES.map((mod) => (
-                  <label
-                    key={mod.key}
-                    className={`flex items-start gap-2 p-2 rounded-lg border transition ${
-                      mod.sensitive
-                        ? 'border-amber-200 bg-amber-50/50'
-                        : 'border-transparent'
-                    }`}
-                  >
-                    <input
-                      type="checkbox"
-                      checked={modulosPermitidos.includes(mod.key)}
-                      onChange={() => setModulosPermitidos(toggleModulo(modulosPermitidos, mod.key))}
-                      className="w-4 h-4 mt-0.5 rounded border-secondary/30"
-                    />
-                    <div>
-                      <span className={`text-sm font-medium ${mod.sensitive ? 'text-amber-700' : 'text-foreground'}`}>
-                        {mod.label}
-                      </span>
-                      <p className={`text-xs ${mod.sensitive ? 'text-amber-600' : 'text-brand-brown/60'}`}>
-                        {mod.description}
-                      </p>
-                    </div>
-                  </label>
-                ))}
+          <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 gap-4">
+            <DialogBody className="space-y-4">
+              {/* Usuario vinculado */}
+              <div>
+                <Label htmlFor="usuario-vinculado">Usuario vinculado</Label>
+                <select
+                  id="usuario-vinculado"
+                  value={usuarioVinculadoId ?? ''}
+                  onChange={(e) => {
+                    const id = e.target.value || null;
+                    setUsuarioVinculadoId(id);
+                    if (id) {
+                      const usr = usuariosSistema.find((u) => u.id === id);
+                      if (usr?.nombre_completo) setNombreDisplay(usr.nombre_completo);
+                    }
+                  }}
+                  className="w-full mt-1 px-3 py-2 border border-secondary/30 rounded-lg bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  <option value="">— Sin vincular —</option>
+                  {usuariosSistema.map((usr) => (
+                    <option key={usr.id} value={usr.id}>
+                      {usr.nombre_completo ?? usr.email} ({usr.rol})
+                    </option>
+                  ))}
+                </select>
+                <p className="text-xs text-brand-brown/50 mt-1">
+                  Seleccionar un usuario auto-completa el nombre.
+                </p>
               </div>
-            </div>
 
-            {/* Buttons */}
-            <div className="flex gap-3 pt-4">
+              {/* Nombre */}
+              <div>
+                <Label htmlFor="nombre">Nombre completo *</Label>
+                <Input
+                  id="nombre"
+                  placeholder="Ej: Carlos Mendoza"
+                  value={nombreDisplay}
+                  onChange={(e) => setNombreDisplay(e.target.value)}
+                  className="mt-1"
+                />
+              </div>
+
+              {/* Rol */}
+              <div>
+                <Label htmlFor="rol">Rol en el bot</Label>
+                <select
+                  id="rol"
+                  value={rolBot}
+                  onChange={(e) => {
+                    const val = e.target.value;
+                    if (ROLES_BOT.some((r) => r.key === val)) {
+                      setRolBot(val as RolBot);
+                    }
+                  }}
+                  className="w-full mt-1 px-3 py-2 border border-secondary/30 rounded-lg bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary"
+                >
+                  {ROLES_BOT.map((r) => (
+                    <option key={r.key} value={r.key}>{r.label}</option>
+                  ))}
+                </select>
+              </div>
+
+              {/* Modules */}
+              <div>
+                <Label>Módulos permitidos</Label>
+                <div className="mt-2 space-y-2">
+                  {TELEGRAM_MODULES.map((mod) => (
+                    <label
+                      key={mod.key}
+                      className={`flex items-start gap-2 p-2 rounded-lg border transition ${
+                        mod.sensitive
+                          ? 'border-amber-200 bg-amber-50/50'
+                          : 'border-transparent'
+                      }`}
+                    >
+                      <input
+                        type="checkbox"
+                        checked={modulosPermitidos.includes(mod.key)}
+                        onChange={() => setModulosPermitidos(toggleModulo(modulosPermitidos, mod.key))}
+                        className="w-4 h-4 mt-0.5 rounded border-secondary/30"
+                      />
+                      <div>
+                        <span className={`text-sm font-medium ${mod.sensitive ? 'text-amber-700' : 'text-foreground'}`}>
+                          {mod.label}
+                        </span>
+                        <p className={`text-xs ${mod.sensitive ? 'text-amber-600' : 'text-brand-brown/60'}`}>
+                          {mod.description}
+                        </p>
+                      </div>
+                    </label>
+                  ))}
+                </div>
+              </div>
+
+            </DialogBody>
+
+            <DialogFooter className="gap-3">
               <Button type="button" variant="outline" onClick={() => setModalOpen(false)} className="flex-1">
                 Cancelar
               </Button>
@@ -547,7 +549,7 @@ export function TelegramConfig() {
                     ? 'Crear usuario'
                     : 'Guardar cambios'}
               </Button>
-            </div>
+            </DialogFooter>
           </form>
         </DialogContent>
       </Dialog>
@@ -562,7 +564,7 @@ export function TelegramConfig() {
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
+          <DialogBody className="space-y-4">
             <div className="bg-secondary/10 p-4 rounded-lg border-2 border-primary">
               <p className="text-xs text-brand-brown/70 mb-2">Enviar este mensaje al bot:</p>
               <div className="flex items-center gap-2">
@@ -586,10 +588,13 @@ export function TelegramConfig() {
               </p>
             </div>
 
+          </DialogBody>
+
+          <DialogFooter>
             <Button onClick={() => setCodigoModal(null)} className="w-full">
               Listo
             </Button>
-          </div>
+          </DialogFooter>
         </DialogContent>
       </Dialog>
 

--- a/src/components/configuracion/UsuariosConfig.tsx
+++ b/src/components/configuracion/UsuariosConfig.tsx
@@ -3,7 +3,7 @@ import { Card } from '../ui/card';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
-import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription } from '../ui/dialog';
+import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogBody, DialogFooter } from '../ui/dialog';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { toast } from 'sonner';
 import { useAuth } from '../../contexts/AuthContext';
@@ -378,142 +378,143 @@ export function UsuariosConfig() {
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <FormDraftBanner
-              variant="available"
-              show={draft.hasDraft}
-              onRestore={handleRestoreDraft}
-              onDiscard={draft.discardDraft}
-            />
-
-            {/* Nombre Completo */}
-            <div>
-              <Label htmlFor="nombre" className="text-foreground">
-                Nombre Completo *
-              </Label>
-              <Input
-                id="nombre"
-                value={nombreCompleto}
-                onChange={(e) => setNombreCompleto(e.target.value)}
-                placeholder="Ej: Juan Pérez García"
-                required
-                className="border-secondary/30 focus:border-primary"
+          <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 gap-4">
+            <DialogBody className="space-y-4">
+              <FormDraftBanner
+                variant="available"
+                show={draft.hasDraft}
+                onRestore={handleRestoreDraft}
+                onDiscard={draft.discardDraft}
               />
-            </div>
 
-            {/* Email */}
-            <div>
-              <Label htmlFor="email" className="text-foreground">
-                Email *
-              </Label>
-              <Input
-                id="email"
-                type="email"
-                value={email}
-                onChange={(e) => setEmail(e.target.value)}
-                placeholder="usuario@ejemplo.com"
-                required
-                disabled={modalMode === 'editar'}
-                className="border-secondary/30 focus:border-primary disabled:opacity-50"
-              />
-              {modalMode === 'editar' && (
-                <p className="text-xs text-brand-brown/60 mt-1">
-                  El email no se puede modificar
-                </p>
-              )}
-            </div>
-
-            {/* Rol */}
-            <div>
-              <Label htmlFor="rol" className="text-foreground">
-                Rol *
-              </Label>
-              <select
-                id="rol"
-                value={rol}
-                onChange={(e) => setRol(e.target.value as any)}
-                className="w-full px-3 py-2 border border-secondary/30 rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
-                required
-              >
-                <option value="Administrador">Administrador</option>
-                <option value="Verificador">Verificador</option>
-                <option value="Gerencia">Gerencia</option>
-                <option value="Monitor">Monitor (solo Telegram)</option>
-              </select>
-            </div>
-
-            {/* Módulos de acceso */}
-            <div>
-              <Label className="text-foreground">Módulos de acceso</Label>
-              <div className="mt-2 space-y-2">
-                {MODULOS.map((modulo) => (
-                  <div key={modulo.key} className="flex items-center gap-2">
-                    <input
-                      type="checkbox"
-                      id={`modulo-${modulo.key}`}
-                      checked={rol === 'Gerencia' ? true : modulosAcceso.includes(modulo.key)}
-                      disabled={rol === 'Gerencia'}
-                      onChange={() => setModulosAcceso((prev) => toggleModulo(prev, modulo.key))}
-                      className="w-4 h-4 text-primary border-secondary/30 rounded focus:ring-primary disabled:opacity-50"
-                    />
-                    <Label htmlFor={`modulo-${modulo.key}`} className="text-foreground cursor-pointer font-normal">
-                      {modulo.label}
-                    </Label>
-                  </div>
-                ))}
-              </div>
-              {rol === 'Gerencia' && (
-                <p className="text-xs text-brand-brown/60 mt-1">
-                  Gerencia tiene acceso a todo
-                </p>
-              )}
-            </div>
-
-            {/* Clave */}
-            <div>
-              <Label htmlFor="clave" className="text-foreground">
-                Clave {modalMode === 'crear' ? '*' : '(dejar vacío para no cambiar)'}
-              </Label>
-              <div className="relative">
+              {/* Nombre Completo */}
+              <div>
+                <Label htmlFor="nombre" className="text-foreground">
+                  Nombre Completo *
+                </Label>
                 <Input
-                  id="clave"
-                  type={showPassword ? 'text' : 'password'}
-                  value={clave}
-                  onChange={(e) => setClave(e.target.value)}
-                  placeholder={modalMode === 'crear' ? 'Mínimo 6 caracteres' : 'Nueva clave (opcional)'}
-                  required={modalMode === 'crear'}
-                  className="border-secondary/30 focus:border-primary pr-10"
+                  id="nombre"
+                  value={nombreCompleto}
+                  onChange={(e) => setNombreCompleto(e.target.value)}
+                  placeholder="Ej: Juan Pérez García"
+                  required
+                  className="border-secondary/30 focus:border-primary"
                 />
-                <button
-                  type="button"
-                  onClick={() => setShowPassword(!showPassword)}
-                  className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-brown/50 hover:text-brand-brown"
-                >
-                  {showPassword ? (
-                    <EyeOff className="w-4 h-4" />
-                  ) : (
-                    <Eye className="w-4 h-4" />
-                  )}
-                </button>
               </div>
-            </div>
 
-            {/* Estado Activo/Inactivo */}
-            <div className="flex items-center gap-2">
-              <input
-                type="checkbox"
-                id="activo"
-                checked={activo}
-                onChange={(e) => setActivo(e.target.checked)}
-                className="w-4 h-4 text-primary border-secondary/30 rounded focus:ring-primary"
-              />
-              <Label htmlFor="activo" className="text-foreground cursor-pointer">
-                Usuario activo
-              </Label>
-            </div>
+              {/* Email */}
+              <div>
+                <Label htmlFor="email" className="text-foreground">
+                  Email *
+                </Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={email}
+                  onChange={(e) => setEmail(e.target.value)}
+                  placeholder="usuario@ejemplo.com"
+                  required
+                  disabled={modalMode === 'editar'}
+                  className="border-secondary/30 focus:border-primary disabled:opacity-50"
+                />
+                {modalMode === 'editar' && (
+                  <p className="text-xs text-brand-brown/60 mt-1">
+                    El email no se puede modificar
+                  </p>
+                )}
+              </div>
 
-            {/* Botones */}
-            <div className="flex gap-3 pt-4">
+              {/* Rol */}
+              <div>
+                <Label htmlFor="rol" className="text-foreground">
+                  Rol *
+                </Label>
+                <select
+                  id="rol"
+                  value={rol}
+                  onChange={(e) => setRol(e.target.value as any)}
+                  className="w-full px-3 py-2 border border-secondary/30 rounded-md focus:outline-none focus:ring-2 focus:ring-primary/50 focus:border-primary"
+                  required
+                >
+                  <option value="Administrador">Administrador</option>
+                  <option value="Verificador">Verificador</option>
+                  <option value="Gerencia">Gerencia</option>
+                  <option value="Monitor">Monitor (solo Telegram)</option>
+                </select>
+              </div>
+
+              {/* Módulos de acceso */}
+              <div>
+                <Label className="text-foreground">Módulos de acceso</Label>
+                <div className="mt-2 space-y-2">
+                  {MODULOS.map((modulo) => (
+                    <div key={modulo.key} className="flex items-center gap-2">
+                      <input
+                        type="checkbox"
+                        id={`modulo-${modulo.key}`}
+                        checked={rol === 'Gerencia' ? true : modulosAcceso.includes(modulo.key)}
+                        disabled={rol === 'Gerencia'}
+                        onChange={() => setModulosAcceso((prev) => toggleModulo(prev, modulo.key))}
+                        className="w-4 h-4 text-primary border-secondary/30 rounded focus:ring-primary disabled:opacity-50"
+                      />
+                      <Label htmlFor={`modulo-${modulo.key}`} className="text-foreground cursor-pointer font-normal">
+                        {modulo.label}
+                      </Label>
+                    </div>
+                  ))}
+                </div>
+                {rol === 'Gerencia' && (
+                  <p className="text-xs text-brand-brown/60 mt-1">
+                    Gerencia tiene acceso a todo
+                  </p>
+                )}
+              </div>
+
+              {/* Clave */}
+              <div>
+                <Label htmlFor="clave" className="text-foreground">
+                  Clave {modalMode === 'crear' ? '*' : '(dejar vacío para no cambiar)'}
+                </Label>
+                <div className="relative">
+                  <Input
+                    id="clave"
+                    type={showPassword ? 'text' : 'password'}
+                    value={clave}
+                    onChange={(e) => setClave(e.target.value)}
+                    placeholder={modalMode === 'crear' ? 'Mínimo 6 caracteres' : 'Nueva clave (opcional)'}
+                    required={modalMode === 'crear'}
+                    className="border-secondary/30 focus:border-primary pr-10"
+                  />
+                  <button
+                    type="button"
+                    onClick={() => setShowPassword(!showPassword)}
+                    className="absolute right-3 top-1/2 -translate-y-1/2 text-brand-brown/50 hover:text-brand-brown"
+                  >
+                    {showPassword ? (
+                      <EyeOff className="w-4 h-4" />
+                    ) : (
+                      <Eye className="w-4 h-4" />
+                    )}
+                  </button>
+                </div>
+              </div>
+
+              {/* Estado Activo/Inactivo */}
+              <div className="flex items-center gap-2">
+                <input
+                  type="checkbox"
+                  id="activo"
+                  checked={activo}
+                  onChange={(e) => setActivo(e.target.checked)}
+                  className="w-4 h-4 text-primary border-secondary/30 rounded focus:ring-primary"
+                />
+                <Label htmlFor="activo" className="text-foreground cursor-pointer">
+                  Usuario activo
+                </Label>
+              </div>
+            </DialogBody>
+
+            <DialogFooter className="gap-3">
               <Button
                 type="button"
                 variant="outline"
@@ -528,7 +529,7 @@ export function UsuariosConfig() {
               >
                 {modalMode === 'crear' ? 'Crear Usuario' : 'Guardar Cambios'}
               </Button>
-            </div>
+            </DialogFooter>
           </form>
         </DialogContent>
       </Dialog>

--- a/src/components/finanzas/components/CompradoresConfig.tsx
+++ b/src/components/finanzas/components/CompradoresConfig.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../ui/dropdown-menu';
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -357,49 +358,51 @@ export function CompradoresConfig() {
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="nombre">Nombre *</Label>
-              <Input
-                id="nombre"
-                value={formData.nombre}
-                onChange={(e) => setFormData(prev => ({ ...prev, nombre: e.target.value }))}
-                placeholder="Nombre del comprador"
-                required
-              />
-            </div>
+          <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 gap-4">
+            <DialogBody className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="nombre">Nombre *</Label>
+                <Input
+                  id="nombre"
+                  value={formData.nombre}
+                  onChange={(e) => setFormData(prev => ({ ...prev, nombre: e.target.value }))}
+                  placeholder="Nombre del comprador"
+                  required
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="telefono">Teléfono</Label>
-              <Input
-                id="telefono"
-                value={formData.telefono}
-                onChange={(e) => setFormData(prev => ({ ...prev, telefono: e.target.value }))}
-                placeholder="Número de teléfono"
-              />
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="telefono">Teléfono</Label>
+                <Input
+                  id="telefono"
+                  value={formData.telefono}
+                  onChange={(e) => setFormData(prev => ({ ...prev, telefono: e.target.value }))}
+                  placeholder="Número de teléfono"
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                value={formData.email}
-                onChange={(e) => setFormData(prev => ({ ...prev, email: e.target.value }))}
-                placeholder="correo@ejemplo.com"
-              />
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={formData.email}
+                  onChange={(e) => setFormData(prev => ({ ...prev, email: e.target.value }))}
+                  placeholder="correo@ejemplo.com"
+                />
+              </div>
 
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="activo"
-                checked={formData.activo}
-                onCheckedChange={(checked) => setFormData(prev => ({ ...prev, activo: checked }))}
-              />
-              <Label htmlFor="activo">Comprador activo</Label>
-            </div>
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="activo"
+                  checked={formData.activo}
+                  onCheckedChange={(checked) => setFormData(prev => ({ ...prev, activo: checked }))}
+                />
+                <Label htmlFor="activo">Comprador activo</Label>
+              </div>
+            </DialogBody>
 
-            <DialogFooter>
+            <DialogFooter className="gap-3">
               <Button
                 type="button"
                 variant="outline"

--- a/src/components/finanzas/components/IngresoForm.tsx
+++ b/src/components/finanzas/components/IngresoForm.tsx
@@ -558,7 +558,7 @@ export function IngresoForm({ open, onOpenChange, ingreso, onSuccess, onCancel }
             </DialogDescription>
           </DialogHeader>
 
-          <div className="space-y-4">
+          <DialogBody className="space-y-4">
             <div className="space-y-2">
               <Label htmlFor="nuevo-nombre">Nombre *</Label>
               <Input
@@ -589,7 +589,7 @@ export function IngresoForm({ open, onOpenChange, ingreso, onSuccess, onCancel }
                 placeholder="correo@ejemplo.com"
               />
             </div>
-          </div>
+          </DialogBody>
 
           <DialogFooter>
             <Button

--- a/src/components/finanzas/components/MediosPagoConfig.tsx
+++ b/src/components/finanzas/components/MediosPagoConfig.tsx
@@ -21,6 +21,7 @@ import {
 } from '../../ui/dropdown-menu';
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -341,38 +342,40 @@ export function MediosPagoConfig() {
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="nombre">Nombre *</Label>
-              <Input
-                id="nombre"
-                value={formData.nombre}
-                onChange={(e) => setFormData(prev => ({ ...prev, nombre: e.target.value }))}
-                placeholder="Ej: Efectivo, Transferencia, Tarjeta de crédito"
-                required
-              />
-            </div>
+          <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 gap-4">
+            <DialogBody className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="nombre">Nombre *</Label>
+                <Input
+                  id="nombre"
+                  value={formData.nombre}
+                  onChange={(e) => setFormData(prev => ({ ...prev, nombre: e.target.value }))}
+                  placeholder="Ej: Efectivo, Transferencia, Tarjeta de crédito"
+                  required
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="descripcion">Descripción</Label>
-              <Input
-                id="descripcion"
-                value={formData.descripcion}
-                onChange={(e) => setFormData(prev => ({ ...prev, descripcion: e.target.value }))}
-                placeholder="Descripción opcional del medio de pago"
-              />
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="descripcion">Descripción</Label>
+                <Input
+                  id="descripcion"
+                  value={formData.descripcion}
+                  onChange={(e) => setFormData(prev => ({ ...prev, descripcion: e.target.value }))}
+                  placeholder="Descripción opcional del medio de pago"
+                />
+              </div>
 
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="activo"
-                checked={formData.activo}
-                onCheckedChange={(checked) => setFormData(prev => ({ ...prev, activo: checked }))}
-              />
-              <Label htmlFor="activo">Medio de pago activo</Label>
-            </div>
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="activo"
+                  checked={formData.activo}
+                  onCheckedChange={(checked) => setFormData(prev => ({ ...prev, activo: checked }))}
+                />
+                <Label htmlFor="activo">Medio de pago activo</Label>
+              </div>
+            </DialogBody>
 
-            <DialogFooter>
+            <DialogFooter className="gap-3">
               <Button
                 type="button"
                 variant="outline"

--- a/src/components/finanzas/components/ProveedoresConfig.tsx
+++ b/src/components/finanzas/components/ProveedoresConfig.tsx
@@ -24,6 +24,7 @@ import {
 } from '../../ui/dropdown-menu';
 import {
   Dialog,
+  DialogBody,
   DialogContent,
   DialogDescription,
   DialogFooter,
@@ -366,59 +367,61 @@ export function ProveedoresConfig() {
             </DialogDescription>
           </DialogHeader>
 
-          <form onSubmit={handleSubmit} className="space-y-4">
-            <div className="space-y-2">
-              <Label htmlFor="nombre">Nombre *</Label>
-              <Input
-                id="nombre"
-                value={formData.nombre}
-                onChange={(e) => setFormData(prev => ({ ...prev, nombre: e.target.value }))}
-                placeholder="Nombre del proveedor"
-                required
-              />
-            </div>
+          <form onSubmit={handleSubmit} className="flex flex-col flex-1 min-h-0 gap-4">
+            <DialogBody className="space-y-4">
+              <div className="space-y-2">
+                <Label htmlFor="nombre">Nombre *</Label>
+                <Input
+                  id="nombre"
+                  value={formData.nombre}
+                  onChange={(e) => setFormData(prev => ({ ...prev, nombre: e.target.value }))}
+                  placeholder="Nombre del proveedor"
+                  required
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="nit">NIT</Label>
-              <Input
-                id="nit"
-                value={formData.nit}
-                onChange={(e) => setFormData(prev => ({ ...prev, nit: e.target.value }))}
-                placeholder="Número de identificación tributaria"
-              />
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="nit">NIT</Label>
+                <Input
+                  id="nit"
+                  value={formData.nit}
+                  onChange={(e) => setFormData(prev => ({ ...prev, nit: e.target.value }))}
+                  placeholder="Número de identificación tributaria"
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="telefono">Teléfono</Label>
-              <Input
-                id="telefono"
-                value={formData.telefono}
-                onChange={(e) => setFormData(prev => ({ ...prev, telefono: e.target.value }))}
-                placeholder="Número de teléfono"
-              />
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="telefono">Teléfono</Label>
+                <Input
+                  id="telefono"
+                  value={formData.telefono}
+                  onChange={(e) => setFormData(prev => ({ ...prev, telefono: e.target.value }))}
+                  placeholder="Número de teléfono"
+                />
+              </div>
 
-            <div className="space-y-2">
-              <Label htmlFor="email">Email</Label>
-              <Input
-                id="email"
-                type="email"
-                value={formData.email}
-                onChange={(e) => setFormData(prev => ({ ...prev, email: e.target.value }))}
-                placeholder="correo@ejemplo.com"
-              />
-            </div>
+              <div className="space-y-2">
+                <Label htmlFor="email">Email</Label>
+                <Input
+                  id="email"
+                  type="email"
+                  value={formData.email}
+                  onChange={(e) => setFormData(prev => ({ ...prev, email: e.target.value }))}
+                  placeholder="correo@ejemplo.com"
+                />
+              </div>
 
-            <div className="flex items-center space-x-2">
-              <Switch
-                id="activo"
-                checked={formData.activo}
-                onCheckedChange={(checked) => setFormData(prev => ({ ...prev, activo: checked }))}
-              />
-              <Label htmlFor="activo">Proveedor activo</Label>
-            </div>
+              <div className="flex items-center space-x-2">
+                <Switch
+                  id="activo"
+                  checked={formData.activo}
+                  onCheckedChange={(checked) => setFormData(prev => ({ ...prev, activo: checked }))}
+                />
+                <Label htmlFor="activo">Proveedor activo</Label>
+              </div>
+            </DialogBody>
 
-            <DialogFooter>
+            <DialogFooter className="gap-3">
               <Button
                 type="button"
                 variant="outline"

--- a/src/components/monitoreo/ConfigApiarios.tsx
+++ b/src/components/monitoreo/ConfigApiarios.tsx
@@ -9,7 +9,9 @@ import { Card } from '../ui/card';
 import { Badge } from '../ui/badge';
 import {
   Dialog,
+  DialogBody,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
@@ -237,7 +239,7 @@ export function ConfigApiarios() {
             <DialogHeader>
               <DialogTitle>{editando ? 'Editar Apiario' : 'Nuevo Apiario'}</DialogTitle>
             </DialogHeader>
-            <div className="space-y-4 py-4">
+            <DialogBody className="space-y-4 py-4">
               <div>
                 <Label>Nombre *</Label>
                 <Input
@@ -278,15 +280,16 @@ export function ConfigApiarios() {
                   <Label>Activo</Label>
                 </div>
               )}
-              <div className="flex gap-3 pt-2">
-                <Button variant="outline" onClick={() => setModalAbierto(false)} className="flex-1">
-                  Cancelar
-                </Button>
-                <Button onClick={guardar} disabled={guardando} className="flex-1 bg-primary hover:bg-primary-dark">
-                  {guardando ? 'Guardando...' : 'Guardar'}
-                </Button>
-              </div>
-            </div>
+            </DialogBody>
+
+            <DialogFooter className="gap-3">
+              <Button variant="outline" onClick={() => setModalAbierto(false)} className="flex-1">
+                Cancelar
+              </Button>
+              <Button onClick={guardar} disabled={guardando} className="flex-1 bg-primary hover:bg-primary-dark">
+                {guardando ? 'Guardando...' : 'Guardar'}
+              </Button>
+            </DialogFooter>
           </DialogContent>
         </Dialog>
 

--- a/src/components/monitoreo/RegistroColmenas.tsx
+++ b/src/components/monitoreo/RegistroColmenas.tsx
@@ -11,7 +11,9 @@ import {
 } from '../ui/select';
 import {
   Dialog,
+  DialogBody,
   DialogContent,
+  DialogFooter,
   DialogHeader,
   DialogTitle,
 } from '../ui/dialog';
@@ -130,7 +132,7 @@ export function RegistroColmenas({ open, onClose, onSuccess }: RegistroColmenasP
           <DialogTitle>Registrar Monitoreo de Colmenas</DialogTitle>
         </DialogHeader>
 
-        <div className="space-y-4 py-4">
+        <DialogBody className="space-y-4 py-4">
           <FormDraftBanner
             variant="available"
             show={draft.hasDraft}
@@ -235,15 +237,16 @@ export function RegistroColmenas({ open, onClose, onSuccess }: RegistroColmenasP
             />
           </div>
 
-          <div className="flex gap-3 pt-2">
-            <Button variant="outline" onClick={handleClose} disabled={loading} className="flex-1">
-              Cancelar
-            </Button>
-            <Button onClick={guardar} disabled={loading} className="flex-1 bg-primary hover:bg-primary-dark">
-              {loading ? 'Guardando...' : 'Guardar'}
-            </Button>
-          </div>
-        </div>
+        </DialogBody>
+
+        <DialogFooter className="gap-3">
+          <Button variant="outline" onClick={handleClose} disabled={loading} className="flex-1">
+            Cancelar
+          </Button>
+          <Button onClick={guardar} disabled={loading} className="flex-1 bg-primary hover:bg-primary-dark">
+            {loading ? 'Guardando...' : 'Guardar'}
+          </Button>
+        </DialogFooter>
       </DialogContent>
     </Dialog>
   );

--- a/src/components/produccion/hooks/useProduccionData.ts
+++ b/src/components/produccion/hooks/useProduccionData.ts
@@ -83,13 +83,12 @@ export function useProduccionData() {
    * Cargar KPIs del periodo
    */
   const getKPIs = async (filtros: FiltrosProduccion): Promise<KPIProduccion> => {
-    try {
 
-      // Obtener todos los registros (lote y sublote) y consolidar para evitar doble conteo
-      let query = supabase
-        .from('produccion')
-        .select(
-          `
+    // Obtener todos los registros (lote y sublote) y consolidar para evitar doble conteo
+    let query = supabase
+      .from('produccion')
+      .select(
+        `
           sublote_id,
           kg_totales,
           arboles_registrados,
@@ -99,61 +98,58 @@ export function useProduccionData() {
           cosecha_tipo,
           lotes!inner(area_hectareas, activo)
         `
-        );
-
-      query = aplicarFiltros(query, filtros);
-      const { data: rawData, error: queryError } = await query;
-
-      if (queryError) throw queryError;
-
-      const data = consolidarRegistros(rawData || []);
-
-      // Calcular totales
-      const produccionTotal =
-        data.reduce((sum, r) => sum + (Number(r.kg_totales) || 0), 0) || 0;
-      const totalArboles =
-        data?.reduce((sum, r) => sum + (r.arboles_registrados || 0), 0) || 0;
-      const rendimientoPromedio =
-        totalArboles > 0 ? produccionTotal / totalArboles : 0;
-
-      // Calcular ton/ha (usando area unica por lote)
-      const lotesUnicos = new Map<string, number>();
-      data?.forEach((r: any) => {
-        if (r.lote_id && r.lotes?.area_hectareas) {
-          lotesUnicos.set(r.lote_id, Number(r.lotes.area_hectareas));
-        }
-      });
-      const areaTotal = Array.from(lotesUnicos.values()).reduce(
-        (sum, area) => sum + area,
-        0
       );
-      const tonPorHa = areaTotal > 0 ? produccionTotal / 1000 / areaTotal : 0;
 
-      // Contar lotes activos
-      const { count: lotesActivos } = await supabase
-        .from('lotes')
-        .select('*', { count: 'exact', head: true })
-        .eq('activo', true);
+    query = aplicarFiltros(query, filtros);
+    const { data: rawData, error: queryError } = await query;
 
-      // Construir descripcion del periodo
-      const periodo =
-        filtros.anos.length === 1
-          ? `${filtros.anos[0]}`
-          : filtros.anos.length > 1
-            ? `${Math.min(...filtros.anos)}-${Math.max(...filtros.anos)}`
-            : 'Todos los anos';
+    if (queryError) throw queryError;
 
-      return {
-        produccion_total_kg: Math.round(produccionTotal),
-        rendimiento_promedio_kg_arbol:
-          Math.round(rendimientoPromedio * 100) / 100,
-        ton_por_ha_promedio: Math.round(tonPorHa * 100) / 100,
-        lotes_activos: lotesActivos || 0,
-        periodo,
-      };
-    } catch (err: any) {
-      throw err;
-    }
+    const data = consolidarRegistros(rawData || []);
+
+    // Calcular totales
+    const produccionTotal =
+      data.reduce((sum, r) => sum + (Number(r.kg_totales) || 0), 0) || 0;
+    const totalArboles =
+      data?.reduce((sum, r) => sum + (r.arboles_registrados || 0), 0) || 0;
+    const rendimientoPromedio =
+      totalArboles > 0 ? produccionTotal / totalArboles : 0;
+
+    // Calcular ton/ha (usando area unica por lote)
+    const lotesUnicos = new Map<string, number>();
+    data?.forEach((r: any) => {
+      if (r.lote_id && r.lotes?.area_hectareas) {
+        lotesUnicos.set(r.lote_id, Number(r.lotes.area_hectareas));
+      }
+    });
+    const areaTotal = Array.from(lotesUnicos.values()).reduce(
+      (sum, area) => sum + area,
+      0
+    );
+    const tonPorHa = areaTotal > 0 ? produccionTotal / 1000 / areaTotal : 0;
+
+    // Contar lotes activos
+    const { count: lotesActivos } = await supabase
+      .from('lotes')
+      .select('*', { count: 'exact', head: true })
+      .eq('activo', true);
+
+    // Construir descripcion del periodo
+    const periodo =
+      filtros.anos.length === 1
+        ? `${filtros.anos[0]}`
+        : filtros.anos.length > 1
+          ? `${Math.min(...filtros.anos)}-${Math.max(...filtros.anos)}`
+          : 'Todos los anos';
+
+    return {
+      produccion_total_kg: Math.round(produccionTotal),
+      rendimiento_promedio_kg_arbol:
+        Math.round(rendimientoPromedio * 100) / 100,
+      ton_por_ha_promedio: Math.round(tonPorHa * 100) / 100,
+      lotes_activos: lotesActivos || 0,
+      periodo,
+    };
   };
 
   /**
@@ -299,13 +295,12 @@ export function useProduccionData() {
   const getTendenciasHistoricas = async (
     filtros: FiltrosProduccion
   ): Promise<TendenciaHistoricaData[]> => {
-    try {
 
-      // Obtener todos los registros y consolidar para evitar doble conteo
-      let query = supabase
-        .from('produccion')
-        .select(
-          `
+    // Obtener todos los registros y consolidar para evitar doble conteo
+    let query = supabase
+      .from('produccion')
+      .select(
+        `
           sublote_id,
           lote_id,
           ano,
@@ -315,77 +310,74 @@ export function useProduccionData() {
           arboles_registrados,
           lotes!inner(nombre, area_hectareas)
         `
-        );
+      );
 
-      query = aplicarFiltros(query, filtros);
-      const { data: rawData, error: queryError } = await query;
+    query = aplicarFiltros(query, filtros);
+    const { data: rawData, error: queryError } = await query;
 
-      if (queryError) throw queryError;
+    if (queryError) throw queryError;
 
-      const data = consolidarRegistros(rawData || []);
+    const data = consolidarRegistros(rawData || []);
 
-      // Agrupar por cosecha y luego por lote
-      const cosechaMap: Record<
-        string,
-        {
-          ano: number;
-          tipo: CosechaTipo;
-          lotes: Record<string, number>;
-        }
-      > = {};
+    // Agrupar por cosecha y luego por lote
+    const cosechaMap: Record<
+      string,
+      {
+        ano: number;
+        tipo: CosechaTipo;
+        lotes: Record<string, number>;
+      }
+    > = {};
 
-      data?.forEach((record: any) => {
-        const cosechaCode = formatCosechaCode(record.ano, record.cosecha_tipo);
+    data?.forEach((record: any) => {
+      const cosechaCode = formatCosechaCode(record.ano, record.cosecha_tipo);
 
-        if (!cosechaMap[cosechaCode]) {
-          cosechaMap[cosechaCode] = {
-            ano: record.ano,
-            tipo: record.cosecha_tipo,
-            lotes: {},
-          };
-        }
-
-        const loteCode = getLoteCode(record.lotes?.nombre || '');
-
-        // Calcular valor segun metrica seleccionada
-        let valor = 0;
-        switch (filtros.metrica) {
-          case 'kg_totales':
-            valor = Number(record.kg_totales) || 0;
-            break;
-          case 'kg_por_arbol':
-            valor = Number(record.kg_por_arbol) || 0;
-            break;
-          case 'ton_por_ha': {
-            const area = Number(record.lotes?.area_hectareas) || 1;
-            valor = (Number(record.kg_totales) || 0) / 1000 / area;
-            break;
-          }
-        }
-
-        // Acumular si hay multiples registros para el mismo lote/cosecha
-        cosechaMap[cosechaCode].lotes[loteCode] =
-          (cosechaMap[cosechaCode].lotes[loteCode] || 0) + valor;
-      });
-
-      // Convertir a array ordenado por cosecha
-      const tendencias: TendenciaHistoricaData[] = COSECHAS_ORDEN.filter(
-        (code) => cosechaMap[code]
-      ).map((cosechaCode) => {
-        const cosechaData = cosechaMap[cosechaCode];
-        return {
-          cosecha: cosechaCode,
-          cosecha_label: formatCosechaLabel(cosechaData.ano, cosechaData.tipo),
-          ano: cosechaData.ano,
-          tipo: cosechaData.tipo,
-          ...cosechaData.lotes,
+      if (!cosechaMap[cosechaCode]) {
+        cosechaMap[cosechaCode] = {
+          ano: record.ano,
+          tipo: record.cosecha_tipo,
+          lotes: {},
         };
-      });
+      }
 
-      return tendencias;
-    } catch (err: any) {
-      throw err;
-    }
+      const loteCode = getLoteCode(record.lotes?.nombre || '');
+
+      // Calcular valor segun metrica seleccionada
+      let valor = 0;
+      switch (filtros.metrica) {
+        case 'kg_totales':
+          valor = Number(record.kg_totales) || 0;
+          break;
+        case 'kg_por_arbol':
+          valor = Number(record.kg_por_arbol) || 0;
+          break;
+        case 'ton_por_ha': {
+          const area = Number(record.lotes?.area_hectareas) || 1;
+          valor = (Number(record.kg_totales) || 0) / 1000 / area;
+          break;
+        }
+      }
+
+      // Acumular si hay multiples registros para el mismo lote/cosecha
+      cosechaMap[cosechaCode].lotes[loteCode] =
+        (cosechaMap[cosechaCode].lotes[loteCode] || 0) + valor;
+    });
+
+    // Convertir a array ordenado por cosecha
+    const tendencias: TendenciaHistoricaData[] = COSECHAS_ORDEN.filter(
+      (code) => cosechaMap[code]
+    ).map((cosechaCode) => {
+      const cosechaData = cosechaMap[cosechaCode];
+      return {
+        cosecha: cosechaCode,
+        cosecha_label: formatCosechaLabel(cosechaData.ano, cosechaData.tipo),
+        ano: cosechaData.ano,
+        tipo: cosechaData.tipo,
+        ...cosechaData.lotes,
+      };
+    });
+
+    return tendencias;
   };
 
   /**
@@ -394,13 +386,12 @@ export function useProduccionData() {
   const getRendimientoSublotes = async (
     filtros: FiltrosProduccion
   ): Promise<RendimientoSubloteData[]> => {
-    try {
 
-      // Solo obtener registros a nivel sublote
-      let query = supabase
-        .from('produccion')
-        .select(
-          `
+    // Solo obtener registros a nivel sublote
+    let query = supabase
+      .from('produccion')
+      .select(
+        `
           sublote_id,
           kg_totales,
           kg_por_arbol,
@@ -410,38 +401,35 @@ export function useProduccionData() {
           sublotes!inner(nombre, numero_sublote),
           lotes!inner(nombre, area_hectareas)
         `
-        )
-        .not('sublote_id', 'is', null);
+      )
+      .not('sublote_id', 'is', null);
 
-      query = aplicarFiltros(query, filtros);
-      const { data, error: queryError } = await query;
+    query = aplicarFiltros(query, filtros);
+    const { data, error: queryError } = await query;
 
-      if (queryError) throw queryError;
+    if (queryError) throw queryError;
 
-      return (
-        data?.map((record: any) => {
-          const loteNombre = record.lotes?.nombre || 'Desconocido';
-          const area = Number(record.lotes?.area_hectareas) || 1;
-          // Estimar area del sublote como area del lote / 3 (asumiendo 3 sublotes por lote)
-          const areaSublote = area / 3;
+    return (
+      data?.map((record: any) => {
+        const loteNombre = record.lotes?.nombre || 'Desconocido';
+        const area = Number(record.lotes?.area_hectareas) || 1;
+        // Estimar area del sublote como area del lote / 3 (asumiendo 3 sublotes por lote)
+        const areaSublote = area / 3;
 
-          return {
-            sublote_id: record.sublote_id,
-            sublote_nombre: record.sublotes?.nombre || 'Desconocido',
-            lote_id: record.lote_id,
-            lote_nombre: loteNombre,
-            lote_color: getLoteColor(loteNombre),
-            kg_totales: Number(record.kg_totales) || 0,
-            kg_por_arbol: Number(record.kg_por_arbol) || 0,
-            ton_por_ha: (Number(record.kg_totales) || 0) / 1000 / areaSublote,
-            arboles: record.arboles_registrados || 0,
-            cosecha: formatCosechaCode(record.ano, record.cosecha_tipo),
-          };
-        }) || []
-      );
-    } catch (err: any) {
-      throw err;
-    }
+        return {
+          sublote_id: record.sublote_id,
+          sublote_nombre: record.sublotes?.nombre || 'Desconocido',
+          lote_id: record.lote_id,
+          lote_nombre: loteNombre,
+          lote_color: getLoteColor(loteNombre),
+          kg_totales: Number(record.kg_totales) || 0,
+          kg_por_arbol: Number(record.kg_por_arbol) || 0,
+          ton_por_ha: (Number(record.kg_totales) || 0) / 1000 / areaSublote,
+          arboles: record.arboles_registrados || 0,
+          cosecha: formatCosechaCode(record.ano, record.cosecha_tipo),
+        };
+      }) || []
+    );
   };
 
   /**
@@ -451,37 +439,33 @@ export function useProduccionData() {
     filtros: FiltrosProduccion,
     limit: number = 10
   ): Promise<TopSubloteData[]> => {
-    try {
-      const sublotes = await getRendimientoSublotes(filtros);
+    const sublotes = await getRendimientoSublotes(filtros);
 
-      // Agregar valor segun metrica y ordenar
-      const withValue = sublotes.map((s) => ({
-        ...s,
-        valor:
-          filtros.metrica === 'kg_totales'
-            ? s.kg_totales
-            : filtros.metrica === 'kg_por_arbol'
-              ? s.kg_por_arbol
-              : s.ton_por_ha,
-      }));
+    // Agregar valor segun metrica y ordenar
+    const withValue = sublotes.map((s) => ({
+      ...s,
+      valor:
+        filtros.metrica === 'kg_totales'
+          ? s.kg_totales
+          : filtros.metrica === 'kg_por_arbol'
+            ? s.kg_por_arbol
+            : s.ton_por_ha,
+    }));
 
-      // Ordenar descendente y limitar
-      const sorted = withValue
-        .sort((a, b) => b.valor - a.valor)
-        .slice(0, limit);
+    // Ordenar descendente y limitar
+    const sorted = withValue
+      .sort((a, b) => b.valor - a.valor)
+      .slice(0, limit);
 
-      return sorted.map((s, i) => ({
-        sublote_id: s.sublote_id,
-        sublote_nombre: s.sublote_nombre,
-        lote_nombre: s.lote_nombre,
-        lote_color: s.lote_color,
-        valor: Math.round(s.valor * 100) / 100,
-        metrica: filtros.metrica,
-        ranking: i + 1,
-      }));
-    } catch (err: any) {
-      throw err;
-    }
+    return sorted.map((s, i) => ({
+      sublote_id: s.sublote_id,
+      sublote_nombre: s.sublote_nombre,
+      lote_nombre: s.lote_nombre,
+      lote_color: s.lote_color,
+      valor: Math.round(s.valor * 100) / 100,
+      metrica: filtros.metrica,
+      ranking: i + 1,
+    }));
   };
 
   /**
@@ -490,13 +474,12 @@ export function useProduccionData() {
   const getEdadRendimiento = async (
     filtros: FiltrosProduccion
   ): Promise<EdadRendimientoData[]> => {
-    try {
 
-      // Obtener todos los registros y consolidar para evitar doble conteo
-      let query = supabase
-        .from('produccion')
-        .select(
-          `
+    // Obtener todos los registros y consolidar para evitar doble conteo
+    let query = supabase
+      .from('produccion')
+      .select(
+        `
           sublote_id,
           lote_id,
           ano,
@@ -506,82 +489,79 @@ export function useProduccionData() {
           arboles_registrados,
           lotes!inner(nombre, fecha_siembra, area_hectareas)
         `
-        );
+      );
 
-      query = aplicarFiltros(query, filtros);
-      const { data: rawData, error: queryError } = await query;
+    query = aplicarFiltros(query, filtros);
+    const { data: rawData, error: queryError } = await query;
 
-      if (queryError) throw queryError;
+    if (queryError) throw queryError;
 
-      const data = consolidarRegistros(rawData || []);
+    const data = consolidarRegistros(rawData || []);
 
-      // Agrupar por lote y calcular promedios
-      const loteMap: Record<
-        string,
-        {
-          nombre: string;
-          fecha_siembra: string | null;
-          area: number;
-          totalKg: number;
-          totalArboles: number;
-          numRegistros: number;
+    // Agrupar por lote y calcular promedios
+    const loteMap: Record<
+      string,
+      {
+        nombre: string;
+        fecha_siembra: string | null;
+        area: number;
+        totalKg: number;
+        totalArboles: number;
+        numRegistros: number;
+      }
+    > = {};
+
+    data?.forEach((record: any) => {
+      const loteId = record.lote_id;
+
+      if (!loteMap[loteId]) {
+        loteMap[loteId] = {
+          nombre: record.lotes?.nombre || 'Desconocido',
+          fecha_siembra: record.lotes?.fecha_siembra,
+          area: Number(record.lotes?.area_hectareas) || 1,
+          totalKg: 0,
+          totalArboles: 0,
+          numRegistros: 0,
+        };
+      }
+
+      loteMap[loteId].totalKg += Number(record.kg_totales) || 0;
+      loteMap[loteId].totalArboles += record.arboles_registrados || 0;
+      loteMap[loteId].numRegistros += 1;
+    });
+
+    // Convertir a array con calculo de edad
+    const currentYear = new Date().getFullYear();
+
+    return Object.entries(loteMap)
+      .filter(([, lote]) => lote.fecha_siembra) // Solo lotes con fecha de siembra
+      .map(([loteId, lote]) => {
+        const fechaSiembra = new Date(lote.fecha_siembra!);
+        const edadAnos = currentYear - fechaSiembra.getFullYear();
+
+        // Calcular rendimiento promedio segun metrica
+        let rendimiento = 0;
+        if (filtros.metrica === 'ton_por_ha') {
+          rendimiento =
+            lote.numRegistros > 0
+              ? lote.totalKg / 1000 / lote.area / lote.numRegistros
+              : 0;
+        } else {
+          // kg/arbol promedio
+          rendimiento =
+            lote.totalArboles > 0 ? lote.totalKg / lote.totalArboles : 0;
         }
-      > = {};
 
-      data?.forEach((record: any) => {
-        const loteId = record.lote_id;
-
-        if (!loteMap[loteId]) {
-          loteMap[loteId] = {
-            nombre: record.lotes?.nombre || 'Desconocido',
-            fecha_siembra: record.lotes?.fecha_siembra,
-            area: Number(record.lotes?.area_hectareas) || 1,
-            totalKg: 0,
-            totalArboles: 0,
-            numRegistros: 0,
-          };
-        }
-
-        loteMap[loteId].totalKg += Number(record.kg_totales) || 0;
-        loteMap[loteId].totalArboles += record.arboles_registrados || 0;
-        loteMap[loteId].numRegistros += 1;
+        return {
+          lote_id: loteId,
+          lote_nombre: lote.nombre,
+          lote_codigo: getLoteCode(lote.nombre),
+          lote_color: getLoteColor(lote.nombre),
+          edad_anos: edadAnos,
+          rendimiento: Math.round(rendimiento * 100) / 100,
+          arboles: Math.round(lote.totalArboles / (lote.numRegistros || 1)),
+        };
       });
-
-      // Convertir a array con calculo de edad
-      const currentYear = new Date().getFullYear();
-
-      return Object.entries(loteMap)
-        .filter(([, lote]) => lote.fecha_siembra) // Solo lotes con fecha de siembra
-        .map(([loteId, lote]) => {
-          const fechaSiembra = new Date(lote.fecha_siembra!);
-          const edadAnos = currentYear - fechaSiembra.getFullYear();
-
-          // Calcular rendimiento promedio segun metrica
-          let rendimiento = 0;
-          if (filtros.metrica === 'ton_por_ha') {
-            rendimiento =
-              lote.numRegistros > 0
-                ? lote.totalKg / 1000 / lote.area / lote.numRegistros
-                : 0;
-          } else {
-            // kg/arbol promedio
-            rendimiento =
-              lote.totalArboles > 0 ? lote.totalKg / lote.totalArboles : 0;
-          }
-
-          return {
-            lote_id: loteId,
-            lote_nombre: lote.nombre,
-            lote_codigo: getLoteCode(lote.nombre),
-            lote_color: getLoteColor(lote.nombre),
-            edad_anos: edadAnos,
-            rendimiento: Math.round(rendimiento * 100) / 100,
-            arboles: Math.round(lote.totalArboles / (lote.numRegistros || 1)),
-          };
-        });
-    } catch (err: any) {
-      throw err;
-    }
   };
 
   /**
@@ -620,18 +600,14 @@ export function useProduccionData() {
   const getSublotesByLote = async (
     loteId: string
   ): Promise<SubloteProduccion[]> => {
-    try {
-      const { data, error: queryError } = await supabase
-        .from('sublotes')
-        .select('id, nombre, lote_id, numero_sublote, total_arboles')
-        .eq('lote_id', loteId)
-        .order('numero_sublote', { ascending: true });
+    const { data, error: queryError } = await supabase
+      .from('sublotes')
+      .select('id, nombre, lote_id, numero_sublote, total_arboles')
+      .eq('lote_id', loteId)
+      .order('numero_sublote', { ascending: true });
 
-      if (queryError) throw queryError;
-      return (data || []) as unknown as SubloteProduccion[];
-    } catch (err: any) {
-      throw err;
-    }
+    if (queryError) throw queryError;
+    return (data || []) as unknown as SubloteProduccion[];
   };
 
   /**

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -274,6 +274,14 @@ input[type='number'] {
   max-height: 100dvh;
 }
 
+/* Not present in the frozen index.css build, but referenced across the app.
+   Lets a flex item shrink below its content height — required on wrappers that
+   are NOT scroll containers themselves (e.g. a <form> holding a DialogBody),
+   since `overflow: visible` keeps the automatic minimum size at min-content. */
+.min-h-0 {
+  min-height: 0;
+}
+
 /* Dialog size tiers — fixed rem values, capped by viewport via min() */
 .dialog-viewport-cap {
   max-height: calc(100vh - 2rem);

--- a/src/types/database.ts
+++ b/src/types/database.ts
@@ -3408,6 +3408,10 @@ export type Database = {
         }[]
       }
       es_usuario_gerencia: { Args: never; Returns: boolean }
+      fn_cleanup_compra_dependencies: {
+        Args: { p_compra_id: string }
+        Returns: undefined
+      }
       get_user_role: {
         Args: never
         Returns: Database["public"]["Enums"]["rol_usuario"]


### PR DESCRIPTION
## El bug reportado

En Configuración → Usuarios, el diálogo "Editar Usuario" recortaba su contenido a media fila, no permitía scroll y dejaba los botones Cancelar/Guardar inalcanzables — solo se podía salir con la X.

**Causa raíz:** el `<form>` estaba montado como hijo directo de `DialogContent`, que es `flex flex-col` + `overflow-hidden` con altura máxima fija por tier (512 px en `md`). El formulario mide ~660 px, no puede encogerse, y quedaba clipeado sin barra de scroll. Lo disparó el bloque "Módulos de acceso" de `4690945`, sobre un defecto estructural que venía de `385c30f`.

## Resultó sistémico: 9 diálogos, no 1

Migrados a `DialogBody` (scrollea) + `DialogFooter` (anclado, siempre visible):

| Archivo | Tier |
|---|---|
| `UsuariosConfig.tsx` | md |
| `TelegramConfig.tsx` (×2) | sm |
| `ProveedoresConfig.tsx` · `CompradoresConfig.tsx` · `MediosPagoConfig.tsx` | sm |
| `IngresoForm.tsx` (#2) | md |
| `RegistroColmenas.tsx` · `ConfigApiarios.tsx` | sm |

`RegistroConductividad.tsx` y `ui/command.tsx` ya gestionaban su propio scroll — quedan en la allowlist del guard.

## `min-h-0` era una clase muerta

No existe en el `index.css` congelado, así que todo `className="min-h-0"` del repo era un no-op silencioso. Resultó **load-bearing**: sin ella, envolver en `DialogBody` no arregla nada cuando hay un `<form>` intermedio, porque el form conserva su altura de contenido.

Medido en navegador con `index.css` + `globals.css` reales, panel a 512 px:

| Estructura | Botón "Guardar" | ¿Visible? |
|---|---|---|
| Antes | 671 px | **No** — 159 px fuera del panel |
| `DialogBody` **sin** `.min-h-0` | 653 px | **No** — el fix no surte efecto |
| `DialogBody` **con** `.min-h-0` | 433 px | **Sí**, y el body scrollea (500 vs 280 px) |

Por eso se agregó `.min-h-0 { min-height: 0 }` como regla real en `globals.css`. Las otras 5 apariciones están sobre scroll containers donde el mínimo automático ya resuelve a 0 — no-op para ellas, sin riesgo de regresión.

## Guard de regresión

`src/__tests__/dialogScrollContract.test.ts` falla si un `DialogContent` no tiene `DialogBody` ni scroll propio, y si un `<form>` que envuelve `DialogBody` no declara `flex-1 min-h-0`. **Detectó un 9º diálogo** (`IngresoForm.tsx` #2) que la revisión manual a nivel de archivo había pasado por alto.

## Fallos preexistentes arreglados

Estaban rojos antes de esta rama:

1. **`reporteSemanal.test.ts`** — test obsoleto, no bug de código. El filtro de actividad de 30 días de `1753706` (2026-06-29) cambió deliberadamente el empty-state y no actualizó los tests. Además el mock no distinguía las 3 consultas a `monitoreos`, así que los tests pasaban **por coincidencia**; ahora se mockea cada escalón por separado y el caso vacío se partió en dos tests diferenciales.
2. **`PurchaseHistory.tsx:354`** — `fn_cleanup_compra_dependencies` (migración 039) nunca se agregó a `database.ts`. Crucé todos los `.rpc()` del repo: era el único faltante.
3. **`useProduccionData.ts`** — 6 `try/catch` que solo re-lanzaban. Los strings de `.select()` quedaron idénticos byte a byte (verificado).

## Verificación

- `npm run typecheck` — limpio
- `npm run lint` — **0 errores** (eran 6)
- `npm test` — **488/488** (eran 486/487)

## Pendiente / a tener en cuenta

- **No se probó en la app corriendo**: falta `.env.local` y la app lanza al arrancar sin las vars de Supabase. La verificación fue del mecanismo CSS en aislamiento, no de las pantallas. Vale una pasada manual por los 9 diálogos.
- **En móvil el orden de botones cambia**: `DialogFooter` usa `flex-col-reverse`, así que el submit queda arriba del de cancelar — difiere del orden lado a lado anterior.

Informe completo: `docs/bugs/2026-07-21-dialog-sin-scroll-usuarios.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)
