### PR TITLE
fix(fechas): tomar "hoy" en hora local, no en UTC

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -471,6 +471,21 @@ See `src/guidelines/Guidelines.md` for the full design system.
 - **There is no purchases → expenses trigger.** `crear_gasto_pendiente_de_compra()` and `trigger_compra_a_gasto` were dropped from production on 2026-07-02 (migration 079); a compra posts nothing to `fin_gastos`. `src/sql/trigger_compra_a_gasto.sql`, `src/sql/update_trigger_compra_a_gasto.sql` and migration 038 are historical — do not re-run them. New triggers that touch cross-role tables should still use SECURITY DEFINER (the 038/039 precedent).
 - The `fn_cleanup_compra_dependencies()` RPC function uses SECURITY DEFINER for the same reason (migration 039). Purchase deletion calls this via `.rpc()` instead of direct `fin_gastos.delete()`.
 
+### ⚠️ "Hoy" siempre se toma en hora LOCAL, nunca en UTC
+
+`new Date().toISOString().split('T')[0]` (o `.slice(0, 10)`) is **not** today — it is the **UTC** day. Bogotá is UTC-5, so from 19:00 to midnight it already returns **tomorrow**. Always use `obtenerFechaHoy()` from `@/utils/fechas`, which builds the string from local `getFullYear`/`getMonth`/`getDate`.
+
+This is a data-corrupting trap, not a rendering nit, and it bites twice over:
+
+- The **form** defaults `fecha` to the UTC day and persists a future date.
+- The **list** filters with `fecha <= obtenerFechaHoy()` (local) — `periodo: 'ytd'` via `calcularRangoFechasPorPeriodo` (`fechas.ts`) is the default in Gastos/Ingresos and the Finanzas dashboard.
+
+So the record saves correctly and then **vanishes from the screen**, which reads as data loss to the user. Verified live 2026-08-03: Consuelito captured 5 gastos at 21:13–21:18 Bogotá, all stored `Confirmado` with `fecha = 2026-08-04`, none visible in the historial. 12 rows in `fin_gastos` carry this desfase historically — all 12 created after 19:00 Bogotá.
+
+Fixed across all 36 browser call sites (finanzas, monitoreo, inventario, labores, ganado, aplicaciones, clima, PDF filenames). `src/__tests__/hatoFechaLocalGuard.test.ts` is the static guard — it now covers **all of `src/components/` and `src/utils/`** (it previously only watched `src/components/hato/`, and only the `.slice(0, 10)` spelling, which is why the 36 `.split('T')[0]` sites went unseen) plus a fixed-clock regression asserting the form default falls inside the list's default window.
+
+**Edge functions are deliberately out of scope.** `src/supabase/functions/` runs on Deno servers already in UTC, where `obtenerFechaHoy()` reads local = UTC and fixes nothing; those sites need an explicit `America/Bogota` conversion instead. Still open: `chat.tsx`, `generar-reporte-semanal.tsx`, `telegram/bot.ts`, `telegram/conversations/{pesajeLeche,ingreso}.ts`.
+
 ### Dialog Size System (`src/components/ui/dialog.tsx`)
 All dialogs use a fixed-size tier via the `size` prop on `DialogContent`: `sm` (448×384px), `md` (576×512px), `lg` (768×640px), `xl` (1024×704px). These are max dimensions in rem — they never fill the screen. The base `DialogContent` enforces `overflow-hidden`, so scrollable content MUST go inside `<DialogBody>`. Never put `overflow-y-auto` on `DialogContent` directly. `StandardDialog` was removed — use `Dialog` + `DialogContent` + `DialogHeader` + `DialogBody` + `DialogFooter` directly.
 

