### PR TITLE
feat(finanzas): port the gastos historial rework to ingresos

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -155,7 +155,7 @@ These are consumed in `src/utils/supabase/client.ts` via `import.meta.env`. The 
 │   │   └── validation.ts               # Data validation utilities
 │   │
 │   ├── sql/                             # SQL scripts & migrations
-│   │   ├── migrations/                  # Sequential numbered migrations (001–050)
+│   │   ├── migrations/                  # Sequential numbered migrations (001–063)
 │   │   └── *.sql                        # Standalone SQL scripts
 │   │
 │   ├── styles/
@@ -360,7 +360,7 @@ The applications module has two distinct tracking layers — **do not confuse th
 
 ### Migrations
 
-Sequential SQL migrations live in `src/sql/migrations/` (001–050). See `src/sql/migrations/README_MIGRATION.md` for instructions on running them.
+Sequential SQL migrations live in `src/sql/migrations/` (001–063). See `src/sql/migrations/README_MIGRATION.md` for instructions on running them.
 
 - **023**: `create_fin_transacciones_ganado` — cattle buy/sell transactions table with RLS
 - **024**: `alter_fin_ingresos_add_columns` — adds `cantidad`, `precio_unitario`, `cosecha`, `alianza`, `cliente`, `finca` to `fin_ingresos`
