### PR TITLE
feat(finanzas): rework gastos historial + attribute expenses to their creator

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -145,7 +145,7 @@ These are consumed in `src/utils/supabase/client.ts` via `import.meta.env`. The 
 │   │   └── validation.ts               # Data validation utilities
 │   │
 │   ├── sql/                             # SQL scripts & migrations
-│   │   ├── migrations/                  # Sequential numbered migrations (001–031)
+│   │   ├── migrations/                  # Sequential numbered migrations (001–050)
 │   │   └── *.sql                        # Standalone SQL scripts
 │   │
 │   ├── styles/
@@ -350,7 +350,7 @@ The applications module has two distinct tracking layers — **do not confuse th
 
 ### Migrations
 
-Sequential SQL migrations live in `src/sql/migrations/` (001–046). See `src/sql/migrations/README_MIGRATION.md` for instructions on running them.
+Sequential SQL migrations live in `src/sql/migrations/` (001–050). See `src/sql/migrations/README_MIGRATION.md` for instructions on running them.
 
 - **023**: `create_fin_transacciones_ganado` — cattle buy/sell transactions table with RLS
 - **024**: `alter_fin_ingresos_add_columns` — adds `cantidad`, `precio_unitario`, `cosecha`, `alianza`, `cliente`, `finca` to `fin_ingresos`