--- a/src/__tests__/finTransaccionesGanadoEsHatoGuard.test.ts
+++ b/src/__tests__/finTransaccionesGanadoEsHatoGuard.test.ts
@@ -43,7 +43,9 @@ const SUPABASE_FUNCTIONS = join(REPO_ROOT, 'supabase/functions');
  * relativas a la raíz del repo.
  */
 const ALLOWLIST_FROM = new Set([
-  'src/components/finanzas/components/TransaccionGanadoForm.tsx:87',
+  // Selector de fincas (solo lee la columna `finca`, sin agregación financiera).
+  // Corrido de 87 a 88 al importar `obtenerFechaHoy` en el arreglo de fecha local.
+  'src/components/finanzas/components/TransaccionGanadoForm.tsx:88',
   'src/supabase/functions/server/telegram/conversations/ingreso.ts:275',
   'src/supabase/functions/server/telegram/conversations/gasto.ts:290',
   // Árbol espejo (supabase/functions/make-server-1ccce916) — mismo motivo.

--- a/src/__tests__/hatoFechaLocalGuard.test.ts
+++ b/src/__tests__/hatoFechaLocalGuard.test.ts
@@ -23,12 +23,27 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { obtenerFechaHoy } from '@/utils/fechas';
+import { obtenerFechaHoy, calcularRangoFechasPorPeriodo } from '@/utils/fechas';
 
-const RAIZ_HATO = join(process.cwd(), 'src', 'components', 'hato');
+/** Árboles de código de NAVEGADOR cubiertos por el guard. Las edge functions
+ * (`src/supabase/functions/`) quedan FUERA a propósito: corren en Deno sobre un
+ * servidor en UTC, donde `obtenerFechaHoy()` -- que lee getFullYear/getMonth/
+ * getDate LOCALES -- devolvería igualmente UTC. Ahí el arreglo no es este
+ * helper sino convertir explícitamente a America/Bogota. */
+const RAICES_CUBIERTAS = [
+  join(process.cwd(), 'src', 'components'),
+  join(process.cwd(), 'src', 'utils'),
+];
 
-/** Patrón prohibido: tomar "hoy" del reloj en UTC. */
-const PATRON_UTC_HOY = /new Date\(\)\.toISOString\(\)\.slice\(0,\s*10\)/;
+/** Patrón prohibido: tomar "hoy" del reloj en UTC.
+ *
+ * Cubre las TRES formas de recortar el `toISOString()` a `AAAA-MM-DD`. El
+ * guard original solo miraba `.slice(0, 10)` -- la forma que usaba el módulo
+ * hato -- y por eso no vio nunca las 36 apariciones de `.split('T')[0]` que
+ * vivían en finanzas, monitoreo, inventario, labores, ganado y aplicaciones.
+ * Un guard que solo conoce una sintaxis del mismo bug no es un guard. */
+const PATRON_UTC_HOY =
+  /new Date\(\)\.toISOString\(\)\.(?:slice\(0,\s*10\)|split\('T'\)\[0\]|substring\(0,\s*10\))/;
 
 /** Quita comentarios antes de buscar el patrón. Varios archivos DOCUMENTAN el
  * antipatrón en prosa ("NUNCA `new Date().toISOString().slice(0, 10)`") y esas
@@ -109,20 +124,71 @@ describe('obtenerFechaHoy — contrato de fecha LOCAL', () => {
   });
 });
 
-describe('guard estático: el módulo hato nunca toma "hoy" en UTC', () => {
-  it('ningún archivo bajo src/components/hato/ usa new Date().toISOString().slice(0,10)', () => {
-    const infractores = archivosTs(RAIZ_HATO).filter((ruta) =>
+// ============================================================================
+// Regresión del caso Consuelito (2026-08-03, 21:13 Bogotá).
+//
+// El bug NO era que un lado estuviera mal en abstracto: era que los dos lados
+// de la misma pantalla usaban relojes DISTINTOS. El formulario de gasto ponía
+// la fecha por defecto con `toISOString()` (UTC -> 2026-08-04) y el historial
+// filtraba con el periodo `ytd`, cuyo `fecha_hasta` sale de `obtenerFechaHoy()`
+// (LOCAL -> 2026-08-03). El `.lte('fecha', fecha_hasta)` dejaba fuera los 5
+// gastos recién guardados: quedaban en la base (confirmado en producción) e
+// invisibles en pantalla.
+//
+// Este test fija el invariante real: la fecha que el formulario propone SIEMPRE
+// tiene que caer dentro de la ventana que la lista abre por defecto.
+// ============================================================================
+describe('regresión: el default del formulario cae dentro de la ventana por defecto de la lista', () => {
+  const TZ_ORIGINAL = process.env.TZ;
+
+  beforeEach(() => {
+    process.env.TZ = 'America/Bogota';
+    vi.useFakeTimers();
+    // El instante exacto en que Consuelito guardó el primero de los 5 gastos.
+    vi.setSystemTime(new Date('2026-08-03T21:13:25-05:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.TZ = TZ_ORIGINAL;
+  });
+
+  it('un gasto capturado a las 21:13 de Bogotá es visible en el periodo `ytd`', () => {
+    const fechaPorDefectoDelFormulario = obtenerFechaHoy();
+    const { fecha_desde, fecha_hasta } = calcularRangoFechasPorPeriodo('ytd');
+
+    expect(fechaPorDefectoDelFormulario).toBe('2026-08-03');
+    expect(fechaPorDefectoDelFormulario >= fecha_desde).toBe(true);
+    // Este es el assert que fallaba: el default era 2026-08-04 y el tope 2026-08-03.
+    expect(fechaPorDefectoDelFormulario <= fecha_hasta).toBe(true);
+  });
+
+  it('el antipatrón UTC habría quedado FUERA de la ventana -- prueba de que el bug era real', () => {
+    const defaultViejoEnUTC = new Date().toISOString().split('T')[0];
+    const { fecha_hasta } = calcularRangoFechasPorPeriodo('ytd');
+
+    expect(defaultViejoEnUTC).toBe('2026-08-04');
+    expect(defaultViejoEnUTC <= fecha_hasta).toBe(false);
+  });
+});
+
+describe('guard estático: el código de navegador nunca toma "hoy" en UTC', () => {
+  it('ningún archivo bajo src/components/ ni src/utils/ toma "hoy" del reloj en UTC', () => {
+    const infractores = RAICES_CUBIERTAS.flatMap(archivosTs).filter((ruta) =>
       PATRON_UTC_HOY.test(sinComentarios(readFileSync(ruta, 'utf-8'))),
     );
 
     expect(
       infractores.map((r) => r.replace(process.cwd() + '/', '')),
       'Estos archivos toman "hoy" del reloj en UTC, así que después de las 19:00 en ' +
-        'Bogotá devuelven MAÑANA. Los formularios que guardan esa fecha (pesaje, venta, ' +
-        'muerte, uso de pajilla) persisten un día futuro. Usa `obtenerFechaHoy()` de ' +
-        '`@/utils/fechas` -- ya existe y ya es local-correcto. Si de verdad necesitas un ' +
-        'instante UTC (no un día calendario), constrúyelo explícitamente desde un string ' +
-        '`YYYY-MM-DDT00:00:00Z` como hace `fechaCorteTimeline` en EventoTimeline.tsx.',
+        'Bogotá devuelven MAÑANA. Un formulario que guarda esa fecha persiste un día ' +
+        'futuro, y la lista que lo muestra filtra por `fecha <= hoy` LOCAL -- así que el ' +
+        'registro se guarda bien y desaparece de la pantalla (ver el caso Consuelito, ' +
+        '2026-08-03 21:13 Bogotá: 5 gastos guardados con fecha 2026-08-04). Usa ' +
+        '`obtenerFechaHoy()` de `@/utils/fechas` -- ya existe y ya es local-correcto. Si ' +
+        'de verdad necesitas un instante UTC (no un día calendario), constrúyelo ' +
+        'explícitamente desde un string `YYYY-MM-DDT00:00:00Z` como hace ' +
+        '`fechaCorteTimeline` en EventoTimeline.tsx.',
     ).toEqual([]);
   });
 });

--- a/src/components/aplicaciones/CalculadoraAplicaciones.tsx
+++ b/src/components/aplicaciones/CalculadoraAplicaciones.tsx
@@ -28,6 +28,7 @@ import type {
 import { PasoConfiguracion } from './PasoConfiguracion';
 import { PasoMezcla } from './PasoMezcla';
 import { PasoListaCompras } from './PasoListaCompras';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 // ============================================================================
 // CONFIGURACIÓN DE PASOS
@@ -247,7 +248,7 @@ export function CalculadoraAplicaciones() {
       const configuracion: ConfiguracionAplicacion = {
         nombre: aplicacion.nombre_aplicacion || '',
         tipo: tipoAplicacion,
-        fecha_inicio_planeada: aplicacion.fecha_inicio_planeada || new Date().toISOString().split('T')[0],
+        fecha_inicio_planeada: aplicacion.fecha_inicio_planeada || obtenerFechaHoy(),
         fecha_fin_planeada: aplicacion.fecha_fin_planeada || undefined,
         fecha_recomendacion: aplicacion.fecha_recomendacion || undefined,
         proposito: aplicacion.proposito || undefined,

--- a/src/components/aplicaciones/DailyMovementsDashboard.tsx
+++ b/src/components/aplicaciones/DailyMovementsDashboard.tsx
@@ -27,6 +27,7 @@ import type {
   AlertaMovimiento,
   ProductoEnMezcla
 } from '../../types/aplicaciones';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface DailyMovementsDashboardProps {
   aplicacion: Aplicacion;
@@ -429,7 +430,7 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
     const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
     link.setAttribute('href', url);
-    link.setAttribute('download', `movimientos_diarios_${aplicacion.nombre_aplicacion}_${new Date().toISOString().split('T')[0]}.csv`);
+    link.setAttribute('download', `movimientos_diarios_${aplicacion.nombre_aplicacion}_${obtenerFechaHoy()}.csv`);
     link.style.visibility = 'hidden';
     document.body.appendChild(link);
     link.click();

--- a/src/components/aplicaciones/IniciarEjecucionModal.tsx
+++ b/src/components/aplicaciones/IniciarEjecucionModal.tsx
@@ -5,6 +5,7 @@ import { getSupabase } from '../../utils/supabase/client';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import type { Aplicacion } from '../../types/aplicaciones';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface IniciarEjecucionModalProps {
   aplicacion: Aplicacion;
@@ -26,7 +27,7 @@ export function IniciarEjecucionModal({
 }: IniciarEjecucionModalProps) {
   const supabase = getSupabase();
   const [fechaInicio, setFechaInicio] = useState<string>(
-    new Date().toISOString().split('T')[0]
+    obtenerFechaHoy()
   );
   const [loading, setLoading] = useState(false);
   const [validandoStock, setValidandoStock] = useState(false);
@@ -267,7 +268,7 @@ export function IniciarEjecucionModal({
               type="date"
               value={fechaInicio}
               onChange={(e) => setFechaInicio(e.target.value)}
-              max={new Date().toISOString().split('T')[0]}
+              max={obtenerFechaHoy()}
               className="w-full"
             />
             <p className="text-xs text-brand-brown/60 mt-1">

--- a/src/components/clima/ClimaHistorico.tsx
+++ b/src/components/clima/ClimaHistorico.tsx
@@ -9,6 +9,7 @@ import { GraficoTemperatura } from './components/GraficoTemperatura';
 import { GraficoPrecipitacion } from './components/GraficoPrecipitacion';
 import { GraficoHumedadRadiacion } from './components/GraficoHumedadRadiacion';
 import { GraficoViento } from './components/GraficoViento';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 type RangoPreset = '24h' | '7d' | '30d' | '90d' | '365d' | '3y' | 'custom';
 
@@ -88,7 +89,7 @@ export function ClimaHistorico() {
     const url = window.URL.createObjectURL(blob);
     const a = document.createElement('a');
     a.href = url;
-    a.download = `clima-historico-${new Date().toISOString().split('T')[0]}.csv`;
+    a.download = `clima-historico-${obtenerFechaHoy()}.csv`;
     a.click();
     window.URL.revokeObjectURL(url);
   };

--- a/src/components/finanzas/components/CargaMasivaGastos.tsx
+++ b/src/components/finanzas/components/CargaMasivaGastos.tsx
@@ -21,7 +21,7 @@ import {
   Loader2,
   X
 } from 'lucide-react';
-import { parsearFechaFlexible } from '../../../utils/fechas';
+import { parsearFechaFlexible, obtenerFechaHoy } from '../../../utils/fechas';
 import type { Negocio, Region, CategoriaGasto, ConceptoGasto, Proveedor, MedioPago } from '../../../types/finanzas';
 
 interface CargaMasivaGastosProps {
@@ -237,7 +237,7 @@ export function CargaMasivaGastos({
       XLSX.utils.book_append_sheet(wb, ws, 'Plantilla Gastos');
 
       // Generate file
-      const fileName = `plantilla_gastos_${new Date().toISOString().split('T')[0]}.xlsx`;
+      const fileName = `plantilla_gastos_${obtenerFechaHoy()}.xlsx`;
       XLSX.writeFile(wb, fileName);
 
     } catch (error: any) {

--- a/src/components/finanzas/components/CargaMasivaIngresos.tsx
+++ b/src/components/finanzas/components/CargaMasivaIngresos.tsx
@@ -21,7 +21,7 @@ import {
   Loader2,
   X
 } from 'lucide-react';
-import { parsearFechaFlexible } from '../../../utils/fechas';
+import { parsearFechaFlexible, obtenerFechaHoy } from '../../../utils/fechas';
 import type { Negocio, Region, CategoriaIngreso, Comprador, MedioPago } from '../../../types/finanzas';
 
 interface CargaMasivaIngresosProps {
@@ -218,7 +218,7 @@ export function CargaMasivaIngresos({
       XLSX.utils.book_append_sheet(wb, ws, 'Plantilla Ingresos');
 
       // Generate file
-      const fileName = `plantilla_ingresos_${new Date().toISOString().split('T')[0]}.xlsx`;
+      const fileName = `plantilla_ingresos_${obtenerFechaHoy()}.xlsx`;
       XLSX.writeFile(wb, fileName);
 
     } catch (error: any) {

--- a/src/components/finanzas/components/GastoForm.tsx
+++ b/src/components/finanzas/components/GastoForm.tsx
@@ -37,6 +37,7 @@ import type {
   MedioPago
 } from '../../../types/finanzas';
 import { toast } from 'sonner';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface GastoFormProps {
   open: boolean;
@@ -51,7 +52,7 @@ export function GastoForm({ open, onOpenChange, gasto, onSuccess, onCancel }: Ga
   const [formData, setFormData, clearFormData, wasRestored] = useFormPersistence<GastoFormData>({
     key: gasto?.id ? `gasto-edit-${gasto.id}` : 'gasto-new-v1',
     initialState: {
-      fecha: new Date().toISOString().split('T')[0],
+      fecha: obtenerFechaHoy(),
       negocio_id: '',
       region_id: '',
       categoria_id: '',
@@ -105,7 +106,7 @@ export function GastoForm({ open, onOpenChange, gasto, onSuccess, onCancel }: Ga
     } else {
       // Reset form for new gasto
       setFormData({
-        fecha: new Date().toISOString().split('T')[0],
+        fecha: obtenerFechaHoy(),
         negocio_id: '',
         region_id: '',
         categoria_id: '',

--- a/src/components/finanzas/components/GastosBatchTable.tsx
+++ b/src/components/finanzas/components/GastosBatchTable.tsx
@@ -7,6 +7,7 @@ import { GastosBatchRow } from './GastosBatchRow';
 import { ProveedorDialog } from '@/components/shared/ProveedorDialog';
 import type { BatchRowData } from '@/types/finanzas';
 import type { GastosCatalogs } from '../hooks/useGastosCatalogs';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 const DRAFT_KEY = 'gastos_batch_draft';
 
@@ -18,7 +19,7 @@ interface GastosBatchTableProps {
 function createEmptyRow(): BatchRowData {
   return {
     id: crypto.randomUUID(),
-    fecha: new Date().toISOString().split('T')[0],
+    fecha: obtenerFechaHoy(),
     nombre: '',
     valor: '',
     negocio_id: '',

--- a/src/components/finanzas/components/IngresoForm.tsx
+++ b/src/components/finanzas/components/IngresoForm.tsx
@@ -35,6 +35,7 @@ import type {
   MedioPago
 } from '../../../types/finanzas';
 import { toast } from 'sonner';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface IngresoFormProps {
   open: boolean;
@@ -49,7 +50,7 @@ export function IngresoForm({ open, onOpenChange, ingreso, onSuccess, onCancel }
   const [formData, setFormData, clearFormData, wasRestored] = useFormPersistence<IngresoFormData>({
     key: ingreso?.id ? `ingreso-edit-${ingreso.id}` : 'ingreso-new-v2',
     initialState: {
-      fecha: new Date().toISOString().split('T')[0],
+      fecha: obtenerFechaHoy(),
       negocio_id: '',
       region_id: '',
       categoria_id: '',
@@ -124,7 +125,7 @@ export function IngresoForm({ open, onOpenChange, ingreso, onSuccess, onCancel }
     } else {
       // Reset form for new ingreso
       setFormData({
-        fecha: new Date().toISOString().split('T')[0],
+        fecha: obtenerFechaHoy(),
         negocio_id: '',
         region_id: '',
         categoria_id: '',

--- a/src/components/finanzas/components/IngresosBatchTable.tsx
+++ b/src/components/finanzas/components/IngresosBatchTable.tsx
@@ -7,6 +7,7 @@ import { IngresosBatchRow } from './IngresosBatchRow';
 import { CompradorDialog } from './CompradorDialog';
 import type { BatchRowDataIngreso } from '@/types/finanzas';
 import type { IngresosCatalogs } from '../hooks/useIngresosCatalogs';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 const DRAFT_KEY = 'ingresos_batch_draft';
 
@@ -18,7 +19,7 @@ interface IngresosBatchTableProps {
 function createEmptyRow(): BatchRowDataIngreso {
   return {
     id: crypto.randomUUID(),
-    fecha: new Date().toISOString().split('T')[0],
+    fecha: obtenerFechaHoy(),
     nombre: '',
     valor: '',
     negocio_id: '',

--- a/src/components/finanzas/components/TransaccionGanadoForm.tsx
+++ b/src/components/finanzas/components/TransaccionGanadoForm.tsx
@@ -12,6 +12,7 @@ import { ProveedorDialog } from '@/components/shared/ProveedorDialog';
 import { CompradorDialog } from './CompradorDialog';
 import type { TransaccionGanado, Proveedor, Comprador } from '@/types/finanzas';
 import { toast } from 'sonner';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface TransaccionGanadoFormProps {
   open: boolean;
@@ -50,7 +51,7 @@ export function TransaccionGanadoForm({ open, onOpenChange, transaccion, default
     // de ceba sin relación guardado bajo la key genérica 'ganado-new-v1'.
     key: transaccion?.id ? `ganado-edit-${transaccion.id}` : hatoAnimalId ? `ganado-hato-venta-${hatoAnimalId}` : 'ganado-new-v1',
     initialState: {
-      fecha: new Date().toISOString().split('T')[0],
+      fecha: obtenerFechaHoy(),
       tipo: defaultTipo as 'compra' | 'venta',
       finca: '',
       cliente_proveedor: '',

--- a/src/components/ganado/components/MovimientoFormDialog.tsx
+++ b/src/components/ganado/components/MovimientoFormDialog.tsx
@@ -8,6 +8,7 @@ import { Loader2 } from 'lucide-react';
 import { toast } from 'sonner';
 import { useGanadoInventario } from '../hooks/useGanadoInventario';
 import type { GanFinca, GanPotrero } from '@/types/ganado';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface MovimientoFormDialogProps {
   open: boolean;
@@ -40,7 +41,7 @@ export function MovimientoFormDialog({ open, onOpenChange, fincas, potreros, onS
   useEffect(() => {
     if (!open) return;
     setTipo('muerte');
-    setFecha(new Date().toISOString().split('T')[0]);
+    setFecha(obtenerFechaHoy());
     setPotreroOrigen('');
     setPotreroDestino('');
     setNovillos('');

--- a/src/components/ganado/hooks/useGanadoInventario.ts
+++ b/src/components/ganado/hooks/useGanadoInventario.ts
@@ -10,6 +10,7 @@ import type {
   MovimientoConContexto,
   GanMovimiento,
 } from '@/types/ganado';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 // PostgREST devuelve embeds one-to-one como objeto o array según detecte
 // la constraint UNIQUE — normalizamos ambos casos.
@@ -227,7 +228,7 @@ export function useGanadoInventario() {
       potreroPorFinca[fincaId] = (creado as { id: string }).id;
     }
 
-    const fecha = new Date().toISOString().split('T')[0];
+    const fecha = obtenerFechaHoy();
     const movimientos = construirMovimientosCargaInicial(conCabezas, potreroPorFinca, fecha, nota);
     const { error: errorMovs } = await supabase.from('gan_movimientos').insert(movimientos);
     if (errorMovs) throw errorMovs;
@@ -235,7 +236,7 @@ export function useGanadoInventario() {
   }, []);
 
   const ajusteMasivo = useCallback(async (filas: AjusteMasivoFila[], nota: string) => {
-    const fecha = new Date().toISOString().split('T')[0];
+    const fecha = obtenerFechaHoy();
     const movimientos = construirAjustesMasivos(filas, fecha, nota).map((m) => ({ ...m, estado: 'confirmado' }));
     if (movimientos.length === 0) return 0;
     const { error } = await supabase.from('gan_movimientos').insert(movimientos);

--- a/src/components/inventory/NewPurchase.tsx
+++ b/src/components/inventory/NewPurchase.tsx
@@ -28,6 +28,7 @@ import {
   SelectValue,
 } from '../ui/select';
 import { RadioGroup, RadioGroupItem } from '../ui/radio-group';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 // Vendor interface
 interface Proveedor {
@@ -97,7 +98,7 @@ export function NewPurchase({ onSuccess }: { onSuccess?: () => void }) {
 
   // Estados principales
   const [datosCompra, setDatosCompra] = useState<DatosCompra>({
-    fecha: new Date().toISOString().split('T')[0],
+    fecha: obtenerFechaHoy(),
     proveedor_id: '',
     numero_factura: '',
     url_factura: '',

--- a/src/components/inventory/NuevaVerificacion.tsx
+++ b/src/components/inventory/NuevaVerificacion.tsx
@@ -4,7 +4,7 @@ import { ClipboardCheck, Loader2, AlertTriangle, Package } from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
 import { useAuth } from '../../contexts/AuthContext';
 import { VerificacionesNav } from './VerificacionesNav';
-import { formatearFecha } from '../../utils/fechas';
+import { formatearFecha, obtenerFechaHoy } from '../../utils/fechas';
 
 interface Producto {
   id: string;
@@ -73,7 +73,7 @@ export function NuevaVerificacion() {
         .from('verificaciones_inventario')
         .insert([
           {
-            fecha_inicio: new Date().toISOString().split('T')[0],
+            fecha_inicio: obtenerFechaHoy(),
             estado: 'En proceso',
             usuario_verificador: profile?.nombre || profile?.email || 'Usuario',
             observaciones_generales: observaciones || null,
@@ -328,7 +328,7 @@ export function NuevaVerificacion() {
               <div className="pt-4 border-t border-primary/10">
                 <p className="text-sm text-brand-brown/60 mb-1">Fecha de Inicio</p>
                 <p className="text-sm text-foreground">
-                  {formatearFecha(new Date().toISOString().split('T')[0])}
+                  {formatearFecha(obtenerFechaHoy())}
                 </p>
               </div>
             </div>

--- a/src/components/inventory/NuevoMovimientoModal.tsx
+++ b/src/components/inventory/NuevoMovimientoModal.tsx
@@ -6,6 +6,7 @@ import { Input } from '../ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogBody, DialogFooter } from '../ui/dialog';
 import { useFormDraft } from '@/hooks/useFormDraft';
 import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface Product {
   id: string;
@@ -133,7 +134,7 @@ export function NuevoMovimientoModal({ isOpen, onClose, onSuccess }: NuevoMovimi
       const { error: movError } = await supabase
         .from('movimientos_inventario')
         .insert({
-          fecha_movimiento: new Date().toISOString().split('T')[0],
+          fecha_movimiento: obtenerFechaHoy(),
           producto_id: selectedProduct.id,
           tipo_movimiento: tipoMovimiento,
           cantidad: cantidadMovimiento,

--- a/src/components/inventory/PurchaseHistory.tsx
+++ b/src/components/inventory/PurchaseHistory.tsx
@@ -20,7 +20,7 @@ import {
 } from 'lucide-react';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
-import { formatearFecha, formatearFechaHora } from '../../utils/fechas';
+import { formatearFecha, formatearFechaHora, obtenerFechaHoy } from '../../utils/fechas';
 import { toast } from 'sonner';
 
 interface Purchase {
@@ -384,7 +384,7 @@ export function PurchaseHistory({ hideSubNav = false }: { hideSubNav?: boolean }
       const { error: movementAjusteError } = await supabase
         .from('movimientos_inventario')
         .insert({
-            fecha_movimiento: new Date().toISOString().split('T')[0],
+            fecha_movimiento: obtenerFechaHoy(),
             producto_id: purchaseToDelete.producto_id,
             tipo_movimiento: 'Salida' as any,
             cantidad: purchaseToDelete.cantidad,

--- a/src/components/labores/RegistrarTrabajoDialog.tsx
+++ b/src/components/labores/RegistrarTrabajoDialog.tsx
@@ -3,7 +3,7 @@ import { getSupabase } from '../../utils/supabase/client';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Label } from '../ui/label';
-import { formatearFecha } from '../../utils/fechas';
+import { formatearFecha, obtenerFechaHoy } from '../../utils/fechas';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogBody, DialogFooter } from '../ui/dialog';
 import { CalendarIcon, Clock } from 'lucide-react';
 import { useFormDraft } from '@/hooks/useFormDraft';
@@ -45,7 +45,7 @@ const RegistrarTrabajoDialog: React.FC<RegistrarTrabajoDialogProps> = ({
 }) => {
   // Multi-step form state
   const [currentStep, setCurrentStep] = useState(1);
-  const [fechaTrabajo, setFechaTrabajo] = useState(new Date().toISOString().split('T')[0]);
+  const [fechaTrabajo, setFechaTrabajo] = useState(obtenerFechaHoy());
   const [selectedTrabajadores, setSelectedTrabajadores] = useState<Trabajador[]>([]);
   const [workMatrix, setWorkMatrix] = useState<WorkMatrix>({}); // Use shared WorkMatrix type
   const [observaciones, setObservaciones] = useState<ObservacionesMatrix>({}); // Use shared ObservacionesMatrix type
@@ -71,7 +71,7 @@ const RegistrarTrabajoDialog: React.FC<RegistrarTrabajoDialogProps> = ({
   useEffect(() => {
     if (open) {
       setCurrentStep(1);
-      setFechaTrabajo(new Date().toISOString().split('T')[0]);
+      setFechaTrabajo(obtenerFechaHoy());
       setSelectedTrabajadores([]);
       setWorkMatrix({});
       setObservaciones({});
@@ -401,7 +401,7 @@ const RegistrarTrabajoDialog: React.FC<RegistrarTrabajoDialogProps> = ({
                     value={fechaTrabajo}
                     onChange={(e) => setFechaTrabajo(e.target.value)}
                     disabled={loading}
-                    max={new Date().toISOString().split('T')[0]}
+                    max={obtenerFechaHoy()}
                     className="text-center text-lg"
                   />
                 </div>

--- a/src/components/monitoreo/CargaMasiva.tsx
+++ b/src/components/monitoreo/CargaMasiva.tsx
@@ -3,6 +3,7 @@ import { Button } from '../ui/button';
 import { MonitoreoSubNav } from './MonitoreoSubNav';
 import { useState } from 'react';
 import { getSupabase } from '../../utils/supabase/client';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface ResultadoCarga {
   exito: boolean;
@@ -65,7 +66,7 @@ export function CargaMasiva() {
     worksheet['!cols'] = columnWidths;
 
     // Generar el archivo y descargarlo
-    const fecha = new Date().toISOString().split('T')[0];
+    const fecha = obtenerFechaHoy();
     XLSX.writeFile(workbook, `plantilla_monitoreos_${fecha}.xlsx`);
   };
 

--- a/src/components/monitoreo/DashboardMonitoreoV3.tsx
+++ b/src/components/monitoreo/DashboardMonitoreoV3.tsx
@@ -43,7 +43,7 @@ import {
 } from 'recharts';
 import { toast } from 'sonner';
 import { getSupabase } from '../../utils/supabase/client';
-import { formatearFechaCorta } from '../../utils/fechas';
+import { formatearFechaCorta, obtenerFechaHoy } from '../../utils/fechas';
 import {
   calcularEstadoFloracion,
   calcularFloracionPorLote,
@@ -932,7 +932,7 @@ export function DashboardMonitoreoV3() {
     try {
       const { error } = await supabase
         .from('rondas_monitoreo')
-        .update({ fecha_fin: new Date().toISOString().split('T')[0] })
+        .update({ fecha_fin: obtenerFechaHoy() })
         .eq('id', rondaActual.id);
       if (error) throw error;
       toast.success('Ronda cerrada');

--- a/src/components/monitoreo/RegistroColmenas.tsx
+++ b/src/components/monitoreo/RegistroColmenas.tsx
@@ -23,6 +23,7 @@ import { AlertTriangle } from 'lucide-react';
 import { useFormDraft } from '@/hooks/useFormDraft';
 import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
 import type { Apiario } from '../../types/monitoreo';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface RegistroColmenasProps {
   open: boolean;
@@ -34,7 +35,7 @@ export function RegistroColmenas({ open, onClose, onSuccess }: RegistroColmenasP
   const supabase = getSupabase();
 
   const [apiarios, setApiarios] = useState<Apiario[]>([]);
-  const [fecha, setFecha] = useState(new Date().toISOString().split('T')[0]);
+  const [fecha, setFecha] = useState(obtenerFechaHoy());
   const [apiarioId, setApiarioId] = useState('');
   const [fuertes, setFuertes] = useState(0);
   const [debiles, setDebiles] = useState(0);
@@ -117,7 +118,7 @@ export function RegistroColmenas({ open, onClose, onSuccess }: RegistroColmenasP
     setMuertas(0);
     setConReina(0);
     setObservaciones('');
-    setFecha(new Date().toISOString().split('T')[0]);
+    setFecha(obtenerFechaHoy());
   }
 
   function handleClose() {

--- a/src/components/monitoreo/RegistroConductividad.tsx
+++ b/src/components/monitoreo/RegistroConductividad.tsx
@@ -22,6 +22,7 @@ import type { Lote } from '../../types/shared';
 import type { LecturaCE } from '../../types/monitoreo';
 import { useFormDraft } from '@/hooks/useFormDraft';
 import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface RegistroConductividadProps {
   open: boolean;
@@ -33,7 +34,7 @@ export function RegistroConductividad({ open, onClose, onSuccess }: RegistroCond
   const supabase = getSupabase();
 
   const [lotes, setLotes] = useState<Lote[]>([]);
-  const [fecha, setFecha] = useState(new Date().toISOString().split('T')[0]);
+  const [fecha, setFecha] = useState(obtenerFechaHoy());
   const [loteId, setLoteId] = useState('');
   const [numArboles, setNumArboles] = useState(30);
   const [lecturas, setLecturas] = useState<LecturaCE[]>([]);
@@ -268,7 +269,7 @@ export function RegistroConductividad({ open, onClose, onSuccess }: RegistroCond
   function limpiar() {
     setLoteId('');
     setObservaciones('');
-    setFecha(new Date().toISOString().split('T')[0]);
+    setFecha(obtenerFechaHoy());
     setNumArboles(30);
     setLecturas([]);
     setInputStrings({});

--- a/src/components/monitoreo/RegistroMonitoreo.tsx
+++ b/src/components/monitoreo/RegistroMonitoreo.tsx
@@ -24,6 +24,7 @@ import { calcularIncidencia, clasificarGravedad } from '../../utils/calculosMoni
 import { asignarRonda } from '../../utils/calculosMonitoreoV2';
 
 import type { Lote, Sublote } from '../../types/shared';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface Plaga {
   id: string;
@@ -55,7 +56,7 @@ export function RegistroMonitoreo({ open, onClose, onSuccess }: RegistroMonitore
   const [plagas, setPlagas] = useState<Plaga[]>([]);
   
   // Formulario - Datos del evento
-  const [fecha, setFecha] = useState<string>(new Date().toISOString().split('T')[0]);
+  const [fecha, setFecha] = useState<string>(obtenerFechaHoy());
   const [monitores, setMonitores] = useState<string[]>([]);
   const [loteId, setLoteId] = useState<string>('');
   const [subloteId, setSubloteId] = useState<string>('');
@@ -122,7 +123,7 @@ export function RegistroMonitoreo({ open, onClose, onSuccess }: RegistroMonitore
       if (!sessionStr) return;
 
       const session = JSON.parse(sessionStr);
-      const hoy = new Date().toISOString().split('T')[0];
+      const hoy = obtenerFechaHoy();
 
       // Solo restaurar si es el mismo día
       if (session.fecha === hoy && session.monitores?.length > 0) {
@@ -315,7 +316,7 @@ export function RegistroMonitoreo({ open, onClose, onSuccess }: RegistroMonitore
   }
 
   function limpiarFormulario() {
-    setFecha(new Date().toISOString().split('T')[0]);
+    setFecha(obtenerFechaHoy());
     setMonitores([]);
     setLoteId('');
     setSubloteId('');

--- a/src/utils/generarPDFListaCompras.ts
+++ b/src/utils/generarPDFListaCompras.ts
@@ -3,6 +3,7 @@
 
 import type { ListaCompras, ConfiguracionAplicacion } from '../types/aplicaciones';
 import { formatearMoneda, formatearNumero } from './format';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 interface DatosEmpresa {
   nombre: string;
@@ -413,7 +414,7 @@ export async function generarPDFListaCompras(
   // ========================================
   
   const nombreArchivo = `Lista_Compras_${configuracion.nombre.replace(/\s+/g, '_')}_${
-    new Date().toISOString().split('T')[0]
+    obtenerFechaHoy()
   }.pdf`;
   
   doc.save(nombreArchivo);

--- a/src/utils/generarPDFReporteCierre.ts
+++ b/src/utils/generarPDFReporteCierre.ts
@@ -2,6 +2,7 @@
 // Genera PDF del reporte de cierre de una aplicación
 
 import { formatearMoneda, formatearNumero } from './format';
+import { obtenerFechaHoy } from '@/utils/fechas';
 
 export interface DatosReporteCierre {
   nombre: string;
@@ -428,7 +429,7 @@ export async function generarPDFReporteCierre(datos: DatosReporteCierre): Promis
   // ========================================
 
   const nombreArchivo = `Reporte_Cierre_${datos.nombre.replace(/\s+/g, '_')}_${
-    new Date().toISOString().split('T')[0]
+    obtenerFechaHoy()
   }.pdf`;
 
   doc.save(nombreArchivo);


### PR DESCRIPTION
`new Date().toISOString().split('T')[0]` no es "hoy": es el día UTC. Bogotá
es UTC-5, así que entre las 19:00 y la medianoche ya devuelve MAÑANA.

El bug no era que un lado estuviera mal en abstracto, sino que los dos lados
de la misma pantalla usaban relojes distintos: el formulario ponía la fecha
por defecto en UTC y el historial filtraba con `fecha <= obtenerFechaHoy()`
LOCAL (periodo `ytd`, el default de Gastos, Ingresos y el tablero de
Finanzas). El registro se guardaba bien y desaparecía de la pantalla, que
para el usuario se lee como pérdida de datos.

Verificado en producción el 2026-08-03: Consuelito capturó 5 gastos entre
las 21:13 y las 21:18 de Bogotá; los 5 quedaron `Confirmado` con
`fecha = 2026-08-04` y ninguno salía en el historial. En `fin_gastos` hay 12
filas históricas con ese desfase, y las 12 se crearon después de las 19:00.

- 36 sitios corregidos a `obtenerFechaHoy()` (`@/utils/fechas`, que ya
  existía y ya era local-correcto) en finanzas, monitoreo, inventario,
  labores, ganado, aplicaciones, clima y los nombres de archivo de PDF.
- `hatoFechaLocalGuard.test.ts` pasa de vigilar solo `src/components/hato/`
  a cubrir todo `src/components/` y `src/utils/`, y reconoce las tres formas
  del antipatrón. Solo miraba `.slice(0, 10)`, por eso nunca vio las 36
  apariciones de `.split('T')[0]`. Un guard que conoce una sola sintaxis del
  mismo bug no es un guard.
- Regresión con reloj y TZ fijos en el instante exacto del caso: la fecha que
  propone el formulario tiene que caer dentro de la ventana que abre la lista.
- `finTransaccionesGanadoEsHatoGuard`: la allowlist indexa por `archivo:línea`
  y el import corrió el selector de fincas de la 87 a la 88.

Las edge functions quedan FUERA a propósito: corren en Deno sobre servidores
ya en UTC, donde `obtenerFechaHoy()` lee local = UTC y no arregla nada. Esos
sitios necesitan una conversión explícita a America/Bogota.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01J7hX4J77x8QhymT3Jt8hMB