### PR TITLE
fix(fechas): widen the UTC-today guard to any receiver and migrate 23 live sites

### DIFF
--- a/src/__tests__/hatoFechaLocalGuard.test.ts
+++ b/src/__tests__/hatoFechaLocalGuard.test.ts
@@ -23,7 +23,7 @@
 import { describe, it, expect, beforeEach, afterEach, vi } from 'vitest';
 import { readFileSync, readdirSync, statSync } from 'node:fs';
 import { join } from 'node:path';
-import { obtenerFechaHoy, calcularRangoFechasPorPeriodo } from '@/utils/fechas';
+import { obtenerFechaHoy, calcularRangoFechasPorPeriodo, fechaAISODate } from '@/utils/fechas';
 
 /** Árboles de código de NAVEGADOR cubiertos por el guard. Las edge functions
  * (`src/supabase/functions/`) quedan FUERA a propósito: corren en Deno sobre un
@@ -35,15 +35,67 @@ const RAICES_CUBIERTAS = [
   join(process.cwd(), 'src', 'utils'),
 ];
 
-/** Patrón prohibido: tomar "hoy" del reloj en UTC.
+/** Patrón prohibido: recortar un `toISOString()` a `AAAA-MM-DD`.
  *
- * Cubre las TRES formas de recortar el `toISOString()` a `AAAA-MM-DD`. El
- * guard original solo miraba `.slice(0, 10)` -- la forma que usaba el módulo
- * hato -- y por eso no vio nunca las 36 apariciones de `.split('T')[0]` que
- * vivían en finanzas, monitoreo, inventario, labores, ganado y aplicaciones.
- * Un guard que solo conoce una sintaxis del mismo bug no es un guard. */
+ * Cubre las TRES formas de recortar (`slice(0,10)`, `split('T')[0]`,
+ * `substring(0,10)`) y -- desde 2026-08-10 -- **cualquier receptor**, no solo
+ * el literal `new Date()`.
+ *
+ * Historia de los tres modos de falla de este mismo guard:
+ *   1. Solo miraba `.slice(0, 10)` -> no vio 36 `.split('T')[0]`.
+ *   2. Exigía el literal `new Date().toISOString()` -> salió VERDE con 29
+ *      apariciones vivas escritas como `now.toISOString().split('T')[0]`,
+ *      `hace30.toISOString()...`, `new Date(Date.now() - N).toISOString()...`
+ *      Un `const now = new Date()` una línea antes bastaba para esconder el bug.
+ *   3. (este) Ya no mira quién llama: prohíbe el recorte en sí.
+ *
+ * `toISOString()` SIEMPRE devuelve UTC. Recortarlo a 10 caracteres da el día
+ * calendario UTC, que en Bogotá (UTC-5) es MAÑANA desde las 19:00 -- da igual
+ * si la Date venía del reloj directo o de una variable. Por eso el patrón ya
+ * no intenta adivinar el receptor: los pocos usos legítimos van en la lista
+ * blanca de abajo, cerrada y contada. */
 const PATRON_UTC_HOY =
