### PR TITLE
chore(docs): re-verify BUG_REPORT.md against production and main

### DIFF
--- a/BUG_REPORT.md
+++ b/BUG_REPORT.md
@@ -1,385 +1,191 @@
-# Bug Report: Reporte Semanal Module - Critical Issues
+# Bug Report — Reporte Semanal
 
-**Date:** 2026-02-24  
-**Status:** Multiple critical bugs unresolved  
-**Priority:** HIGH
+**Abierto:** 2026-02-24
+**Re-verificado contra producción y `main@7c232f6`:** 2026-08-03
+**Estado:** 5 de los 6 problemas originales están cerrados. 1 sigue abierto, y no por la causa que decía este archivo.
 
----
-
-## Executive Summary
-
-The Reporte Semanal (Weekly Report) module has multiple critical data flow and rendering issues that prevent it from functioning correctly. Despite multiple attempted fixes, the following issues persist:
-
-1. **Personal details (Fallas/Permisos) not appearing in PDF**
-2. **Labores Programadas showing "—" for Tipo and Lotes columns**
-3. **Closed applications cost calculations incorrect**
-4. **Sublote monitoring view showing only 1 observation instead of 3**
-5. **Report saving fails with RLS errors**
-6. **PDF download broken**
+> **Cómo leer este archivo.** Cada issue lleva su veredicto y **la evidencia con la que se comprobó** (archivo:línea, SQL con su resultado). Un issue sin evidencia no se cierra. Si vuelve a aparecer un síntoma listado aquí como cerrado, es un bug **nuevo** — no una reapertura — y merece su propia entrada.
 
 ---
 
-## Issue 1: Fallas/Permisos Details Missing in Report
+## Resumen
 
-### Problem
-User enters fallas (absences) and permisos (permissions) details in the wizard (Step 1), including:
-- Employee names
-- Reasons/motives
+| # | Problema original | Veredicto 2026-08-03 |
+|---|---|---|
+| 1 | Detalle de fallas/permisos no aparece en el PDF | ✅ **Corregido** |
+| 2 | Labores Programadas muestra "—" en Tipo y Lotes | ✅ **Corregido** |
+| 3 | Costos de aplicaciones mal calculados | ⚠️ **Parcial** — la parte reportada está corregida; queda un hueco distinto, ver abajo |
+| 4 | Vista por sublote muestra 1 observación en vez de 3 | ✅ **Corregido** |
+| 5 | Guardar el reporte falla con error de RLS | ✅ **Corregido** |
+| 6 | La descarga del PDF no funciona | ✅ **No reproducible** |
 
-These details appear correctly in the wizard UI but are **NOT** appearing in the generated PDF report. The PDF shows empty tables with "undefined" for employee names.
+El módulo lleva **24 reportes generados y guardados**, con cadencia semanal ininterrumpida hasta la **semana 31 de 2026 (2026-08-01)**. La afirmación original de que "NADA funciona" dejó de ser cierta hace meses; este archivo simplemente no se actualizó.
 
