### PR TITLE
fix(inventario): stop ProductForm from rewriting stock with no movimiento

### DIFF
--- a/src/__tests__/productoStockSinMovimiento.test.ts
+++ b/src/__tests__/productoStockSinMovimiento.test.ts
@@ -1,0 +1,123 @@
+// ARCHIVO: __tests__/productoStockSinMovimiento.test.ts
+// DESCRIPCIÓN: `productos.cantidad_actual` es SALDO DE INVENTARIO. Solo puede
+// cambiar junto con la fila de `movimientos_inventario` que lo explica.
+//
+// `ProductForm` en modo EDICIÓN mandaba `{ ...formData }` completo al UPDATE.
+// Como `cantidad_actual` es un campo más del formulario, el saldo viajaba con
+// el resto y se sobrescribía SIN movimiento: una mutación de stock sin rastro.
+//
+// El defecto era invisible a un grep. Los cuatro escritores legítimos
+// (`NuevoMovimientoModal`, `NewPurchase`, `PurchaseHistory`, `CierreAplicacion`)
+// escriben `cantidad_actual:` de forma explícita y todos insertan su movimiento;
+// este escribía el mismo campo montado en un spread, sin nombrarlo nunca.
+//
+// Evidencia en producción (2026-08-10): 5 productos activos tienen desfase
+// entre `cantidad_actual` y la suma de sus `movimientos_inventario` Y su
+// `updated_at` es POSTERIOR al último movimiento -- el orden que deja este bug.
+// El peor es Sulcamag: un único movimiento de +8.000, `cantidad_actual = 16`,
+// `updated_at` 9 días después del movimiento. -7.984 sin una sola fila que lo
+// explique.
+//
+// El camino correcto para corregir un saldo ya existe: `NuevoMovimientoModal`
+// con `tipo = 'Ajuste'`, que inserta en `movimientos_inventario` ANTES de tocar
+// `productos` (NuevoMovimientoModal.tsx:133 -> :150).
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import { prepararDatosProducto } from '@/components/inventory/ProductForm';
+
+/** Formulario mínimo: solo los campos que este contrato mira. El helper
+ * recibe el ProductData completo en producción, pero es agnóstico al resto. */
+const formulario = {
+  nombre: 'Naturboro',
+  categoria: 'Fertilizante',
+  cantidad_actual: 999,
+  stock_minimo: 5,
+  precio_unitario: 1200,
+  registro_ica: '',
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any -- fixture parcial a propósito
+} as any;
+
+describe('prepararDatosProducto — el saldo de inventario no viaja en un UPDATE', () => {
+  it('en EDICIÓN elimina cantidad_actual del payload', () => {
+    const datos = prepararDatosProducto(formulario, true);
+
+    // Este es el assert que fallaba: antes del arreglo `cantidad_actual` salía
+    // en el objeto con el valor del input y se escribía en `productos`.
+    expect('cantidad_actual' in datos).toBe(false);
+  });
+
+  it('en EDICIÓN sí deja pasar el resto de los campos del producto', () => {
+    const datos = prepararDatosProducto(formulario, true);
+
+    expect(datos.nombre).toBe('Naturboro');
+    expect(datos.categoria).toBe('Fertilizante');
+    expect(datos.stock_minimo).toBe(5);
+    expect(datos.precio_unitario).toBe(1200);
+  });
+
+  it('en CREACIÓN sí incluye cantidad_actual: es el saldo de apertura', () => {
+    const datos = prepararDatosProducto(formulario, false);
+
+    expect(datos.cantidad_actual).toBe(999);
+    expect(datos.activo).toBe(true);
+  });
+
+  it('convierte los strings vacíos a null, no a 0 -- "sin dato" no es "cero"', () => {
+    const datos = prepararDatosProducto(formulario, true);
+
+    expect(datos.registro_ica).toBeNull();
+  });
+
+  it('no marca `activo` en EDICIÓN -- reactivaría un producto dado de baja', () => {
+    const datos = prepararDatosProducto(formulario, true);
+
+    expect('activo' in datos).toBe(false);
+  });
+});
+
+// ============================================================================
+// Guard estático: nadie más puede escribir el saldo sin dejar movimiento.
+//
+// El helper de arriba cierra ProductForm, pero el patrón que lo causó -- mandar
+// un objeto de formulario entero a `productos` -- puede repetirse en cualquier
+// pantalla nueva. Los escritores legítimos están enumerados; cualquier archivo
+// que escriba `cantidad_actual` a `productos` sin insertar en
+// `movimientos_inventario` en el mismo archivo rompe el contrato.
+// ============================================================================
+
+/** Archivos autorizados a mover el saldo, cada uno con su movimiento al lado. */
+const ESCRITORES_AUTORIZADOS = [
+  'src/components/inventory/NuevoMovimientoModal.tsx',
+  'src/components/inventory/NewPurchase.tsx',
+  'src/components/inventory/PurchaseHistory.tsx',
+  'src/components/aplicaciones/CierreAplicacion.tsx',
+];
+
+describe('guard: todo escritor de productos.cantidad_actual inserta su movimiento', () => {
+  it.each(ESCRITORES_AUTORIZADOS)('%s inserta en movimientos_inventario', (archivo) => {
+    const fuente = readFileSync(join(process.cwd(), archivo), 'utf-8');
+
+    expect(/cantidad_actual\s*:/.test(fuente), `${archivo} ya no escribe el saldo`).toBe(true);
+    expect(
+      fuente.includes("from('movimientos_inventario')"),
+      `${archivo} escribe productos.cantidad_actual pero ya no toca movimientos_inventario. ` +
+        'Un saldo que cambia sin movimiento es stock sin trazabilidad.',
+    ).toBe(true);
+  });
+
+  it('ProductForm NO escribe el saldo: lo borra del payload en edición', () => {
+    const fuente = readFileSync(
+      join(process.cwd(), 'src/components/inventory/ProductForm.tsx'),
+      'utf-8',
+    );
+
+    expect(
+      fuente.includes('delete datos.cantidad_actual'),
+      'ProductForm volvió a mandar cantidad_actual en el UPDATE. Eso sobrescribe el ' +
+        'saldo de inventario sin dejar fila en movimientos_inventario. Para corregir un ' +
+        "saldo está NuevoMovimientoModal con tipo 'Ajuste'.",
+    ).toBe(true);
+  });
+});