-  /new Date\(\)\.toISOString\(\)\.(?:slice\(0,\s*10\)|split\('T'\)\[0\]|substring\(0,\s*10\))/;
+  /\.toISOString\(\)\s*\.\s*(?:slice\(0,\s*10\)|split\('T'\)\[0\]|substring\(0,\s*10\))/g;
+
+/** Lista blanca CERRADA Y CONTADA de usos legítimos del recorte.
+ *
+ * No basta con nombrar el archivo: se declara cuántas apariciones puede tener.
+ * Si alguien agrega una línea nueva al archivo el conteo deja de cuadrar y el
+ * guard falla igual -- que es justo lo que un whitelist por archivo suelto no
+ * consigue en un archivo de 1.900 líneas.
+ *
+ * El caso legítimo es SIEMPRE el mismo: una Date construida en UTC a
+ * propósito (`new Date('AAAA-MM-DDT00:00:00Z')`, o `new Date('AAAA-MM-DD')`,
+ * que el motor parsea como medianoche UTC) sobre la que se hace aritmética y
+ * se vuelve a leer en UTC. Ahí el ida y vuelta se cancela y `toISOString()` es
+ * el lector CORRECTO -- pasarlas a `fechaAISODate()` (que lee getters LOCALES)
+ * les correría un día hacia atrás en UTC-5. */
+const LISTA_BLANCA_UTC: { archivo: string; ocurrencias: number; razon: string }[] = [
+  {
+    archivo: 'src/components/hato/components/EventoTimeline.tsx',
+    ocurrencias: 1,
+    razon:
+      'fechaCorteTimeline() construye la Date desde `${fechaHoy}T00:00:00Z` y hace ' +
+      'setUTCMonth(); el recorte UTC es la lectura correcta y el mensaje de error de ' +
+      'este mismo guard ya lo citaba como el patrón a imitar.',
+  },
+  {
+    archivo: 'src/utils/fetchDatosReporteSemanal.ts',
+    ocurrencias: 3,
+    razon:
+      'restarDias() y el cálculo de histInicio parsean `new Date(fechaISO)` -> medianoche ' +
+      'UTC; enumerarFechas() itera con cursor. Los tres son ida y vuelta UTC coherente.',
+  },
+  {
+    archivo: 'src/components/monitoreo/TablaMonitoreos.tsx',
+    ocurrencias: 2,
+    razon:
+      'agruparPorSemana() mezcla `new Date(fecha_monitoreo)` (UTC) con getDay()/getDate() ' +
+      'LOCALES. Está mal, pero el arreglo es la aritmética de semana entera, no el ' +
+      'recorte -- cambiar solo la lectura movería las etiquetas sin corregir el cálculo. ' +
+      'Congelado aquí a propósito para que no se cuele un sitio nuevo mientras tanto.',
+  },
+];
 
 /** Quita comentarios antes de buscar el patrón. Varios archivos DOCUMENTAN el
  * antipatrón en prosa ("NUNCA `new Date().toISOString().slice(0, 10)`") y esas
@@ -172,23 +224,101 @@ describe('regresión: el default del formulario cae dentro de la ventana por def
   });
 });
 
+// ============================================================================
+// Regresión del sitio con impacto VISIBLE de la barrida 2026-08-10.
+//
+// `useInventoryDashboard.getAlertasVencimiento()` marcaba
+// `vencido: fecha_vencimiento <= hoyStr`, con `hoyStr` recortado de
+// `hoy.toISOString()`. `hoy` es `new Date()` (hora de pared), así que desde las
+// 19:00 en Bogotá el string era el día SIGUIENTE y un producto que vence MAÑANA
+// aparecía como YA VENCIDO en el tablero de Inventario.
+//
+// El guard estático no alcanzaba a ver este sitio: estaba escrito como
+// `hoy.toISOString()`, con la Date en una variable, y el patrón viejo exigía el
+// literal `new Date().toISOString()`.
+// ============================================================================
+describe('regresión: un producto que vence MAÑANA no se marca vencido de noche', () => {
+  const TZ_ORIGINAL = process.env.TZ;
+
+  beforeEach(() => {
+    process.env.TZ = 'America/Bogota';
+    vi.useFakeTimers();
+    // 2026-08-03T21:13:25-05:00 (Bogotá) == 2026-08-04T02:13:25Z (UTC).
+    vi.setSystemTime(new Date('2026-08-03T21:13:25-05:00'));
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.TZ = TZ_ORIGINAL;
+  });
+
+  it('fechaAISODate(new Date()) da el día LOCAL, así que `vence mañana` sigue vigente', () => {
+    const hoy = new Date();
+    const hoyStr = fechaAISODate(hoy);
+    const venceManana = '2026-08-04';
+
+    expect(hoyStr).toBe('2026-08-03');
+    expect(venceManana <= hoyStr).toBe(false); // vigente, que es lo correcto
+  });
+
+  it('el antipatrón lo habría marcado vencido -- prueba de que el bug era real', () => {
+    const hoyStrViejo = new Date().toISOString().split('T')[0];
+    const venceManana = '2026-08-04';
+
+    expect(hoyStrViejo).toBe('2026-08-04');
+    expect(venceManana <= hoyStrViejo).toBe(true); // falso positivo de "vencido"
+  });
+
+  it('fechaAISODate coincide con obtenerFechaHoy() cuando la Date es el reloj', () => {
+    expect(fechaAISODate(new Date())).toBe(obtenerFechaHoy());
+  });
+});
+
+/** Cuenta apariciones del patrón en un archivo, ignorando comentarios. */
+function contarInfracciones(ruta: string): number {
+  const fuente = sinComentarios(readFileSync(ruta, 'utf-8'));
+  return fuente.match(new RegExp(PATRON_UTC_HOY.source, 'g'))?.length ?? 0;
+}
+
 describe('guard estático: el código de navegador nunca toma "hoy" en UTC', () => {
   it('ningún archivo bajo src/components/ ni src/utils/ toma "hoy" del reloj en UTC', () => {
-    const infractores = RAICES_CUBIERTAS.flatMap(archivosTs).filter((ruta) =>
-      PATRON_UTC_HOY.test(sinComentarios(readFileSync(ruta, 'utf-8'))),
-    );
+    const permitidos = new Map(LISTA_BLANCA_UTC.map((e) => [e.archivo, e.ocurrencias]));
+
+    const infractores = RAICES_CUBIERTAS.flatMap(archivosTs)
+      .map((ruta) => ({ rel: ruta.replace(process.cwd() + '/', ''), n: contarInfracciones(ruta) }))
+      .filter(({ rel, n }) => n > 0 && n !== (permitidos.get(rel) ?? 0))
+      .map(({ rel, n }) => `${rel} (${n} apariciones, permitidas ${permitidos.get(rel) ?? 0})`);
 
     expect(
-      infractores.map((r) => r.replace(process.cwd() + '/', '')),
+      infractores,
       'Estos archivos toman "hoy" del reloj en UTC, así que después de las 19:00 en ' +
         'Bogotá devuelven MAÑANA. Un formulario que guarda esa fecha persiste un día ' +
         'futuro, y la lista que lo muestra filtra por `fecha <= hoy` LOCAL -- así que el ' +
         'registro se guarda bien y desaparece de la pantalla (ver el caso Consuelito, ' +
         '2026-08-03 21:13 Bogotá: 5 gastos guardados con fecha 2026-08-04). Usa ' +
-        '`obtenerFechaHoy()` de `@/utils/fechas` -- ya existe y ya es local-correcto. Si ' +
-        'de verdad necesitas un instante UTC (no un día calendario), constrúyelo ' +
-        'explícitamente desde un string `YYYY-MM-DDT00:00:00Z` como hace ' +
-        '`fechaCorteTimeline` en EventoTimeline.tsx.',
+        '`obtenerFechaHoy()` de `@/utils/fechas` para "hoy", o `fechaAISODate(d)` para ' +
+        'cualquier Date derivada -- los dos ya existen y ya son local-correctos. Si de ' +
+        'verdad necesitas un día calendario UTC, construye la Date explícitamente desde ' +
+        'un string `AAAA-MM-DDT00:00:00Z` como hace `fechaCorteTimeline` en ' +
+        'EventoTimeline.tsx, y agrega el archivo a LISTA_BLANCA_UTC con su conteo.',
+    ).toEqual([]);
+  });
+
+  // Una lista blanca que se queda vieja es peor que no tenerla: sigue tapando
+  // el archivo aunque el uso legítimo ya no exista. Este caso la obliga a
+  // describir la realidad exacta.
+  it('la lista blanca está viva: cada entrada existe y tiene EXACTAMENTE las apariciones declaradas', () => {
+    const desfases = LISTA_BLANCA_UTC.filter(
+      ({ archivo, ocurrencias }) => contarInfracciones(join(process.cwd(), archivo)) !== ocurrencias,
+    ).map(
+      ({ archivo, ocurrencias }) =>
+        `${archivo}: declaradas ${ocurrencias}, reales ${contarInfracciones(join(process.cwd(), archivo))}`,
+    );
+
+    expect(
+      desfases,
+      'LISTA_BLANCA_UTC quedó desactualizada. Si eliminaste un uso legítimo, baja el ' +
+        'conteo o borra la entrada; nunca la subas para silenciar un sitio nuevo.',
     ).toEqual([]);
   });
 });