-### Data Flow
-1. **Wizard Input** (`ReporteSemanalWizard.tsx`, lines ~400-500)
-   - User inputs: `fallas`, `permisos` counts + `detalleFallas[]`, `detallePermisos[]` arrays
-   - Each detail has: `{ empleado: string, razon?: string }`
-
-2. **Data Aggregation** (`fetchDatosReporteSemanal.ts`, lines ~1280-1360)
-   ```typescript
-   return {
-     semana,
-     personal: {
-       ...personalBase,
-       fallas,
-       permisos,
-       detalleFallas,      // ← Passed correctly
-       detallePermisos,    // ← Passed correctly
-       // ...
-     }
-   }
-   ```
-
-3. **Edge Function** (`generar-reporte-semanal.tsx`)
-   - **CURRENTLY:** Does NOT read `detalleFallas` or `detallePermisos` from the data
-   - **ATTEMPTED FIX:** Added explicit handling (lines ~69-84), but still not appearing
-
-4. **PDF Generation**
-   - Uses Gemini to generate HTML
-   - HTML template for fallas/permisos shows empty data
-
-### Root Cause Analysis
-The Edge Function receives the data but may not be:
-- Properly formatting it for the Gemini prompt
-- The Gemini prompt template doesn't instruct showing the details
-- HTML template may have incorrect data structure access
-
-### Files to Check
-- `src/supabase/functions/server/generar-reporte-semanal.tsx` - `formatearDatosParaPrompt()` function
-- `construirSlidePersonal()` function in same file
-
----
-
-## Issue 2: Labores Programadas - Empty Tipo and Lotes
-
-### Problem
-In the "Labores Programadas" slide of the PDF:
-- **Nombre** shows correctly (e.g., "Visita ICA", "Zanjas")
-- **Tipo** column shows "—" (should show task type like "Mantenimiento", "Fumigación")
-- **Lotes** column shows "—" (should show comma-separated lot names)
-
-### Data Flow
-1. **Database Query** (`fetchDatosReporteSemanal.ts`, lines ~175-191)
-   ```typescript
-   const { data: tareas } = await supabase
-     .from('vista_tareas_resumen')
-     .select(`
-       id,
-       codigo_tarea,
-       nombre,
-       estado,
-       fecha_estimada_inicio,
-       fecha_estimada_fin,
-       fecha_inicio_real,
-       fecha_fin_real,
-       lote_nombres,        // ← Field from view
-       tipo_tarea_nombre    // ← Field from view
-     `)
-   ```
-
-2. **Data Transformation** (lines ~218-232)
-   ```typescript
-   resultado.push({
-     id: t.id,
-     codigoTarea: t.codigo_tarea,
-     nombre: t.nombre,
-     tipoTarea: (t as any).tipo_tarea_nombre || 'Sin tipo',  // ← May be undefined
-     lotes: lotesNombres,  // ← Parsed from t.lote_nombres
-   })
-   ```
-
-3. **Edge Function Processing** (`generar-reporte-semanal.tsx`, lines ~118-128)
-   ```typescript
-   datos.labores.programadas.forEach((labor: any) => {
-     const tipoTarea = labor.tipoTarea || labor.tipo || 'Sin tipo';
-     const lotesStr = (labor.lotes || []).join(', ') || 'Sin lotes';
-   ```
-
-### Root Cause Analysis
-**LIKELY:** The database view `vista_tareas_resumen` is not returning `tipo_tarea_nombre` or `lote_nombres` as expected.
-
-**Debug Steps:**
-1. Check if `vista_tareas_resumen` actually returns these fields
-2. Log the raw data from Supabase query
-3. Verify field names match exactly (case-sensitive)
-
-### Screenshot Evidence
-User screenshot shows:
-```
-Nombre          Tipo    Estado      Inicio      Fin         Lotes
-Visita ICA      —       Terminada   2026-01-19  2026-02-20  —
-Zanjas          —       En proceso  2026-01-21  2026-07-04  —
-```
-
----
-
-## Issue 3: Closed Applications Cost Calculations Wrong
-
-### Problem
-For closed applications (aplicaciones cerradas) in the report:
-- Planned costs for materials (insumos) not calculated correctly
-- Mano de Obra (labor) costs showing same value for planned and real
-- Costo Total = Costo Insumos + Costo Mano de Obra, but each should be compared separately
-- Grand totals missing from tables
-
-### Current Behavior
-From screenshot of "Plan: Fumigación N°2 (Floración)":
-- Lista de Compras shows products with "Costo Est." column showing $0 for all items
-- Costo por litro and Costo por árbol showing "—" (not calculated)
-
-### Expected Behavior
-- Costo Total = Costo Pedido (purchase) + Valor Inventario (inventory used)
-- Should show breakdown: Insumos vs Mano de Obra vs Total
-- Should calculate: Costo por litro/kg and Costo por árbol
-
-### Data Flow
-1. **Query** (`fetchDatosReporteSemanal.ts`, `fetchAplicacionesCerradas()`)
-   - Fetches `aplicaciones` with `costo_total_insumos`, `costo_total_mano_obra`
-   - Distributes costs by lote weight
-
-2. **Calculations** (lines ~800-850, PREVIOUSLY FIXED)
-   ```typescript
-   // FIXED: Calculate planned MO cost from planned jornales * average cost per jornal
-   const avgCostoJornal = totalJornalesReal > 0 ? costoManoObraTotal / totalJornalesReal : 50000;
-   const costoLoteManoObraPlan = jornalesPlan * avgCostoJornal;  // ← Was copying real value
-   ```
-
-3. **Grand Totals Added** (lines ~849-888)
-   - Added `TOTAL` row to KPI table
-   - Added `TOTAL` row to Financial table
-
-### Issue: Planned Applications (Not Closed)
-For planned (not closed) applications, costs not calculated at all.
-- Shows $0 for all items
-- Missing cost per litro/kg and cost per arbol
-
----
-
-## Issue 4: Sublote View Shows Only 1 Observation
-
-### Problem
-In the monitoreo por sublote slide:
-- Should show 3 observations per cell (for 3 monitoring dates)
-- Currently shows only 1 observation per cell
-
-### Data Structure
-**Correct Structure** (from `buildVistasPorSublote()` in `fetchDatosReporteSemanal.ts`):
-```typescript
-interface VistaMonitoreoSublote {
-  loteId: string;
-  loteNombre: string;
-  sublotes: string[];    // Column names
-  plagas: string[];      // Row names  
-  celdas: Record<string, Record<string, ObservacionFecha[]>>;
-  // celdas[plaga][sublote] = [obs1, obs2, obs3]
-}
-
-interface ObservacionFecha {
-  fecha: string;
-  incidencia: number | null;
-}
-```
-
-### Edge Function Bug
-**File:** `generar-reporte-semanal.tsx`
-
-**Line ~1218:** Wrong data source
-```typescript
-// WRONG:
-const vistasPorSublote: any[] = monitoreo?.detallePorLote || [];
-
-// SHOULD BE:
-const vistasPorSublote: any[] = monitoreo?.vistasPorSublote || [];
-```
-
-**Function `construirSlideMonitoreoPorSublote()` (lines ~1099-1139):**
-- Was expecting wrong data structure
-- Fixed to use `loteVista.celdas[plaga][sublote]`
-
----
-
-## Issue 5: RLS Policy Errors on Save
-
-### Error Message
-```
-No se pudo guardar en almacenamiento: Error al guardar metadatos: 
-new row violates row-level security policy (USING expression) 
-for table "reportes_semanales"
-```
-
-### SQL Migration File
-**File:** `src/sql/migrations/018_create_reportes_semanales.sql`
-
-Current policies:
 ```sql
--- INSERT policy - should work
-CREATE POLICY "Authenticated users can create reports"
-  ON reportes_semanales FOR INSERT
-  TO authenticated
-  WITH CHECK (true);
-
--- UPDATE policy - ATTEMPTED FIX
-CREATE POLICY "Users can update own reports"
-  ON reportes_semanales FOR UPDATE
-  TO authenticated
-  USING (true)  -- Changed from (generado_por = auth.uid())
-  WITH CHECK (generado_por = auth.uid());
+select numero_semana, ano, (url_storage is not null) tiene_url, created_at::date
+from reportes_semanales order by created_at desc limit 4;
+-- 31 | 2026 | true | 2026-08-01
+-- 30 | 2026 | true | 2026-07-27
+-- 29 | 2026 | true | 2026-07-21
+-- 28 | 2026 | true | 2026-07-13
 ```
