### PR TITLE
feat(finanzas): detalle de gastos al hacer clic en la ejecución del presupuesto

### DIFF
--- a/src/components/finanzas/presupuesto/GastosEjecucionDialog.tsx
+++ b/src/components/finanzas/presupuesto/GastosEjecucionDialog.tsx
@@ -1,0 +1,215 @@
+import { useEffect, useState } from 'react';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogDescription,
+  DialogBody,
+} from '@/components/ui/dialog';
+import { getSupabase } from '@/utils/supabase/client';
+import { fetchAll } from '@/utils/supabase/fetchAll';
+import { getQuarterRange } from '@/components/finanzas/hooks/usePresupuestoData';
+import { formatCurrency } from '@/utils/format';
+import { formatearFechaCorta } from '@/utils/fechas';
+import { Loader2 } from 'lucide-react';
+
+/** Fila cruda de `fin_gastos` tal como la devuelve el select de abajo. */
+interface GastoDetalle {
+  id: string;
+  fecha: string;
+  nombre: string | null;
+  valor: number;
+  fin_proveedores: { nombre: string } | null;
+  fin_conceptos_gastos: { nombre: string } | null;
+}
+
+export interface GastosEjecucionTarget {
+  /** Nombre del concepto o de la categoría sobre la que se hizo clic. */
+  titulo: string;
+  /** Categoría a la que pertenece el concepto (solo cuando el target es un concepto). */
+  categoriaNombre?: string;
+  /**
+   * Conceptos que suman la cifra: uno para una fila de concepto, todos los de
+   * la categoría para una fila de categoría.
+   *
+   * Se filtra por concepto y no por `fin_gastos.categoria_id` a propósito: la
+   * tabla agrupa cada concepto bajo la categoría del catálogo, mientras que el
+   * gasto lleva su propia categoría desnormalizada. Si las dos divergen, un
+   * filtro por categoría mostraría un total distinto al de la celda.
+   */
+  conceptoIds: string[];
+}
+
+interface GastosEjecucionDialogProps {
+  target: GastosEjecucionTarget | null;
+  onClose: () => void;
+  negocioId: string;
+  anio: number;
+  quarters: number[];
+}
+
+function formatQuarterLabel(quarters: number[]): string {
+  if (quarters.length === 4) return 'Año completo';
+  return quarters.map((q) => `Q${q}`).join('+');
+}
+
+/**
+ * Lista los gastos que suman la cifra de "Ejecución" de una fila del
+ * presupuesto.
+ *
+ * Replica exactamente el filtro de `aggregateGastos` en `usePresupuestoData`
+ * (negocio + estado Confirmado + rango de cada trimestre seleccionado), para
+ * que el total del diálogo nunca contradiga la celda desde la que se abrió.
+ */
+export function GastosEjecucionDialog({
+  target,
+  onClose,
+  negocioId,
+  anio,
+  quarters,
+}: GastosEjecucionDialogProps) {
+  const [gastos, setGastos] = useState<GastoDetalle[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [error, setError] = useState<string | null>(null);
+  const [truncado, setTruncado] = useState(false);
+
+  const conceptosKey = target?.conceptoIds.join(',') ?? '';
+  const quartersKey = quarters.join(',');
+  const abierto = target !== null;
+  const unSoloConcepto = target?.conceptoIds.length === 1;
+
+  useEffect(() => {
+    if (!abierto) return;
+    // Sin conceptos no hay nada que consultar, pero tampoco puede quedar en
+    // pantalla la lista del target anterior.
+    if (!negocioId || !conceptosKey) {
+      setGastos([]);
+      setLoading(false);
+      return;
+    }
+
+    let cancelado = false;
+    const quartersList = quartersKey.split(',').map(Number);
+    const conceptoIds = conceptosKey.split(',');
+
+    async function cargar() {
+      setLoading(true);
+      setError(null);
+      setTruncado(false);
+
+      try {
+        const supabase = getSupabase();
+
+        // Una consulta por trimestre: los trimestres seleccionados pueden no
+        // ser contiguos (p. ej. Q1 + Q3), así que un único rango de fechas
+        // metería meses que la tabla no está sumando.
+        const resultados = await Promise.all(
+          quartersList.map((q) => {
+            const rango = getQuarterRange(anio, q);
+            return fetchAll<GastoDetalle>(
+              (desde, hasta) =>
+                supabase
+                  .from('fin_gastos')
+                  .select('id, fecha, nombre, valor, fin_proveedores(nombre), fin_conceptos_gastos(nombre)')
+                  .eq('negocio_id', negocioId)
+                  .eq('estado', 'Confirmado')
+                  .in('concepto_id', conceptoIds)
+                  .gte('fecha', rango.desde)
+                  .lte('fecha', rango.hasta)
+                  .order('fecha', { ascending: false })
+                  .range(desde, hasta) as unknown as PromiseLike<{
+                  data: GastoDetalle[] | null;
+                  error: { message: string } | null;
+                }>,
+            );
+          }),
+        );
+
+        if (cancelado) return;
+
+        const filas = resultados.flatMap((r) => r.filas);
+        filas.sort((a, b) => b.fecha.localeCompare(a.fecha));
+        setGastos(filas);
+        setTruncado(resultados.some((r) => r.truncado));
+      } catch (e) {
+        if (!cancelado) setError(e instanceof Error ? e.message : 'Error al cargar los gastos');
+      } finally {
+        if (!cancelado) setLoading(false);
+      }
+    }
+
+    cargar();
+    return () => {
+      cancelado = true;
+    };
+  }, [abierto, negocioId, anio, quartersKey, conceptosKey]);
+
+  const total = gastos.reduce((s, g) => s + Number(g.valor), 0);
+  // En vista de categoría el concepto es lo que distingue una fila de otra.
+  const mostrarConcepto = !unSoloConcepto;
+
+  return (
+    <Dialog open={abierto} onOpenChange={(v) => !v && onClose()}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <DialogTitle>{target?.titulo ?? ''}</DialogTitle>
+          <DialogDescription>
+            {target?.categoriaNombre ? `${target.categoriaNombre} · ` : ''}
+            Gastos confirmados {formatQuarterLabel(quarters)} {anio}
+          </DialogDescription>
+        </DialogHeader>
+
+        <DialogBody>
+          {loading ? (
+            <div className="flex items-center justify-center py-8 text-gray-500">
+              <Loader2 className="w-4 h-4 animate-spin" />
+              <span className="ml-2 text-sm">Cargando gastos...</span>
+            </div>
+          ) : error ? (
+            <div className="py-8 text-center text-sm text-red-600">{error}</div>
+          ) : gastos.length === 0 ? (
+            <div className="py-8 text-center text-sm text-gray-400">
+              No hay gastos confirmados en este período
+            </div>
+          ) : (
+            <div className="divide-y divide-gray-100">
+              {gastos.map((g) => (
+                <div key={g.id} className="flex items-start justify-between gap-3 py-2">
+                  <div className="min-w-0">
+                    <div className="text-sm text-foreground truncate">
+                      {g.nombre || 'Sin descripción'}
+                    </div>
+                    <div className="text-xs text-gray-500 truncate">
+                      {formatearFechaCorta(g.fecha)}
+                      {mostrarConcepto && g.fin_conceptos_gastos?.nombre
+                        ? ` · ${g.fin_conceptos_gastos.nombre}`
+                        : ''}
+                      {g.fin_proveedores?.nombre ? ` · ${g.fin_proveedores.nombre}` : ''}
+                    </div>
+                  </div>
+                  <div className="celda-num text-sm font-medium text-foreground shrink-0">
+                    {formatCurrency(Number(g.valor))}
+                  </div>
+                </div>
+              ))}
+            </div>
+          )}
+
+          {truncado && (
+            <p className="mt-3 text-xs text-amber-600">
+              Se alcanzó el límite de páginas: puede que falten gastos por mostrar.
+            </p>
+          )}
+        </DialogBody>
+
+        <div className="flex flex-shrink-0 items-center justify-between gap-3 border-t pt-3 text-sm">
+          <span className="text-gray-500">
+            {gastos.length} {gastos.length === 1 ? 'gasto' : 'gastos'}
+          </span>
+          <span className="celda-num font-semibold text-foreground">{formatCurrency(total)}</span>
+        </div>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/finanzas/presupuesto/PresupuestoCategoriaRow.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoCategoriaRow.tsx
@@ -9,9 +9,10 @@ interface PresupuestoCategoriaRowProps {
   expanded: boolean;
   onToggle: () => void;
   showPct: boolean;
+  onVerGastos: () => void;
 }
 
-export function PresupuestoCategoriaRow({ categoria, expanded, onToggle, showPct }: PresupuestoCategoriaRowProps) {
+export function PresupuestoCategoriaRow({ categoria, expanded, onToggle, showPct, onVerGastos }: PresupuestoCategoriaRowProps) {
   const exec = categoria.ejecucion_vs_q;
   const bgColor =
     exec === null
@@ -43,8 +44,24 @@ export function PresupuestoCategoriaRow({ categoria, expanded, onToggle, showPct
         </div>
       </td>
 
-      {/* Actual Q */}
-      <td className="px-3 py-2.5 text-center tabular-nums">{fmt(categoria.actual_q)}</td>
+      {/* Actual Q — abre el detalle de gastos; el clic no debe plegar la fila */}
+      <td className="px-3 py-2.5 text-center tabular-nums">
+        {categoria.actual_q > 0 ? (
+          <button
+            type="button"
+            onClick={(e) => {
+              e.stopPropagation();
+              onVerGastos();
+            }}
+            className="cursor-pointer hover:underline"
+            title="Ver gastos"
+          >
+            {fmt(categoria.actual_q)}
+          </button>
+        ) : (
+          fmt(categoria.actual_q)
+        )}
+      </td>
 
       {/* Act % */}
       {showPct && <td className="px-2 py-2.5 text-center text-gray-500 tabular-nums">{categoria.pct_actual > 0 ? Math.round(categoria.pct_actual) + '%' : ''}</td>}

--- a/src/components/finanzas/presupuesto/PresupuestoConceptoRow.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoConceptoRow.tsx
@@ -8,9 +8,10 @@ interface PresupuestoConceptoRowProps {
   showPct: boolean;
   editable: boolean;
   onBudgetChange: (conceptoId: string, categoriaId: string, newAmount: number) => void;
+  onVerGastos: () => void;
 }
 
-export function PresupuestoConceptoRow({ row, showPct, editable, onBudgetChange }: PresupuestoConceptoRowProps) {
+export function PresupuestoConceptoRow({ row, showPct, editable, onBudgetChange, onVerGastos }: PresupuestoConceptoRowProps) {
   const [editing, setEditing] = useState(false);
   const [editValue, setEditValue] = useState('');
   const inputRef = useRef<HTMLInputElement>(null);
@@ -50,8 +51,21 @@ export function PresupuestoConceptoRow({ row, showPct, editable, onBudgetChange 
         </span>
       </td>
 
-      {/* Actual Q */}
-      <td className="px-3 py-1.5 text-center tabular-nums">{fmt(row.actual_q)}</td>
+      {/* Actual Q — abre el detalle de gastos que suman esta cifra */}
+      <td className="px-3 py-1.5 text-center tabular-nums">
+        {row.actual_q > 0 ? (
+          <button
+            type="button"
+            onClick={onVerGastos}
+            className="cursor-pointer hover:underline"
+            title="Ver gastos"
+          >
+            {fmt(row.actual_q)}
+          </button>
+        ) : (
+          fmt(row.actual_q)
+        )}
+      </td>
 
       {/* Act % (toggleable) */}
       {showPct && <td className="px-2 py-1.5 text-center text-gray-400 tabular-nums">{row.pct_actual > 0 ? Math.round(row.pct_actual) + '%' : ''}</td>}

--- a/src/components/finanzas/presupuesto/PresupuestoTable.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoTable.tsx
@@ -1,8 +1,8 @@
 import { useState } from 'react';
 import { formatCompact } from '@/utils/format';
-import { EjecucionBadge, VariacionBadge } from './EjecucionBadge';
 import { PresupuestoCategoriaRow } from './PresupuestoCategoriaRow';
 import { PresupuestoConceptoRow } from './PresupuestoConceptoRow';
+import { GastosEjecucionDialog, type GastosEjecucionTarget } from './GastosEjecucionDialog';
 import type { PresupuestoData } from '@/types/finanzas';
 
 function formatQuarterLabel(quarters: number[]): string {
@@ -16,12 +16,14 @@ interface PresupuestoTableProps {
   showPct: boolean;
   anio: number;
   quarters: number[];
+  negocioId: string;
   modoPresupuesto: boolean;
   onBudgetChange: (conceptoId: string, categoriaId: string, newAmount: number) => void;
 }
 
-export function PresupuestoTable({ data, showPct, anio, quarters, modoPresupuesto, onBudgetChange }: PresupuestoTableProps) {
+export function PresupuestoTable({ data, showPct, anio, quarters, negocioId, modoPresupuesto, onBudgetChange }: PresupuestoTableProps) {
   const [expanded, setExpanded] = useState<Set<string>>(new Set());
+  const [detalleTarget, setDetalleTarget] = useState<GastosEjecucionTarget | null>(null);
 
   const toggleCategory = (catId: string) => {
     setExpanded((prev) => {
@@ -35,10 +37,8 @@ export function PresupuestoTable({ data, showPct, anio, quarters, modoPresupuest
   const fmt = (v: number) => (v > 0 ? '$' + formatCompact(v) : '');
   const t = data.totals;
 
-  // Column count varies with showPct toggle
-  const extraCols = showPct ? 3 : 0; // Act%, Ppto%, EjecAño
-
   return (
+    <>
     <div className="bg-white rounded-lg border border-gray-200 overflow-x-auto">
       <table className="w-full table-fixed text-left">
         {/* Column widths: concepto gets remaining space, numerics are fixed */}
@@ -117,12 +117,22 @@ export function PresupuestoTable({ data, showPct, anio, quarters, modoPresupuest
                 showPct={showPct}
                 modoPresupuesto={modoPresupuesto}
                 onBudgetChange={onBudgetChange}
+                onVerGastos={setDetalleTarget}
               />
             );
           })}
         </tbody>
       </table>
     </div>
+
+    <GastosEjecucionDialog
+      target={detalleTarget}
+      onClose={() => setDetalleTarget(null)}
+      negocioId={negocioId}
+      anio={anio}
+      quarters={quarters}
+    />
+    </>
   );
 }
 
@@ -133,6 +143,7 @@ function PresupuestoCategoryGroup({
   showPct,
   modoPresupuesto,
   onBudgetChange,
+  onVerGastos,
 }: {
   categoria: PresupuestoData['categorias'][0];
   expanded: boolean;
@@ -140,6 +151,7 @@ function PresupuestoCategoryGroup({
   showPct: boolean;
   modoPresupuesto: boolean;
   onBudgetChange: (conceptoId: string, categoriaId: string, newAmount: number) => void;
+  onVerGastos: (target: GastosEjecucionTarget) => void;
 }) {
   const visibleConceptos = modoPresupuesto
     ? categoria.conceptos
@@ -152,6 +164,12 @@ function PresupuestoCategoryGroup({
         expanded={expanded}
         onToggle={onToggle}
         showPct={showPct}
+        onVerGastos={() =>
+          onVerGastos({
+            titulo: categoria.categoria_nombre,
+            conceptoIds: categoria.conceptos.map((c) => c.concepto_id),
+          })
+        }
       />
       {expanded &&
         visibleConceptos.map((row) => (
@@ -161,6 +179,13 @@ function PresupuestoCategoryGroup({
             showPct={showPct}
             editable={modoPresupuesto}
             onBudgetChange={onBudgetChange}
+            onVerGastos={() =>
+              onVerGastos({
+                titulo: row.concepto_nombre,
+                categoriaNombre: row.categoria_nombre,
+                conceptoIds: [row.concepto_id],
+              })
+            }
           />
         ))}
     </>

--- a/src/components/finanzas/presupuesto/PresupuestoView.tsx
+++ b/src/components/finanzas/presupuesto/PresupuestoView.tsx
@@ -133,12 +133,13 @@ export function PresupuestoView() {
             <Loader2 className="w-6 h-6 animate-spin text-primary" />
             <span className="ml-2 text-sm text-gray-500">Cargando presupuesto...</span>
           </div>
-        ) : data ? (
+        ) : data && negocioId ? (
           <PresupuestoTable
             data={data}
             showPct={showPct}
             anio={anio}
             quarters={quarters}
+            negocioId={negocioId}
             modoPresupuesto={modoPresupuesto}
             onBudgetChange={handleBudgetChange}
           />


### PR DESCRIPTION
## Qué cambia

En `/finanzas/presupuesto`, cada cifra de la columna **Ejecución** ahora es clicable y abre un diálogo con los gastos individuales que la componen: descripción, fecha, proveedor y valor, con el conteo y el total al pie. Funciona tanto en la fila de categoría como en la de concepto.

## Por qué

La tabla mostraba la ejecución como una cifra agregada sin forma de auditarla. Para saber qué había dentro de los $157.4M de "Alimentos y Fertilizantes" tocaba salirse a `/finanzas/gastos` y reconstruir los filtros a mano.

## Decisiones que un reviewer debería revisar

**El filtro es por `concepto_id`, nunca por `fin_gastos.categoria_id`.** La tabla agrupa cada concepto bajo la categoría del *catálogo*, mientras que el gasto lleva su propia `categoria_id` desnormalizada. Si las dos divergen, un filtro por categoría mostraría un total distinto al de la celda desde la que se abrió el diálogo — que es justo lo que esta feature promete no hacer. Para una categoría se filtra por los `concepto_id` de sus conceptos.

**Una consulta por trimestre**, replicando `aggregateGastos` en `usePresupuestoData`. Los trimestres seleccionados pueden no ser contiguos (Q1+Q3), y un único rango de fechas metería meses que la tabla no está sumando.

**Las consultas pasan por `fetchAll`** — PostgREST corta en 1.000 filas en silencio.

**La fila "Suma Total" no es clicable, a propósito.** Sin filtro de concepto incluiría gastos cuyo concepto está inactivo o ausente del catálogo (que `buildPresupuestoData` descarta), así que mostraría *más* que la fila desde la que se abre. Un `.in()` con ~150 UUIDs además generaría una URL de ~6KB.

**`stopPropagation` en la cifra de categoría**, para que ver el detalle no pliegue la fila.

## Limpieza incluida

Se elimina código muerto preexistente en `PresupuestoTable`: los imports de `EjecucionBadge`/`VariacionBadge` y la variable `extraCols`, sin uso. Con esto `npx eslint src/components/finanzas/presupuesto/` queda limpio.

## Verificación

`npm run typecheck`, `npm run build` y la suite completa (663 tests, incluido `dialogScrollContract`) pasan.

Probado en la app contra datos reales de 2026:

| Caso | Resultado |
|---|---|
| Categoría *Alimentos y Fertilizantes*, Q1+Q2+Q3 | 38 gastos, **$157.387.860** = celda $157.4M |
| Concepto *Abonos y fertilizantes* | 32 gastos, **$156.389.660** = celda $156.4M |
| Categoría *Control de Plagas*, solo Q3 | **1 gasto**, $429.257 = celda $429.3K |

Los dos niveles cuadran entre sí: 156.389.660 + 544.000 + 385.400 + 68.800 = **157.387.860**, el total de la categoría.

También verificado: el clic en la cifra no pliega la categoría; el cuerpo del diálogo hace scroll con encabezado y pie fijos; las fechas ordenan de más reciente a más antigua; el nombre del concepto se omite en las filas cuando ya se está dentro de un solo concepto; el encabezado dice "Q3 2026" cuando hay un solo trimestre.

Sobre responsive: el panel de preview no emula fielmente un viewport móvil, así que se verificó midiendo el DOM — forzando el diálogo a 343px (equivalente a un teléfono de 375px) no hay desbordamiento horizontal y las 32 filas caben. El diálogo usa `DialogContent size="lg"` estándar, sin anchos propios.

## Nota aparte

Al abrir cualquier diálogo aparece un warning de React sobre refs en `DialogOverlay` (`src/components/ui/dialog.tsx:76`). Es preexistente y afecta a toda la app, no a este cambio; arreglarlo implica tocar el componente compartido, así que queda fuera de este PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)