### PR TITLE
refactor(monitoreo): route incidencia/gravedad through the shared engine + first tests for it

### DIFF
--- a/src/__tests__/calculosMonitoreo.test.ts
+++ b/src/__tests__/calculosMonitoreo.test.ts
@@ -1,0 +1,128 @@
+// Tests del motor puro compartido de monitoreo (`src/utils/calculosMonitoreo.ts`).
+//
+// POR QUÉ EXISTE ESTE ARCHIVO: nueve módulos dependen de él -- la captura de
+// registros (`RegistroMonitoreo.tsx`), el mapa de calor, el tablero V3, la
+// priorización de scouting (`priorizacionMonitoreo.ts` y su port Deno
+// `priorizacion-scouting.ts`, con paridad garantizada por
+// `priorizacionScoutingParidad.test.ts`), la UI del hato y el bot de Telegram.
+// Hasta ahora no tenía NINGÚN test propio: los cortes 10% / 30% que pintan de
+// amarillo o rojo toda la finca no estaban fijados por nada.
+//
+// El corte NO es cosmético: `gravedad_texto` se PERSISTE en `monitoreos` y lo
+// leen la tabla de registros, el reporte semanal (`fetchDatosReporteSemanal.ts`)
+// y Esco (`chat.tsx`). Una copia paralela de esta regla ya se desincronizó
+// (`CargaMasiva.tsx` usa 15% para "Media" en lugar de 10%).
+
+import { describe, it, expect } from 'vitest';
+import {
+  calcularIncidencia,
+  clasificarGravedad,
+  calcularDensidad,
+  calcularTendencia,
+  formatearCambio,
+} from '../utils/calculosMonitoreo';
+
+describe('calcularIncidencia', () => {
+  it('devuelve el porcentaje ponderado de árboles afectados', () => {
+    expect(calcularIncidencia(5, 20)).toBe(25);
+    expect(calcularIncidencia(35, 100)).toBe(35);
+  });
+
+  it('devuelve 0 -- no NaN ni Infinity -- cuando no se monitoreó ningún árbol', () => {
+    // Este es el guard que las derivaciones inline del tablero replicaban a
+    // mano (`monitoreados > 0 ? ... : 0`). Si desaparece, la vista muestra NaN%.
+    expect(calcularIncidencia(0, 0)).toBe(0);
+    expect(calcularIncidencia(3, 0)).toBe(0);
+  });
+
+  it('devuelve 0% cuando no hay árboles afectados y 100% cuando lo están todos', () => {
+    expect(calcularIncidencia(0, 40)).toBe(0);
+    expect(calcularIncidencia(40, 40)).toBe(100);
+  });
+});
+
+describe('clasificarGravedad', () => {
+  it('clasifica Baja por debajo del 10%', () => {
+    expect(clasificarGravedad(0)).toEqual({ texto: 'Baja', numerica: 1 });
+    expect(clasificarGravedad(9.99)).toEqual({ texto: 'Baja', numerica: 1 });
+  });
+
+  it('clasifica Media entre 10% (inclusive) y 30%', () => {
+    expect(clasificarGravedad(10)).toEqual({ texto: 'Media', numerica: 2 });
+    expect(clasificarGravedad(29.99)).toEqual({ texto: 'Media', numerica: 2 });
+  });
+
+  it('clasifica Alta desde 30% (inclusive)', () => {
+    expect(clasificarGravedad(30)).toEqual({ texto: 'Alta', numerica: 3 });
+    expect(clasificarGravedad(100)).toEqual({ texto: 'Alta', numerica: 3 });
+  });
+
+  it('fija los bordes exactos 10 y 30: son inclusivos, no exclusivos', () => {
+    // Contrato explícito. La banda [10, 15) es justamente donde
+    // `CargaMasiva.tsx` diverge hoy (guarda "Baja" donde esto dice "Media").
+    expect(clasificarGravedad(10).texto).toBe('Media');
+    expect(clasificarGravedad(12.5).texto).toBe('Media');
+    expect(clasificarGravedad(14.9).texto).toBe('Media');
+    expect(clasificarGravedad(30).texto).toBe('Alta');
+  });
+
+  it('texto y numérica nunca se contradicen', () => {
+    for (const inc of [0, 5, 10, 15, 25, 30, 55, 100]) {
+      const { texto, numerica } = clasificarGravedad(inc);
+      const esperado = { Baja: 1, Media: 2, Alta: 3 }[texto];
+      expect(numerica).toBe(esperado);
+    }
+  });
+});
+
+describe('calcularDensidad', () => {
+  it('promedia individuos por árbol afectado', () => {
+    expect(calcularDensidad(30, 10)).toBe(3);
+  });
+
+  it('devuelve 0 cuando no hay árboles afectados (evita división por cero)', () => {
+    expect(calcularDensidad(30, 0)).toBe(0);
+    expect(calcularDensidad(0, 0)).toBe(0);
+  });
+});
+
+describe('calcularTendencia', () => {
+  it('trata una serie de menos de dos puntos como estable', () => {
+    // Una sola ronda no es una tendencia: la vista de priorización muestra el
+    // valor sin flecha en vez de inventar una dirección.
+    expect(calcularTendencia([])).toBe('estable');
+    expect(calcularTendencia([42])).toBe('estable');
+  });
+
+  it('detecta subida cuando la pendiente supera +2 puntos por ronda', () => {
+    expect(calcularTendencia([10, 20, 30])).toBe('subiendo');
+  });
+
+  it('detecta bajada cuando la pendiente cae por debajo de -2 puntos por ronda', () => {
+    expect(calcularTendencia([30, 20, 10])).toBe('bajando');
+  });
+
+  it('considera estable un cambio menor al umbral de ±2', () => {
+    expect(calcularTendencia([10, 11, 12])).toBe('estable');
+    expect(calcularTendencia([12, 11, 10])).toBe('estable');
+    expect(calcularTendencia([15, 15, 15])).toBe('estable');
+  });
+
+  it('usa la pendiente de toda la serie, no solo el último salto', () => {
+    // Sube 20 puntos en total pero el último tramo baja: la tendencia global
+    // sigue siendo "subiendo".
+    expect(calcularTendencia([5, 15, 25, 24])).toBe('subiendo');
+  });
+});
+
+describe('formatearCambio', () => {
+  it('antepone el signo + a los cambios positivos y conserva el - de los negativos', () => {
+    expect(formatearCambio(25.5)).toBe('(+25.5%)');
+    expect(formatearCambio(-10.24)).toBe('(-10.2%)');
+    expect(formatearCambio(0)).toBe('(+0.0%)');
+  });
+
+  it('redondea siempre a un decimal', () => {
+    expect(formatearCambio(3.456)).toBe('(+3.5%)');
+  });
+});

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -14,6 +14,7 @@ import {
 } from './dashboard/index';
 import { useGanadoInventario } from './ganado/hooks/useGanadoInventario';
 import { calcularKPIsInventario, calcularVariacion } from '../utils/calculosGanado';
