### PR TITLE
fix(reportes): drench reportaba progreso en 0% en el resumen semanal

### DIFF
--- a/src/__tests__/reporteSemanal.test.ts
+++ b/src/__tests__/reporteSemanal.test.ts
@@ -675,6 +675,51 @@ describe('fetchAplicacionesActivas', () => {
     expect(loteST!.porcentaje).toBeCloseTo(53.3, 0);
   });
 
+  // Regresión: el reporte leía numero_bultos para todo lo que no fuera 'Fumigación',
+  // así que Drench (que sólo escribe numero_canecas/litros_mezcla) salía en 0%.
+  // Caso real: "Drench agosto" 2026 — 634,7 canecas planeadas, 97 ejecutadas,
+  // se reportaba 0 de 0.
+  it('calcula progreso en canecas para drench, no en bultos', async () => {
+    const MOCK_DRENCH = [{
+      id: 'app-drench',
+      nombre_aplicacion: 'Drench agosto',
+      tipo_aplicacion: 'Drench',
+      proposito: 'Nutrición radicular',
+      estado: 'En ejecución',
+      fecha_inicio_ejecucion: '2026-08-04',
+      aplicaciones_calculos: [
+        { lote_id: 'lote-1', numero_canecas: 400, numero_bultos: null, lotes: { nombre: 'Lote PP' } },
+        { lote_id: 'lote-2', numero_canecas: 234.7, numero_bultos: null, lotes: { nombre: 'Lote ST' } },
+      ],
+      movimientos_diarios: [
+        { lote_id: 'lote-1', numero_canecas: 60, numero_bultos: null },
+        { lote_id: 'lote-1', numero_canecas: 25, numero_bultos: null },
+        { lote_id: 'lote-2', numero_canecas: 12, numero_bultos: null },
+      ],
+    }];
+
+    const appChain = createChainableMock({ data: MOCK_DRENCH, error: null });
+    mockFrom.mockImplementation((table: string) => {
+      if (table === 'aplicaciones') return appChain;
+      return createChainableMock();
+    });
+
+    const resultado = await fetchAplicacionesActivas();
+
+    expect(resultado.length).toBe(1);
+    const app = resultado[0];
+    expect(app.unidad).toBe('canecas');
+    expect(app.totalPlaneado).toBeCloseTo(634.7, 1);
+    expect(app.totalEjecutado).toBe(97);
+    expect(app.porcentajeGlobal).toBeGreaterThan(0);
+    expect(app.porcentajeGlobal).toBeCloseTo(15.3, 1);
+
+    const lotePP = app.progresoPorLote.find(l => l.loteNombre === 'Lote PP');
+    expect(lotePP!.planeado).toBe(400);
+    expect(lotePP!.ejecutado).toBe(85);
+    expect(lotePP!.unidad).toBe('canecas');
+  });
+
   it('retorna lista vacía cuando no hay aplicaciones activas', async () => {
     const appChain = createChainableMock({ data: [], error: null });
     mockFrom.mockReturnValue(appChain);

--- a/src/components/aplicaciones/DailyMovementsDashboard.tsx
+++ b/src/components/aplicaciones/DailyMovementsDashboard.tsx
@@ -28,6 +28,7 @@ import type {
   ProductoEnMezcla
 } from '../../types/aplicaciones';
 import { obtenerFechaHoy } from '@/utils/fechas';
+import { usaCanecas } from '@/utils/calculosAplicaciones';
 
 interface DailyMovementsDashboardProps {
   aplicacion: Aplicacion;
@@ -493,7 +494,9 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
       </div>
 
       {/* Resumen de Canecas/Bultos Totales */}
-      {aplicacion.tipo_aplicacion === 'Fumigación' && canecasTotales && (
+      {/* Drench se mide en canecas igual que Fumigación: loadCanecasPlaneadas() lee
+          numero_canecas, que es justamente lo que la calculadora escribe para ambos. */}
+      {usaCanecas(aplicacion.tipo_aplicacion) && canecasTotales && (
         <div className="bg-gradient-to-br from-primary/10 to-secondary/10 rounded-2xl border border-primary/20 p-6">
           <div className="flex items-center gap-4">
             <div className="w-14 h-14 bg-primary/20 rounded-xl flex items-center justify-center">

--- a/src/utils/calculosAplicaciones.ts
+++ b/src/utils/calculosAplicaciones.ts
@@ -12,8 +12,30 @@ import type {
 } from '../types/aplicaciones';
 
 /**
+ * ¿Esta aplicación se mide en canecas (mezcla líquida) o en bultos (sólido)?
+ *
+ * Solo Fertilización trabaja con bultos/kilos. Fumigación y Drench comparten la
+ * misma lógica de mezcla líquida, así que ambas se miden en canecas/litros.
+ *
+ * Esta es la MISMA regla que aplica la calculadora al guardar
+ * (`CalculadoraAplicaciones.tsx`): para fumigación y drench escribe
+ * `numero_canecas`/`litros_mezcla` y deja `numero_bultos`/`kilos_totales` en NULL.
+ * Todo consumidor de `aplicaciones_calculos` o `movimientos_diarios` debe usar
+ * esta función y NUNCA preguntar `tipo === 'Fumigación'`: eso clasifica Drench
+ * como fertilización y lee columnas que siempre están vacías, produciendo ceros.
+ */
+export function usaCanecas(tipo: string | null | undefined): boolean {
+  return tipo !== 'Fertilización';
+}
+
+/** Unidad de recipiente correspondiente al tipo de aplicación. */
+export function unidadAplicacion(tipo: string | null | undefined): 'canecas' | 'bultos' {
+  return usaCanecas(tipo) ? 'canecas' : 'bultos';
+}
+
+/**
  * CÁLCULOS PARA FUMIGACIÓN Y DRENCH
- * 
+ *
  * IMPORTANTE: Fumigación y Drench usan LA MISMA LÓGICA de cálculo:
  * - Fumigación: Aplicación foliar (spray sobre hojas)
  * - Drench: Aplicación edáfica (directo al suelo/raíz)

--- a/src/utils/fetchDatosReporteSemanal.ts
+++ b/src/utils/fetchDatosReporteSemanal.ts
@@ -4,6 +4,7 @@
 
 import { getSupabase } from './supabase/client';
 import { fetchDatosRealesAplicacion, fetchJornalesRealesPorLote } from './aplicacionesReales';
+import { usaCanecas, unidadAplicacion } from './calculosAplicaciones';
 import type {
   RangoSemana,
   DatosPersonal,
@@ -543,7 +544,7 @@ export async function fetchAplicacionesPlaneadas(): Promise<AplicacionPlaneada[]
     });
     
     ((app as any).aplicaciones_calculos || []).forEach((ac: any) => {
-      if (app.tipo_aplicacion === 'Fumigación') {
+      if (usaCanecas(app.tipo_aplicacion)) {
         totalLitrosKg += Number(ac.litros_mezcla) || 0;
       } else {
         totalLitrosKg += Number(ac.kilos_totales) || 0;
@@ -608,15 +609,15 @@ export async function fetchAplicacionesActivas(): Promise<AplicacionActiva[]> {
   const resultado: AplicacionActiva[] = [];
 
   for (const app of aplicaciones || []) {
-    const esFumigacion = app.tipo_aplicacion === 'Fumigación';
-    const unidad: 'canecas' | 'bultos' = esFumigacion ? 'canecas' : 'bultos';
+    const enCanecas = usaCanecas(app.tipo_aplicacion);
+    const unidad = unidadAplicacion(app.tipo_aplicacion);
 
     const movimientos = (app as any).movimientos_diarios || [];
 
     const planeadoPorLote = new Map<string, { nombre: string; planeado: number }>();
     ((app as any).aplicaciones_calculos || []).forEach((calc: any) => {
       const loteNombre = calc.lotes?.nombre || 'Sin lote';
-      const planeado = esFumigacion
+      const planeado = enCanecas
         ? (Number(calc.numero_canecas) || 0)
         : (Number(calc.numero_bultos) || 0);
       planeadoPorLote.set(calc.lote_id, { nombre: loteNombre, planeado });
@@ -624,7 +625,7 @@ export async function fetchAplicacionesActivas(): Promise<AplicacionActiva[]> {
 
     const ejecutadoPorLote = new Map<string, number>();
     movimientos.forEach((mov: any) => {
-      const ejecutado = esFumigacion
+      const ejecutado = enCanecas
         ? (Number(mov.numero_canecas) || 0)
         : (Number(mov.numero_bultos) || 0);
       ejecutadoPorLote.set(
@@ -714,8 +715,8 @@ export async function fetchAplicacionesCerradas(
 
       if (appError || !app) continue;
 
-      const esFumigacion = app.tipo_aplicacion === 'Fumigación';
-      const unidad: 'canecas' | 'bultos' = esFumigacion ? 'canecas' : 'bultos';
+      const enCanecas = usaCanecas(app.tipo_aplicacion);
+      const unidad = unidadAplicacion(app.tipo_aplicacion);
 
       const fechaInicio = app.fecha_inicio_ejecucion || '';
       const fechaFin = app.fecha_fin_ejecucion || app.fecha_cierre || '';
@@ -847,7 +848,7 @@ export async function fetchAplicacionesCerradas(
       let totalCanecasAnt = 0;
       if (prevApp && prevApp.movimientos_diarios) {
         prevApp.movimientos_diarios.forEach((m: any) => {
-          totalCanecasAnt += Number(esFumigacion ? m.numero_canecas : m.numero_bultos) || 0;
+          totalCanecasAnt += Number(enCanecas ? m.numero_canecas : m.numero_bultos) || 0;
         });
       }
       
@@ -885,7 +886,7 @@ export async function fetchAplicacionesCerradas(
       let totalJornalesPlan = 0;
       let totalJornalesReal = 0;
       const totalPlannedApp = Array.from(calcMap.values()).reduce(
-        (sum, c) => sum + (esFumigacion ? (Number(c.litros_mezcla) || 0) : (Number(c.kilos_totales) || 0)),
+        (sum, c) => sum + (enCanecas ? (Number(c.litros_mezcla) || 0) : (Number(c.kilos_totales) || 0)),
         0
       );
       const totalJornalesRealesPorLote = Array.from(jornalesMap.values()).reduce(
@@ -903,15 +904,15 @@ export async function fetchAplicacionesCerradas(
         const mov = movMap.get(loteId) || { canecas: 0, bultos: 0 };
         const jornales = jornalesMap.get(loteId) || { jornales: 0, costo: 0 };
         const arboles = loteInfo.arboles || 1;
-        const totalPlannedQuantity = esFumigacion
+        const totalPlannedQuantity = enCanecas
           ? (Number(calc.litros_mezcla) || 0)
           : (Number(calc.kilos_totales) || 0);
         const quantityRatio = totalPlannedApp > 0 ? totalPlannedQuantity / totalPlannedApp : 0;
 
-        const canecasPlan = esFumigacion ? (Number(calc.numero_canecas) || 0) : (Number(calc.numero_bultos) || 0);
-        const canecasReal = esFumigacion ? mov.canecas : mov.bultos;
+        const canecasPlan = enCanecas ? (Number(calc.numero_canecas) || 0) : (Number(calc.numero_bultos) || 0);
+        const canecasReal = enCanecas ? mov.canecas : mov.bultos;
         const canecasDesv = canecasPlan > 0 ? ((canecasReal - canecasPlan) / canecasPlan) * 100 : 0;
-        const tamanoRecipiente = esFumigacion
+        const tamanoRecipiente = enCanecas
           ? (
             canecasPlan > 0
               ? (Number(calc.litros_mezcla) || 0) / canecasPlan
@@ -966,7 +967,7 @@ export async function fetchAplicacionesCerradas(
           insumosPlaneados: insumosPlaneados > 0 ? Math.round(insumosPlaneados) : undefined,
           insumosReales: insumosReales > 0 ? Math.round(insumosReales) : undefined,
           insumosDesviacion: Math.round(insumosDesv * 10) / 10,
-          insumosUnidad: esFumigacion ? 'L' : 'Kg',
+          insumosUnidad: enCanecas ? 'L' : 'Kg',
           jornalesPlaneados: Math.round(jornalesPlan * 10) / 10 || undefined,
           jornalesReales: jornalesReal || undefined,
           jornalesDesviacion: Math.round(jornalesDesv * 10) / 10,


### PR DESCRIPTION
El reporte semanal decidía la unidad de una aplicación preguntando
`tipo_aplicacion === 'Fumigación'` y mandaba todo lo demás a la rama de
bultos/kilos. Drench cae en ese "todo lo demás", pero la calculadora
guarda drench igual que fumigación: escribe `numero_canecas` y
`litros_mezcla`, y deja `numero_bultos`/`kilos_totales` en NULL. El
reporte terminaba leyendo columnas siempre vacías, así que planeado y
ejecutado daban 0 y el progreso salía 0%.

Verificado contra producción: "Drench agosto" tiene 634,70 canecas
planeadas y 97 ejecutadas (~15%), con 0 en ambas columnas de bultos. El
módulo de aplicaciones sí mostraba el avance porque ahí la pregunta es
`=== 'Fertilización'`, que es la correcta.

- Nuevos helpers `usaCanecas()` / `unidadAplicacion()` en
  calculosAplicaciones.ts, con la regla escrita una sola vez: sólo
  Fertilización usa bultos/kilos; Fumigación y Drench usan canecas/litros.
- fetchDatosReporteSemanal.ts: aplicados en aplicaciones planeadas,
  activas y cerradas (progreso, unidad, insumos L/Kg y tamaño de
  recipiente). La variable `esFumigacion` pasa a `enCanecas`, que es lo
  que realmente significaba.
- DailyMovementsDashboard.tsx: la tarjeta "Progreso de Canecas" estaba
  limitada a Fumigación y no aparecía en drench, aunque su cálculo ya
  leía numero_canecas y era correcto.
- Test de regresión con las cifras reales de "Drench agosto"; falla con
  la regla anterior.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01N1XVZ6hCdC6RxB7ran9G5C