-
-### Root Cause
-Upsert operation fails because:
-1. If record exists → tries UPDATE
-2. UPDATE policy requires `USING (true)` or ownership check
-3. Original policy had `USING (generado_por = auth.uid())` which fails for upsert
-
-### ATTEMPTED FIXES
-1. Changed UPDATE policy to `USING (true)` ✓
-2. Added fallback in `reporteSemanalService.ts` to try insert-only if upsert fails ✓
-3. Added detailed error logging ✓
-
-**Still failing** - User reports SQL was run but error persists.
 
 ---
 
-## Issue 6: PDF Download Broken
+## Issue 1 — Detalle de fallas/permisos en el PDF ✅ CORREGIDO
 
-### Problem
-PDF download not working after report generation.
+**Síntoma original:** el usuario capturaba nombres y motivos de fallas/permisos en el wizard y el PDF salía vacío o con "undefined".
 
-### Potential Causes
-1. **RLS on Storage Bucket:** `reportes-semanales` bucket may have restrictive policies
-2. **Missing File:** File not saved to storage before download attempt
-3. **CORS Issues:** Browser blocking download from Supabase storage
+**Evidencia de la corrección** — `src/supabase/functions/server/generar-reporte-semanal.tsx`:
 
-### Storage Policies (File: `019_storage_policies_reportes.sql`)
+- **Líneas 382-394** — `formatearDatosParaPrompt()` sí lee y serializa ambos arreglos:
+  ```ts
+  if (datos.personal.detalleFallas?.length > 0) {
+    partes.push(`### DETALLE DE FALLAS`);
+    datos.personal.detalleFallas.forEach((falla: any) => {
+      partes.push(`- ${falla.empleado}${falla.razon ? `: ${falla.razon}` : ''}`);
+    });
+  }
+  ```
+- **Líneas 938-944** — el slide de personal los renderiza en HTML, con fallback explícito de nombre (`f.empleado || f.nombre || '—'`), que es justamente lo que producía el "undefined" reportado.
+
+---
+
+## Issue 2 — Labores Programadas: Tipo y Lotes en "—" ✅ CORREGIDO
+
+**Síntoma original:** las columnas Tipo y Lotes salían vacías; se sospechaba que `vista_tareas_resumen` no devolvía los campos.
+
+**Evidencia de la corrección** — la vista sí los devuelve, en el 100% de las filas:
+
 ```sql