+import { calcularIncidencia } from '../utils/calculosMonitoreo';
 
 interface KPIsDashboard {
   plagas: PlagaKPI[];
@@ -139,7 +140,7 @@ export function Dashboard() {
         }
         const resultado = new Map<string, number>();
         for (const [nombre, { afectados, monitoreados }] of acumulado) {
-          resultado.set(nombre, monitoreados > 0 ? (afectados / monitoreados) * 100 : 0);
+          resultado.set(nombre, calcularIncidencia(afectados, monitoreados));
         }
         return resultado;
       };
@@ -326,7 +327,10 @@ export function Dashboard() {
 
         const alertas: Alerta[] = [];
         for (const [nombre, { afectados, monitoreados }] of Object.entries(porPlaga)) {
-          const avg = monitoreados > 0 ? (afectados / monitoreados) * 100 : 0;
+          const avg = calcularIncidencia(afectados, monitoreados);
+          // OJO: `> 10` es el umbral de ALERTA de este tablero, no el corte de
+          // gravedad de `clasificarGravedad` (que es `>= 10`). Se deja tal cual
+          // a propósito: cambiarlo movería qué alertas se muestran.
           if (avg > 10) {
             alertas.push({
               id: `monitoreo-${nombre}`,

--- a/src/components/monitoreo/DashboardMonitoreoV3.tsx
+++ b/src/components/monitoreo/DashboardMonitoreoV3.tsx
@@ -475,7 +475,7 @@ export function DashboardMonitoreoV3() {
         const rondaMap = plagasPorRondaPlaga.get(r.id);
         if (rondaMap) {
           for (const [plaga, stats] of rondaMap) {
-            row[plaga] = stats.monitoreados > 0 ? +((stats.afectados / stats.monitoreados) * 100).toFixed(1) : 0;
+            row[plaga] = +calcularIncidencia(stats.afectados, stats.monitoreados).toFixed(1);
           }
         }
         // Per-lote data stored separately
@@ -485,7 +485,7 @@ export function DashboardMonitoreoV3() {
             const loteId = key.split('|')[1];
             const loteData: Record<string, number> = {};
             for (const [plaga, stats] of loteMap) {
-              loteData[plaga] = stats.monitoreados > 0 ? +((stats.afectados / stats.monitoreados) * 100).toFixed(1) : 0;
+              loteData[plaga] = +calcularIncidencia(stats.afectados, stats.monitoreados).toFixed(1);
             }
             row._porLote.set(loteId, loteData);
           }
@@ -546,6 +546,15 @@ export function DashboardMonitoreoV3() {
   const rondaActual = rondas.find(r => r.id === rondaSeleccionada);
   const esRondaAbierta = rondaActual?.fecha_fin == null;
 
+  // Mismos cortes (10% / 30%) que el resto del módulo de monitoreo, vía
+  // `clasificarGravedad` -- igual que `MapaCalorIncidencias.obtenerColorIncidencia`.
+  // Antes estaban escritos a mano aquí (`>= 30 ? 'rojo' : >= 10 ? 'amarillo'`),
+  // que es exactamente cómo `CargaMasiva.tsx` acabó con un corte distinto (15%).
+  function semaforoDeIncidencia(incidencia: number): EstadoSemaforo {
+    const { numerica } = clasificarGravedad(incidencia);
+    return numerica === 3 ? 'rojo' : numerica === 2 ? 'amarillo' : 'verde';
+  }
+
   // Top 5 plagas by average incidencia in the ronda
   function calcularTopPlagas(): { nombre: string; incidenciaProm: number; estado: EstadoSemaforo }[] {
     if (monitoreos.length === 0) return [];
@@ -566,7 +575,7 @@ export function DashboardMonitoreoV3() {
         return {
           nombre,
           incidenciaProm: prom,
-          estado: (prom >= 30 ? 'rojo' : prom >= 10 ? 'amarillo' : 'verde') as EstadoSemaforo,
+          estado: semaforoDeIncidencia(prom),
         };
       })
       .sort((a, b) => b.incidenciaProm - a.incidenciaProm)
@@ -574,9 +583,9 @@ export function DashboardMonitoreoV3() {
   }
 
   const topPlagas = calcularTopPlagas();
-  const plagasEstado: EstadoSemaforo = topPlagas.length === 0 ? 'sin_datos'
-    : topPlagas[0].incidenciaProm >= 30 ? 'rojo'
-    : topPlagas[0].incidenciaProm >= 10 ? 'amarillo' : 'verde';
+  const plagasEstado: EstadoSemaforo = topPlagas.length === 0
+    ? 'sin_datos'
+    : semaforoDeIncidencia(topPlagas[0].incidenciaProm);
 
   function calcularSemaforoFloracion(): SemaforoCard {
     const flor = calcularEstadoFloracion(monitoreos);


### PR DESCRIPTION
Barrido mensual de Code Quality — corrida `2026-08-03-lunes`.

## El problema

`src/utils/calculosMonitoreo.ts` es la casa canónica de las dos reglas sobre las que está construido todo el módulo de monitoreo: `calcularIncidencia` y los cortes 10% / 30% de `clasificarGravedad`. Nueve módulos lo importan, incluido el par con paridad garantizada (`priorizacionMonitoreo.ts` / `priorizacion-scouting.ts`).

Tenía **cero tests**. Y cuatro sitios vivos re-derivaban su aritmética inline en vez de importarla — justo lo que el `CLAUDE.md` raíz prohíbe explícitamente ("components must not re-derive it inline").

**Eso ya costó datos.** Una quinta copia se desincronizó: `CargaMasiva.tsx:184` usa `>= 15` para "Media" donde la regla canónica dice `>= 10`, y esa copia **escribe `gravedad_texto` en `monitoreos`**:

```sql
SELECT gravedad_texto, count(*), min(fecha_monitoreo), max(fecha_monitoreo)
FROM monitoreos
WHERE incidencia IS NOT NULL
  AND gravedad_texto IS DISTINCT FROM
      (CASE WHEN incidencia >= 30 THEN 'Alta'
            WHEN incidencia >= 10 THEN 'Media' ELSE 'Baja' END)::gravedad_texto
GROUP BY 1;
-- Baja | 48 | 2025-11-26 | 2026-04-22
```

48 filas de producción guardadas como "Baja" donde la regla de todos los lectores dice "Media". Ese valor guardado alimenta la tabla de Registros, el reporte semanal (`fetchDatosReporteSemanal.ts:1687`) y a Esco (`chat.tsx:884`).

**Este PR NO toca eso.** Arreglar `CargaMasiva` cambia lo que la app escribe, así que va aparte como propuesta, junto con la decisión de si se corrigen o no las 48 filas históricas. Lo que este PR hace es **cerrar los sitios donde la misma deriva podría volver a pasar en silencio**.

## Cambios (todos preservan el comportamiento)

- `Dashboard.tsx:143` y `:330` — `monitoreados > 0 ? (afectados / monitoreados) * 100 : 0` → `calcularIncidencia(afectados, monitoreados)`.
- `DashboardMonitoreoV3.tsx:478` y `:488` (tendencia por ronda y su desglose por lote) — misma sustitución, conservando el `.toFixed(1)`.
- `DashboardMonitoreoV3.tsx` — los cortes del semáforo escritos a mano (`prom >= 30 ? 'rojo' : prom >= 10 ? 'amarillo' : 'verde'`, duplicados en dos sitios) ahora pasan por un `semaforoDeIncidencia()` local construido sobre `clasificarGravedad`, replicando lo que `MapaCalorIncidencias.tsx` ya hace en `obtenerColorIncidencia`.

**Deliberadamente NO cambiado**: el disparo de alerta de `Dashboard.tsx` es `avg > 10`, no `>= 10`. Ese es el umbral de *alerta* de ese tablero, no un corte de gravedad; alinearlo cambiaría qué alertas aparecen. Ahora hay un comentario que lo dice, para que el siguiente lector no lo "arregle".

## Equivalencia probada, no afirmada

Barrido exhaustivo de todos los pares (afectados, monitoreados) para monitoreados 0..200, más incidencias de -5 a 200 en pasos de 0.01 — **20.301 comparaciones, 0 divergencias** entre la expresión vieja y la nueva, incluyendo el guard de `monitoreados === 0` y el redondeo `.toFixed(1)`.

## Tests nuevos

`src/__tests__/calculosMonitoreo.test.ts` (17 tests) fija los cinco exports. Los bordes 10 y 30 quedan aseverados como **inclusivos**, y la banda `[10, 15)` — exactamente donde `CargaMasiva.tsx` diverge hoy — está señalada de forma explícita, para que el arreglo pendiente tenga dónde aterrizar.

## Verificación

- `npx tsc --noEmit` — limpio
- `npm run lint` — 0 errores, 1.031 warnings (sin cambio respecto a `main`)
- `npm test` — **73 archivos / 1.742 tests en verde** (eran 72 / 1.725; +1 archivo, +17 tests)

Sin cambios en edge functions, así que no hace falta redespliegue. Para la revisión: el port Deno `src/supabase/functions/server/priorizacion-scouting.ts` queda intacto y `priorizacionScoutingParidad.test.ts` sigue pasando.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_017vKRC7TXnSnjh4SybBJwyW

---
_Generated by [Claude Code](https://claude.ai/code/session_017vKRC7TXnSnjh4SybBJwyW)_