--- a/src/components/Dashboard.tsx
+++ b/src/components/Dashboard.tsx
@@ -15,6 +15,7 @@ import {
 import { useGanadoInventario } from './ganado/hooks/useGanadoInventario';
 import { calcularKPIsInventario, calcularVariacion } from '../utils/calculosGanado';
 import { calcularIncidencia } from '../utils/calculosMonitoreo';
+import { fechaAISODate } from '../utils/fechas';
 
 interface KPIsDashboard {
   plagas: PlagaKPI[];
@@ -181,11 +182,11 @@ export function Dashboard() {
           contratista_id,
           tareas!inner(tipo_tarea_id, tipos_tareas(nombre))
         `)
-        .gte('fecha_trabajo', lunesAnterior.toISOString().split('T')[0])
-        .lte('fecha_trabajo', now.toISOString().split('T')[0]);
+        .gte('fecha_trabajo', fechaAISODate(lunesAnterior))
+        .lte('fecha_trabajo', fechaAISODate(now));
       if (error || !data) return { jornalesSemana: 0, variacion: undefined, sparkline: [], contexto: null };
 
-      const fechaLunesActual = lunesActual.toISOString().split('T')[0];
+      const fechaLunesActual = fechaAISODate(lunesActual);
       let jornalesSemana = 0;
       let jornalesSemanaAnterior = 0;
       const porDia = new Map<string, number>();
@@ -212,7 +213,7 @@ export function Dashboard() {
 
       const sparkline: number[] = [];
       for (const d = new Date(lunesActual); d <= now; d.setDate(d.getDate() + 1)) {
-        sparkline.push(porDia.get(d.toISOString().split('T')[0]) || 0);
+        sparkline.push(porDia.get(fechaAISODate(d)) || 0);
       }
 
       const topActividad = Array.from(actividadMap.entries()).sort((a, b) => b[1] - a[1])[0];
@@ -224,16 +225,16 @@ export function Dashboard() {
     };
 
     const loadGasto = async (): Promise<{ gastoMes: number; variacion: number | undefined; contexto: string | null }> => {
-      const inicioMesActual = new Date(now.getFullYear(), now.getMonth(), 1).toISOString().split('T')[0];
-      const inicioMesAnterior = new Date(now.getFullYear(), now.getMonth() - 1, 1).toISOString().split('T')[0];
-      const finMesAnterior = new Date(now.getFullYear(), now.getMonth(), 0).toISOString().split('T')[0];
+      const inicioMesActual = fechaAISODate(new Date(now.getFullYear(), now.getMonth(), 1));
+      const inicioMesAnterior = fechaAISODate(new Date(now.getFullYear(), now.getMonth() - 1, 1));
+      const finMesAnterior = fechaAISODate(new Date(now.getFullYear(), now.getMonth(), 0));
 
       const { data, error } = await supabase
         .from('fin_gastos')
         .select('valor, fecha, categoria_id, fin_categorias_gastos(nombre)')
         .eq('estado', 'Confirmado')
         .gte('fecha', inicioMesAnterior)
-        .lte('fecha', now.toISOString().split('T')[0]);
+        .lte('fecha', fechaAISODate(now));
       if (error || !data) return { gastoMes: 0, variacion: undefined, contexto: null };
 
       let gastoMes = 0;
@@ -264,7 +265,7 @@ export function Dashboard() {
         const kpisGanado = calcularKPIsInventario(rows);
         const hace30Dias = new Date(now);
         hace30Dias.setDate(hace30Dias.getDate() - 30);
-        const variacionCabezas = calcularVariacion(movimientos, hace30Dias.toISOString().split('T')[0]);
+        const variacionCabezas = calcularVariacion(movimientos, fechaAISODate(hace30Dias));
         const contexto = variacionCabezas.entradas > 0 || variacionCabezas.salidas > 0
           ? `${variacionCabezas.entradas} entran · ${variacionCabezas.salidas} salen (30d)`
           : 'Sin movimientos en 30 días';
@@ -376,7 +377,7 @@ export function Dashboard() {
       const loadPresupuestoAlertas = async (): Promise<Alerta[]> => {
         const anioActual = now.getFullYear();
         const inicioAnio = `${anioActual}-01-01`;
-        const hoyStr = now.toISOString().split('T')[0];
+        const hoyStr = fechaAISODate(now);
         // Q1..Q4 según el mes actual (0-11) — ej. julio (mes 6) -> Q3
         const trimestreActual = Math.floor(now.getMonth() / 3) + 1;
 

--- a/src/components/clima/components/ContextoSolar.tsx
+++ b/src/components/clima/components/ContextoSolar.tsx
@@ -2,6 +2,7 @@ import { useMemo } from 'react';
 import { Sun, TrendingUp, TrendingDown, Minus } from 'lucide-react';
 import type { ResumenDiario } from '@/types/clima';
 import { buildRadiationPeriodContext, type RadiationPeriodContext } from '@/utils/calculosRadiacion';
+import { fechaAISODate } from '@/utils/fechas';
 import { Skeleton } from '@/components/ui/skeleton';
 
 interface ContextoSolarProps {
@@ -24,8 +25,8 @@ function splitRowsByPeriod(rows: ResumenDiario[], days: number) {
   const now = new Date();
   const cutoff = new Date(now.getTime() - days * 24 * 60 * 60 * 1000);
   const priorCutoff = new Date(cutoff.getTime() - days * 24 * 60 * 60 * 1000);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
-  const priorStr = priorCutoff.toISOString().slice(0, 10);
+  const cutoffStr = fechaAISODate(cutoff);
+  const priorStr = fechaAISODate(priorCutoff);
 
   const current = rows.filter(r => r.fecha >= cutoffStr);
   const prior = rows.filter(r => r.fecha >= priorStr && r.fecha < cutoffStr);

--- a/src/components/dashboard/ClimaCard.tsx
+++ b/src/components/dashboard/ClimaCard.tsx
@@ -5,6 +5,7 @@ import { useClimaData } from '@/hooks/useClimaData';
 import { getSupabase } from '@/utils/supabase/client';
 import { projectId } from '@/utils/supabase/info.tsx';
 import { aggregateRadiation } from '@/utils/calculosRadiacion';
+import { fechaAISODate } from '@/utils/fechas';
 
 interface DiaPronostico {
   date: string;
@@ -16,7 +17,7 @@ interface DiaPronostico {
 const EDGE_FUNCTION_BASE = `https://${projectId}.supabase.co/functions/v1`;
 
 function sunHoursUltimos7Dias(resumenesDiarios: { fecha: string; radiacion_wm2_avg: number | null }[]): number | null {
-  const cutoffStr = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
+  const cutoffStr = fechaAISODate(new Date(Date.now() - 7 * 24 * 60 * 60 * 1000));
   const rows = resumenesDiarios.filter((r) => r.fecha >= cutoffStr);
   return aggregateRadiation(rows).avgSunHours;
 }

--- a/src/components/ganado/GanadoDashboard.tsx
+++ b/src/components/ganado/GanadoDashboard.tsx
@@ -7,6 +7,7 @@ import { AjusteMasivoDialog } from './components/AjusteMasivoDialog';
 import { InventarioInicialDialog } from './components/InventarioInicialDialog';
 import { calcularKPIsInventario, calcularVariacion, cabezasPorHaFinca } from '@/utils/calculosGanado';
 import { formatNumber } from '@/utils/format';
+import { fechaAISODate } from '@/utils/fechas';
 import { Button } from '@/components/ui/button';
 import { AlertTriangle, SlidersHorizontal, Loader2, TrendingUp, TrendingDown, ClipboardPlus } from 'lucide-react';
 import { toast } from 'sonner';
@@ -45,7 +46,7 @@ export function GanadoDashboard() {
     try {
       const hace30 = new Date();
       hace30.setDate(hace30.getDate() - 30);
-      const fechaDesde = hace30.toISOString().split('T')[0];
+      const fechaDesde = fechaAISODate(hace30);
 
       const [inv, estructura, pend, movs] = await Promise.all([
         fetchInventario(),

--- a/src/components/inventory/dashboard/hooks/useInventoryDashboard.ts
+++ b/src/components/inventory/dashboard/hooks/useInventoryDashboard.ts
@@ -1,6 +1,6 @@
 import { useState } from 'react';
 import { getSupabase } from '@/utils/supabase/client';
-import { calcularRangoFechasPorPeriodo } from '@/utils/fechas';
+import { calcularRangoFechasPorPeriodo, fechaAISODate } from '@/utils/fechas';
 import type { DashboardPeriodo, KPIConVariacion } from '@/types/finanzas';
 
 export interface TreemapCategoriaItem {
@@ -112,14 +112,14 @@ export function useInventoryDashboard() {
       const now = new Date();
       const mesAnteriorFin = new Date(now.getFullYear(), now.getMonth(), 0); // ultimo dia mes anterior
       const mesAnteriorInicio = new Date(now.getFullYear(), now.getMonth() - 1, 1);
-      const mesAnteriorFinStr = mesAnteriorFin.toISOString().split('T')[0];
+      const mesAnteriorFinStr = fechaAISODate(mesAnteriorFin);
 
       // Calculate approximate previous month valuation by subtracting this month's movements
       const { data: movEsteMes } = await supabase
         .from('movimientos_inventario')
         .select('tipo_movimiento, valor_movimiento')
         .gte('fecha_movimiento', `${now.getFullYear()}-${String(now.getMonth() + 1).padStart(2, '0')}-01`)
-        .lte('fecha_movimiento', now.toISOString().split('T')[0]);
+        .lte('fecha_movimiento', fechaAISODate(now));
 
       let deltaEsteMes = 0;
       (movEsteMes as any[])?.forEach((m: any) => {
@@ -211,8 +211,8 @@ export function useInventoryDashboard() {
     const hoy = new Date();
     const limite = new Date();
     limite.setDate(limite.getDate() + 60);
-    const limiteStr = limite.toISOString().split('T')[0];
-    const hoyStr = hoy.toISOString().split('T')[0];
+    const limiteStr = fechaAISODate(limite);
+    const hoyStr = fechaAISODate(hoy);
 
     const { data } = await supabase
       .from('compras')

--- a/src/components/labores/ReportesView.tsx
+++ b/src/components/labores/ReportesView.tsx
@@ -3,7 +3,7 @@ import { getSupabase } from '../../utils/supabase/client';
 import { Button } from '../ui/button';
 import { Card, CardContent, CardDescription, CardHeader, CardTitle } from '../ui/card';
 import { Badge } from '../ui/badge';
-import { formatearFecha, formatearFechaCorta } from '../../utils/fechas';
+import { formatearFecha, formatearFechaCorta, fechaAISODate } from '../../utils/fechas';
 import {
   Select,
   SelectContent,
@@ -120,14 +120,14 @@ const ReportesView: React.FC<ReportesViewProps> = ({
     const day = now.getDay();
     const monday = new Date(now);
     monday.setDate(now.getDate() - (day === 0 ? 6 : day - 1));
-    return monday.toISOString().split('T')[0];
+    return fechaAISODate(monday);
   });
   const [fechaFin, setFechaFin] = useState(() => {
     const now = new Date();
     const day = now.getDay();
     const sunday = new Date(now);
     sunday.setDate(now.getDate() + (day === 0 ? 0 : 7 - day));
-    return sunday.toISOString().split('T')[0];
+    return fechaAISODate(sunday);
   });
 
   // Estados de datos

--- a/src/components/monitoreo/MapaCalorIncidencias.tsx
+++ b/src/components/monitoreo/MapaCalorIncidencias.tsx
@@ -21,7 +21,7 @@ import {
   FilaMapaCalor,
   RondaMonitoreo
 } from '../../types/monitoreo';
-import { formatearFecha } from '../../utils/fechas';
+import { formatearFecha, fechaAISODate } from '../../utils/fechas';
 import { calcularIncidencia, clasificarGravedad } from '../../utils/calculosMonitoreo';
 
 // ============================================
@@ -42,7 +42,7 @@ interface MapaCalorIncidenciasProps {
 const DIAS_VIGENCIA_LOTE = 30;
 
 function obtenerFecha(fecha: Date | string): string {
-  return typeof fecha === 'string' ? fecha : fecha.toISOString().split('T')[0];
+  return typeof fecha === 'string' ? fecha : fechaAISODate(fecha);
 }
 
 // "Beneficos"/"Benéficos" (con o sin tilde, cualquier capitalización) no son una

--- a/src/components/monitoreo/hooks/usePriorizacionMonitoreo.ts
+++ b/src/components/monitoreo/hooks/usePriorizacionMonitoreo.ts
@@ -37,6 +37,7 @@
 
 import { useState, useCallback } from 'react';
 import { getSupabase } from '@/utils/supabase/client';
+import { fechaAISODate } from '@/utils/fechas';
 import { priorizarMonitoreo, calcularCoberturaRonda } from '@/utils/priorizacionMonitoreo';
 import type {
   HistorialSublotePlaga,
@@ -61,7 +62,7 @@ function uno<T>(v: T | T[] | null | undefined): T | null {
 function fechaHaceNDias(dias: number): string {
   const d = new Date();
   d.setDate(d.getDate() - dias);
-  return d.toISOString().split('T')[0];
+  return fechaAISODate(d);
 }
 
 interface MonitoreoRawRow {

--- a/src/utils/calculosClima.ts
+++ b/src/utils/calculosClima.ts
@@ -1,4 +1,5 @@
 import type { LecturaClima, ResumenClima, ResumenDiario, LecturaClimaAgregada, DatoAnualOverlay, SerieAnual } from '@/types/clima';
+import { fechaAISODate } from '@/utils/fechas';
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
@@ -57,7 +58,7 @@ export function lecturaActual(rows: LecturaClima[]): LecturaClima | null {
 
 export function calcularResumenPeriodoDiario(rows: ResumenDiario[], dias: number): ResumenClima {
   const cutoff = new Date(Date.now() - dias * 24 * 60 * 60 * 1000);
-  const cutoffStr = cutoff.toISOString().slice(0, 10);
+  const cutoffStr = fechaAISODate(cutoff);
   const filtered = rows.filter(r => r.fecha >= cutoffStr);
   return buildResumenFromDaily(filtered);
 }


### PR DESCRIPTION
## Bug

`src/__tests__/hatoFechaLocalGuard.test.ts` is the static guard for the "hoy en UTC" data-corruption class documented in the root `CLAUDE.md`. It was **green while 23 live occurrences of the same antipattern existed in 9 files**, because `PATRON_UTC_HOY` required the literal `new Date().toISOString()`. A `const now = new Date()` one line earlier was enough to hide the bug:

```ts
const now = new Date();
...
const hoyStr = now.toISOString().split('T')[0];   // invisible to the guard
```

This is the **third** failure mode of this same guard (1: only `.slice(0,10)`, missed 36 `.split('T')[0]`; 2: only the literal receiver, missed these 23).

Who hits it: everyone, every evening. `toISOString()` is always UTC, so from 19:00 Bogotá (UTC-5) the truncated string is **tomorrow**.

The one site with **visible impact today** is the Inventario dashboard:

`src/components/inventory/dashboard/hooks/useInventoryDashboard.ts:215` → `:239`
```ts
const hoyStr = hoy.toISOString().split('T')[0];   // 19:00+ -> mañana
...
vencido: fv <= hoyStr,
```
A product expiring **tomorrow** is rendered as **already expired** after 19:00 Bogotá.

The rest shift date windows rather than corrupt stored rows, but two are user-visible numbers:
- `src/components/Dashboard.tsx:184/188/215` — `lunesAnterior` / `lunesActual` / the sparkline cursor all carry wall-clock time, so after 19:00 the "semana actual" boundary lands on Tuesday. Monday's jornales fall into *semana anterior*, and the sparkline keys stop matching `fecha_trabajo`. The weekly jornales KPI and its variación are wrong every evening.
- `src/components/labores/ReportesView.tsx:123/130` — the Reportes de Labores default week opens on the wrong Monday/Sunday after 19:00.

Minor window drift: `GanadoDashboard.tsx:48` (30d), `usePriorizacionMonitoreo.ts:64` (N days), `calculosClima.ts:60`, `ContextoSolar.tsx:27-28`, `ClimaCard.tsx:19` (7/30/90d cutoffs) — each one day short after 19:00.

Neutral in UTC-5 but fragile, migrated for consistency: `Dashboard.tsx:227-229` (`new Date(y,m,d)` is local midnight), `MapaCalorIncidencias.tsx:45`.

## Root cause

`src/__tests__/hatoFechaLocalGuard.test.ts:46`

```ts
const PATRON_UTC_HOY =
  /new Date\(\)\.toISOString\(\)\.(?:slice\(0,\s*10\)|split\('T'\)\[0\]|substring\(0,\s*10\))/;
```

The pattern tried to identify *the receiver* rather than forbid *the operation*. Truncating any `toISOString()` to 10 characters yields the UTC calendar day regardless of where the `Date` came from, so pinning the receiver could never be complete.

## Fix

Two ordered steps, both in this PR (a widened guard without the migration would leave `main` red).

**1. The guard now forbids the truncation itself:**
```ts
const PATRON_UTC_HOY =
  /\.toISOString\(\)\s*\.\s*(?:slice\(0,\s*10\)|split\('T'\)\[0\]|substring\(0,\s*10\))/g;
```

Legitimate uses go in `LISTA_BLANCA_UTC`, a **closed and counted** list — each entry declares its file *and how many occurrences it may have*, so adding a new offending line to an already-whitelisted 1.900-line file still fails the guard. A second test case asserts the whitelist is not stale (declared count must equal the real count), so a whitelist entry cannot outlive the use it covers.

Whitelisted (6 occurrences, 3 files) — all the same legitimate shape: a `Date` **deliberately constructed in UTC** (`new Date('AAAA-MM-DDT00:00:00Z')`, or `new Date('AAAA-MM-DD')`, which the engine parses as UTC midnight), arithmetic done in UTC, read back in UTC. The round trip cancels, so `toISOString()` is the **correct** reader there and `fechaAISODate()` (local getters) would shift them a day **backwards** in UTC-5:
- `hato/components/EventoTimeline.tsx` (1) — `fechaCorteTimeline()`; the old guard's own error message already cited it as the pattern to imitate.
- `utils/fetchDatosReporteSemanal.ts` (3) — `restarDias()`, `enumerarFechas()`, `histInicio`.
- `monitoreo/TablaMonitoreos.tsx` (2) — `agruparPorSemana()` mixes `new Date(fecha_monitoreo)` (UTC) with `getDay()`/`getDate()` (local). **This one is genuinely wrong**, but the fix is the whole week-number arithmetic, not the read-back; changing only the read would move the labels without correcting the calculation. Frozen at 2 on purpose so no *new* site can slip into the file meanwhile. Filed separately.

**2. Migrated the 23 real sites** to the helpers that already exist in `src/utils/fechas.ts` — `obtenerFechaHoy()` for "hoy", `fechaAISODate(d)` for a derived `Date`. No new helper was written, no logic was restructured, no adjacent code touched.

## Verification

- **The guard is red before and green after**, with a closed list. Before the migration it printed exactly:
  ```
  src/components/Dashboard.tsx (10 apariciones, permitidas 0)
  src/components/clima/components/ContextoSolar.tsx (2 ...)
  src/components/dashboard/ClimaCard.tsx (1 ...)
  src/components/ganado/GanadoDashboard.tsx (1 ...)
  src/components/inventory/dashboard/hooks/useInventoryDashboard.ts (4 ...)
  src/components/labores/ReportesView.tsx (2 ...)
  src/components/monitoreo/MapaCalorIncidencias.tsx (1 ...)
  src/components/monitoreo/hooks/usePriorizacionMonitoreo.ts (1 ...)
  src/utils/calculosClima.ts (1 ...)
  ```
- **New deterministic regression** for the visible-impact site (`describe('regresión: un producto que vence MAÑANA no se marca vencido de noche')`), fixed clock + fixed TZ at `2026-08-03T21:13:25-05:00`, asserting both directions: `fechaAISODate(new Date())` keeps `2026-08-04` vigente, and the old spelling marked it vencido. It fails always, not only between 19:00 and midnight.
- `npm test` — **85 files / 2030 tests, all passing.**
- `npx tsc --noEmit` — clean, exit 0.
- `npm run lint` — **0 errors**, 947 warnings. Linting only the 10 changed files gives **69 warnings before and 69 after** (identical), so this PR adds none.

No edge-function copy is affected: `calculosClima.ts` is not mirrored, and `fechaHaceNDias` in `chat.tsx` is the Deno-side implementation, which the root `CLAUDE.md` puts deliberately out of scope for this helper (Deno runs in UTC; it needs an explicit `America/Bogota` conversion instead). No redeploy required.

## Rollback

`git revert` the single commit. The change is mechanical and self-contained — no schema, no migration, no edge function, no CSS.

## Follow-up (deliberately out of scope)

1. `TablaMonitoreos.agruparPorSemana()` mixes UTC parsing with local getters; needs its own fix to the week arithmetic.
2. The root `CLAUDE.md` claim that this class is closed ("Fixed across all 36 browser call sites") is now accurate again but should say **59** and describe the counted-whitelist contract. Left out so this PR stays code-only.
3. The 4 edge-function sites named in `CLAUDE.md` (`chat.tsx`, `generar-reporte-semanal.tsx`, `telegram/bot.ts`, `telegram/conversations/*`) are still open and still need the `America/Bogota` treatment, not this helper.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyKKf7nZDsMozfEYmoJfAP)_