-CREATE POLICY "Authenticated users can upload reports"
-  ON storage.objects FOR INSERT
-  TO authenticated
-  WITH CHECK (bucket_id = 'reportes-semanales');
+select count(*) filas,
+       count(*) filter (where tipo_tarea_nombre is not null) con_tipo,
+       count(*) filter (where lote_nombres  is not null) con_lotes
+from vista_tareas_resumen;
+-- filas = 61 | con_tipo = 61 | con_lotes = 61
+```
 
-CREATE POLICY "Authenticated users can read reports"
-  ON storage.objects FOR SELECT
-  TO authenticated
-  USING (bucket_id = 'reportes-semanales');
+La hipótesis del archivo original ("LIKELY: la vista no está devolviendo estos campos") queda descartada con datos.
+
+---
+
+## Issue 3 — Costos de aplicaciones ⚠️ PARCIAL
+
+Este issue mezclaba dos cosas distintas. Una está corregida; la otra sigue viva y **no** es la que describía el texto original.
+
+### 3a. "Costo Est. muestra $0 en todos los items" — ✅ corregido para aplicaciones nuevas
+
+El síntoma era real y se reprodujo exactamente en la aplicación que el reporte original citaba, *Fumigación N°2 (Floración)* (creada el 2026-02-24, el mismo día de este bug report):
+
+```sql
+select producto_nombre, unidades_a_comprar, costo_estimado
+from aplicaciones_compras
+where aplicacion_id = '22e2d0ba-16b0-48cc-ade6-e238f694c50c';
+-- Sistoato 40EC          | 14 | NULL   (precio_por_presentacion del producto = 44.000)
+-- Danadim progress 400EC |  2 | NULL   (precio_por_presentacion del producto = 60.400)
+```
+
+`costo_estimado` quedaba en NULL aun habiendo unidades a comprar y precio vigente en `productos`.
+
+**Ya no ocurre.** Contando filas con `costo_estimado IS NULL` pese a `unidades_a_comprar > 0`, por aplicación y fecha de creación:
+
+```sql
+select a.nombre_aplicacion, a.created_at::date,
+       count(*) filter (where c.costo_estimado is null
+                          and coalesce(c.unidades_a_comprar,0) > 0) nulo_pese_a_comprar
+from aplicaciones_compras c join aplicaciones a on a.id = c.aplicacion_id
+group by 1,2 order by 2;
+-- 2026-01-10  Fumigación refuerzo post cosecha diciembre  -> 16
+-- 2026-02-09  Aplicación edáfica general - 01.            ->  1
+-- 2026-02-24  Fumigación N°2 (Floración)                  ->  2
+-- 2026-04-01 en adelante (10 aplicaciones)                ->  0  (salvo 1 producto sin precio)
+```
+
+El corte es limpio: **toda aplicación creada desde abril de 2026 escribe `costo_estimado` correctamente.** Las 19 filas mal escritas son datos históricos de 3 aplicaciones ya cerradas, no un defecto vivo. No se corrigen aquí: reescribir costos de aplicaciones cerradas es una decisión del dueño, no una limpieza.
+
+### 3b. El inventario consumido se valora en $0 — ❌ SIGUE ABIERTO (causa distinta a la reportada)
+
+`src/utils/fetchDatosReporteSemanal.ts:511-522` calcula el valor del inventario que la aplicación va a consumir derivando un precio unitario **a partir de lo que hay que comprar**:
+
+```ts
+const unitCost = item.costoEstimado > 0 && cantidadComprar > 0
+  ? item.costoEstimado / cantidadComprar
+  : 0;
+```
+
+Cuando el producto está **totalmente cubierto por inventario** — el caso normal — `cantidadComprar` es 0, así que `unitCost` es 0 y ese insumo aporta **cero** al costo. Si ninguna línea requiere compra, `costoTotal` (línea 525) es 0 y `costoPorLitroKg` / `costoPorArbol` salen en 0.
+
+Hoy eso aplica a **7 de las 18 aplicaciones** registradas — las que tienen lista de compras pero ninguna línea por comprar (`cantidad_faltante = 0` en todas): *Drench Enero 26*, *Fumigación 01*, *Foco Irlanda*, *Fumigación control monalonion y hongos - Mayo*, *Fertilizante mes de junio*, *Fumigacion Post cosecha junio* y *Fumigación control acaro - Julio*.
+
+```sql
+select a.nombre_aplicacion, count(c.id) items,
+       sum((coalesce(c.cantidad_faltante,0) > 0)::int) items_a_comprar
+from aplicaciones a join aplicaciones_compras c on c.aplicacion_id = a.id
+group by 1 having sum((coalesce(c.cantidad_faltante,0) > 0)::int) = 0;
+-- 7 filas: toda la lista cubierta por inventario -> costoTotal = 0
+```
+
+**Por qué no se corrige en este archivo:** existe una fuente de precio obvia (`productos.precio_unitario`, que es la que ya usa el motor de costo/kg en `calculosCostoKg.ts`), pero decidir **a qué precio se valora un insumo sacado de bodega** es una regla contable, no un bug de aritmética. Requiere aprobación del dueño antes de tocar un número que Gerencia lee.
+
+**Impacto acotado:** `fetchAplicacionesPlaneadas()` solo trae aplicaciones en estado `Calculada`. Hoy hay **una** (*Aplicacion Enmienda*) y no tiene filas en `aplicaciones_compras`, así que la sección de planeadas del reporte sale vacía casi siempre. Es un error latente, no uno que esté ensuciando el reporte cada semana.
+
+---
+
+## Issue 4 — Vista por sublote: 1 observación en vez de 3 ✅ CORREGIDO
+
+**Síntoma original:** la diapositiva de monitoreo por sublote mostraba una sola observación por celda. El archivo apuntaba a la línea exacta: `const vistasPorSublote = monitoreo?.detallePorLote || []` en vez de `monitoreo?.vistasPorSublote`.
+
+**Evidencia de la corrección** — `generar-reporte-semanal.tsx:2085` ya lee la fuente correcta, y además filtra las vistas vacías:
+
+```ts
+const vistasPorSublote: any[] = (monitoreo?.vistasPorSublote || []).filter(
+  (v: any) => v.sublotes && v.sublotes.length > 0 && !v.sinDatos
+);
 ```
 
 ---
 
-## Attempted Fixes Summary
+## Issue 5 — Error de RLS al guardar ✅ CORREGIDO
 
-### By Previous Agent:
+**Síntoma original:** `new row violates row-level security policy ... for table "reportes_semanales"` en el upsert.
 
-1. ✅ **RLS Policy Update** - Added UPDATE policy for upsert
-2. ✅ **Cost Calculation Fix** - Fixed MO planned cost calculation (was copying real value)
-3. ✅ **Grand Totals** - Added TOTAL rows to KPI and Financial tables
-4. ✅ **Monitoreo Order** - Fixed to show oldest→newest (WORKING)
-5. ✅ **Sublote Data Structure** - Fixed Edge Function to use correct data structure
-6. ⚠️ **Fallas/Permisos** - Added to prompt but NOT appearing in PDF
-7. ⚠️ **Labores Tipo/Lotes** - Debug logging added but root cause not found
-8. ⚠️ **Planned App Costs** - Partial fix, still showing $0
+**Evidencia de la corrección** — las políticas vivas en producción ya no tienen el `USING (generado_por = auth.uid())` que rompía el upsert:
 
----
+```sql
+select policyname, cmd, qual, with_check from pg_policies
+where tablename = 'reportes_semanales';
+-- Authenticated users can create reports | INSERT | -      | true
+-- Authenticated users can view reports   | SELECT | true   | -
+-- Authenticated users can update reports | UPDATE | true   | true
+-- Users can update own reports           | UPDATE | true   | true
+-- Users can delete own reports           | DELETE | (generado_por = auth.uid()) | -
+-- Service role full access               | ALL    | true   | true
+```
 
-## Recommended Next Steps
+Confirmado además por el hecho de que hay 24 reportes guardados (ver Resumen).
 
-### Priority 1: Fix Data Flow Issues
-
-1. **Verify Database Views:**
-   ```sql
-   -- Check if vista_tareas_resumen returns expected fields
-   SELECT id, codigo_tarea, nombre, tipo_tarea_nombre, lote_nombres
-   FROM vista_tareas_resumen
-   LIMIT 5;
-   ```
-
-2. **Add Console Logging:**
-   - In browser, check what `detalleFallas` and `labores.programadas` contain before sending to Edge Function
-   - Log the actual data structure received by Edge Function
-
-3. **Test Edge Function Locally:**
-   ```bash
-   supabase functions serve generar-reporte-semanal
-   ```
-
-### Priority 2: Fix RLS Issues
-
-1. **Verify policies applied:**
-   ```sql
-   SELECT * FROM pg_policies WHERE tablename = 'reportes_semanales';
-   ```
-
-2. **Test insert manually:**
-   ```sql
-   -- As authenticated user
-   INSERT INTO reportes_semanales (fecha_inicio, fecha_fin, numero_semana, ano, generado_por, url_storage)
-   VALUES ('2025-01-01', '2025-01-07', 1, 2025, auth.uid(), 'test/path.pdf');
-   ```
-
-### Priority 3: Verify Cost Data
-
-1. Check if `aplicaciones_compras` has `costo_estimado` values
-2. Verify `aplicaciones_calculos` has correct totals
-3. Check if inventory values are available for cost calculation
+**Deuda menor asociada (no es un bug):** quedaron **dos** políticas UPDATE redundantes con el mismo predicado (`Authenticated users can update reports` y `Users can update own reports`). No causa daño — PostgreSQL las combina con OR — pero la segunda ya no hace lo que su nombre dice. Limpiarla es cosmético y necesita migración propia.
 
 ---
 
-## Files Modified (With Issues)
+## Issue 6 — Descarga del PDF rota ✅ NO REPRODUCIBLE
 
-| File | Lines | Changes | Status |
-|------|-------|---------|--------|
-| `src/sql/migrations/018_create_reportes_semanales.sql` | 49-60 | Added UPDATE policy | Applied? |
-| `src/utils/fetchDatosReporteSemanal.ts` | ~800-888 | Fixed MO cost, added totals | Need verification |
-| `src/supabase/functions/server/generar-reporte-semanal.tsx` | ~69-84, ~1099-1140 | Fixed fallas/permisos, sublote | Need Edge Function deploy |
-| `src/utils/reporteSemanalService.ts` | ~173-260 | Added RLS fallback | Need verification |
+**Síntoma original:** el PDF no se descargaba tras generar el reporte; se sospechaba de RLS en el bucket o de archivos que nunca llegaban a Storage.
 
----
+**Evidencia:** los 24 reportes tienen `url_storage` poblada, y el más reciente es de hace dos días. Un reporte que no llega a Storage no obtiene URL.
 
-## Environment
+```sql
+select count(*) total, count(url_storage) con_url, max(created_at)::date ultimo
+from reportes_semanales;
+-- total = 24 | con_url = 24 | ultimo = 2026-08-01
+```
 
-- **Frontend:** React + Vite + TypeScript + Tailwind
-- **Backend:** Supabase (PostgreSQL + Edge Functions)
-- **AI:** Gemini for HTML generation
-- **PDF:** html2pdf.js for conversion
-- **Port:** 3002 (running locally)
+Si vuelve a fallar una descarga, ábrase como bug nuevo con el error del navegador: el modo de falla de 2026-02 (archivo inexistente) ya no aplica.
 
 ---
 
-## User's Main Complaint
+## Lo que sigue
 
-> "NOTHING works. The LITERAL ONLY FIX YOU DID WAS SORTING THE MONITOREO OBSERVATIONS RIGHT"
-
-**Confirmed Working:**
-- ✅ Monitoreo column order (oldest→newest)
-
-**Still Broken:**
-- ❌ Fallas/Permisos details in PDF
-- ❌ Labores Tipo and Lotes showing "—"
-- ❌ Cost calculations for planned apps
-- ❌ Sublote multiple observations
-- ❌ Report saving (RLS errors)
-- ❌ PDF download
-
----
-
-## End of Report
-
-**Next Action Required:** Deploy Edge Function and verify data structures in browser console.
+1. **Issue 3b** — llevar a decisión del dueño la regla de valoración del inventario consumido. Es lo único abierto de este archivo.
+2. **Datos históricos** — 19 filas de `aplicaciones_compras` en 3 aplicaciones cerradas (enero–febrero 2026) tienen `costo_estimado` en NULL. Solo se tocan si el dueño quiere recalcular costos históricos.
+3. **Cosmético** — la política UPDATE duplicada del Issue 5.


### PR DESCRIPTION
## Bug

`BUG_REPORT.md` is the repo's active bug tracker and the root `CLAUDE.md` points at it under *Known Issues*. It was last touched **2026-02-24** — about five months ago — and still declared all six Reporte Semanal issues open and "HIGH" priority, closing with the user's quote *"NOTHING works"*.

Five of the six are demonstrably fixed. Every time Santiago reads the file he pays attention to problems that no longer exist, and — worse — the one issue that *is* still open is described with the wrong cause, so anyone who picked it up would have gone looking in the wrong place.

## Root cause

No process ever struck a fixed issue from the file. This is a documentation defect, not a code defect.

## What changed

`BUG_REPORT.md` rewritten. Every verdict now carries **the evidence it was checked with** — `file:line` or the SQL plus its actual output — so the next reader can re-run it instead of trusting a paraphrase.

| # | Original problem | Verdict | Evidence |
|---|---|---|---|
| 1 | Fallas/permisos detail missing from PDF | ✅ Fixed | `generar-reporte-semanal.tsx:382-394` (prompt) and `:938-944` (HTML, with the `f.empleado \|\| f.nombre \|\| '—'` fallback that produced the reported "undefined") |
| 2 | Labores Programadas shows "—" for Tipo/Lotes | ✅ Fixed | `vista_tareas_resumen`: 61/61 rows carry both `tipo_tarea_nombre` and `lote_nombres`. The file's own hypothesis ("LIKELY the view isn't returning these fields") is refuted with data |
| 3 | Application cost calculations wrong | ⚠️ **Split** — see below | |
| 4 | Sublote view shows 1 observation instead of 3 | ✅ Fixed | `generar-reporte-semanal.tsx:2085` reads `monitoreo?.vistasPorSublote` — the exact line the file said was wrong — and now also filters empty views |
| 5 | RLS error on save | ✅ Fixed | `pg_policies` on `reportes_semanales`: the breaking `USING (generado_por = auth.uid())` on UPDATE is gone |
| 6 | PDF download broken | ✅ Not reproducible | 24 reports saved, **all 24 with `url_storage`**, weekly cadence unbroken through week 31 / 2026-08-01 |

### Issue 3 was two different problems

**3a — "Costo Est. shows $0 for all items": fixed for new applications.** It reproduced exactly on the application the original report cited, *Fumigación N°2 (Floración)* (created 2026-02-24, the same day as the bug report): `Sistoato 40EC` had `unidades_a_comprar = 14` and the product carried `precio_por_presentacion = 44.000`, yet `costo_estimado` was `NULL`. Grouping by creation date shows a clean cutover — 16 / 1 / 2 bad rows in the three applications created Jan–Feb 2026, and **0 in every one of the 10 applications created from 2026-04 onward** (the single exception is a product genuinely without a price). 19 legacy rows in 3 already-closed applications stay as they are; rewriting historical costs is the owner's call.

**3b — the still-open one, and it is not what the file said.** `src/utils/fetchDatosReporteSemanal.ts:511-522` values the inventory an application will consume by back-deriving a unit price *from what has to be purchased*:

```ts
const unitCost = item.costoEstimado > 0 && cantidadComprar > 0
  ? item.costoEstimado / cantidadComprar
  : 0;