--- a/src/components/inventory/ProductForm.tsx
+++ b/src/components/inventory/ProductForm.tsx
@@ -116,6 +116,41 @@ const initialFormData: ProductData = {
   link_hoja_seguridad: '',
 };
 
+/**
+ * Arma el objeto que viaja a `productos` en INSERT o UPDATE.
+ *
+ * `cantidad_actual` es SALDO DE INVENTARIO, no un atributo del producto: solo
+ * puede cambiar junto con la fila que lo explica en `movimientos_inventario`.
+ * En modo EDICIÓN se saca del payload, porque el formulario mandaba el valor
+ * del input con un `{ ...formData }` y sobrescribía el saldo sin dejar
+ * movimiento -- una mutación de stock sin rastro, justo lo que el módulo de
+ * inventario existe para impedir. Para corregir un saldo está
+ * `NuevoMovimientoModal` con `tipo = 'Ajuste'`, que inserta el movimiento
+ * ANTES de tocar `productos`.
+ *
+ * En modo CREACIÓN sí viaja: es el saldo de apertura del producto, y no hay
+ * nada anterior que un movimiento pudiera explicar.
+ */
+export function prepararDatosProducto(
+  formData: ProductData,
+  esEdicion: boolean,
+): Record<string, unknown> {
+  const datos: Record<string, unknown> = { ...formData };
+
+  // Los strings vacíos de los inputs numéricos son "sin valor", no 0.
+  Object.keys(datos).forEach((key) => {
+    if (datos[key] === '') datos[key] = null;
+  });
+
+  if (esEdicion) {
+    delete datos.cantidad_actual;
+  } else {
+    datos.activo = true;
+  }
+
+  return datos;
+}
+
 export function ProductForm({ isOpen, onClose, productId, onSuccess }: ProductFormProps) {
   const { profile } = useAuth();
   const [formData, setFormData, clearFormData, wasRestored] = useFormPersistence<ProductData>({
@@ -236,20 +271,10 @@ export function ProductForm({ isOpen, onClose, productId, onSuccess }: ProductFo
     try {
       const supabase = getSupabase();
       
-      // Preparar datos para insertar/actualizar
-      const dataToSave: any = { ...formData };
-      
-      // Convertir strings vacíos a null para campos numéricos
-      Object.keys(dataToSave).forEach(key => {
-        if (dataToSave[key] === '') {
-          dataToSave[key] = null;
-        }
-      });
-
-      // Agregar campo activo si es creación
-      if (!productId) {
-        dataToSave.activo = true;
-      }
+      // Preparar datos para insertar/actualizar. En edición NO incluye
+      // `cantidad_actual` -- ver prepararDatosProducto().
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any -- el builder tipado de Supabase no acepta un Record genérico; este objeto ya era `any` antes de extraer el helper
+      const dataToSave = prepararDatosProducto(formData, Boolean(productId)) as any;
 
       if (productId) {
         // MODO EDICIÓN
@@ -504,10 +529,13 @@ export function ProductForm({ isOpen, onClose, productId, onSuccess }: ProductFo
 
                 <h4 className="text-md text-gray-800 mt-6 mb-3">Inventario</h4>
                 <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-                  {/* Cantidad Actual */}
+                  {/* Cantidad Actual — solo editable al CREAR (saldo de
+                      apertura). En edición es de solo lectura: el saldo se
+                      corrige con un movimiento de Ajuste, que deja rastro. */}
                   <div>
                     <label className="block text-sm text-gray-700 mb-1">
                       Cantidad Actual
+                      {productId && <span className="text-xs text-primary"> ✓ Solo movimientos</span>}
                     </label>
                     <input
                       type="number"
@@ -515,11 +543,22 @@ export function ProductForm({ isOpen, onClose, productId, onSuccess }: ProductFo
                       name="cantidad_actual"
                       value={formData.cantidad_actual}
                       onChange={handleChange}
+                      readOnly={Boolean(productId)}
                       step="0.01"
                       min="0"
-                      className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent"
+                      className={
+                        productId
+                          ? 'w-full px-4 py-2 border border-gray-300 rounded-lg bg-gray-50 text-gray-600 cursor-not-allowed'
+                          : 'w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary focus:border-transparent'
+                      }
                       placeholder="Cantidad en inventario"
                     />
+                    {productId && (
+                      <p className="mt-1 text-xs text-gray-500">
+                        El saldo solo cambia con un movimiento. Para corregirlo usa
+                        Movimientos → Nuevo movimiento → Ajuste.
+                      </p>
+                    )}
                   </div>
 
                   {/* Stock Mínimo */}


### PR DESCRIPTION
## Bug

Editing a product from Inventario → Productos → Editar could **overwrite the inventory balance with no row in `movimientos_inventario`**. Stock changes with nothing to explain it — exactly what the inventory module exists to prevent.

Who hits it: any Administrador or Gerencia user who opens the edit form for any reason (fixing a name, a price, a registro ICA). The `Cantidad Actual` input is live and pre-filled, so the balance is re-sent on **every** save, and any stray keystroke or stale draft in it silently becomes the new stock.

Since when: the form has always worked this way. Note migration 073 (2026-07-31) closed the *other* untraceable stock path (`actualizar_cantidad_producto()`, dropped); this one is in app code and is still live today.

**Evidence in production** — active products whose `cantidad_actual` does not reconcile with the sum of their `movimientos_inventario` **and** whose `updated_at` is *later* than their last movimiento (the ordering this bug leaves behind):

```sql
WITH mov AS (
  SELECT producto_id,
         SUM(CASE WHEN lower(btrim(tipo_movimiento::text)) = 'entrada' THEN cantidad
                  WHEN lower(btrim(tipo_movimiento::text)) LIKE 'salida%' THEN -cantidad
                  WHEN lower(btrim(tipo_movimiento::text)) = 'ajuste'  THEN cantidad
                  ELSE 0 END) AS saldo_movs,
         COUNT(*) AS n_movs, MAX(created_at) AS ultimo_mov_creado
  FROM movimientos_inventario GROUP BY producto_id
)
SELECT p.nombre, p.cantidad_actual, m.saldo_movs,
       p.cantidad_actual - m.saldo_movs AS desfase, m.n_movs,
       m.ultimo_mov_creado, p.updated_at
FROM productos p JOIN mov m ON m.producto_id = p.id
WHERE p.activo AND ABS(p.cantidad_actual - m.saldo_movs) > 0.001
  AND p.updated_at > m.ultimo_mov_creado
ORDER BY p.updated_at DESC;
```

| nombre | cantidad_actual | saldo_movs | desfase | n_movs | último movimiento | updated_at |
|---|---|---|---|---|---|---|
| Sulcamag | 16,00 | 8.000,00 | **−7.984,00** | 1 | 2026-07-15 12:27 | 2026-07-24 20:05 |
| Borozinco | 165,00 | −155,00 | +320,00 | 3 | 2026-06-13 13:37 | 2026-06-16 21:03 |
| Rafos | 569,00 | −3.031,00 | +3.600,00 | 4 | 2026-06-13 13:37 | 2026-06-16 21:02 |
| Integrador | 184,00 | −6,00 | +190,00 | 2 | 2026-05-04 12:57 | 2026-05-04 14:52 |
| TecniFeed Boro | 0,40 | −19,49 | +19,89 | 1 | 2026-02-02 21:29 | 2026-04-13 14:09 |

Sulcamag is the clearest: **one** movimiento of +8.000, a current balance of 16, and an `updated_at` nine days after that single movimiento. −7.984 with not one row explaining it.

(The wider 209-of-226 reconciliation gap is mostly opening balances seeded at product creation and is **not** claimed here — the `updated_at > último movimiento` filter above is what isolates the out-of-band edit.)

## Root cause

`src/components/inventory/ProductForm.tsx:240-259` (pre-fix)

```ts
const dataToSave: any = { ...formData };   // formData incluye cantidad_actual
...
if (productId) {
  await supabase.from('productos').update(dataToSave).eq('id', productId);
}
```

`cantidad_actual` is one more field of `ProductData`, so it rides the spread into the UPDATE. The form never inserts into `movimientos_inventario`.

**The defect was invisible to grep.** The four legitimate writers — `NuevoMovimientoModal.tsx:154`, `NewPurchase.tsx:393`, `PurchaseHistory.tsx:344`, `CierreAplicacion.tsx:608` — all write `cantidad_actual:` explicitly *and* all insert their movimiento. This one wrote the same column mounted on an object spread, never naming it.

## Fix

Three small changes, no refactor beyond what the test needs:

1. **Extracted `prepararDatosProducto(formData, esEdicion)`** — the same empty-string→null normalisation and `activo` handling that was inline, plus `delete datos.cantidad_actual` when editing. Pure and exported, so the contract is testable without a DOM (the repo has no jsdom/testing-library). On **create** the balance still goes through: that is the opening balance, and there is nothing prior for a movimiento to explain.
2. **`readOnly` on the input in edit mode**, with the grey styling already used by the calculated `precio_unitario` field right above it, a `✓ Solo movimientos` label, and a hint pointing at **Movimientos → Nuevo movimiento → Ajuste** — the flow that already does this correctly (`NuevoMovimientoModal.tsx:133` inserts the movimiento *before* `:150` touches `productos`).
3. The `as any` at the call site is preserved deliberately — the object was already `any`, and Supabase's typed builder rejects a generic `Record`. Marked with an eslint-disable and a reason rather than widening the helper's return type.

`ImportarProductosCSV.tsx` was checked and cleared: it posts to the edge function, which only ever calls `.insert(producto)` (`importar-productos.tsx:407`) — no upsert, no `onConflict`, so it cannot update an existing row's balance.

## Verification

- **New test `src/__tests__/productoStockSinMovimiento.test.ts` (10 cases), proven red before the fix.** Commenting out the single `delete datos.cantidad_actual` line fails exactly one case (`en EDICIÓN elimina cantidad_actual del payload`) and leaves the other 9 green.
- It also covers: the other fields still pass through, create keeps the opening balance, `''` normalises to `null` (not `0`), and `activo` is **not** set on edit (which would silently reactivate a discontinued product).
- Plus a static guard asserting the four authorised writers still insert into `movimientos_inventario` in the same file, so a future edit cannot quietly decouple a balance write from its movimiento.
- `npm test` — **86 files / 2036 tests, all passing** (`dialogScrollContract` and `numberInputWheelContract` included).
- `npx tsc --noEmit` — clean, exit 0.
- `npm run lint` — **0 errors**, 946 warnings (one fewer than `main`). The changed files carry 6 warnings, all pre-existing patterns.

No edge function touched, no migration, no CSS, no redeploy required.

## Rollback

`git revert` the single commit. It restores the previous inline payload construction; no data or schema is involved.

## Follow-up (deliberately NOT in this PR)

**Repairing the 5 products' historical balances is data surgery and needs Santiago's approval** — it is filed as a separate finding with the exact SQL, a rollback and a row count, not shipped here. This PR only stops new damage. Each of the five needs a decision on which number is true (the balance on screen or the sum of movimientos) before any `Ajuste` movimiento is written to reconcile it.


---
_Generated by [Claude Code](https://claude.ai/code/session_01WyKKf7nZDsMozfEYmoJfAP)_