@@ -394,6 +394,7 @@ Sequential SQL migrations live in `src/sql/migrations/` (001–050). See `src/sq
   - **060**: `hato_alertas_cron` — pg_cron `'45 10 * * *'` (05:45 Bogotá) → `net.http_post` to `/make-server-1ccce916/hato/alertas/tick`, secret read from Supabase Vault (`vault.decrypted_secrets`, never committed). Endpoint ships in S6 — until then a daily benign 404, no data mutated.
 - **061**: `hato_pesajes_litros_total` — corrects 054. `litros_total` was `GENERATED ALWAYS AS (COALESCE(litros_am,0)+COALESCE(litros_pm,0))`, but the farm records **one figure per cow per weighing day (am+pm already summed)** — no per-milking split exists, historically or going forward. The generated column forced a choice between two lies: put the total in `litros_am`, or leave both NULL and store `litros_total = 0` — and a stored 0 is indistinguishable from "this cow gave 0 litres", which is exactly what Épica D forbids. Uses `ALTER COLUMN … DROP EXPRESSION` (PG 14+; prod runs 17) to convert in place, then `SET NOT NULL` + `CHECK >= 0`. `litros_am`/`litros_pm` survive as optional detail that no longer feeds the total. Applied to production 2026-07-22 (table verified empty first).
 - **062**: `hato_chequeo_estado_normalizado` — `hato_chequeo_vacas` stored `estado_raw` with **no normalized counterpart**, unlike every other column in that table, so `parseEstado()` had nowhere to land. Adds `estado TEXT` (`vacia_apta` | `vacia_problema` | `fecha_heredada` | `desconocido`; NULL = empty cell, never defaulted to "apta") and exposes it in `v_hato_estado_actual` as `ultimo_estado_chequeo` (appended **last** — `CREATE OR REPLACE VIEW` cannot reorder or insert columns). Also seeds a 10th `hato_config` key, `dias_espera_voluntaria_post_parto` (**provisional 60, unconfirmed by the owner**): the engine was borrowing `dias_servicio_sin_confirmacion` as a proxy, which coupled two different concepts — one counts from the *service*, the other from the *parto* — so changing one silently moved the other. Applied to production 2026-07-22.
+- **063**: `ingresos_created_by_tracking` — the 050 fix, applied to `fin_ingresos`. The `created_by` column has existed since the original schema but no write path ever populated it, which blocked the Usuario filter in the Ingresos historial. Adds `set_ingreso_created_by()` + BEFORE INSERT trigger (same `COALESCE(created_by, auth.uid())` pattern as 050/040) and backfills **every** NULL row to Santiago. The unconditional backfill deliberately departs from 050, which left pre-2026 gastos NULL because their author was genuinely unrecoverable; here the author of the whole history is known. `fin_transacciones_ganado` is untouched — 050 already covers it, so ganado ventas need nothing. **Not yet applied to production.** The backfill targets `sforero94@gmail.com` — Santiago's account in `usuarios`, not the `santiago@thinksid.co` address the repo is worked from; the DO block aborts loudly if the lookup misses. Known gap, identical to gastos post-050: the Telegram bot inserts via the service role where `auth.uid()` is NULL, so bot-created rows still land as "Sin usuario".
 
 ### Hato Lechero Module (`/hato-lechero`, plan `docs/plan_hato_lechero_module.md`)
 
@@ -474,6 +475,20 @@ Two reports × four views (Global, Aguacate Hass, Ganado, Hato Lechero). Global 
 - **Selection subtotal** — per-row checkboxes plus "seleccionar todos"; the subtotal is computed over `unifiedItems`, so it always reflects the active filters. Selection resets whenever filters or the search query change.
 - **Detail dialog** (`GastoDetalleDialog.tsx`) — opens on row click for gasto and ganado items alike, and carries Editar / Eliminar / Completar. The row's `onClick` is suppressed on the checkbox and the `⋮` wrapper via `stopPropagation`.
 - **Mobile** — the `⋮` menu is `hidden sm:block` **on purpose**: it is gated on `group-hover`, which never fires on touch, so on mobile the detail dialog is the only path to the actions. Do not re-enable it on mobile without also removing the hover gate. The two-line mobile row and the collapsible filter bar rely on the custom `globals.css` classes listed in the frozen-Tailwind caution zone below.
+- **The list container must not carry `overflow-hidden`.** The `⋮` menu is absolutely positioned and opens downward, so clipping the container hid the actions on the last rows entirely — on desktop that menu is the only path to them besides the dialog. Corner rounding is handled instead by `.lista-financiera` (`globals.css`), which rounds the first and last row. Note its radius is `calc(var(--radius) + 4px)`, not Tailwind's stock `0.75rem`: **this build redefines `rounded-xl`** (`--radius` is `1rem`, so the real radius is 20px). Anything matching that container's corners must use the same expression.
+- Row hover was written `hover:bg-gray-50/50` and did **nothing** — the frozen build ships `.hover\:bg-gray-50` but no opacity-modified variant. Corrected to `hover:bg-gray-50`, which matters now that the whole row is clickable and needs the affordance. A live row background is also what makes the `.lista-financiera` rounding load-bearing rather than decorative.
+
+### Ingresos historial (`/finanzas/ingresos`) — view contract
+
+Mirrors the Gastos contract above (Historial default + leftmost, `?tab=registrar` deep-link, `ytd` default repeated in the same three places, Usuario filter, selection subtotal, row-click detail dialog, collapsible mobile filters, no `overflow-hidden` on the list container). It reuses the same `globals.css` classes — `.filtros-toggle`, `.filtros-colapsables`, `.gasto-nombre`, `.gasto-meta-movil`, `.lista-financiera`. The `gasto-` prefix is historical: **the rules are module-agnostic and shared with Ingresos on purpose** — renaming them means touching both lists.
+
+Where it deliberately differs from Gastos, because `fin_ingresos` has no such column:
+
+- **No `estado`** — no Confirmado/Pendiente filter, no estado icon, no "N pendientes" counter, and no Completar action. `IngresoDetalleDialog` therefore has no `onCompletar` prop, unlike its gastos twin.
+- **No `concepto`** — the categoría filter has no cascade; instead it is **scoped by negocio** (`categoriasFiltradas`), and selecting a negocio clears `categoria_id`. Gastos does neither.
+- **Extra ingreso-only fields** surfaced in the detail dialog: `cantidad`, `precio_unitario`, `cosecha`, `alianza`, `cliente`, `finca` (migration 024 columns that had no UI until now).
+- **Usuario filter** — `created_by` on `fin_ingresos` is populated by migration **063**, not 050; the `fin_transacciones_ganado` half was already covered by 050.
+Everything else is intentionally identical to Gastos — the two lists should stay in sync.
 
 ### Cattle Inventory Module (`/ganado`, issue #51)
 

--- a/src/components/finanzas/IngresosView.tsx
+++ b/src/components/finanzas/IngresosView.tsx
@@ -1,4 +1,5 @@
 import { useState } from 'react';
+import { useSearchParams } from 'react-router-dom';
 import { IngresosList } from './components/IngresosList';
 import { IngresoForm } from './components/IngresoForm';
 import { IngresosBatchTable } from './components/IngresosBatchTable';
@@ -10,8 +11,15 @@ import { Tabs, TabsContent, TabsList, TabsTrigger } from '../ui/tabs';
 import { Plus, FileSpreadsheet, ClipboardList, History } from 'lucide-react';
 import { toast } from 'sonner';
 
+// Debe coincidir con los `value` de los TabsTrigger definidos más abajo
+const TABS_VALIDOS = ['registrar', 'historial'];
+
 export function IngresosView() {
-  const [activeTab, setActiveTab] = useState('registrar');
+  const [searchParams] = useSearchParams();
+  const tabInicial = TABS_VALIDOS.includes(searchParams.get('tab') || '')
+    ? (searchParams.get('tab') as string)
+    : 'historial';
+  const [activeTab, setActiveTab] = useState(tabInicial);
   const [showForm, setShowForm] = useState(false);
   const [showCargaMasiva, setShowCargaMasiva] = useState(false);
   const [editingIngreso, setEditingIngreso] = useState<any>(null);
@@ -56,15 +64,19 @@ export function IngresosView() {
 
       <Tabs value={activeTab} onValueChange={setActiveTab} activationMode="manual" className="w-full">
         <TabsList className="grid w-full grid-cols-2">
-          <TabsTrigger value="registrar" className="flex items-center gap-2">
-            <ClipboardList className="w-4 h-4" />
-            Registrar
-          </TabsTrigger>
           <TabsTrigger value="historial" className="flex items-center gap-2">
             <History className="w-4 h-4" />
             Historial
           </TabsTrigger>
+          <TabsTrigger value="registrar" className="flex items-center gap-2">
+            <ClipboardList className="w-4 h-4" />
+            Registrar
+          </TabsTrigger>
         </TabsList>
+
+        <TabsContent value="historial" className="mt-6">
+          <IngresosList key={refreshKey} onEdit={handleEditIngreso} />
+        </TabsContent>
 
         <TabsContent value="registrar" className="mt-6 space-y-6">
           <div className="flex flex-wrap gap-3">
@@ -94,10 +106,6 @@ export function IngresosView() {
           </div>
 
           <IngresosBatchTable catalogs={catalogs} onSaved={handleBatchSaved} />
-        </TabsContent>
-
-        <TabsContent value="historial" className="mt-6">
-          <IngresosList key={refreshKey} onEdit={handleEditIngreso} />
         </TabsContent>
       </Tabs>
 

--- a/src/components/finanzas/components/GastosList.tsx
+++ b/src/components/finanzas/components/GastosList.tsx
@@ -456,8 +456,12 @@ export function GastosList({ onEdit }: GastosListProps) {
         )}
       </div>
 
-      {/* Compact expense list */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      {/* Compact expense list.
+          Sin `overflow-hidden`: el menú `⋮` es absolute y se abre hacia abajo, así que
+          el contenedor lo recortaba en las últimas filas (acciones inalcanzables en
+          desktop). Las esquinas las redondea ahora la primera/última fila via
+          `.lista-financiera`, que es para lo que servía el overflow. */}
+      <div className="bg-white rounded-xl border border-gray-200">
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
             <Loader2 className="w-6 h-6 text-primary animate-spin" />
@@ -469,14 +473,14 @@ export function GastosList({ onEdit }: GastosListProps) {
             </p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-100">
+          <div className="lista-financiera divide-y divide-gray-100">
             {unifiedItems.map((item) => {
               const itemKey = `${item.source}-${item.id}`;
               return (
               <div
                 key={itemKey}
                 onClick={() => setDetalleItem(item)}
-                className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50/50 transition-colors group cursor-pointer"
+                className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition-colors group cursor-pointer"
               >
                 <span onClick={(e) => e.stopPropagation()} className="flex-shrink-0 flex items-center">
                   <Checkbox

--- a/src/components/finanzas/components/IngresoDetalleDialog.tsx
+++ b/src/components/finanzas/components/IngresoDetalleDialog.tsx
@@ -1,0 +1,183 @@
+import { useState } from 'react';
+import { Edit2, Trash2, FileText, Loader2 } from 'lucide-react';
+import { getSupabase } from '@/utils/supabase/client';
+import { formatNumber } from '@/utils/format';
+import { formatearFechaLarga } from '@/utils/fechas';
+import { Button } from '@/components/ui/button';
+import {
+  Dialog,
+  DialogContent,
+  DialogHeader,
+  DialogTitle,
+  DialogBody,
+  DialogFooter,
+} from '@/components/ui/dialog';
+import type { Ingreso, TransaccionGanado, UnifiedFinanceItem } from '@/types/finanzas';
+import { toast } from 'sonner';
+
+interface IngresoDetalleDialogProps {
+  item: UnifiedFinanceItem | null;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
+  /** Resuelve created_by → nombre del usuario que registró el ingreso. */
+  nombreUsuario?: string;
+  onEdit: () => void;
+  onEliminar: () => void;
+}
+
+/** Una fila etiqueta/valor. Se omite por completo cuando no hay dato. */
+function Campo({ label, value }: { label: string; value?: string | null }) {
+  if (!value) return null;
+  return (
+    <div>
+      <p className="text-xs text-gray-400 uppercase tracking-wide">{label}</p>
+      <p className="text-sm text-gray-900 mt-1">{value}</p>
+    </div>
+  );
+}
+
+export function IngresoDetalleDialog({
+  item,
+  open,
+  onOpenChange,
+  nombreUsuario,
+  onEdit,
+  onEliminar,
+}: IngresoDetalleDialogProps) {
+  const [abriendoFactura, setAbriendoFactura] = useState(false);
+
+  if (!item) return null;
+
+  const esGanado = item.source === 'ganado';
+  const ingreso = !esGanado ? (item.raw as Ingreso) : null;
+  const ganado = esGanado ? (item.raw as TransaccionGanado) : null;
+  // El query de IngresosList trae los catálogos como joins anidados (fin_negocios, etc.),
+  // que no están declarados en el tipo Ingreso.
+  const relaciones = (item.raw ?? {}) as unknown as Record<string, { nombre?: string } | undefined>;
+  const urlFactura = ingreso?.url_factura;
+
+  const verFactura = async () => {
+    if (!urlFactura) return;
+    try {
+      setAbriendoFactura(true);
+      const { data, error } = await getSupabase()
+        .storage
+        .from('facturas')
+        .createSignedUrl(urlFactura, 60 * 60);
+      if (error || !data?.signedUrl) throw error ?? new Error('No se pudo generar el enlace');
+      window.open(data.signedUrl, '_blank');
+    } catch {
+      toast.error('No se pudo abrir la factura');
+    } finally {
+      setAbriendoFactura(false);
+    }
+  };
+
+  return (
+    <Dialog open={open} onOpenChange={onOpenChange}>
+      <DialogContent size="md">
+        <DialogHeader>
+          <DialogTitle className="text-base">{item.nombre}</DialogTitle>
+        </DialogHeader>
+
+        <DialogBody>
+          {/* Valor + badge */}
+          <div className="flex items-center justify-between gap-3 pb-4 border-b border-gray-100">
+            <div>
+              <p className="text-xs text-gray-400 uppercase tracking-wide">Valor</p>
+              <p className="text-2xl font-bold text-green-700 mt-1">${formatNumber(item.valor)}</p>
+            </div>
+            {esGanado && (
+              <span className="px-2 py-1 text-xs font-semibold rounded-lg bg-amber-100 text-amber-700">
+                Ganado
+              </span>
+            )}
+          </div>
+
+          {/* Campos */}
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 py-4">
+            <Campo label="Fecha" value={formatearFechaLarga(item.fecha)} />
+
+            {esGanado ? (
+              <>
+                <Campo label="Finca" value={ganado?.finca} />
+                <Campo label="Cliente" value={ganado?.cliente_proveedor} />
+                <Campo
+                  label="Cabezas"
+                  value={ganado?.cantidad_cabezas ? formatNumber(ganado.cantidad_cabezas) : null}
+                />
+                <Campo
+                  label="Kilos pagados"
+                  value={ganado?.kilos_pagados ? `${formatNumber(ganado.kilos_pagados)} kg` : null}
+                />
+                <Campo
+                  label="Precio por kilo"
+                  value={ganado?.precio_kilo ? `$${formatNumber(ganado.precio_kilo)}` : null}
+                />
+              </>
+            ) : (
+              <>
+                <Campo label="Negocio" value={relaciones.fin_negocios?.nombre} />
+                <Campo label="Región" value={relaciones.fin_regiones?.nombre} />
+                <Campo label="Categoría" value={relaciones.fin_categorias_ingresos?.nombre} />
+                <Campo label="Comprador" value={relaciones.fin_compradores?.nombre} />
+                <Campo label="Medio de pago" value={relaciones.fin_medios_pago?.nombre} />
+                <Campo
+                  label="Cantidad"
+                  value={ingreso?.cantidad != null ? formatNumber(ingreso.cantidad) : null}
+                />
+                <Campo
+                  label="Precio unitario"
+                  value={ingreso?.precio_unitario != null ? `$${formatNumber(ingreso.precio_unitario)}` : null}
+                />
+                <Campo label="Cosecha" value={ingreso?.cosecha} />
+                <Campo label="Alianza" value={ingreso?.alianza} />
+                <Campo label="Cliente" value={ingreso?.cliente} />
+                <Campo label="Finca" value={ingreso?.finca} />
+              </>
+            )}
+
+            <Campo label="Registrado por" value={nombreUsuario || 'Sin usuario'} />
+          </div>
+
+          {(item.raw as Ingreso | TransaccionGanado)?.observaciones && (
+            <div className="pt-4 border-t border-gray-100">
+              <p className="text-xs text-gray-400 uppercase tracking-wide">Observaciones</p>
+              <p className="text-sm text-gray-900 mt-1">
+                {(item.raw as Ingreso | TransaccionGanado).observaciones}
+              </p>
+            </div>
+          )}
+
+          {urlFactura && (
+            <div className="pt-4 border-t border-gray-100">
+              <Button variant="outline" size="sm" onClick={verFactura} disabled={abriendoFactura}>
+                {abriendoFactura ? (
+                  <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+                ) : (
+                  <FileText className="w-4 h-4 mr-2" />
+                )}
+                Ver factura
+              </Button>
+            </div>
+          )}
+        </DialogBody>
+
+        <DialogFooter>
+          <Button
+            variant="outline"
+            onClick={onEliminar}
+            className="border-red-200 text-red-600 hover:bg-red-50"
+          >
+            <Trash2 className="w-4 h-4 mr-2" />
+            Eliminar
+          </Button>
+          <Button onClick={onEdit}>
+            <Edit2 className="w-4 h-4 mr-2" />
+            Editar
+          </Button>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
+  );
+}

--- a/src/components/finanzas/components/IngresosList.tsx
+++ b/src/components/finanzas/components/IngresosList.tsx
@@ -7,11 +7,14 @@ import {
   Trash2,
   Loader2,
   X,
+  Filter,
 } from 'lucide-react';
 import { getSupabase } from '@/utils/supabase/client';
 import { formatNumber } from '@/utils/format';
 import { formatearFechaCorta, calcularRangoFechasPorPeriodo } from '@/utils/fechas';
 import { Input } from '@/components/ui/input';
+import { Checkbox } from '@/components/ui/checkbox';
+import { IngresoDetalleDialog } from './IngresoDetalleDialog';
 import type { Ingreso, Negocio, Region, CategoriaIngreso, TransaccionGanado, UnifiedFinanceItem } from '@/types/finanzas';
 import { toast } from 'sonner';
 import { ConfirmDialog } from '@/components/ui/confirm-dialog';
@@ -26,9 +29,17 @@ interface FiltrosState {
   negocio_id: string;
   region_id: string;
   categoria_id: string;
+  usuario_id: string;
   fecha_desde: string;
   fecha_hasta: string;
 }
+
+interface UsuarioOption {
+  id: string;
+  nombre_completo: string;
+}
+
+const SIN_USUARIO = '__sin_usuario__';
 
 const selectClass = 'px-2 py-1.5 text-sm border border-gray-200 rounded-xl bg-white focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary min-w-0';
 
@@ -42,10 +53,11 @@ export function IngresosList({ onEdit }: IngresosListProps) {
   const [filtros, setFiltros] = useState<FiltrosState>(() => {
     const state = location.state as any;
     return {
-      periodo: state?.periodo || 'mes_actual',
+      periodo: state?.periodo || 'ytd',
       negocio_id: state?.negocio_id || '',
       region_id: state?.region_id || '',
       categoria_id: state?.categoria || '',
+      usuario_id: '',
       fecha_desde: state?.fecha_desde || '',
       fecha_hasta: state?.fecha_hasta || '',
     };
@@ -56,11 +68,15 @@ export function IngresosList({ onEdit }: IngresosListProps) {
   const [deleteTargetId, setDeleteTargetId] = useState<string | null>(null);
   const [deleteTargetSource, setDeleteTargetSource] = useState<'ingreso' | 'ganado'>('ingreso');
   const [editingGanado, setEditingGanado] = useState<TransaccionGanado | null>(null);
+  const [seleccionados, setSeleccionados] = useState<Set<string>>(new Set());
+  const [detalleItem, setDetalleItem] = useState<UnifiedFinanceItem | null>(null);
+  const [filtrosAbiertos, setFiltrosAbiertos] = useState(false);
 
   // Catalogs
   const [negocios, setNegocios] = useState<Negocio[]>([]);
   const [regiones, setRegiones] = useState<Region[]>([]);
   const [categorias, setCategorias] = useState<CategoriaIngreso[]>([]);
+  const [usuarios, setUsuarios] = useState<UsuarioOption[]>([]);
 
   const aplicadoKey = useRef<string | null>(location.key);
 
@@ -71,10 +87,12 @@ export function IngresosList({ onEdit }: IngresosListProps) {
       supabase.from('fin_negocios').select('*').eq('activo', true).order('nombre'),
       supabase.from('fin_regiones').select('*').eq('activo', true).order('nombre'),
       supabase.from('fin_categorias_ingresos').select('*').eq('activo', true).order('nombre'),
-    ]).then(([neg, reg, cat]) => {
+      supabase.from('usuarios').select('id, nombre_completo').eq('activo', true).order('nombre_completo'),
+    ]).then(([neg, reg, cat, usr]) => {
       if (neg.data) setNegocios(neg.data);
       if (reg.data) setRegiones(reg.data);
       if (cat.data) setCategorias(cat.data);
+      if (usr.data) setUsuarios(usr.data as UsuarioOption[]);
     });
   }, []);
 
@@ -85,7 +103,7 @@ export function IngresosList({ onEdit }: IngresosListProps) {
       aplicadoKey.current = location.key;
       setFiltros((prev) => ({
         ...prev,
-        periodo: state.periodo || 'mes_actual',
+        periodo: state.periodo || 'ytd',
         negocio_id: state.negocio_id || '',
         region_id: state.region_id || '',
         categoria_id: state.categoria || '',
@@ -98,6 +116,7 @@ export function IngresosList({ onEdit }: IngresosListProps) {
   // Auto-load on any filter change
   useEffect(() => {
     loadIngresos();
+    setSeleccionados(new Set());
   }, [filtros, searchQuery]);
 
   useEffect(() => {
@@ -128,6 +147,8 @@ export function IngresosList({ onEdit }: IngresosListProps) {
       if (filtros.negocio_id) query = query.eq('negocio_id', filtros.negocio_id);
       if (filtros.region_id) query = query.eq('region_id', filtros.region_id);
       if (filtros.categoria_id) query = query.eq('categoria_id', filtros.categoria_id);
+      if (filtros.usuario_id === SIN_USUARIO) query = query.is('created_by', null);
+      else if (filtros.usuario_id) query = query.eq('created_by', filtros.usuario_id);
 
       query = query.order('fecha', { ascending: false });
       const { data, error } = await query;
@@ -142,6 +163,8 @@ export function IngresosList({ onEdit }: IngresosListProps) {
         .eq('tipo', 'venta');
       if (fechaDesde) ganadoQuery = ganadoQuery.gte('fecha', fechaDesde);
       if (fechaHasta) ganadoQuery = ganadoQuery.lte('fecha', fechaHasta);
+      if (filtros.usuario_id === SIN_USUARIO) ganadoQuery = ganadoQuery.is('created_by', null);
+      else if (filtros.usuario_id) ganadoQuery = ganadoQuery.eq('created_by', filtros.usuario_id);
       ganadoQuery = ganadoQuery.order('fecha', { ascending: false });
       const { data: ganadoData } = await ganadoQuery;
 
@@ -207,7 +230,13 @@ export function IngresosList({ onEdit }: IngresosListProps) {
     ? categorias.filter((c) => c.negocio_id === filtros.negocio_id)
     : categorias;
 
-  const tieneFiltrosActivos = filtros.negocio_id || filtros.region_id || filtros.categoria_id;
+  const tieneFiltrosActivos = filtros.negocio_id || filtros.region_id || filtros.categoria_id || filtros.usuario_id;
+  const conteoFiltrosActivos = [
+    filtros.negocio_id,
+    filtros.region_id,
+    filtros.categoria_id,
+    filtros.usuario_id,
+  ].filter(Boolean).length;
   const valorTotalIngresos = ingresos.reduce((sum, i) => sum + (i.valor || 0), 0);
   const valorTotalGanado = ganadoItems.reduce((sum, g) => sum + (g.valor_total || 0), 0);
   const valorTotal = valorTotalIngresos + valorTotalGanado;
@@ -236,9 +265,37 @@ export function IngresosList({ onEdit }: IngresosListProps) {
 
   const totalCount = unifiedItems.length;
 
+  const toggleSeleccionado = (key: string) => {
+    setSeleccionados((prev) => {
+      const next = new Set(prev);
+      if (next.has(key)) next.delete(key);
+      else next.add(key);
+      return next;
+    });
+  };
+
+  const todosSeleccionados = totalCount > 0 && unifiedItems.every((item) => seleccionados.has(`${item.source}-${item.id}`));
+
+  const toggleSeleccionarTodos = () => {
+    if (todosSeleccionados) {
+      setSeleccionados(new Set());
+    } else {
+      setSeleccionados(new Set(unifiedItems.map((item) => `${item.source}-${item.id}`)));
+    }
+  };
+
+  const itemsSeleccionados = unifiedItems.filter((item) => seleccionados.has(`${item.source}-${item.id}`));
+  const subtotalSeleccionado = itemsSeleccionados.reduce((sum, item) => sum + (item.valor || 0), 0);
+
+  const nombreCreadoPor = (item: UnifiedFinanceItem | null) => {
+    const creadoPor = (item?.raw as { created_by?: string | null } | undefined)?.created_by;
+    if (!creadoPor) return undefined;
+    return usuarios.find((u) => u.id === creadoPor)?.nombre_completo;
+  };
+
   return (
     <div className="space-y-3">
-      {/* Compact filter bar */}
+      {/* Compact filter bar: search + all filters in one row */}
       <div className="bg-white rounded-xl border border-gray-200 px-3 py-2.5">
         <div className="flex flex-wrap items-center gap-2">
           {/* Search */}
@@ -253,46 +310,67 @@ export function IngresosList({ onEdit }: IngresosListProps) {
             />
           </div>
 
-          {/* Periodo */}
-          <select value={filtros.periodo} onChange={(e) => updateFiltro('periodo', e.target.value)} className={selectClass}>
-            <option value="mes_actual">Mes Actual</option>
-            <option value="trimestre">Trimestre</option>
-            <option value="ytd">YTD</option>
-            <option value="ano_anterior">Ano Anterior</option>
-            <option value="rango_personalizado">Personalizado</option>
-          </select>
+          {/* Mobile-only: the filters below collapse behind this toggle */}
+          <button
+            onClick={() => setFiltrosAbiertos((prev) => !prev)}
+            className="filtros-toggle items-center gap-2 h-8 px-3 text-sm border border-gray-200 rounded-xl bg-white text-gray-600"
+          >
+            <Filter className="w-4 h-4" />
+            Filtros
+            {conteoFiltrosActivos > 0 && (
+              <span className="px-2 rounded-md bg-primary text-white text-xs">{conteoFiltrosActivos}</span>
+            )}
+          </button>
 
-          {/* Negocio */}
-          <select value={filtros.negocio_id} onChange={(e) => { updateFiltro('negocio_id', e.target.value); updateFiltro('categoria_id', ''); }} className={selectClass}>
-            <option value="">Negocio</option>
-            {negocios.map((n) => <option key={n.id} value={n.id}>{n.nombre}</option>)}
-          </select>
+          <div className={filtrosAbiertos ? 'filtros-colapsables abierto' : 'filtros-colapsables'}>
+            {/* Periodo */}
+            <select value={filtros.periodo} onChange={(e) => updateFiltro('periodo', e.target.value)} className={selectClass}>
+              <option value="mes_actual">Mes Actual</option>
+              <option value="trimestre">Trimestre</option>
+              <option value="ytd">YTD</option>
+              <option value="ano_anterior">Ano Anterior</option>
+              <option value="rango_personalizado">Personalizado</option>
+            </select>
 
-          {/* Region */}
-          <select value={filtros.region_id} onChange={(e) => updateFiltro('region_id', e.target.value)} className={selectClass}>
-            <option value="">Region</option>
-            {regiones.map((r) => <option key={r.id} value={r.id}>{r.nombre}</option>)}
-          </select>
+            {/* Negocio */}
+            <select value={filtros.negocio_id} onChange={(e) => { updateFiltro('negocio_id', e.target.value); updateFiltro('categoria_id', ''); }} className={selectClass}>
+              <option value="">Negocio</option>
+              {negocios.map((n) => <option key={n.id} value={n.id}>{n.nombre}</option>)}
+            </select>
 
-          {/* Categoria */}
-          <select value={filtros.categoria_id} onChange={(e) => updateFiltro('categoria_id', e.target.value)} className={selectClass}>
-            <option value="">Categoria</option>
-            {categoriasFiltradas.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
-          </select>
+            {/* Region */}
+            <select value={filtros.region_id} onChange={(e) => updateFiltro('region_id', e.target.value)} className={selectClass}>
+              <option value="">Region</option>
+              {regiones.map((r) => <option key={r.id} value={r.id}>{r.nombre}</option>)}
+            </select>
 
-          {/* Clear filters */}
-          {tieneFiltrosActivos && (
-            <button
-              onClick={() => setFiltros({ periodo: 'mes_actual', negocio_id: '', region_id: '', categoria_id: '', fecha_desde: '', fecha_hasta: '' })}
-              className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
-              title="Limpiar filtros"
-            >
-              <X className="w-4 h-4" />
-            </button>
-          )}
+            {/* Categoria */}
+            <select value={filtros.categoria_id} onChange={(e) => updateFiltro('categoria_id', e.target.value)} className={selectClass}>
+              <option value="">Categoria</option>
+              {categoriasFiltradas.map((c) => <option key={c.id} value={c.id}>{c.nombre}</option>)}
+            </select>
+
+            {/* Usuario */}
+            <select value={filtros.usuario_id} onChange={(e) => updateFiltro('usuario_id', e.target.value)} className={selectClass}>
+              <option value="">Usuario</option>
+              {usuarios.map((u) => <option key={u.id} value={u.id}>{u.nombre_completo}</option>)}
+              <option value={SIN_USUARIO}>Sin usuario</option>
+            </select>
+
+            {/* Clear filters */}
+            {tieneFiltrosActivos && (
+              <button
+                onClick={() => setFiltros({ periodo: 'ytd', negocio_id: '', region_id: '', categoria_id: '', usuario_id: '', fecha_desde: '', fecha_hasta: '' })}
+                className="p-1.5 rounded-lg hover:bg-gray-100 text-gray-400 hover:text-gray-600 transition-colors"
+                title="Limpiar filtros"
+              >
+                <X className="w-4 h-4" />
+              </button>
+            )}
+          </div>
         </div>
 
-        {/* Custom date range */}
+        {/* Custom date range — only when selected */}
         {filtros.periodo === 'rango_personalizado' && (
           <div className="flex items-center gap-2 mt-2 pt-2 border-t border-gray-100">
             <span className="text-xs text-gray-500">Desde</span>
@@ -304,19 +382,42 @@ export function IngresosList({ onEdit }: IngresosListProps) {
       </div>
 
       {/* Inline stats summary */}
-      <div className="flex items-center gap-4 px-1 text-sm text-gray-500">
+      <div className="flex items-center gap-4 px-1 text-sm text-gray-500 flex-wrap">
+        {totalCount > 0 && (
+          <label className="flex items-center gap-1.5 cursor-pointer select-none">
+            <Checkbox checked={todosSeleccionados} onCheckedChange={toggleSeleccionarTodos} />
+            <span>Seleccionar todos</span>
+          </label>
+        )}
         <span><strong className="text-gray-900">{totalCount}</strong> ingresos</span>
-        <span className="text-gray-300">|</span>
+        <span className="hidden sm:inline text-gray-300">|</span>
         <span>Total: <strong className="text-green-700">${formatNumber(valorTotal)}</strong></span>
+        {seleccionados.size > 0 && (
+          <>
+            <span className="hidden sm:inline text-gray-300">|</span>
+            <span className="text-primary">
+              Subtotal seleccionado ({seleccionados.size}): <strong>${formatNumber(subtotalSeleccionado)}</strong>
+            </span>
+            <button
+              onClick={() => setSeleccionados(new Set())}
+              className="text-gray-400 hover:text-gray-600 underline"
+            >
+              Limpiar selección
+            </button>
+          </>
+        )}
         {ganadoItems.length > 0 && (
           <>
-            <span className="text-gray-300">|</span>
+            <span className="hidden sm:inline text-gray-300">|</span>
             <span className="text-amber-700">{ganadoItems.length} ganado</span>
           </>
         )}
       </div>
 
-      {/* Compact income list */}
+      {/* Compact income list.
+          Sin `overflow-hidden`: el menú `⋮` es absolute y se abre hacia abajo, así que
+          el contenedor lo recortaría en las últimas filas. Las esquinas las redondea
+          la primera/última fila via `.lista-financiera`. Igual que GastosList. */}
       <div className="bg-white rounded-xl border border-gray-200">
         {isLoading ? (
           <div className="flex items-center justify-center py-8">
@@ -329,40 +430,60 @@ export function IngresosList({ onEdit }: IngresosListProps) {
             </p>
           </div>
         ) : (
-          <div className="divide-y divide-gray-100">
-            {unifiedItems.map((item) => (
-              <div key={`${item.source}-${item.id}`} className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50/50 transition-colors group">
-                {/* Ganado badge or spacer for alignment */}
+          <div className="lista-financiera divide-y divide-gray-100">
+            {unifiedItems.map((item) => {
+              const itemKey = `${item.source}-${item.id}`;
+              return (
+              <div
+                key={itemKey}
+                onClick={() => setDetalleItem(item)}
+                className="flex items-center gap-3 px-3 py-2 hover:bg-gray-50 transition-colors group cursor-pointer"
+              >
+                <span onClick={(e) => e.stopPropagation()} className="flex-shrink-0 flex items-center">
+                  <Checkbox
+                    checked={seleccionados.has(itemKey)}
+                    onCheckedChange={() => toggleSeleccionado(itemKey)}
+                  />
+                </span>
+
+                {/* Ganado badge */}
                 {item.source === 'ganado' && (
-                  <span className="px-1.5 py-0.5 text-[10px] font-semibold rounded-md bg-amber-100 text-amber-800 flex-shrink-0">
+                  <span className="px-1.5 py-0.5 text-[10px] font-semibold rounded-md bg-amber-100 text-amber-700 flex-shrink-0">
                     Ganado
                   </span>
                 )}
 
-                {/* Date */}
-                <span className="text-xs text-gray-400 w-[70px] flex-shrink-0">
+                {/* Date — own column on desktop; on mobile it moves to the meta line below */}
+                <span className="hidden sm:block text-xs text-gray-400 w-[70px] flex-shrink-0">
                   {formatearFechaCorta(item.fecha)}
                 </span>
 
-                {/* Name + details */}
-                <div className="flex-1 min-w-0 flex items-center gap-2">
-                  <span className="text-sm font-medium text-gray-900 truncate">
-                    {item.nombre}
-                  </span>
-                  {item.details && (
-                    <span className="hidden sm:inline text-xs text-gray-400 truncate">
-                      {item.details}
+                {/* Name (+ details inline on desktop, stacked below on mobile) */}
+                <div className="flex-1 min-w-0">
+                  <div className="flex items-center gap-2">
+                    <span className="gasto-nombre text-sm font-medium text-gray-900 truncate">
+                      {item.nombre}
                     </span>
-                  )}
+                    {item.details && (
+                      <span className="hidden sm:inline text-xs text-gray-400 truncate">
+                        {item.details}
+                      </span>
+                    )}
+                  </div>
+                  <div className="gasto-meta-movil text-xs text-gray-400 truncate">
+                    {formatearFechaCorta(item.fecha)}
+                    {item.details ? ` · ${item.details}` : ''}
+                  </div>
                 </div>
 
                 {/* Value */}
-                <span className="text-sm font-semibold text-green-700 flex-shrink-0 tabular-nums">
+                <span className="text-sm font-semibold text-green-700 flex-shrink-0">
                   +${formatNumber(item.valor)}
                 </span>
 
-                {/* Actions menu */}
-                <div className="relative flex-shrink-0">
+                {/* Actions menu — desktop only; on mobile the row opens the detail dialog,
+                    which carries the same actions (the hover-gated button is unreachable on touch) */}
+                <div className="hidden sm:block relative flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                   <button
                     onClick={(e) => {
                       e.stopPropagation();
@@ -413,7 +534,8 @@ export function IngresosList({ onEdit }: IngresosListProps) {
                   )}
                 </div>
               </div>
-            ))}
+              );
+            })}
           </div>
         )}
       </div>
@@ -427,6 +549,24 @@ export function IngresosList({ onEdit }: IngresosListProps) {
           onSuccess={() => { setEditingGanado(null); loadIngresos(); }}
         />
       )}
+
+      <IngresoDetalleDialog
+        item={detalleItem}
+        open={!!detalleItem}
+        onOpenChange={(open) => { if (!open) setDetalleItem(null); }}
+        nombreUsuario={nombreCreadoPor(detalleItem)}
+        onEdit={() => {
+          if (!detalleItem) return;
+          if (detalleItem.source === 'ganado') setEditingGanado(detalleItem.raw as TransaccionGanado);
+          else onEdit?.(detalleItem.raw as Ingreso);
+          setDetalleItem(null);
+        }}
+        onEliminar={() => {
+          if (!detalleItem) return;
+          handleEliminar(detalleItem.id, detalleItem.source === 'ganado' ? 'ganado' : 'ingreso');
+          setDetalleItem(null);
+        }}
+      />
 
       <ConfirmDialog
         open={confirmDeleteOpen}

--- a/src/sql/migrations/063_ingresos_created_by_tracking.sql
+++ b/src/sql/migrations/063_ingresos_created_by_tracking.sql
@@ -1,0 +1,82 @@
+-- Migration 063: Track who registers an ingreso + one-time backfill to Santiago
+--
+-- Context: fin_ingresos.created_by has existed since the original schema
+-- (src/sql/create_finanzas_tables.sql, the fin_ingresos CREATE TABLE — it
+-- REFERENCEs auth.users(id) just like fin_gastos.created_by did before
+-- migration 050), but no app code path ever populates it. Every row today
+-- has created_by = NULL. This blocks a new "Usuario" filter in the Ingresos
+-- historial view being built in parallel.
+--
+-- This is the exact same bug migration 050 fixed for fin_gastos (and, in the
+-- same migration, for fin_transacciones_ganado — that trigger already exists
+-- and covers ganado ventas, so it is NOT re-added here).
+--
+-- Fix (mirrors migration 050's set_gasto_created_by(), which itself mirrors
+-- migration 040's set_tarea_created_by()):
+--  1. A BEFORE INSERT trigger on fin_ingresos that sets
+--     created_by := COALESCE(created_by, auth.uid()) going forward.
+--  2. A one-time backfill of every fin_ingresos row with created_by IS NULL
+--     to Santiago (sforero94@gmail.com), who loaded the historical income
+--     data. This deliberately differs from migration 050: there, pre-2026
+--     gastos were left NULL because the author was genuinely unknown and
+--     unrecoverable. Here the author of every historical row is known, so
+--     the backfill is unconditional (not scoped to a year) rather than a
+--     partial attribution.
+--
+-- Known gap (accepted, same as it already is for fin_gastos post-050): the
+-- Telegram bot inserts ingresos via the service role
+-- (src/supabase/functions/server/telegram/conversations/ingreso.ts, the
+-- fin_ingresos insert in the confirm step), where auth.uid() is NULL. Those
+-- bot-created rows will continue to land as "Sin usuario" after this
+-- migration — the trigger only fills the value auth.uid() actually has.
+--
+-- Nota sobre el correo: 'sforero94@gmail.com' lo indico Santiago
+-- explicitamente; no es el correo con el que trabaja el repo
+-- (santiago@thinksid.co), que en usuarios no corresponde a esta cuenta. El
+-- DO de abajo aborta con RAISE EXCEPTION si el lookup no encuentra fila, asi
+-- que un correo inexistente falla ruidosamente y nunca escribe NULLs.
+
+-- ============================================================================
+-- PART 1: AUTO-POPULATE created_by GOING FORWARD
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION set_ingreso_created_by()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.created_by := COALESCE(NEW.created_by, auth.uid());
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trigger_set_ingreso_created_by ON fin_ingresos;
+CREATE TRIGGER trigger_set_ingreso_created_by
+  BEFORE INSERT ON fin_ingresos
+  FOR EACH ROW
+  EXECUTE FUNCTION set_ingreso_created_by();
+
+-- ============================================================================
+-- PART 2: ONE-TIME BACKFILL — ALL NULL ROWS ATTRIBUTED TO SANTIAGO
+-- ============================================================================
+-- Unlike migration 050 (which split 2026 gastos between two people and left
+-- earlier years untouched because the author was unknown), every historical
+-- fin_ingresos row was loaded by Santiago, so this backfill is not scoped to
+-- a year: every row still lacking a created_by gets attributed to him.
+-- Guarded by created_by IS NULL so this block is idempotent and never
+-- overwrites an already-attributed row.
+
+DO $$
+DECLARE
+  v_santiago_id UUID;
+BEGIN
+  SELECT id INTO v_santiago_id FROM usuarios WHERE email = 'sforero94@gmail.com';
+
+  IF v_santiago_id IS NULL THEN
+    RAISE EXCEPTION 'No se encontro usuario con email sforero94@gmail.com; backfill abortado';
+  END IF;
+
+  UPDATE fin_ingresos
+  SET created_by = v_santiago_id
+  WHERE created_by IS NULL;
+
+  RAISE NOTICE 'Ingresos asignados a Santiago: %', (SELECT count(*) FROM fin_ingresos WHERE created_by = v_santiago_id);
+END $$;

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -445,10 +445,12 @@ input[type='number'] {
   color: var(--primary);
 }
 
-/* Gastos historial — mobile filter collapse.
-   Defined here because src/index.css is a FROZEN pre-compiled Tailwind build
-   that ships no `sm:hidden` / `sm:flex` utilities: writing them in JSX would
-   silently do nothing. Breakpoint matches Tailwind's `sm` (640px). */
+/* Historial de Gastos e Ingresos — mobile filter collapse.
+   Compartido por GastosList e IngresosList: el prefijo `gasto-` es histórico,
+   las reglas no son de un módulo en particular. Definido aquí porque
+   src/index.css es un build precompilado y CONGELADO de Tailwind que no trae
+   utilidades `sm:hidden` / `sm:flex`: escribirlas en el JSX no haría nada.
+   El breakpoint coincide con el `sm` de Tailwind (640px). */
 
 /* Toggle button: only reachable on mobile, where the filters are collapsed. */
 .filtros-toggle {
@@ -503,6 +505,28 @@ input[type='number'] {
   .filtros-colapsables.abierto {
     display: contents;
   }
+}
+
+/* Lista de filas del historial (gastos e ingresos).
+   El contenedor NO puede llevar `overflow-hidden`: el menú `⋮` de cada fila es
+   absolute y se abre hacia abajo, así que recortarlo dejaba las acciones de las
+   últimas filas fuera de la vista — inalcanzables en desktop, donde ese menú es
+   la única vía además del modal. Lo que aportaba el overflow era que el fondo de
+   hover de la primera/última fila no pisara las esquinas redondeadas del
+   contenedor, y eso se resuelve redondeando esas filas directamente.
+
+   OJO con el radio: este build redefine `rounded-xl` como
+   `calc(var(--radius) + 4px)` (--radius: 1rem → 20px), NO el 0.75rem por
+   defecto de Tailwind. Se referencia la misma expresión para que las esquinas
+   no se desalineen si cambia el token. */
+.lista-financiera > :first-child {
+  border-top-left-radius: calc(var(--radius) + 4px);
+  border-top-right-radius: calc(var(--radius) + 4px);
+}
+
+.lista-financiera > :last-child {
+  border-bottom-left-radius: calc(var(--radius) + 4px);
+  border-bottom-right-radius: calc(var(--radius) + 4px);
 }
 /* ── Tablas financieras (P&G y Flujo de Caja) ─────────────────────────────
    src/index.css es un build precompilado y CONGELADO de Tailwind: no incluye


### PR DESCRIPTION
Replica los seis cambios de #73 en el submódulo de Ingresos, más la migración que los habilita, y de paso arregla el menú de acciones que #73 dejó recortado en Gastos.

## Portado a Ingresos

1. **Historial por defecto** — pestaña izquierda y activa al entrar. Se le agregó el deep-link `?tab=registrar` que `IngresosView` nunca tuvo.
2. **YTD por defecto** en el filtro de período.
3. **Filtro por Usuario** — con "Sin usuario", aplicado a `fin_ingresos` y a las ventas de ganado.
4. **Selección con checkboxes** — subtotal parcial que respeta los filtros activos.
5. **Layout móvil legible** — nombre a dos líneas, detalles visibles, filtros colapsables.
6. **Modal de detalle** (`IngresoDetalleDialog`) — abre al tocar la fila, con Editar / Eliminar y "Ver factura". Expone además las columnas de la migración 024 que hasta ahora no tenían UI: `cantidad`, `precio_unitario`, `cosecha`, `alianza`, `cliente`, `finca`.

## Lo que NO se portó, a propósito

`fin_ingresos` no tiene esas columnas:

- **Sin `estado`** → sin filtro Confirmado/Pendiente, sin ícono de estado, sin contador de pendientes, sin acción Completar.
- **Sin `concepto`** → la categoría no cascadea; en su lugar está acotada por negocio, que es como ya funcionaba.

## Migración 063

`fin_ingresos.created_by` existe desde el esquema original pero **ningún camino de la app lo llenaba** — eso es lo que bloqueaba el filtro por usuario. Agrega el trigger `BEFORE INSERT` (mismo patrón `COALESCE(created_by, auth.uid())` de 050/040) y hace backfill de **todas** las filas en NULL a Santiago (`sforero94@gmail.com`).

A diferencia de 050, el backfill no está acotado a un año: allá el autor de lo viejo era irrecuperable, acá se conoce toda la historia. `fin_transacciones_ganado` no se toca — 050 ya lo cubre.

⚠️ **No aplicada todavía.** El `DO` aborta con `RAISE EXCEPTION` si el correo no existe en `usuarios`, así que falla ruidosamente antes que escribir mal.

## Arreglos que se llevaron también a Gastos

- **`overflow-hidden` fuera del contenedor de la lista.** El menú `⋮` es absolute y se abre hacia abajo, así que el contenedor lo recortaba en las últimas filas — en desktop ese menú es la única vía a Editar/Eliminar además del modal. El redondeo de esquinas pasa a `.lista-financiera`, que redondea la primera y la última fila. Su radio es `calc(var(--radius) + 4px)`: **este build redefine `rounded-xl`**, son 20px y no los 0.75rem de Tailwind.
- **El hover de fila estaba muerto.** Estaba escrito `hover:bg-gray-50/50` y el build congelado no trae variantes con opacidad, así que las filas no tenían ninguna reacción al hover. Corregido a `hover:bg-gray-50`, que importa ahora que la fila entera es clickeable.

## Verificación

- `typecheck` limpio, `lint` 0 errores, **773/773** tests pasando.
- ⚠️ **No probado dentro de la app corriendo** (requiere login), misma limitación que #73. Conviene revisar el flujo real — abrir el modal, editar, eliminar, filtrar por usuario — antes de confiar en él.
- Hasta que corra la 063, el filtro por Usuario funciona pero todo aparece como "Sin usuario". Degrada, no rompe.

## Nota

Queda pendiente el mismo hueco que ya tiene Gastos desde la 050: el bot de Telegram inserta con el service role, donde `auth.uid()` es NULL, así que esas filas siguen cayendo como "Sin usuario".

🤖 Generated with [Claude Code](https://claude.com/claude-code)