@@ -370,6 +370,7 @@ Sequential SQL migrations live in `src/sql/migrations/` (001–046). See `src/sq
 - **045**: `fix_aplicar_movimiento_ganado_upsert` — fixes 044's apply-trigger: `INSERT ... ON CONFLICT DO UPDATE` validates CHECK constraints on the proposed row before conflict arbitration, so every negative-delta movement (venta/muerte/traslado_salida) failed even with sufficient inventory. Rewritten UPDATE-first with INSERT fallback. Applied to production 2026-06-10.
 - **046**: `add_produccion_calidad` — adds optional `kg_exportacion`/`kg_nacional` NUMERIC(12,2) columns to `produccion` with CHECK enforcing exact sum against `kg_totales` when both are non-null. Applied to production 2026-06-12.
 - **049**: `add_usuarios_modulos_acceso` — adds `modulos_acceso text[] NOT NULL DEFAULT '{}'` to `usuarios`. Per-user app-module visibility (`aguacate` | `hato_lechero` | `ganado` | `finanzas`). Navigation/visibility only — **NOT enforced by RLS**. Gerencia bypasses it in app code. Applied to production 2026-07-21.
+- **050**: `gastos_created_by_tracking` — BEFORE INSERT triggers on `fin_gastos` and `fin_transacciones_ganado` (`set_gasto_created_by()` / `set_transaccion_ganado_created_by()`, same `COALESCE(created_by, auth.uid())` pattern as migration 040's tareas trigger) so every new row is attributed to its creator going forward. One-time backfill for 2026: 48 gastos Efrain confirmed as his (matched by `fecha`+`nombre`+`valor`, 3 of the 45 identified entries had 2 identical physical rows each — pre-existing duplicate data entry) are attributed to him; the remaining 453 `fin_gastos` rows dated in 2026 are attributed to Consuelo. Rows outside 2026 (3870), and `fin_transacciones_ganado` history, are left with `created_by = NULL` (never populated pre-migration, no way to backfill). Applied to production 2026-07-21.
 
 ### Monitoring Module (`/monitoreo`) — incidencia aggregation
 
@@ -402,6 +403,15 @@ Key files:
 - `src/types/finanzas.ts` — `UnifiedFinanceItem` type
 - `src/components/finanzas/components/GastosList.tsx` — merges `fin_transacciones_ganado` compras
 - `src/components/finanzas/components/IngresosList.tsx` — merges `fin_transacciones_ganado` ventas
+
+### Gastos historial (`/finanzas/gastos`) — view contract
+
+`GastosView` opens on the **Historial** tab (leftmost); `?tab=registrar` still deep-links to the capture grid. `GastosList` defaults its period filter to **`ytd`**, not `mes_actual` — that default is repeated in three places (initial state, the navigation-state effect, and the clear-filters reset); change all three together or they silently disagree.
+
+- **Usuario filter** — filters `created_by` on both `fin_gastos` and `fin_transacciones_ganado`, plus a "Sin usuario" option for `created_by IS NULL` (everything before migration 050, i.e. all pre-2026 rows and all ganado history).
+- **Selection subtotal** — per-row checkboxes plus "seleccionar todos"; the subtotal is computed over `unifiedItems`, so it always reflects the active filters. Selection resets whenever filters or the search query change.
+- **Detail dialog** (`GastoDetalleDialog.tsx`) — opens on row click for gasto and ganado items alike, and carries Editar / Eliminar / Completar. The row's `onClick` is suppressed on the checkbox and the `⋮` wrapper via `stopPropagation`.
+- **Mobile** — the `⋮` menu is `hidden sm:block` **on purpose**: it is gated on `group-hover`, which never fires on touch, so on mobile the detail dialog is the only path to the actions. Do not re-enable it on mobile without also removing the hover gate. The two-line mobile row and the collapsible filter bar rely on the custom `globals.css` classes listed in the frozen-Tailwind caution zone below.
 
 ### Cattle Inventory Module (`/ganado`, issue #51)
 
@@ -554,7 +564,14 @@ Before using an unfamiliar utility, check it exists:
 ```bash
 grep -cF 'bg-sidebar-accent' src/index.css   # 0 = does not exist, will do nothing
 ```
-If it doesn't exist, add a real CSS rule to `src/styles/globals.css` (a live stylesheet, imported *after* `index.css`, so it wins the cascade) — e.g. `.nav-item-active`. Never hand-edit `index.css`.
+⚠️ That plain form only works for classes **without a `:`**. Variants (`sm:`, `hover:`, `focus:`) are written escaped in the CSS (`.sm\:inline`), so `grep -F 'sm:inline'` returns 0 even when the class exists — a false negative. Search the escaped form instead:
+```bash
+grep -oF 'sm\:inline' src/index.css | wc -l      # variant classes
+grep -oE '\.sm\\:[a-z0-9\\:.\[\]-]+' src/index.css | sort -u   # list every sm: variant present
+```
+Beware substring matches: `sm\:flex` also matches inside `sm\:flex-row`. Verified **absent** as of migration 050 work: `sm:hidden`, `sm:flex`, `sm:w-auto`, `sm:text-right`, `sm:gap-*`, `tabular-nums`, `break-words`, `text-[10px]`, `px-1.5`/`py-1.5`, `w-[70px]` — several of these are already written in existing JSX and silently do nothing.
+
+If it doesn't exist, add a real CSS rule to `src/styles/globals.css` (a live stylesheet, imported *after* `index.css`, so it wins the cascade) — e.g. `.nav-item-active`, or the `.filtros-toggle` / `.filtros-colapsables` / `.gasto-meta-movil` / `.gasto-nombre` rules that give the Gastos historial its mobile layout. Never hand-edit `index.css`.
 
 See `src/guidelines/Guidelines.md` for the full design system.
 

--- a/src/components/finanzas/GastosView.tsx
+++ b/src/components/finanzas/GastosView.tsx
@@ -18,7 +18,7 @@ export function GastosView() {
   const [searchParams] = useSearchParams();
   const tabInicial = TABS_VALIDOS.includes(searchParams.get('tab') || '')
     ? (searchParams.get('tab') as string)
-    : 'registrar';
+    : 'historial';
   const [activeTab, setActiveTab] = useState(tabInicial);
   const [showForm, setShowForm] = useState(false);
   const [showCargaMasiva, setShowCargaMasiva] = useState(false);
@@ -64,15 +64,19 @@ export function GastosView() {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} activationMode="manual" className="w-full">
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="registrar" className="flex items-center gap-2">
-            <ClipboardList className="w-4 h-4" />
-            Registrar
-          </TabsTrigger>
           <TabsTrigger value="historial" className="flex items-center gap-2">
             <History className="w-4 h-4" />
             Historial
           </TabsTrigger>
+          <TabsTrigger value="registrar" className="flex items-center gap-2">
+            <ClipboardList className="w-4 h-4" />
+            Registrar
+          </TabsTrigger>
         </TabsList>
+
+        <TabsContent value="historial" className="mt-6">
+          <GastosList key={refreshKey} onEdit={handleEditGasto} />
+        </TabsContent>
 
         <TabsContent value="registrar" className="mt-6 space-y-6">
           <div className="flex flex-wrap gap-3">
@@ -102,10 +106,6 @@ export function GastosView() {
           </div>
 
           <GastosBatchTable catalogs={catalogs} onSaved={handleBatchSaved} />
-        </TabsContent>
-
-        <TabsContent value="historial" className="mt-6">
-          <GastosList key={refreshKey} onEdit={handleEditGasto} />
         </TabsContent>
       </Tabs>
 

--- a/src/components/finanzas/components/GastoDetalleDialog.tsx
+++ b/src/components/finanzas/components/GastoDetalleDialog.tsx
@@ -1,0 +1,196 @@
+import { useState } from 'react';
+import { CheckCircle2, Clock, Edit2, Trash2, AlertTriangle, FileText, Loader2 } from 'lucide-react';
+import { getSupabase } from '../../../utils/supabase/client';
+import { formatNumber } from '../../../utils/format';
+import { formatearFechaLarga } from '../../../utils/fechas';
+import { Button } from '../../ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from '../../ui/dialog';
+import type { Gasto, TransaccionGanado, UnifiedFinanceItem } from '../../../types/finanzas';
+import { toast } from 'sonner';
+
+interface GastoDetalleDialogProps {
+  item: UnifiedFinanceItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Resuelve created_by → nombre del usuario que registró el gasto. */
+  nombreUsuario?: string;
+  onEdit: () => void;
+  onEliminar: () => void;
+  onCompletar?: () => void;
+}
+
+/** Una fila etiqueta/valor. Se omite por completo cuando no hay dato. */
+function Campo({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+  return (
+    <div>
+      <p className="text-xs text-gray-400 uppercase tracking-wide">{label}</p>
+      <p className="text-sm text-gray-900 mt-1">{value}</p>
+    </div>
+  );
+}
+
+export function GastoDetalleDialog({
+  item,
+  open,
+  onOpenChange,
+  nombreUsuario,
+  onEdit,
+  onEliminar,
+  onCompletar,
+}: GastoDetalleDialogProps) {
+  const [abriendoFactura, setAbriendoFactura] = useState(false);
+
+  if (!item) return null;
+
+  const esGanado = item.source === 'ganado';
+  const gasto = !esGanado ? (item.raw as Gasto) : null;
+  const ganado = esGanado ? (item.raw as TransaccionGanado) : null;
+  // El query de GastosList trae los catálogos como joins anidados (fin_negocios, etc.),
+  // que no están declarados en el tipo Gasto.
+  const relaciones = (item.raw ?? {}) as unknown as Record<string, { nombre?: string } | undefined>;
+  const urlFactura = gasto?.url_factura;
+  const esPendiente = gasto?.estado === 'Pendiente';
+
+  const verFactura = async () => {
+    if (!urlFactura) return;
+    try {
+      setAbriendoFactura(true);
+      const { data, error } = await getSupabase()
+        .storage
+        .from('facturas')
+        .createSignedUrl(urlFactura, 60 * 60);
+      if (error || !data?.signedUrl) throw error ?? new Error('No se pudo generar el enlace');
+      window.open(data.signedUrl, '_blank');
+    } catch {
+      toast.error('No se pudo abrir la factura');
+    } finally {
+      setAbriendoFactura(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle className="text-base">{item.nombre}</DialogTitle>
+        </DialogHeader>
+
+        <DialogBody>
+          {/* Valor + estado */}
+          <div className="flex items-center justify-between gap-3 pb-4 border-b border-gray-100">
+            <div>
+              <p className="text-xs text-gray-400 uppercase tracking-wide">Valor</p>
+              <p className="text-2xl font-bold text-gray-900 mt-1">${formatNumber(item.valor)}</p>
+            </div>
+            {esGanado ? (
+              <span className="px-2 py-1 text-xs font-semibold rounded-lg bg-amber-100 text-amber-700">
+                Ganado
+              </span>
+            ) : (
+              <span
+                className={`px-2 py-1 text-xs font-semibold rounded-lg flex items-center gap-1.5 ${
+                  gasto?.estado === 'Confirmado'
+                    ? 'bg-green-50 text-green-700'
+                    : 'bg-yellow-50 text-yellow-700'
+                }`}
+              >
+                {gasto?.estado === 'Confirmado' ? (
+                  <CheckCircle2 className="w-4 h-4" />
+                ) : (
+                  <Clock className="w-4 h-4" />
+                )}
+                {gasto?.estado}
+              </span>
+            )}
+          </div>
+
+          {/* Campos */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-4">
+            <Campo label="Fecha" value={formatearFechaLarga(item.fecha)} />
+
+            {esGanado ? (
+              <>
+                <Campo label="Finca" value={ganado?.finca} />
+                <Campo label="Proveedor" value={ganado?.cliente_proveedor} />
+                <Campo
+                  label="Cabezas"
+                  value={ganado?.cantidad_cabezas ? formatNumber(ganado.cantidad_cabezas) : null}
+                />
+                <Campo
+                  label="Kilos pagados"
+                  value={ganado?.kilos_pagados ? `${formatNumber(ganado.kilos_pagados)} kg` : null}
+                />
+                <Campo
+                  label="Precio por kilo"
+                  value={ganado?.precio_kilo ? `$${formatNumber(ganado.precio_kilo)}` : null}
+                />
+              </>
+            ) : (
+              <>
+                <Campo label="Negocio" value={relaciones.fin_negocios?.nombre} />
+                <Campo label="Región" value={relaciones.fin_regiones?.nombre} />
+                <Campo label="Categoría" value={relaciones.fin_categorias_gastos?.nombre} />
+                <Campo label="Concepto" value={relaciones.fin_conceptos_gastos?.nombre} />
+                <Campo label="Proveedor" value={relaciones.fin_proveedores?.nombre} />
+                <Campo label="Medio de pago" value={relaciones.fin_medios_pago?.nombre} />
+              </>
+            )}
+
+            <Campo label="Registrado por" value={nombreUsuario || 'Sin usuario'} />
+          </div>
+
+          {(item.raw as Gasto | TransaccionGanado)?.observaciones && (
+            <div className="pt-4 border-t border-gray-100">
+              <p className="text-xs text-gray-400 uppercase tracking-wide">Observaciones</p>
+              <p className="text-sm text-gray-900 mt-1">
+                {(item.raw as Gasto | TransaccionGanado).observaciones}
+              </p>
+            </div>
+          )}
+
+          {urlFactura && (
+            <div className="pt-4 border-t border-gray-100">
+              <Button variant="outline" size="sm" onClick={verFactura} disabled={abriendoFactura}>
+                {abriendoFactura ? (
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <FileText className="w-4 h-4 mr-2" />
+                )}
+                Ver factura
+              </Button>
+            </div>
+          )}
+        </DialogBody>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onEliminar}
+            className="border-red-200 text-red-600 hover:bg-red-50"
+          >
+            <Trash2 className="w-4 h-4 mr-2" />
+            Eliminar
+          </Button>
+          {esPendiente && onCompletar && (
+            <Button variant="outline" onClick={onCompletar} className="border-orange-200 text-orange-600">
+              <AlertTriangle className="w-4 h-4 mr-2" />
+              Completar
+            </Button>
+          )}
+          <Button onClick={onEdit}>
+            <Edit2 className="w-4 h-4 mr-2" />
+            Editar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/finanzas/components/GastosList.tsx
+++ b/src/components/finanzas/components/GastosList.tsx
@@ -10,12 +10,15 @@ import {
   Loader2,
   AlertTriangle,
   X,
+  Filter,
 } from 'lucide-react';
 import { getSupabase } from '../../../utils/supabase/client';
 import { formatNumber } from '../../../utils/format';
 import { formatearFechaCorta, calcularRangoFechasPorPeriodo } from '../../../utils/fechas';
 import { Input } from '../../ui/input';
+import { Checkbox } from '../../ui/checkbox';
 import { CompletarGastoDialog } from './CompletarGastoDialog';
+import { GastoDetalleDialog } from './GastoDetalleDialog';
 import type { Gasto, Negocio, Region, CategoriaGasto, ConceptoGasto, TransaccionGanado, UnifiedFinanceItem } from '../../../types/finanzas';
 import { toast } from 'sonner';
 import { ConfirmDialog } from '../../ui/confirm-dialog';
@@ -32,9 +35,17 @@ interface FiltrosState {
   categoria_id: string;
   concepto_id: string;
   estado: string;
+  usuario_id: string;
   fecha_desde: string;
   fecha_hasta: string;
 }
+
+interface UsuarioOption {
+  id: string;
+  nombre_completo: string;
+}
+
+const SIN_USUARIO = '__sin_usuario__';
 
 const selectClass = 'px-2 py-1.5 text-sm border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary min-w-0';
 
@@ -48,12 +59,13 @@ export function GastosList({ onEdit }: GastosListProps) {
   const [filtros, setFiltros] = useState<FiltrosState>(() => {
     const state = location.state as any;
     return {
-      periodo: state?.periodo || 'mes_actual',
+      periodo: state?.periodo || 'ytd',
       negocio_id: state?.negocio_id || '',
       region_id: state?.region_id || '',
       categoria_id: state?.categoria || '',
       concepto_id: '',
       estado: '',
+      usuario_id: '',
       fecha_desde: state?.fecha_desde || '',
       fecha_hasta: state?.fecha_hasta || '',
     };
@@ -65,12 +77,16 @@ export function GastosList({ onEdit }: GastosListProps) {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [deleteTargetSource, setDeleteTargetSource] = useState<'gasto' | 'ganado'>('gasto');
   const [editingGanado, setEditingGanado] = useState<TransaccionGanado | null>(null);
+  const [seleccionados, setSeleccionados] = useState<Set<string>>(new Set());
+  const [detalleItem, setDetalleItem] = useState<UnifiedFinanceItem | null>(null);
+  const [filtrosAbiertos, setFiltrosAbiertos] = useState(false);
 
   // Catalogs
   const [negocios, setNegocios] = useState<Negocio[]>([]);
   const [regiones, setRegiones] = useState<Region[]>([]);
   const [categorias, setCategorias] = useState<CategoriaGasto[]>([]);
   const [conceptos, setConceptos] = useState<ConceptoGasto[]>([]);
+  const [usuarios, setUsuarios] = useState<UsuarioOption[]>([]);
 
   const aplicadoKey = useRef<string | null>(location.key);
 
@@ -82,11 +98,13 @@ export function GastosList({ onEdit }: GastosListProps) {
       supabase.from('fin_regiones').select('*').eq('activo', true).order('nombre'),
       supabase.from('fin_categorias_gastos').select('*').eq('activo', true).order('nombre'),
       supabase.from('fin_conceptos_gastos').select('*').eq('activo', true).order('nombre'),
-    ]).then(([neg, reg, cat, con]) => {
+      supabase.from('usuarios').select('id, nombre_completo').eq('activo', true).order('nombre_completo'),
+    ]).then(([neg, reg, cat, con, usr]) => {
       if (neg.data) setNegocios(neg.data);
       if (reg.data) setRegiones(reg.data);
       if (cat.data) setCategorias(cat.data);
       if (con.data) setConceptos(con.data);
+      if (usr.data) setUsuarios(usr.data as UsuarioOption[]);
     });
   }, []);
 
@@ -97,7 +115,7 @@ export function GastosList({ onEdit }: GastosListProps) {
       aplicadoKey.current = location.key;
       setFiltros((prev) => ({
         ...prev,
-        periodo: state.periodo || 'mes_actual',
+        periodo: state.periodo || 'ytd',
         negocio_id: state.negocio_id || '',
         region_id: state.region_id || '',
         categoria_id: state.categoria || '',
@@ -110,6 +128,7 @@ export function GastosList({ onEdit }: GastosListProps) {
   // Auto-load on any filter change
   useEffect(() => {
     loadGastos();
+    setSeleccionados(new Set());
   }, [filtros, searchQuery]);
 
   useEffect(() => {
@@ -142,6 +161,8 @@ export function GastosList({ onEdit }: GastosListProps) {
       if (filtros.estado) query = query.eq('estado', filtros.estado);
       if (filtros.categoria_id) query = query.eq('categoria_id', filtros.categoria_id);
       if (filtros.concepto_id) query = query.eq('concepto_id', filtros.concepto_id);
+      if (filtros.usuario_id === SIN_USUARIO) query = query.is('created_by', null);
+      else if (filtros.usuario_id) query = query.eq('created_by', filtros.usuario_id);
 
       query = query.order('fecha', { ascending: false });
       const { data, error } = await query;
@@ -156,6 +177,8 @@ export function GastosList({ onEdit }: GastosListProps) {
         .eq('tipo', 'compra');
       if (fechaDesde) ganadoQuery = ganadoQuery.gte('fecha', fechaDesde);
       if (fechaHasta) ganadoQuery = ganadoQuery.lte('fecha', fechaHasta);
+      if (filtros.usuario_id === SIN_USUARIO) ganadoQuery = ganadoQuery.is('created_by', null);
+      else if (filtros.usuario_id) ganadoQuery = ganadoQuery.eq('created_by', filtros.usuario_id);
       ganadoQuery = ganadoQuery.order('fecha', { ascending: false });
       const { data: ganadoData } = await ganadoQuery;
 
@@ -225,7 +248,15 @@ export function GastosList({ onEdit }: GastosListProps) {
     ? conceptos.filter((c) => c.categoria_id === filtros.categoria_id)
     : [];
 
-  const tieneFiltrosActivos = filtros.negocio_id || filtros.region_id || filtros.categoria_id || filtros.concepto_id || filtros.estado;
+  const tieneFiltrosActivos = filtros.negocio_id || filtros.region_id || filtros.categoria_id || filtros.concepto_id || filtros.estado || filtros.usuario_id;
+  const conteoFiltrosActivos = [
+    filtros.negocio_id,
+    filtros.region_id,
+    filtros.categoria_id,
+    filtros.concepto_id,
+    filtros.estado,
+    filtros.usuario_id,
+  ].filter(Boolean).length;
   const valorTotalGastos = gastos.reduce((sum, g) => sum + (g.valor || 0), 0);
   const valorTotalGanado = ganadoItems.reduce((sum, g) => sum + (g.valor_total || 0), 0);
   const valorTotal = valorTotalGastos + valorTotalGanado;
@@ -255,6 +286,34 @@ export function GastosList({ onEdit }: GastosListProps) {
 
   const totalCount = unifiedItems.length;
 
+  const toggleSeleccionado = (key: string) => {
+    setSeleccionados((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const todosSeleccionados = totalCount > 0 && unifiedItems.every((item) => seleccionados.has(`${item.source}-${item.id}`));
+
+  const toggleSeleccionarTodos = () => {
+    if (todosSeleccionados) {
+      setSeleccionados(new Set());
+    } else {
+      setSeleccionados(new Set(unifiedItems.map((item) => `${item.source}-${item.id}`)));
+    }
+  };
+
+  const itemsSeleccionados = unifiedItems.filter((item) => seleccionados.has(`${item.source}-${item.id}`));
+  const subtotalSeleccionado = itemsSeleccionados.reduce((sum, item) => sum + (item.valor || 0), 0);
+
+  const nombreCreadoPor = (item: UnifiedFinanceItem | null) => {
+    const creadoPor = (item?.raw as { created_by?: string | null } | undefined)?.created_by;
+    if (!creadoPor) return undefined;
+    return usuarios.find((u) => u.id === creadoPor)?.nombre_completo;
+  };
+
   return (
     <div className="space-y-3">
       {/* Compact filter bar: search + all filters in one row */}
@@ -272,58 +331,79 @@ export function GastosList({ onEdit }: GastosListProps) {
             />
           </div>
 
-          {/* Periodo */}
-          <select value={filtros.periodo} onChange={(e) => updateFiltro('periodo', e.target.value)} className={selectClass}>
-            <option value="mes_actual">Mes Actual</option>
-            <option value="trimestre">Trimestre</option>
-            <option value="ytd">YTD</option>
-            <option value="ano_anterior">Ano Anterior</option>
-            <option value="rango_personalizado">Personalizado</option>
-          </select>
+          {/* Mobile-only: the filters below collapse behind this toggle */}
+          <button
+            onClick={() => setFiltrosAbiertos((prev) => !prev)}
+            className="filtros-toggle items-center gap-2 h-8 px-3 text-sm border border-gray-200 rounded-xl bg-white text-gray-600"
+          >
+            <Filter className="w-4 h-4" />
+            Filtros
+            {conteoFiltrosActivos > 0 && (
+              <span className="px-2 rounded-md bg-primary text-white text-xs">{conteoFiltrosActivos}</span>
+            )}
+          </button>
 
-          {/* Negocio */}
-          <select value={filtros.negocio_id} onChange={(e) => updateFiltro('negocio_id', e.target.value)} className={selectClass}>
-            <option value="">Negocio</option>
-            {negocios.map((n) => <option key={n.id} value={n.id}>{n.nombre}</option>)}
-          </select>
-
-          {/* Region */}
-          <select value={filtros.region_id} onChange={(e) => updateFiltro('region_id', e.target.value)} className={selectClass}>
-            <option value="">Region</option>
-            {regiones.map((r) => <option key={r.id} value={r.id}>{r.nombre}</option>)}
-          </select>
-
-          {/* Categoria */}
-          <select value={filtros.categoria_id} onChange={(e) => updateFiltro('categoria_id', e.target.value)} className={selectClass}>
-            <option value="">Categoria</option>
-            {categorias.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
-          </select>
-
-          {/* Concepto */}
-          {filtros.categoria_id && (
-            <select value={filtros.concepto_id} onChange={(e) => updateFiltro('concepto_id', e.target.value)} className={selectClass}>
-              <option value="">Concepto</option>
-              {conceptosFiltrados.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
+          <div className={filtrosAbiertos ? 'filtros-colapsables abierto' : 'filtros-colapsables'}>
+            {/* Periodo */}
+            <select value={filtros.periodo} onChange={(e) => updateFiltro('periodo', e.target.value)} className={selectClass}>
+              <option value="mes_actual">Mes Actual</option>
+              <option value="trimestre">Trimestre</option>
+              <option value="ytd">YTD</option>
+              <option value="ano_anterior">Ano Anterior</option>
+              <option value="rango_personalizado">Personalizado</option>
             </select>
-          )}
 
-          {/* Estado */}
-          <select value={filtros.estado} onChange={(e) => updateFiltro('estado', e.target.value)} className={selectClass}>
-            <option value="">Estado</option>
-            <option value="Confirmado">Confirmado</option>
-            <option value="Pendiente">Pendiente</option>
-          </select>
+            {/* Negocio */}
+            <select value={filtros.negocio_id} onChange={(e) => updateFiltro('negocio_id', e.target.value)} className={selectClass}>
+              <option value="">Negocio</option>
+              {negocios.map((n) => <option key={n.id} value={n.id}>{n.nombre}</option>)}
+            </select>
 
-          {/* Clear filters */}
-          {tieneFiltrosActivos && (
-            <button
-              onClick={() => setFiltros({ periodo: 'mes_actual', negocio_id: '', region_id: '', categoria_id: '', concepto_id: '', estado: '', fecha_desde: '', fecha_hasta: '' })}
-              className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
-              title="Limpiar filtros"
-            >
-              <X className="w-4 h-4" />
-            </button>
-          )}
+            {/* Region */}
+            <select value={filtros.region_id} onChange={(e) => updateFiltro('region_id', e.target.value)} className={selectClass}>
+              <option value="">Region</option>
+              {regiones.map((r) => <option key={r.id} value={r.id}>{r.nombre}</option>)}
+            </select>
+
+            {/* Categoria */}
+            <select value={filtros.categoria_id} onChange={(e) => updateFiltro('categoria_id', e.target.value)} className={selectClass}>
+              <option value="">Categoria</option>
+              {categorias.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
+            </select>
+
+            {/* Concepto */}
+            {filtros.categoria_id && (
+              <select value={filtros.concepto_id} onChange={(e) => updateFiltro('concepto_id', e.target.value)} className={selectClass}>
+                <option value="">Concepto</option>
+                {conceptosFiltrados.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
+              </select>
+            )}
+
+            {/* Estado */}
+            <select value={filtros.estado} onChange={(e) => updateFiltro('estado', e.target.value)} className={selectClass}>
+              <option value="">Estado</option>
+              <option value="Confirmado">Confirmado</option>
+              <option value="Pendiente">Pendiente</option>
+            </select>
+
+            {/* Usuario */}
+            <select value={filtros.usuario_id} onChange={(e) => updateFiltro('usuario_id', e.target.value)} className={selectClass}>
+              <option value="">Usuario</option>
+              {usuarios.map((u) => <option key={u.id} value={u.id}>{u.nombre_completo}</option>)}
+              <option value={SIN_USUARIO}>Sin usuario</option>
+            </select>
+
+            {/* Clear filters */}
+            {tieneFiltrosActivos && (
+              <button
+                onClick={() => setFiltros({ periodo: 'ytd', negocio_id: '', region_id: '', categoria_id: '', concepto_id: '', estado: '', usuario_id: '', fecha_desde: '', fecha_hasta: '' })}
+                className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
+                title="Limpiar filtros"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
         </div>
 
         {/* Custom date range — only when selected */}
@@ -338,19 +418,39 @@ export function GastosList({ onEdit }: GastosListProps) {
       </div>
 
       {/* Inline stats summary */}
-      <div className="flex items-center gap-4 px-1 text-sm text-gray-500">
+      <div className="flex items-center gap-4 px-1 text-sm text-gray-500 flex-wrap">
+        {totalCount > 0 && (
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <Checkbox checked={todosSeleccionados} onCheckedChange={toggleSeleccionarTodos} />
+            <span>Seleccionar todos</span>
+          </label>
+        )}
         <span><strong className="text-gray-900">{totalCount}</strong> gastos</span>
-        <span className="text-gray-300">|</span>
+        <span className="hidden sm:inline text-gray-300">|</span>
         <span>Total: <strong className="text-gray-900">${formatNumber(valorTotal)}</strong></span>
+        {seleccionados.size > 0 && (
+          <>
+            <span className="hidden sm:inline text-gray-300">|</span>
+            <span className="text-primary">
+              Subtotal seleccionado ({seleccionados.size}): <strong>${formatNumber(subtotalSeleccionado)}</strong>
+            </span>
+            <button
+              onClick={() => setSeleccionados(new Set())}
+              className="text-gray-400 hover:text-gray-600 underline"
+            >
+              Limpiar selección
+            </button>
+          </>
+        )}
         {gastos.some((g) => g.estado === 'Pendiente') && (
           <>
-            <span className="text-gray-300">|</span>
+            <span className="hidden sm:inline text-gray-300">|</span>
             <span className="text-yellow-600">{gastos.filter((g) => g.estado === 'Pendiente').length} pendientes</span>
           </>
         )}
         {ganadoItems.length > 0 && (
           <>
-            <span className="text-gray-300">|</span>
+            <span className="hidden sm:inline text-gray-300">|</span>
             <span className="text-amber-700">{ganadoItems.length} ganado</span>
           </>
         )}
@@ -370,11 +470,24 @@ export function GastosList({ onEdit }: GastosListProps) {
           </div>
         ) : (
           <div className="divide-y divide-gray-100">
-            {unifiedItems.map((item) => (
-              <div key={`${item.source}-${item.id}`} className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50/50 transition-colors group">
+            {unifiedItems.map((item) => {
+              const itemKey = `${item.source}-${item.id}`;
+              return (
+              <div
+                key={itemKey}
+                onClick={() => setDetalleItem(item)}
+                className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50/50 transition-colors group cursor-pointer"
+              >
+                <span onClick={(e) => e.stopPropagation()} className="flex-shrink-0 flex items-center">
+                  <Checkbox
+                    checked={seleccionados.has(itemKey)}
+                    onCheckedChange={() => toggleSeleccionado(itemKey)}
+                  />
+                </span>
+
                 {/* Estado icon or Ganado badge */}
                 {item.source === 'ganado' ? (
-                  <span className="px-1.5 py-0.5 text-[10px] font-semibold rounded-md bg-amber-100 text-amber-800 flex-shrink-0">
+                  <span className="px-1.5 py-0.5 text-[10px] font-semibold rounded-md bg-amber-100 text-amber-700 flex-shrink-0">
                     Ganado
                   </span>
                 ) : item.source === 'gasto' ? (
@@ -388,21 +501,27 @@ export function GastosList({ onEdit }: GastosListProps) {
                   </div>
                 ) : null}
 
-                {/* Date */}
-                <span className="text-xs text-gray-400 w-[70px] flex-shrink-0">
+                {/* Date — own column on desktop; on mobile it moves to the meta line below */}
+                <span className="hidden sm:block text-xs text-gray-400 w-[70px] flex-shrink-0">
                   {formatearFechaCorta(item.fecha)}
                 </span>
 
-                {/* Name + details in one line */}
-                <div className="flex-1 min-w-0 flex items-center gap-2">
-                  <span className="text-sm font-medium text-gray-900 truncate">
-                    {item.nombre}
-                  </span>
-                  {item.details && (
-                    <span className="hidden sm:inline text-xs text-gray-400 truncate">
-                      {item.details}
+                {/* Name (+ details inline on desktop, stacked below on mobile) */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="gasto-nombre text-sm font-medium text-gray-900 truncate">
+                      {item.nombre}
                     </span>
-                  )}
+                    {item.details && (
+                      <span className="hidden sm:inline text-xs text-gray-400 truncate">
+                        {item.details}
+                      </span>
+                    )}
+                  </div>
+                  <div className="gasto-meta-movil text-xs text-gray-400 truncate">
+                    {formatearFechaCorta(item.fecha)}
+                    {item.details ? ` · ${item.details}` : ''}
+                  </div>
                 </div>
 
                 {/* Value */}
@@ -410,8 +529,9 @@ export function GastosList({ onEdit }: GastosListProps) {
                   ${formatNumber(item.valor)}
                 </span>
 
-                {/* Actions menu */}
-                <div className="relative flex-shrink-0">
+                {/* Actions menu — desktop only; on mobile the row opens the detail dialog,
+                    which carries the same actions (the hover-gated button is unreachable on touch) */}
+                <div className="hidden sm:block relative flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
@@ -470,7 +590,8 @@ export function GastosList({ onEdit }: GastosListProps) {
                   )}
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
@@ -494,6 +615,29 @@ export function GastosList({ onEdit }: GastosListProps) {
           onSuccess={() => { setEditingGanado(null); loadGastos(); }}
         />
       )}
+
+      <GastoDetalleDialog
+        item={detalleItem}
+        open={!!detalleItem}
+        onOpenChange={(open) => { if (!open) setDetalleItem(null); }}
+        nombreUsuario={nombreCreadoPor(detalleItem)}
+        onEdit={() => {
+          if (!detalleItem) return;
+          if (detalleItem.source === 'ganado') setEditingGanado(detalleItem.raw as TransaccionGanado);
+          else onEdit?.(detalleItem.raw as Gasto);
+          setDetalleItem(null);
+        }}
+        onEliminar={() => {
+          if (!detalleItem) return;
+          handleEliminar(detalleItem.id, detalleItem.source === 'ganado' ? 'ganado' : 'gasto');
+          setDetalleItem(null);
+        }}
+        onCompletar={() => {
+          if (!detalleItem || detalleItem.source === 'ganado') return;
+          setCompletandoGasto(detalleItem.raw as Gasto);
+          setDetalleItem(null);
+        }}
+      />
 
       <ConfirmDialog
         open={confirmDeleteOpen}

--- a/src/sql/migrations/050_gastos_created_by_tracking.sql
+++ b/src/sql/migrations/050_gastos_created_by_tracking.sql
@@ -1,0 +1,145 @@
+-- Migration 050: Track who registers a gasto/transaccion de ganado + backfill 2026
+--
+-- Context: fin_gastos.created_by and fin_transacciones_ganado.created_by have
+-- existed since the original schema (both REFERENCE auth.users(id)), but no
+-- app code path (GastoForm, GastosBatchTable, CargaMasivaGastos,
+-- TransaccionGanadoForm, or the crear_gasto_pendiente_de_compra() trigger)
+-- ever populates them. Every row today has created_by = NULL. This blocks a
+-- new "Usuario" filter in the Gastos historial view (Efrain wants to see the
+-- gastos he registers separated from everyone else's).
+--
+-- Fix (mirrors migration 040's set_tarea_created_by() pattern exactly):
+--  1. BEFORE INSERT triggers on fin_gastos and fin_transacciones_ganado that
+--     set created_by := COALESCE(created_by, auth.uid()) — covers manual
+--     inserts, batch/CSV inserts, and the compra-to-gasto auto-trigger.
+--  2. One-time backfill for 2026: a specific list of gastos Efrain confirmed
+--     he registered gets attributed to him; every other still-unattributed
+--     fin_gastos row dated in 2026 is attributed to Consuelo (the only other
+--     person who registers gastos this year). Rows outside 2026, and any
+--     already-attributed row, are left untouched.
+
+-- ============================================================================
+-- PART 1: AUTO-POPULATE created_by GOING FORWARD
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION set_gasto_created_by()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.created_by := COALESCE(NEW.created_by, auth.uid());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_set_gasto_created_by ON fin_gastos;
+CREATE TRIGGER trigger_set_gasto_created_by
+  BEFORE INSERT ON fin_gastos
+  FOR EACH ROW
+  EXECUTE FUNCTION set_gasto_created_by();
+
+CREATE OR REPLACE FUNCTION set_transaccion_ganado_created_by()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.created_by := COALESCE(NEW.created_by, auth.uid());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_set_transaccion_ganado_created_by ON fin_transacciones_ganado;
+CREATE TRIGGER trigger_set_transaccion_ganado_created_by
+  BEFORE INSERT ON fin_transacciones_ganado
+  FOR EACH ROW
+  EXECUTE FUNCTION set_transaccion_ganado_created_by();
+
+-- ============================================================================
+-- PART 2: ONE-TIME BACKFILL FOR 2026
+-- ============================================================================
+-- Efrain (efraforero@gmail.com) identified the specific gastos below as his.
+-- Matched on (fecha, nombre, valor) since no other identifier survives from
+-- how the list was compiled. Verified row-by-row against production before
+-- applying (list_projects/execute_sql via the Supabase MCP): 3 of the 45
+-- entries have two rows sharing the exact same (fecha, nombre, valor) —
+-- pre-existing duplicate data entry, unrelated to this migration — both get
+-- attributed to Efrain since the match is on values, not a unique row id
+-- (expect 48 physical rows updated, not 45). Guarded by created_by IS NULL
+-- so this block is safe to re-run and never overwrites an already-attributed
+-- row.
+
+DO $$
+DECLARE
+  v_efrain_id UUID;
+  v_consuelo_id UUID;
+BEGIN
+  SELECT id INTO v_efrain_id FROM usuarios WHERE email = 'efraforero@gmail.com';
+  SELECT id INTO v_consuelo_id FROM usuarios WHERE email = 'consuelobn57@gmail.com';
+
+  IF v_efrain_id IS NULL THEN
+    RAISE EXCEPTION 'No se encontro usuario con email efraforero@gmail.com; backfill abortado';
+  END IF;
+
+  IF v_consuelo_id IS NULL THEN
+    RAISE EXCEPTION 'No se encontro usuario con email consuelobn57@gmail.com; backfill abortado';
+  END IF;
+
+  -- 2a. Gastos confirmados como registrados por Efrain
+  UPDATE fin_gastos
+  SET created_by = v_efrain_id
+  WHERE created_by IS NULL
+    AND (fecha, nombre, valor) IN (
+      ('2026-03-15', 'gasolina', 579000),
+      ('2026-03-15', 'gasto ganado utica', 1900000),
+      ('2026-03-15', 'viruta', 2100000),
+      ('2026-03-15', 'jabon lavar uniformes', 75000),
+      ('2026-03-15', 'dar vuelta supata', 100000),
+      ('2026-03-15', 'vender ganado supata', 100000),
+      ('2026-03-15', 'azucasr', 158000),
+      ('2026-03-15', 'hewrrero', 1260000),
+      ('2026-03-15', 'Contratos Rodriguez', 1050000),
+      ('2026-03-15', 'luz', 235000),
+      ('2026-03-15', 'ferreteria', 1319000),
+      ('2026-03-15', 'droga novillo', 36000),
+      ('2026-03-15', 'Calra 4 dias', 280000),
+      ('2026-03-15', 'Boston tren y hotel', 7733000),
+      ('2026-03-15', 'Zoe Santa Maria 2 saltos de Zafiro', 5000000),
+      ('2026-03-15', 'Saltos Fenomenal de San Pedro', 5000000),
+      ('2026-02-14', 'Contrato zanjas y roceria', 3000000),
+      ('2026-06-07', 'suero microbiologia', 120000),
+      ('2026-06-07', 'jornales eri apicultura', 210000),
+      ('2026-06-07', 'luz', 204000),
+      ('2026-06-07', 'ferreteria', 613000),
+      ('2026-06-07', 'picar pasto', 230000),
+      ('2026-06-07', 'abono moscas', 270000),
+      ('2026-06-07', 'guadana australia', 2600000),
+      ('2026-06-07', 'despinche braselio', 30000),
+      ('2026-06-07', 'comida ganado', 650000),
+      ('2026-06-07', 'droga supata', 500000),
+      ('2026-06-07', 'jornal erradicacion 6', 450000),
+      ('2026-06-07', 'herrero', 1120000),
+      ('2026-06-07', 'veterinario', 150000),
+      ('2026-06-07', 'cerveza almuerzo', 450000),
+      ('2026-06-07', 'camioneta emiliano', 300000),
+      ('2026-06-07', 'joirnales cosecha 33', 2475000),
+      ('2026-06-07', 'arreglo guadana', 650000),
+      ('2026-06-07', 'asrreglo picapasto', 90000),
+      ('2026-06-07', 'castrada supata', 650000),
+      ('2026-06-07', 'guadana irlanda', 600000),
+      ('2026-06-07', 'herrero', 1200000),
+      ('2026-06-07', 'vieuta', 2100000),
+      ('2026-06-07', 'jornales ', 260000),
+      ('2026-06-07', 'descargar viruta', 215000),
+      ('2026-06-07', 'jornales prado', 260000),
+      ('2026-06-07', 'azucar', 386000),
+      ('2026-06-07', 'contrato zanjas', 900000),
+      ('2026-06-07', 'heno', 2125000)
+    );
+
+  RAISE NOTICE 'Gastos asignados a Efrain: %', (SELECT count(*) FROM fin_gastos WHERE created_by = v_efrain_id);
+
+  -- 2b. Todo lo demas de 2026 que siga sin usuario se asigna a Consuelo
+  UPDATE fin_gastos
+  SET created_by = v_consuelo_id
+  WHERE created_by IS NULL
+    AND fecha >= '2026-01-01'
+    AND fecha <= '2026-12-31';
+
+  RAISE NOTICE 'Gastos asignados a Consuelo: %', (SELECT count(*) FROM fin_gastos WHERE created_by = v_consuelo_id);
+END $$;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -436,3 +436,63 @@ input[type='number'] {
   background-color: var(--sidebar-accent);
   color: var(--primary);
 }
+
+/* Gastos historial — mobile filter collapse.
+   Defined here because src/index.css is a FROZEN pre-compiled Tailwind build
+   that ships no `sm:hidden` / `sm:flex` utilities: writing them in JSX would
+   silently do nothing. Breakpoint matches Tailwind's `sm` (640px). */
+
+/* Toggle button: only reachable on mobile, where the filters are collapsed. */
+.filtros-toggle {
+  display: inline-flex;
+}
+
+/* Second line of a gastos row, mobile only: carries the fecha + categoría that
+   desktop shows in its own column / inline after the name. The desktop halves
+   use `hidden sm:block`, which the frozen build does provide. */
+.gasto-meta-movil {
+  display: block;
+}
+
+/* On mobile the value column leaves the name too little room to read on one
+   line, so let it wrap to two before ellipsing. Desktop keeps `truncate`. */
+@media (max-width: 639px) {
+  .gasto-nombre {
+    white-space: normal;
+    display: -webkit-box;
+    -webkit-line-clamp: 2;
+    line-clamp: 2;
+    -webkit-box-orient: vertical;
+    overflow: hidden;
+  }
+}
+
+/* Filter group: hidden on mobile until toggled open. From `sm` up it becomes
+   `display: contents`, so its children flow into the parent flex row exactly
+   as they did before this wrapper existed — desktop layout is untouched. */
+.filtros-colapsables {
+  display: none;
+}
+
+.filtros-colapsables.abierto {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 0.5rem;
+  width: 100%;
+}
+
+@media (min-width: 640px) {
+  .filtros-toggle {
+    display: none;
+  }
+
+  .gasto-meta-movil {
+    display: none;
+  }
+
+  .filtros-colapsables,
+  .filtros-colapsables.abierto {
+    display: contents;
+  }
+}


### PR DESCRIPTION
Seis cambios al submódulo de Gastos, más la migración que los habilita.

## Cambios

1. **Historial por defecto** — pestaña izquierda y activa al entrar. `?tab=registrar` sigue funcionando.
2. **YTD por defecto** en el filtro de período (antes Mes Actual).
3. **Filtro por Usuario** — con opción "Sin usuario", aplicado a gastos y a ganado.
4. **Selección con checkboxes** — subtotal parcial que respeta todos los filtros activos.
5. **Layout móvil legible** — el nombre ya no se trunca a ~12 caracteres, los detalles dejan de estar ocultos, y los filtros colapsan tras un botón.
6. **Modal de detalle** — abre al tocar la fila, con "Ver factura" y Editar / Eliminar / Completar.

## Migración 050 (ya aplicada a producción)

`fin_gastos.created_by` y `fin_transacciones_ganado.created_by` existían desde el esquema original pero **ningún camino de la app los llenaba**: todas las filas tenían `NULL`, lo que hacía imposible el filtro por usuario.

- Triggers `BEFORE INSERT` con el mismo patrón `COALESCE(created_by, auth.uid())` de la migración 040.
- Backfill 2026: 48 filas a Efrain (la lista que confirmó, emparejada por `fecha`+`nombre`+`valor`), 453 a Consuelo.
- Fuera de 2026 y todo el histórico de ganado quedan en `NULL` — nunca se poblaron, no hay forma de recuperarlo.

## Bug de fondo que esto arregla

El menú `⋮` estaba detrás de `opacity-0 group-hover:opacity-100`. En pantalla táctil no hay hover, así que **desde el celular no se podía editar ni eliminar ningún gasto**. Ahora en móvil el modal es la vía a esas acciones; en desktop el `⋮` se mantiene.

## Verificación

- `typecheck` y `lint` sin errores nuevos (el error de `PurchaseHistory.tsx` es preexistente).
- Layout medido con los estilos computados reales a 375px y 1280px. Desktop renderiza idéntico a antes: el wrapper de filtros usa `display: contents` desde `sm`.
- ⚠️ **No probado dentro de la app corriendo** (requiere login). El flujo real — abrir el modal, editar, eliminar, filtrar por usuario contra datos reales — conviene revisarlo antes de confiar en él.

## Notas

- `src/index.css` es un build de Tailwind congelado. Se confirmó que `sm:hidden`, `sm:flex`, `tabular-nums` y `text-[10px]` **no existen** en él (las dos últimas ya estaban escritas en el código y no hacían nada). Las reglas nuevas van en `globals.css`.
- El comando que CLAUDE.md documentaba para verificar clases daba falsos negativos con variantes (`grep -F 'sm:inline'` nunca matchea `.sm\:inline`). Corregido.
- 3 de los 45 gastos que listó Efrain están **duplicados exactos** en la base (mismo fecha+nombre+valor), por eso son 48 filas. Vale revisarlo aparte.

🤖 Generated with [Claude Code](https://claude.com/claude-code)