```

When a product is fully covered by stock — the normal case — `cantidadComprar` is 0, so `unitCost` is 0 and that input contributes **nothing**. If no line needs buying, `costoTotal` (line 525) is 0 and `costoPorLitroKg` / `costoPorArbol` come out 0. That is true today for **7 of the 18 registered applications** (verified by SQL, listed in the file).

Deliberately **not** fixed here. There is an obvious price source (`productos.precio_unitario`, already used by the cost/kg engine in `calculosCostoKg.ts`), but *what price a consumed input is valued at* is an accounting rule, not arithmetic — and it changes a number Gerencia reads. It needs Santiago's approval first. Its blast radius is currently small: `fetchAplicacionesPlaneadas()` only reads `estado = 'Calculada'`, and the single such application today has no `aplicaciones_compras` rows at all.

## Verification

Documentation-only change (`BUG_REPORT.md`, +127 / −321). Gate run anyway on this branch:

- `npm run lint` → 0 errors (1031 pre-existing warnings, unchanged)
- `npx tsc --noEmit` → clean
- `npm test` → 72 files / 1725 tests passing

Every SQL statement quoted in the file was executed read-only against production (`ywhtjwawnkeqlwxbvgup`) on 2026-08-03 and its real output is pasted under it. No DML, no DDL.

## Rollback

`git revert 197777a` — single-file documentation change.

## Follow-up (out of scope here)

- The root `CLAUDE.md` *Known Issues* section still says the module "has several critical issues including PDF generation failures and RLS policy errors". That sentence is now false and should be softened to point at this file, but editing the project contract is left as its own deliberate change rather than folded into a doc cleanup.
- `reportes_semanales` carries **two** redundant UPDATE policies with identical predicates (`Authenticated users can update reports` and `Users can update own reports`); the second no longer does what its name says. Harmless (OR-combined) and cosmetic — needs its own migration.


---
_Generated by [Claude Code](https://claude.ai/code/session_017vKRC7TXnSnjh4SybBJwyW)_