### PR TITLE
feat(hato): eventos y pesaje por Telegram, 5 estados, planilla sincronizada y suscripciones a alertas

### DIFF
--- a/docs/hato/regenerar-copias-importhato.py
+++ b/docs/hato/regenerar-copias-importhato.py
@@ -64,6 +64,11 @@ MODULOS = [
     # `ocrChequeo.ts` (import relativo `./ocrChequeo`), por eso va DESPUÉS
     # en esta lista -- orden de dependencia, solo por legibilidad del log.
     'ocrPesaje.ts',
+    # N12 de docs/plan_hato_telegram_estados_agosto_2026.md: corrección en
+    # texto libre del pesaje por foto (decisión D-C), usada por el bot de
+    # Telegram (`hato-pesaje-pipeline.ts`). Importa `resolverNombreEnRosterPesaje`
+    # de `ocrPesaje.ts` (import relativo `./ocrPesaje`), por eso va AL FINAL.
+    'ocrPesajeCorreccion.ts',
 ]
 
 DESTINOS = [

--- a/docs/plan_hato_telegram_estados_agosto_2026.md
+++ b/docs/plan_hato_telegram_estados_agosto_2026.md
@@ -20,8 +20,10 @@ Estas cinco respuestas gobiernan el grafo. Cambiar una cambia la forma del grafo
 | **D-D** | **Cinco estados: vacía · servida · confirmada · por secar · seca.** Servida = preñada por presunción. Confirmada = palpada. | El estado ya no absorbe "aborto/indeterminado": eso vive en una **columna de alertas** aparte que dice qué pasó, y el dato se captura **manualmente**. |
 | **D-E** | **La planilla del chequeo sale pre-impresa con lo registrado** (ej. "servida 10/ago, toro X") y al lado va la columna de Martha (ok / rech / nota manuscrita). | El chequeo deja de ser captura en blanco y pasa a ser **verificación de lo registrado**. Es el mecanismo de sincronía: lo que Fernando marcó en agosto llega al papel de la vet en agosto. |
 
-**Dato abierto que bloquea un solo nodo (N14):** los nombres exactos con los que quieres los 2 toros
-de monta en el catálogo ("Jersey" y "ternero Holstein" son descripciones de raza, no nombres).
+**Nombres de los 2 toros de monta (resuelto 2026-08-13):** los animales todavía no tienen nombre
+propio; se quedan como **`Jersey`** y **`Ternero Holstein`**. Ambas filas **ya existen** en
+`hato_toros`, así que N14 no crea ninguna (ver N14). No queda ningún dato abierto: el grafo está
+listo para ejecutarse completo.
 
 ---
 
@@ -70,7 +72,7 @@ graph TD
   end
 
   subgraph TOROS["Capa 3 · Toros y pajillas"]
-    N14["N14 · Migración 095<br/>limpieza del catálogo<br/>+ alta de los 2 de monta"]
+    N14["N14 · Migración 095<br/>limpieza del catálogo<br/>(los 2 de monta ya existen)"]
     N15["N15 · Seed de pajillas<br/>6 toros / 27 unidades"]
     N16["N16 · UI: selectores sólo<br/>toros activos"]
   end
@@ -253,9 +255,27 @@ rechaza sola. `fuente='telegram'`, `created_by` explícito.
 Guardada igual que 075/080/081: `RAISE EXCEPTION` si los conteos previos y posteriores no cuadran
 exactamente, y respaldo en el esquema **`respaldos`**, nunca en `public` (lección de la alerta
 crítica del linter del 2026-08-03). `DELETE` de los toros sin referencias en `hato_eventos` /
-`hato_animales`; `activo=false` en los referenciados; alta de los 2 toros de monta con
-`tipo='monta'`.
-*Bloqueado por el dato abierto: los nombres de los 2 toros.*
+`hato_animales`; `activo=false` en los referenciados.
+
+**No da de alta ningún toro de monta: los dos ya existen** (verificado en producción 2026-08-13).
+
+| Fila | raza | tipo | activo hoy | eventos | Qué hace N14 |
+|---|---|---|---|---|---|
+| `Jersey` | Jersey | monta | sí | **44** | **Nada** — ya está exactamente como se necesita. Excepción explícita a la regla "desactivar los referenciados". |
+| `Ternero Holstein` | Holstein | monta | **no** | 0 | **Reactivar** (`activo=true`). |
+| `Holstein` *(histórico)* | — | — | sí | **48** | **Desactivar**, como cualquier otro referenciado. |
+
+La tercera fila es la trampa de este nodo. `Holstein` a secas viene de la importación histórica,
+donde la planilla escribía sólo la raza cuando el toro no tenía nombre (`parseToro` canonicaliza
+`hol/hols/HOLST/…` a un único "Holstein"). **No se fusiona con `Ternero Holstein`**: no hay forma
+de saber cuáles de esos 48 servicios corresponden a este ternero, y fusionar sería inventar
+historia. Mismo criterio que la regla del módulo "dos nombres en la misma hoja son dos animales,
+nunca un rename".
+
+Consecuencia para el índice único: `hato_toros` tiene `UNIQUE (lower(nombre))`, así que un
+`INSERT` de "Jersey" o "Ternero Holstein" habría fallado con `23505`. La migración usa
+**SELECT-or-UPDATE por id**, nunca un upsert de PostgREST — mismo patrón que ya usa `PajillasView`.
+*Sin dependencias. Bloquea N15 y N16.*
 
 **N15 · Seed de pajillas**
 6 toros `tipo='inseminacion'` + sus lotes en `hato_pajillas`, **27 unidades en total**:
@@ -338,7 +358,7 @@ ve antes de aprobar.
 
 | Ola | Nodos | Notas |
 |---|---|---|
-| 1 | N1 · N4 · N11 · N18 · **N14** | Cinco frentes sin dependencias entre sí. N14 espera los nombres de los toros. |
+| 1 | N1 · N4 · N11 · N18 · N14 | Cinco frentes sin dependencias entre sí. Nada bloqueado: los 2 toros de monta ya existen en el catálogo. |
 | 2 | N2 · N5 · N6 · N7 · N8 · N12 · N15 | N2 es el cuello de botella real del grafo. |
 | 3 | N3 · N9 · N10 · N13 · N16 · N19 | |
 | 4 | N17 · N20 · N21 | |

--- a/docs/plan_hato_telegram_estados_agosto_2026.md
+++ b/docs/plan_hato_telegram_estados_agosto_2026.md
@@ -1,0 +1,369 @@
+# Plan — Hato Lechero: eventos por Telegram, 5 estados, display y pajillas
+
+**Origen:** visita de campo del dueño a la finca (2026-08-13). Fernando registró en vivo una monta
+(vio la vaca en celo y llevó el toro) sin ninguna forma de dejarlo asentado hasta el chequeo
+bimensual. De ahí sale todo este alcance.
+
+**Estado del documento:** grafo de trabajo aprobado. Ninguna tarea ejecutada todavía.
+
+---
+
+## 0. Decisiones del dueño (2026-08-13)
+
+Estas cinco respuestas gobiernan el grafo. Cambiar una cambia la forma del grafo, no sólo un nodo.
+
+| # | Decisión | Consecuencia |
+|---|---|---|
+| **D-A** | **Toros: borrar los no usados, desactivar los usados.** | `DELETE` físico de los toros del catálogo sin referencias; `activo=false` en los que sí aparecen en `hato_eventos`. Quedan activos únicamente los 2 de monta + los 6 de pajillas. La historia (232 servicios) sobrevive intacta. |
+| **D-B** | **Telegram escribe directo**, marcado `fuente='telegram'`. | Sin cola de aprobación. El evento existe apenas Fernando lo registra; Martha lo corrige después desde la Hoja de Vida. Rompe la regla D-7 ("solo Gerencia marca el ciclo") para el canal Telegram — decisión explícita, ver R-3. |
+| **D-C** | **Pesaje por foto con corrección en texto libre interpretada por Esco.** | El bot muestra la lectura, Fernando responde en lenguaje natural ("MONZA sem 2 AM son 6.5 y BONITA no se pesó"), Esco traduce a celdas, vuelve a mostrar el resumen y **sólo entonces** persiste. |
+| **D-D** | **Cinco estados: vacía · servida · confirmada · por secar · seca.** Servida = preñada por presunción. Confirmada = palpada. | El estado ya no absorbe "aborto/indeterminado": eso vive en una **columna de alertas** aparte que dice qué pasó, y el dato se captura **manualmente**. |
+| **D-E** | **La planilla del chequeo sale pre-impresa con lo registrado** (ej. "servida 10/ago, toro X") y al lado va la columna de Martha (ok / rech / nota manuscrita). | El chequeo deja de ser captura en blanco y pasa a ser **verificación de lo registrado**. Es el mecanismo de sincronía: lo que Fernando marcó en agosto llega al papel de la vet en agosto. |
+
+**Dato abierto que bloquea un solo nodo (N14):** los nombres exactos con los que quieres los 2 toros
+de monta en el catálogo ("Jersey" y "ternero Holstein" son descripciones de raza, no nombres).
+
+---
+
+## 1. Estado real verificado en producción (2026-08-13)
+
+Todo el grafo está dimensionado contra esto, no contra suposiciones:
+
+- `hato_toros`: **63** filas, **61** activas. **52** están referenciadas por **232** eventos de servicio.
+  `hato_animales.padre_toro_id` está poblado en **0** filas.
+- `hato_pajillas`: **0** filas. `hato_pajillas_uso`: **0**. *No hay inventario que borrar — sólo sembrar.*
+- `hato_eventos`: servicio 412 · parto 300 · aborto 23 · venta 21 · **secado_real 10**. **31** eventos
+  tienen `chequeo_vaca_id IS NULL` (manuales, intocables por el commit de chequeo).
+- `hato_animales`: **65** activos, de los cuales **45** tienen `fecha_nacimiento` (20 no → la columna
+  "Edad" nace con 20 celdas en `—`, nunca en 0).
+- `hato_pesajes_leche`: 549 filas.
+- **El LAZO ABIERTO documentado en `src/components/hato/CLAUDE.md` está cerrado**: los 5 tipos de
+  `hato_alertas_config` ya tienen `destinatario_telegram_id = 8505349717` (Santiago) y están activos.
+- Telegram: Fernando Jiménez (`8587641614`) ya existe y está activo, con rol **Administrador**.
+
+---
+
+## 2. El grafo
+
+```mermaid
+graph TD
+  subgraph BASE["Capa 0 · Motor y contratos (bloquea casi todo)"]
+    N1["N1 · Migración 094<br/>v_hato_estado_actual expone<br/>metodo de preñez + último aborto"]
+    N2["N2 · Motor: 5 estados<br/>derivarEstadoReproductivo<br/>(trío de paridad)"]
+    N3["N3 · Etiquetas de 5 estados<br/>+ señal de revisión<br/>(hatoUi)"]
+  end
+
+  subgraph TG_EV["Capa 1 · Telegram: eventos"]
+    N4["N4 · Selector de vaca<br/>reutilizable (nombre/#,<br/>homónimas)"]
+    N5["N5 · /evento monta e<br/>inseminación (+ uso de pajilla)"]
+    N6["N6 · /evento secado<br/>(avisa si es antes de lo previsto)"]
+    N7["N7 · /evento parto<br/>(sexo/destino de la cría)"]
+    N8["N8 · /evento aborto y novedad<br/>(el dato de la columna de alertas)"]
+    N9["N9 · Resumen + deshacer<br/>(compartido N5–N8)"]
+    N10["N10 · Dedupe chequeo↔manual<br/>(sin esto, cada chequeo<br/>duplica la monta)"]
+  end
+
+  subgraph TG_PES["Capa 2 · Telegram: pesaje por foto"]
+    N11["N11 · /pesaje por foto<br/>1..6 fotos → OCR → resumen"]
+    N12["N12 · Corrección en texto libre<br/>interpretada por Esco"]
+    N13["N13 · Persistir por celda<br/>(revalidación + fuente telegram)"]
+  end
+
+  subgraph TOROS["Capa 3 · Toros y pajillas"]
+    N14["N14 · Migración 095<br/>limpieza del catálogo<br/>+ alta de los 2 de monta"]
+    N15["N15 · Seed de pajillas<br/>6 toros / 27 unidades"]
+    N16["N16 · UI: selectores sólo<br/>toros activos"]
+  end
+
+  subgraph DISPLAY["Capa 4 · Display del hato"]
+    N18["N18 · edadEnAnios (puro)"]
+    N19["N19 · proximoEvento (puro)"]
+    N17["N17 · AnimalesList: edad · partos ·<br/>última cría · estado · próximo<br/>evento · alerta"]
+    N20["N20 · Coherencia Tablero /<br/>Hoja de Vida / Esco"]
+  end
+
+  subgraph CHEQ["Capa 5 · Chequeo sincronizado"]
+    N21["N21 · Pre-llenado desde la capa<br/>de EVENTOS (no del último chequeo)"]
+    N22["N22 · Planilla: columna 'Estado<br/>registrado' + columna de Martha<br/>(ok/rech/nota)"]
+    N23["N23 · Diff/commit consciente:<br/>registrado vs. papel = conflicto"]
+  end
+
+  subgraph CIERRE["Capa 6 · Cierre"]
+    N24["N24 · Tests + paridad de espejos"]
+    N25["N25 · Deploy edge fn + curl<br/>a cada ruta nueva"]
+    N26["N26 · Aplicar migraciones<br/>a producción"]
+    N27["N27 · Destinatarios de alertas<br/>(Fernando en secado/parto)"]
+  end
+
+  N1 --> N2 --> N3
+  N3 --> N17
+  N3 --> N20
+  N18 --> N17
+  N2 --> N19 --> N17
+
+  N4 --> N5
+  N4 --> N6
+  N4 --> N7
+  N4 --> N8
+  N2 --> N8
+  N5 --> N9
+  N6 --> N9
+  N7 --> N9
+  N8 --> N9
+  N5 --> N10
+  N7 --> N10
+
+  N14 --> N15 --> N5
+  N14 --> N16
+  N15 --> N16
+
+  N11 --> N12 --> N13
+
+  N2 --> N21
+  N5 --> N21
+  N7 --> N21
+  N21 --> N22 --> N23
+  N10 --> N23
+
+  N9 --> N24
+  N13 --> N24
+  N17 --> N24
+  N23 --> N24
+  N24 --> N25 --> N26
+  N6 --> N27
+```
+
+**Camino crítico:** `N1 → N2 → N21 → N22 → N23 → N24 → N25 → N26`. Todo lo demás cuelga de él o
+corre en paralelo.
+
+---
+
+## 3. Especificación por nodo
+
+### Capa 0 — Motor y contratos
+
+**N1 · Migración 094 — la vista expone el método de preñez y el último aborto**
+`v_hato_estado_actual` hoy no distingue una confirmación por palpación de una por presunción, y
+D-D las separa en dos estados distintos. Agrega dos columnas al final (`CREATE OR REPLACE VIEW` no
+reordena): `ultima_confirmacion_prenez_metodo` (`datos->>'metodo'` de la confirmación más reciente)
+y `ultimo_aborto_fecha`. Sin esto, N2 no tiene de dónde leer y N3 no tiene qué mostrar en la
+columna de alertas.
+*Sin dependencias. Bloquea N2.*
+
+**N2 · Motor: los 5 estados**
+`derivarEstadoReproductivo` (`src/utils/calculosHato.ts`, **trío protegido por paridad** — cambiar
+en las 3 copias en el mismo commit y regenerar con el script, nunca a mano). Reclasificación:
+
+| Hecho | Estado hoy | Estado nuevo |
+|---|---|---|
+| Servicio sin confirmar | `servida` | **Servida** |
+| `confirmacion_prenez` con `metodo='presuncion'` | `preñada` | **Servida** ← cambia |
+| `confirmacion_prenez` con `metodo='palpacion'` | `preñada` | **Confirmada** |
+| Dentro de la ventana de secado | `proxima_a_secar` | **Por secar** |
+| `secado_real` | `seca` | **Seca** |
+| Parió y aún no la sirven | `parida_reciente` | **Vacía** (con la fecha de parto al lado) |
+| Sin servicio ni confirmación | `vacia_por_servir` | **Vacía** |
+| Evento posterior no clasificable | `indeterminado` | **no es un estado** → señal de revisión (N3) |
+
+Trampa documentada que aplica aquí: `ultimo_evento_fecha` es `MAX(fecha)` sobre **toda** la tabla,
+así que un `aborto` o un `celo` con fecha de hoy tira la vaca a `indeterminado`. Por eso N8
+(registrar aborto desde Telegram) **depende de este nodo**: hay que decidir en el mismo commit
+cómo trata el motor ese evento, o Fernando registrando un aborto rompería el estado de la vaca.
+*Depende de N1. Bloquea N3, N8, N19, N21.*
+
+**N3 · Etiquetas y señal de revisión**
+`hatoUi.chipEstadoReproductivo` pasa a devolver las 5 etiquetas. Nueva función pura
+`senalRevisionHato(fila)` → `{ tipo: 'aborto' | 'evento_posterior' | 'sin_datos', texto }` que
+alimenta la columna de alertas de N17. Nunca se disfraza de estado.
+*Depende de N2. Bloquea N17, N20.*
+
+### Capa 1 — Telegram: eventos
+
+**N4 · Selector de vaca reutilizable**
+Búsqueda por nombre o chapeta, con desambiguación explícita de homónimas (el módulo ya sufrió el
+caso MOCA #177/#183). Es la pieza compartida por N5–N8; construirla una vez evita cuatro variantes
+que se desincronizan.
+*Sin dependencias. Bloquea N5–N8.*
+
+**N5 · `/evento` monta e inseminación**
+`hato_eventos` tipo `servicio`, `tipo_servicio` `monta`|`inseminacion` (ambos ya en el CHECK),
+`toro_id` del catálogo activo, `fuente='telegram'`. Si es inseminación con pajilla, registra además
+`hato_pajillas_uso` contra el lote correspondiente (la vista de stock ya descuenta por uso).
+`created_by` se setea **explícito** desde `telegram_usuarios.usuario_id` — el bot escribe con
+service_role, donde `auth.uid()` es NULL.
+*Depende de N4 y N15 (el selector de toro debe ofrecer 8 toros, no 63).*
+
+**N6 · `/evento` secado**
+`secado_real`. Compara la fecha contra la `fecha_secar` derivada por el motor y, si es
+apreciablemente antes, lo dice en el resumen ("estás secando 5 semanas antes de lo previsto") sin
+bloquear — es exactamente el caso de las 2 vacas de baja producción. Advertir, nunca bloquear:
+regla general del módulo.
+*Depende de N4.*
+
+**N7 · `/evento` parto**
+`parto` + `cria_destino`. Reusa el vocabulario que ya existe (`retenida`, `macho_vendido`,
+`hembra_vendida`, `muerta`, `aborto`).
+*Depende de N4.*
+
+**N8 · `/evento` aborto y novedad**
+Es la mitad que hace verdadera la columna de alertas de D-D: hoy un aborto entra sólo por la
+planilla y deja la vaca en `indeterminado` sin explicación. Registrado a mano, la columna dice
+"aborto 12/ago" en vez de un estado roto.
+*Depende de N4 y **N2**.*
+
+**N9 · Resumen y deshacer**
+Cada registro responde con el resumen de lo guardado y un botón "deshacer" que borra el evento
+recién creado. Es lo que hace tolerable escribir directo (D-B) sin cola de aprobación.
+*Depende de N5–N8.*
+
+**N10 · Dedupe chequeo ↔ evento manual**
+El nodo que más silenciosamente puede romper todo. El commit del chequeo (`fn_hato_commit_chequeo`,
+migración 065) deduplica servicios contra `seleccionarFechasServicioConocidasPorAnimal` y partos
+contra `ultimaCriaAnterior`, y **ambas fuentes leen únicamente `hato_chequeo_vacas`**. La monta que
+Fernando registre el 10/ago no está ahí, así que al aprobar el chequeo del 20/ago el sistema
+generaría un **segundo** evento de servicio para la misma monta — el mismo bug que ya costó tres
+rondas de limpieza en julio (385 servicios y 806 partos duplicados). Hay que extender ambos
+lados a leer también `hato_eventos` con `chequeo_vaca_id IS NULL`.
+*Depende de N5 y N7. Bloquea N23.*
+
+### Capa 2 — Telegram: pesaje por foto
+
+**N11 · `/pesaje` por foto**
+Reemplaza la conversación actual vaca-por-vaca (256 líneas iterando 65 animales por chat: inviable
+en el corral). Acepta 1..6 fotos, igual que la ruta web — la planilla real se fotografía por
+franjas porque 35 filas en una toma salen ilegibles. La lógica de OCR ya está espejada en el árbol
+Deno (`importHato/ocrPesaje.ts`): **no se escribe un segundo lector**.
+*Sin dependencias.*
+
+**N12 · Corrección en texto libre (D-C)**
+El bot muestra la lectura en texto plano; Fernando confirma o describe el error en lenguaje
+natural. Esco traduce a celdas concretas, vuelve a mostrar el resumen corregido, y sólo persiste
+tras un "ok" explícito. Nada se escribe antes de esa confirmación.
+*Depende de N11.*
+
+**N13 · Persistencia por celda**
+Reusa la revalidación de `hato-pesaje-commit.ts` (la vaca sigue en el roster, la fecha sigue siendo
+una ocurrencia real del día de pesaje). Commit **por celda**, no todo-o-nada: una celda inválida se
+rechaza sola. `fuente='telegram'`, `created_by` explícito.
+*Depende de N12.*
+
+### Capa 3 — Toros y pajillas
+
+**N14 · Migración 095 — limpieza del catálogo (D-A)**
+Guardada igual que 075/080/081: `RAISE EXCEPTION` si los conteos previos y posteriores no cuadran
+exactamente, y respaldo en el esquema **`respaldos`**, nunca en `public` (lección de la alerta
+crítica del linter del 2026-08-03). `DELETE` de los toros sin referencias en `hato_eventos` /
+`hato_animales`; `activo=false` en los referenciados; alta de los 2 toros de monta con
+`tipo='monta'`.
+*Bloqueado por el dato abierto: los nombres de los 2 toros.*
+
+**N15 · Seed de pajillas**
+6 toros `tipo='inseminacion'` + sus lotes en `hato_pajillas`, **27 unidades en total**:
+
+| Toro | Raza | Pajillas |
+|---|---|---|
+| Matt | Jersey | 7 |
+| Daily Double | Jersey | 5 |
+| Ulozon | Normando | 3 |
+| Hecker | Holstein | 1 |
+| Márquez | Holstein | 1 |
+| Valentino | Simental | 10 |
+
+*Depende de N14. Bloquea N5 y N16.*
+
+**N16 · UI de toros y pajillas**
+Los selectores (Telegram y web) ofrecen sólo `activo=true`, con raza y tipo visibles. El catálogo
+completo sigue consultable para leer la historia.
+*Depende de N14 y N15.*
+
+### Capa 4 — Display del hato
+
+**N17 · Columnas nuevas en `AnimalesList`**
+Orden pedido: **N.º · Nombre · Edad (años) · # Partos · Última cría · Estado (5) · Próximo evento ·
+Alerta · Producción**. Sin fecha de nacimiento → `—`, nunca 0 ni una edad inventada (20 de 65
+activos hoy).
+*Depende de N3, N18, N19.*
+
+**N18 · `edadEnAnios` (puro)**
+Años con un decimal, o `null`. Nodo trivial y sin dependencias: se puede hacer primero.
+
+**N19 · `proximoEvento` (puro)**
+El más cercano entre parto probable, secado, rechequeo y "servir", con los días que faltan. El motor
+ya calcula las cuatro fechas; este nodo sólo elige y rotula.
+*Depende de N2.*
+
+**N20 · Coherencia del resto del módulo**
+`HatoReproCard`, `VacasPorEstadoCard`, `hatoCategorias.ts` y **las dos copias de
+`hato-aggregation.ts`** (Esco) tienen que hablar el mismo vocabulario. La regla del módulo es dura:
+la UI y Esco nunca pueden dar conteos distintos de lo mismo.
+*Depende de N3.*
+
+### Capa 5 — Chequeo sincronizado (D-E)
+
+**N21 · Pre-llenado desde la capa de eventos**
+La planilla **ya es incremental** (arrastra Fecha Servicio, Toro, Estado). Lo que falta es que esos
+valores vengan de `hato_eventos` — incluyendo los manuales de Telegram — y no del último chequeo.
+Ese es el mecanismo completo de sincronía que pediste: la monta del 10/ago aparece impresa en el
+papel del chequeo del 20/ago para que la vet la verifique.
+*Depende de N2, N5, N7.*
+
+**N22 · Columnas nuevas de la planilla**
+Una columna **"Estado registrado"** (pre-impresa, gris: lo que el sistema cree) y al lado la
+**columna de Martha** (blanca: ok / rech / nota manuscrita). Toca `ENCABEZADOS_PLANILLA_CHEQUEO`,
+`COLUMNAS_A_DILIGENCIAR`, los alias del parser en `grilla.ts`, `parseEstado` y el prompt del OCR.
+Regla dura: los alias **se agregan**, nunca se reemplazan — el parser tiene que seguir leyendo las
+3 generaciones históricas de planillas.
+*Depende de N21.*
+
+**N23 · Diff y commit conscientes del estado registrado**
+La fila del diff muestra "registrado vs. papel" y marca conflicto explícito cuando difieren. El
+evento manual nunca se pisa (ya lo garantiza `chequeo_vaca_id IS NULL`), pero la contradicción se
+ve antes de aprobar.
+*Depende de N22 y N10.*
+
+### Capa 6 — Cierre
+
+- **N24 · Tests.** Paridad del trío `calculosHato` + espejos de `importHato` + `hatoAlertas`;
+  tests puros nuevos de N18/N19/N3; round-trip de la planilla (N22).
+- **N25 · Deploy + `curl` a cada ruta nueva.** Un `404 Not Found` en texto plano significa que el
+  deploy no incluyó la ruta — es literalmente el incidente del 2026-08-11.
+- **N26 · Aplicar N1, N14 y N15 a producción**, verificadas contra el catálogo vivo.
+- **N27 · Destinatarios de alertas.** Hoy las 5 alertas van sólo a Santiago. Agregar a Fernando en
+  `secado_due` y `parto_proximo` cierra el circuito con el flujo manual de N6. Es configuración, no
+  código.
+
+---
+
+## 4. Olas de ejecución (paralelizable)
+
+| Ola | Nodos | Notas |
+|---|---|---|
+| 1 | N1 · N4 · N11 · N18 · **N14** | Cinco frentes sin dependencias entre sí. N14 espera los nombres de los toros. |
+| 2 | N2 · N5 · N6 · N7 · N8 · N12 · N15 | N2 es el cuello de botella real del grafo. |
+| 3 | N3 · N9 · N10 · N13 · N16 · N19 | |
+| 4 | N17 · N20 · N21 | |
+| 5 | N22 · N23 | La rama más delicada: toca el parser de las planillas históricas. |
+| 6 | N24 · N25 · N26 · N27 | |
+
+---
+
+## 5. Riesgos
+
+| # | Riesgo | Mitigación |
+|---|---|---|
+| **R-1** | N2 toca el motor protegido por paridad byte-idéntica en 3 copias, y cambia conteos que Esco también reporta. | Regenerar los espejos con el script (nunca editar a mano) y correr la paridad antes de tocar UI. |
+| **R-2** | Un `aborto` o `celo` con fecha de hoy tira la vaca a `indeterminado` — la trampa que el módulo ya documenta. | N8 depende de N2 por eso: se decide el tratamiento del evento en el mismo commit que lo habilita. |
+| **R-3** | D-B contradice D-7 ("sólo Gerencia marca el ciclo"): Fernando es Administrador y escribe directo por Telegram. | Decisión explícita del dueño. Se mitiga con `fuente='telegram'`, `created_by` real, el deshacer de N9 y la corrección de Martha en la Hoja de Vida. La RLS de la app no cambia. |
+| **R-4** | Sin N10, cada chequeo duplica silenciosamente lo que Fernando registró — el bug más caro que ya tuvo este módulo. | N10 va en la misma ola que los flujos que lo causan, no después. |
+| **R-5** | Cambiar los encabezados de la planilla puede romper la lectura de planillas históricas. | Alias aditivos + el test de round-trip existente. |
+| **R-6** | El bot escribe con service_role: `auth.uid()` es NULL, así que ni los triggers de `created_by` ni la traza de `hato_correcciones` se disparan. | `created_by` explícito desde `telegram_usuarios.usuario_id` en todos los nodos de escritura (N5–N8, N13). |
+
+---
+
+## 6. Lo que este alcance NO incluye
+
+- No se toca la contabilidad ni ninguna ruta de `fin_*`.
+- No se reintroduce `PesajeSemanalGrid.tsx` (código muerto deliberado); N11–N13 son el camino de
+  Telegram, y el flujo web de Martha sigue como está.
+- No se cambia la RLS del módulo ni el gate de módulos por usuario.
+- No se re-ejecuta `load.ts` (backfill único, para siempre).

--- a/docs/plan_hato_telegram_estados_agosto_2026.md
+++ b/docs/plan_hato_telegram_estados_agosto_2026.md
@@ -405,15 +405,15 @@ ve antes de aprobar.
 | N3 · Etiquetas + señal | ✅ | `chipEstadoReproductivo` (5 etiquetas) + `chipSenalRevision`. |
 | N4–N9 · `/evento` en Telegram | ✅ | Monta · inseminación · secado · parto · aborto, con Deshacer. Gateado por el módulo `hato_produccion`, que Fernando ya tiene. |
 | N10 · Dedupe chequeo↔manual | ✅ | `fusionarEventosManualesEnDedupe`, 7 tests. |
-| N11–N13 · Pesaje por foto en Telegram | ⬜ pendiente | Requiere extraer el pipeline de `hato-pesaje-foto.ts` (482 líneas) a una función que compartan el endpoint HTTP y el bot, más el loop de corrección en texto libre (D-C). |
+| N11–N13 · Pesaje por foto en Telegram | ✅ **2026-08-14** | Pipeline extraído a `hato-pesaje-pipeline.ts`, compartido por el endpoint HTTP y el bot. Corrección en texto libre con "ok" explícito antes de escribir; nunca se adivina vaca, semana ni AM/PM. Commit por celda. La guarda "sin dato nunca es 0" verificada en los DOS caminos. |
 | N14–N15 · Toros y pajillas | ✅ **aplicada 2026-08-14** | 8 activos / 57 totales, 6 lotes / 27 unidades, 0 eventos huérfanos, Jersey conserva sus 44 servicios, respaldo de 63 filas en `respaldos`. **La primera ejecución abortó por un bug real de la migración** — ver §8.4. |
 | N16 · UI de selectores | ✅ ya cumplido | `PajillaCompraDialog` ya filtra por `activo`; no hizo falta cambio. |
 | N17–N20 · Display del hato | ✅ | Edad · Partos · Estado · Señal · Última cría · Próximo evento. |
-| N21–N23 · Planilla del chequeo | ⬜ pendiente | La planilla ya es incremental; falta que el pre-llenado venga de la capa de eventos y la columna de Martha (ok/rech/nota). |
-| N24 · Tests | ✅ para lo construido | 2.146 en verde, 0 errores de lint. |
+| N21–N23 · Planilla del chequeo | ✅ **2026-08-14** | N21 ya estaba cumplido: el pre-llenado de Fecha Servicio/Toro ya salía de `hato_eventos` vía la vista. Se agrega la columna "Estado registrado" y `conflictoEstadoRegistrado` en el diff. **Falta validación visual impresa** — ver §8.5. |
+| N24 · Tests | ✅ | 2.185 en verde, 0 errores de lint, `tsc` limpio, los 4 generadores de espejos en sincronía. |
 | N25 · Deploy | ✅ **2026-08-14** | Desplegada después de las migraciones (el orden importa: el tick pide las columnas de 094). `/health` → 200. |
 | N26 · Aplicar migraciones | ✅ **2026-08-14** | 094 y 095, verificadas contra el catálogo vivo. |
-| N27 · Destinatarios de alertas | ⬜ pendiente | Cambio de configuración, no de código. |
+| N27 · Destinatarios de alertas | ⬜ pendiente | Cambio de configuración, no de código. **Único nodo del grafo que sigue abierto.** Cambia a quién le llegan mensajes de Telegram, así que espera decisión explícita del dueño. |
 
 
 ---
@@ -474,26 +474,24 @@ sin confirmar**: requiere un humano en Telegram. Lo que sí se verificó desde
 aquí es que la función quedó desplegada y viva (`/health` → 200) y que
 `eventoHato` está registrado en el árbol que se subió.
 
-### 8.2 Lo que queda por construir
+### 8.2 Lo que quedaba por construir — ✅ HECHO (2026-08-14)
 
-Dos bloques, independientes entre sí. Cada uno está especificado en §3.
+Ambos bloques construidos, verificados y desplegados. `npm test` 2.185 en verde,
+0 errores de lint, `tsc --noEmit` limpio, los 4 generadores de espejos en
+sincronía, y las rutas nuevas responden 401 (piden auth), no 404 — que es la
+verificación que pide N25 tras el incidente del 2026-08-11.
 
-- **N11–N13 · Pesaje por foto en Telegram.** El trabajo real es extraer el
-  pipeline de `src/supabase/functions/server/hato-pesaje-foto.ts` (482 líneas)
-  a una función que compartan el endpoint HTTP y el bot — hoy la lectura con
-  el modelo (`leerFotoConModelo`) y el armado del roster viven dentro del
-  handler de Hono y no son reutilizables. Encima de eso van el loop de
-  corrección en texto libre (D-C) y la persistencia por celda reusando la
-  revalidación de `hato-pesaje-commit.ts`. **No escribir un segundo lector de
-  celdas**: `importHato/ocrPesaje.ts` ya es el único, y está espejado.
-- **N21–N23 · Planilla del chequeo.** La planilla YA es incremental (arrastra
-  Fecha Servicio, Toro y Estado). Falta: (a) que ese pre-llenado venga de
-  `hato_eventos` y no del último chequeo, para que la monta que Fernando marcó
-  por Telegram salga impresa; (b) la columna nueva "Estado registrado" más la
-  columna de Martha (ok/rech/nota); (c) que el diff marque el conflicto entre
-  lo registrado y lo que dice el papel. Regla dura: los alias del parser
-  (`importHato/grilla.ts`) **se agregan, nunca se reemplazan** — tiene que
-  seguir leyendo las 3 generaciones históricas de planillas.
+- **N11–N13 · Pesaje por foto.** El pipeline salió de `hato-pesaje-foto.ts` a
+  `hato-pesaje-pipeline.ts`, compartido por el endpoint HTTP y el bot. Se
+  conserva un solo lector de celdas. La corrección en texto libre exige vaca +
+  semana + (AM/PM o "ambos") explícitos: si el modelo no puede extraer alguno de
+  los tres, la corrección se reporta como no entendida en vez de adivinarse —
+  extensión directa de la regla "nunca adivines la vaca" a los otros dos ejes.
+  **`/pesaje` cambia de forma para quien lo usa**: deja de ser vaca-por-vaca
+  semanal y pasa a ser foto de la planilla mensual.
+- **N21–N23 · Planilla del chequeo.** N21 ya estaba cumplido sin que el plan lo
+  supiera (ver la tabla de §7). Lo que faltaba de verdad era exponer el estado
+  derivado y detectar la contradicción, que es lo que se construyó.
 
 ### 8.3 Decisión pendiente del dueño
 
@@ -541,3 +539,38 @@ una que **nombra** al vigente que no quedó activo (en vez de dar un conteo), y
 otra que rechaza pajillas colgadas de un toro inactivo — que es la forma en que
 este bug se habría manifestado en la UI: stock real e invisible, porque N16
 filtra los selectores por `activo`.
+
+### 8.5 Lo que queda abierto (2026-08-14)
+
+Nada de esto bloquea el uso del módulo, pero ninguno se descubre solo.
+
+**1. La planilla impresa no se ha visto en papel.** La 13ª columna ("Estado
+registrado") no cabía: los márgenes bajaron de 10mm a 8mm y **Tratamiento se
+recortó de 35mm a 22,5mm (−36%)**, que es una columna donde Martha escribe a
+mano. El presupuesto quedó en 263,2mm de tabla contra 263,4mm útiles: **0,2mm de
+holgura**. Los tests garantizan que no desborda y que 35 filas siguen cabiendo en
+2 páginas, pero **no** que sea cómodo escribir en ella. Necesita imprimirse una
+vez antes del próximo chequeo. Si Tratamiento quedó corto, el ancho tiene que
+salir de otra columna o la planilla necesita otro formato — no hay más margen.
+
+Se agregó un test con **piso imprimible de 8mm** en los márgenes, porque el
+presupuesto de ancho existente no podía atrapar esto: `ANCHO_UTIL_CARTA_
+HORIZONTAL_MM` se deriva de `MARGENES_PDF_MM`, así que encoger el margen sube el
+techo y el test sigue pasando. Era autorreferencial en ese eje.
+
+**2. Dos huecos menores en el diff del chequeo**, dejados a propósito para no
+ampliar el alcance:
+- `useRevisionChequeo.ts` recalcula el diff en la ventana de corrección pero no
+  `estadosRegistrados`, así que editar cualquier campo ahí borra el indicador de
+  conflicto hasta que se regenere la vista previa.
+- El baseline de "fecha de servicio/toro" en `compararFila` todavía lee sólo
+  `hato_chequeo_vacas`, no los eventos. Es cosmético: N10 ya impide el duplicado
+  en la ESCRITURA, así que lo peor que pasa es un "cambio" espurio en el diff.
+
+**3. N27 sigue abierto** — es el único nodo del grafo que no se tocó. Agregar a
+Fernando como destinatario de `secado_due` y `parto_proximo` cambia a quién le
+llegan mensajes de Telegram, así que espera decisión explícita del dueño.
+
+**4. El frontend no está en producción.** Sigue vigente §8.3: la lista del hato,
+la planilla y el diff sólo llegan cuando la rama se mezcle a `main`. Lo
+desplegado hoy es la edge function (Telegram y los endpoints), que sí está viva.

--- a/docs/plan_hato_telegram_estados_agosto_2026.md
+++ b/docs/plan_hato_telegram_estados_agosto_2026.md
@@ -6,11 +6,10 @@ bimensual. De ahí sale todo este alcance.
 
 **Estado del documento:** grafo aprobado y **en ejecución**. Ver §7 (Estado) al final.
 
-> **Dos hechos que bloquean la puesta en producción de lo ya construido:**
-> las migraciones **094 y 095 NO están aplicadas** (el conector de Supabase de
-> la sesión es solo-lectura) y la **edge function no está desplegada**. Hasta
-> que ambas cosas ocurran, la lista del hato no puede leer el método de preñez
-> y `/evento` no existe en el bot.
+> **Desbloqueado el 2026-08-14.** Las migraciones **094 y 095 están aplicadas a
+> producción** y la **edge function está desplegada** (`/health` responde 200).
+> `/evento` ya existe en el bot y la lista del hato ya puede leer el método de
+> preñez. Lo que queda es N11–N13 y N21–N23 (§8.2).
 
 ---
 
@@ -401,19 +400,19 @@ ve antes de aprobar.
 
 | Nodo | Estado | Notas |
 |---|---|---|
-| N1 · Migración 094 | ✅ escrita, **sin aplicar** | Cuerpo validado ejecutándolo como consulta contra producción. |
+| N1 · Migración 094 | ✅ **aplicada 2026-08-14** | 2 columnas nuevas, `security_invoker` intacto, 179 filas. `ultima_confirmacion_prenez_metodo` sale NULL en las 179: ninguna confirmación histórica trae método, y el motor las lee como PRESUNCIÓN (es lo que dice la cabecera de la migración). 7 animales traen `ultimo_aborto_fecha`. |
 | N2 · Motor de 5 estados | ✅ | Espejos regenerados. Un test atrapó que la proyección "quedará" del diálogo no llevaba el método. |
 | N3 · Etiquetas + señal | ✅ | `chipEstadoReproductivo` (5 etiquetas) + `chipSenalRevision`. |
 | N4–N9 · `/evento` en Telegram | ✅ | Monta · inseminación · secado · parto · aborto, con Deshacer. Gateado por el módulo `hato_produccion`, que Fernando ya tiene. |
 | N10 · Dedupe chequeo↔manual | ✅ | `fusionarEventosManualesEnDedupe`, 7 tests. |
 | N11–N13 · Pesaje por foto en Telegram | ⬜ pendiente | Requiere extraer el pipeline de `hato-pesaje-foto.ts` (482 líneas) a una función que compartan el endpoint HTTP y el bot, más el loop de corrección en texto libre (D-C). |
-| N14–N15 · Toros y pajillas | ✅ escrita, **sin aplicar** | Simulada en solo-lectura: 10 borrados, 4 altas, 57 finales, 8 activos, 0 eventos huérfanos. |
+| N14–N15 · Toros y pajillas | ✅ **aplicada 2026-08-14** | 8 activos / 57 totales, 6 lotes / 27 unidades, 0 eventos huérfanos, Jersey conserva sus 44 servicios, respaldo de 63 filas en `respaldos`. **La primera ejecución abortó por un bug real de la migración** — ver §8.4. |
 | N16 · UI de selectores | ✅ ya cumplido | `PajillaCompraDialog` ya filtra por `activo`; no hizo falta cambio. |
 | N17–N20 · Display del hato | ✅ | Edad · Partos · Estado · Señal · Última cría · Próximo evento. |
 | N21–N23 · Planilla del chequeo | ⬜ pendiente | La planilla ya es incremental; falta que el pre-llenado venga de la capa de eventos y la columna de Martha (ok/rech/nota). |
 | N24 · Tests | ✅ para lo construido | 2.146 en verde, 0 errores de lint. |
-| N25 · Deploy | ⬜ pendiente | `npx supabase functions deploy make-server-1ccce916` + `curl` a `/evento`. |
-| N26 · Aplicar migraciones | ⬜ pendiente | 094 y 095. |
+| N25 · Deploy | ✅ **2026-08-14** | Desplegada después de las migraciones (el orden importa: el tick pide las columnas de 094). `/health` → 200. |
+| N26 · Aplicar migraciones | ✅ **2026-08-14** | 094 y 095, verificadas contra el catálogo vivo. |
 | N27 · Destinatarios de alertas | ⬜ pendiente | Cambio de configuración, no de código. |
 
 
@@ -426,27 +425,33 @@ escribió el código, pueda continuar sin volver a decidir nada.
 
 **Rama:** `claude/telegram-workflows-herd-management-g7ffm6` (7 commits, sin PR).
 
-### 8.1 Lo primero: aplicar y desplegar, en este orden
+### 8.1 Lo primero: aplicar y desplegar, en este orden — ✅ HECHO (2026-08-14)
 
 El orden importa. El tick de alertas (`hato-alertas-tick.ts`) ya pide las dos
 columnas nuevas en su `SELECT` explícito: si la función se despliega antes de
-que exista la vista, el cron de las 05:45 falla.
+que exista la vista, el cron de las 05:45 falla. Se respetó: 094 → 095 → deploy.
+
+**Cómo se aplicaron, para la próxima vez.** El conector de Supabase de la sesión
+es **solo-lectura** (`cannot execute CREATE VIEW in a read-only transaction`, y
+su lista de herramientas no trae `apply_migration`). La ruta que sí escribe, sin
+contraseña de base de datos y sin `psql`, es el CLI contra la **Management API**:
 
 ```bash
-git fetch origin claude/telegram-workflows-herd-management-g7ffm6
-git checkout claude/telegram-workflows-herd-management-g7ffm6
-npm install
-
-# 1) Migración 094 — CREATE OR REPLACE VIEW, no toca datos.
-# 2) Migración 095 — borra 10 toros y desactiva 49, con guardas y respaldo.
-#    Ambas por el SQL editor o psql. NO usar `supabase db push`: el repo
-#    versiona las migraciones en src/sql/migrations/, no en supabase/migrations/.
-
-npx supabase functions deploy make-server-1ccce916 --project-ref ywhtjwawnkeqlwxbvgup
+npx supabase db query --linked --project-ref ywhtjwawnkeqlwxbvgup \
+  -f src/sql/migrations/094_hato_estado_actual_metodo_prenez_aborto.sql
 ```
 
+`--linked` es obligatorio junto a `--project-ref` (solos se rechazan entre sí).
+El token vive en el llavero de macOS, no en `~/.supabase/`. Sigue vigente el
+aviso: **nunca `supabase db push`** — el repo versiona en `src/sql/migrations/`,
+que el CLI no mira.
+
+Para ensayar una migración destructiva sin escribir, copiarla cambiando el
+`COMMIT;` final por `ROLLBACK;` y correrla igual: las guardas se ejecutan
+completas contra datos vivos. Es lo que confirmó los 8/57 antes del pase real.
+
 **Verificación después de aplicar** (read-only, se puede hacer desde cualquier
-sesión):
+sesión). Todas dieron el valor esperado:
 
 ```sql
 -- 094
@@ -464,7 +469,10 @@ select count(*) from hato_eventos e
 
 **Verificación del bot:** escribir `/evento` en Telegram y ver que aparezca el
 menú de 5 tipos. No hay ruta HTTP nueva que probar con `curl` — este cambio
-agrega un comando del bot, no un endpoint.
+agrega un comando del bot, no un endpoint. **Esto es lo único de §8.1 que queda
+sin confirmar**: requiere un humano en Telegram. Lo que sí se verificó desde
+aquí es que la función quedó desplegada y viva (`/health` → 200) y que
+`eventoHato` está registrado en el árbol que se subió.
 
 ### 8.2 Lo que queda por construir
 
@@ -492,3 +500,44 @@ Dos bloques, independientes entre sí. Cada uno está especificado en §3.
 El frontend (lista del hato con Edad/Partos/Señal/Próximo evento) **no llega a
 producción hasta que la rama se mezcle a `main`**, que es de donde construye
 Vercel. No se abrió PR por decisión de proceso, no por olvido.
+
+### 8.4 El bug que atrapó la guarda de la 095 (2026-08-14)
+
+Vale la pena dejarlo escrito porque es exactamente el tipo de error que estas
+migraciones existen para no cometer, y porque confirma que la guarda paga.
+
+La primera ejecución abortó con `Migración 095: deberían quedar 8 toros
+activos, quedaron 7.` **La transacción entera se revirtió: producción quedó
+intacta** (63 toros, 61 activos, 0 pajillas, sin tabla de respaldo).
+
+Causa: `toros_vigentes` guarda dos cosas distintas en dos columnas —
+`clave` es **la grafía con la que el toro vive HOY en la base** y `nombre` es
+**la grafía final**. Para siete de los ocho coinciden; para uno no:
+
+| clave (en la base) | nombre final |
+|---|---|
+| `marquez` | `Márquez` |
+
+El paso 4 renombra la fila a `Márquez`. Los pasos 5 y 6 seguían buscando por
+`v.clave`, así que a partir del renombre esa fila **ya no respondía a su propia
+clave**: `lower(btrim('Márquez'))` es `'márquez'`, con tilde. El paso 6, que
+desactiva "todo lo que no sea vigente", desactivaba entonces al toro que el
+paso 4 acababa de normalizar. 8 − 1 = 7.
+
+La corrección es comparar contra **las dos grafías** en los pasos 5 y 6:
+
+```sql
+NOT EXISTS (SELECT 1 FROM toros_vigentes v
+             WHERE lower(btrim(t.nombre)) IN (v.clave, lower(btrim(v.nombre))))
+```
+
+Se editó la 095 en vez de escribir una 096 porque **nunca llegó a aplicarse**:
+la regla "no modificar migraciones existentes" protege lo que ya corrió en
+producción, y aquí no corrió nada. Parchear con una 096 habría dejado en el
+repo una migración que nadie puede ejecutar.
+
+Se agregaron además dos guardas, para que el próximo fallo se diagnostique solo:
+una que **nombra** al vigente que no quedó activo (en vez de dar un conteo), y
+otra que rechaza pajillas colgadas de un toro inactivo — que es la forma en que
+este bug se habría manifestado en la UI: stock real e invisible, porque N16
+filtra los selectores por `activo`.

--- a/docs/plan_hato_telegram_estados_agosto_2026.md
+++ b/docs/plan_hato_telegram_estados_agosto_2026.md
@@ -415,3 +415,80 @@ ve antes de aprobar.
 | N25 · Deploy | ⬜ pendiente | `npx supabase functions deploy make-server-1ccce916` + `curl` a `/evento`. |
 | N26 · Aplicar migraciones | ⬜ pendiente | 094 y 095. |
 | N27 · Destinatarios de alertas | ⬜ pendiente | Cambio de configuración, no de código. |
+
+
+---
+
+## 8. Arranque de la sesión LOCAL (handoff)
+
+Esta sección existe para que una sesión nueva, sin el contexto de la que
+escribió el código, pueda continuar sin volver a decidir nada.
+
+**Rama:** `claude/telegram-workflows-herd-management-g7ffm6` (7 commits, sin PR).
+
+### 8.1 Lo primero: aplicar y desplegar, en este orden
+
+El orden importa. El tick de alertas (`hato-alertas-tick.ts`) ya pide las dos
+columnas nuevas en su `SELECT` explícito: si la función se despliega antes de
+que exista la vista, el cron de las 05:45 falla.
+
+```bash
+git fetch origin claude/telegram-workflows-herd-management-g7ffm6
+git checkout claude/telegram-workflows-herd-management-g7ffm6
+npm install
+
+# 1) Migración 094 — CREATE OR REPLACE VIEW, no toca datos.
+# 2) Migración 095 — borra 10 toros y desactiva 49, con guardas y respaldo.
+#    Ambas por el SQL editor o psql. NO usar `supabase db push`: el repo
+#    versiona las migraciones en src/sql/migrations/, no en supabase/migrations/.
+
+npx supabase functions deploy make-server-1ccce916 --project-ref ywhtjwawnkeqlwxbvgup
+```
+
+**Verificación después de aplicar** (read-only, se puede hacer desde cualquier
+sesión):
+
+```sql
+-- 094
+select count(*) from information_schema.columns
+ where table_name = 'v_hato_estado_actual'
+   and column_name in ('ultima_confirmacion_prenez_metodo','ultimo_aborto_fecha');  -- 2
+
+-- 095
+select count(*) filter (where activo) as activos, count(*) as total from hato_toros;  -- 8 / 57
+select count(*) as lotes, sum(cantidad_inicial) as unidades from hato_pajillas;       -- 6 / 27
+select count(*) from hato_eventos e
+ where e.toro_id is not null
+   and not exists (select 1 from hato_toros t where t.id = e.toro_id);                -- 0
+```
+
+**Verificación del bot:** escribir `/evento` en Telegram y ver que aparezca el
+menú de 5 tipos. No hay ruta HTTP nueva que probar con `curl` — este cambio
+agrega un comando del bot, no un endpoint.
+
+### 8.2 Lo que queda por construir
+
+Dos bloques, independientes entre sí. Cada uno está especificado en §3.
+
+- **N11–N13 · Pesaje por foto en Telegram.** El trabajo real es extraer el
+  pipeline de `src/supabase/functions/server/hato-pesaje-foto.ts` (482 líneas)
+  a una función que compartan el endpoint HTTP y el bot — hoy la lectura con
+  el modelo (`leerFotoConModelo`) y el armado del roster viven dentro del
+  handler de Hono y no son reutilizables. Encima de eso van el loop de
+  corrección en texto libre (D-C) y la persistencia por celda reusando la
+  revalidación de `hato-pesaje-commit.ts`. **No escribir un segundo lector de
+  celdas**: `importHato/ocrPesaje.ts` ya es el único, y está espejado.
+- **N21–N23 · Planilla del chequeo.** La planilla YA es incremental (arrastra
+  Fecha Servicio, Toro y Estado). Falta: (a) que ese pre-llenado venga de
+  `hato_eventos` y no del último chequeo, para que la monta que Fernando marcó
+  por Telegram salga impresa; (b) la columna nueva "Estado registrado" más la
+  columna de Martha (ok/rech/nota); (c) que el diff marque el conflicto entre
+  lo registrado y lo que dice el papel. Regla dura: los alias del parser
+  (`importHato/grilla.ts`) **se agregan, nunca se reemplazan** — tiene que
+  seguir leyendo las 3 generaciones históricas de planillas.
+
+### 8.3 Decisión pendiente del dueño
+
+El frontend (lista del hato con Edad/Partos/Señal/Próximo evento) **no llega a
+producción hasta que la rama se mezcle a `main`**, que es de donde construye
+Vercel. No se abrió PR por decisión de proceso, no por olvido.

--- a/docs/plan_hato_telegram_estados_agosto_2026.md
+++ b/docs/plan_hato_telegram_estados_agosto_2026.md
@@ -4,7 +4,13 @@
 (vio la vaca en celo y llevó el toro) sin ninguna forma de dejarlo asentado hasta el chequeo
 bimensual. De ahí sale todo este alcance.
 
-**Estado del documento:** grafo de trabajo aprobado. Ninguna tarea ejecutada todavía.
+**Estado del documento:** grafo aprobado y **en ejecución**. Ver §7 (Estado) al final.
+
+> **Dos hechos que bloquean la puesta en producción de lo ya construido:**
+> las migraciones **094 y 095 NO están aplicadas** (el conector de Supabase de
+> la sesión es solo-lectura) y la **edge function no está desplegada**. Hasta
+> que ambas cosas ocurran, la lista del hato no puede leer el método de preñez
+> y `/evento` no existe en el bot.
 
 ---
 
@@ -387,3 +393,25 @@ ve antes de aprobar.
   Telegram, y el flujo web de Martha sigue como está.
 - No se cambia la RLS del módulo ni el gate de módulos por usuario.
 - No se re-ejecuta `load.ts` (backfill único, para siempre).
+
+
+---
+
+## 7. Estado de ejecución (2026-08-13)
+
+| Nodo | Estado | Notas |
+|---|---|---|
+| N1 · Migración 094 | ✅ escrita, **sin aplicar** | Cuerpo validado ejecutándolo como consulta contra producción. |
+| N2 · Motor de 5 estados | ✅ | Espejos regenerados. Un test atrapó que la proyección "quedará" del diálogo no llevaba el método. |
+| N3 · Etiquetas + señal | ✅ | `chipEstadoReproductivo` (5 etiquetas) + `chipSenalRevision`. |
+| N4–N9 · `/evento` en Telegram | ✅ | Monta · inseminación · secado · parto · aborto, con Deshacer. Gateado por el módulo `hato_produccion`, que Fernando ya tiene. |
+| N10 · Dedupe chequeo↔manual | ✅ | `fusionarEventosManualesEnDedupe`, 7 tests. |
+| N11–N13 · Pesaje por foto en Telegram | ⬜ pendiente | Requiere extraer el pipeline de `hato-pesaje-foto.ts` (482 líneas) a una función que compartan el endpoint HTTP y el bot, más el loop de corrección en texto libre (D-C). |
+| N14–N15 · Toros y pajillas | ✅ escrita, **sin aplicar** | Simulada en solo-lectura: 10 borrados, 4 altas, 57 finales, 8 activos, 0 eventos huérfanos. |
+| N16 · UI de selectores | ✅ ya cumplido | `PajillaCompraDialog` ya filtra por `activo`; no hizo falta cambio. |
+| N17–N20 · Display del hato | ✅ | Edad · Partos · Estado · Señal · Última cría · Próximo evento. |
+| N21–N23 · Planilla del chequeo | ⬜ pendiente | La planilla ya es incremental; falta que el pre-llenado venga de la capa de eventos y la columna de Martha (ok/rech/nota). |
+| N24 · Tests | ✅ para lo construido | 2.146 en verde, 0 errores de lint. |
+| N25 · Deploy | ⬜ pendiente | `npx supabase functions deploy make-server-1ccce916` + `curl` a `/evento`. |
+| N26 · Aplicar migraciones | ⬜ pendiente | 094 y 095. |
+| N27 · Destinatarios de alertas | ⬜ pendiente | Cambio de configuración, no de código. |

--- a/docs/plan_hato_telegram_estados_agosto_2026.md
+++ b/docs/plan_hato_telegram_estados_agosto_2026.md
@@ -6,10 +6,13 @@ bimensual. De ahí sale todo este alcance.
 
 **Estado del documento:** grafo aprobado y **en ejecución**. Ver §7 (Estado) al final.
 
-> **Desbloqueado el 2026-08-14.** Las migraciones **094 y 095 están aplicadas a
-> producción** y la **edge function está desplegada** (`/health` responde 200).
-> `/evento` ya existe en el bot y la lista del hato ya puede leer el método de
-> preñez. Lo que queda es N11–N13 y N21–N23 (§8.2).
+> **El grafo está construido (2026-08-14).** Los 26 nodos de código están
+> hechos, las migraciones 094 y 095 aplicadas y la edge function desplegada.
+> **Queda un solo nodo: N27** (destinatarios de alertas), que es configuración y
+> espera decisión del dueño. Lo demás pendiente NO son nodos del grafo sino
+> cierres de campo — imprimir la planilla, probar `/pesaje` por foto en el
+> corral y mezclar a `main` para que el frontend llegue a producción. Todo
+> listado en §8.5.
 
 ---
 
@@ -409,8 +412,8 @@ ve antes de aprobar.
 | N14–N15 · Toros y pajillas | ✅ **aplicada 2026-08-14** | 8 activos / 57 totales, 6 lotes / 27 unidades, 0 eventos huérfanos, Jersey conserva sus 44 servicios, respaldo de 63 filas en `respaldos`. **La primera ejecución abortó por un bug real de la migración** — ver §8.4. |
 | N16 · UI de selectores | ✅ ya cumplido | `PajillaCompraDialog` ya filtra por `activo`; no hizo falta cambio. |
 | N17–N20 · Display del hato | ✅ | Edad · Partos · Estado · Señal · Última cría · Próximo evento. |
-| N21–N23 · Planilla del chequeo | ✅ **2026-08-14** | N21 ya estaba cumplido: el pre-llenado de Fecha Servicio/Toro ya salía de `hato_eventos` vía la vista. Se agrega la columna "Estado registrado" y `conflictoEstadoRegistrado` en el diff. **Falta validación visual impresa** — ver §8.5. |
-| N24 · Tests | ✅ | 2.185 en verde, 0 errores de lint, `tsc` limpio, los 4 generadores de espejos en sincronía. |
+| N21–N23 · Planilla del chequeo | ✅ **2026-08-14** | N21 ya estaba cumplido: el pre-llenado de Fecha Servicio/Toro ya salía de `hato_eventos` vía la vista. Se agrega la columna "Estado registrado" y `conflictoEstadoRegistrado` en el diff. El reparto del PDF se rehízo DOS veces con el dueño a la vista del render (letra 11->9pt, y `Sexo cría` imprimiendo sólo el sexo). **Falta imprimirla en papel** — ver §8.5. |
+| N24 · Tests | ✅ | 2.182 en verde, 0 errores de lint, `tsc` limpio, los 4 generadores de espejos en sincronía. |
 | N25 · Deploy | ✅ **2026-08-14** | Desplegada después de las migraciones (el orden importa: el tick pide las columnas de 094). `/health` → 200. |
 | N26 · Aplicar migraciones | ✅ **2026-08-14** | 094 y 095, verificadas contra el catálogo vivo. |
 | N27 · Destinatarios de alertas | ⬜ pendiente | Cambio de configuración, no de código. **Único nodo del grafo que sigue abierto.** Cambia a quién le llegan mensajes de Telegram, así que espera decisión explícita del dueño. |

--- a/package-lock.json
+++ b/package-lock.json
@@ -3342,9 +3342,6 @@
                         "arm64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "glibc"
-                  ],
                   "license": "MIT",
                   "optional": true,
                   "os": [
@@ -3362,9 +3359,6 @@
                         "arm64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "musl"
-                  ],
                   "license": "MIT",
                   "optional": true,
                   "os": [
@@ -3382,9 +3376,6 @@
                         "x64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "glibc"
-                  ],
                   "license": "MIT",
                   "optional": true,
                   "os": [
@@ -3402,9 +3393,6 @@
                         "x64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "musl"
-                  ],
                   "license": "MIT",
                   "optional": true,
                   "os": [
@@ -5950,9 +5938,6 @@
                         "arm64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "glibc"
-                  ],
                   "license": "MPL-2.0",
                   "optional": true,
                   "os": [
@@ -5974,9 +5959,6 @@
                         "arm64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "musl"
-                  ],
                   "license": "MPL-2.0",
                   "optional": true,
                   "os": [
@@ -5998,9 +5980,6 @@
                         "x64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "glibc"
-                  ],
                   "license": "MPL-2.0",
                   "optional": true,
                   "os": [
@@ -6022,9 +6001,6 @@
                         "x64"
                   ],
                   "dev": true,
-                  "libc": [
-                        "musl"
-                  ],
                   "license": "MPL-2.0",
                   "optional": true,
                   "os": [

--- a/src/__tests__/calculosHato.test.ts
+++ b/src/__tests__/calculosHato.test.ts
@@ -1245,6 +1245,8 @@ describe('derivarEstadoReproductivo', () => {
     ultimo_secado_real_fecha: null,
     ultima_confirmacion_prenez_fecha: null,
     ultimo_evento_fecha: null,
+    ultima_confirmacion_prenez_metodo: null,
+    ultimo_aborto_fecha: null,
     ultimo_estado_chequeo: null,
   };
 
@@ -1334,6 +1336,9 @@ describe('derivarEstadoReproductivo', () => {
         ...filaBase,
         ultimo_servicio_fecha: '2024-03-01',
         ultima_confirmacion_prenez_fecha: '2024-03-15',
+        // D-D: solo la PALPACIÓN deja el estado en `preñada` -- una
+        // confirmación por presunción devolvería `servida`.
+        ultima_confirmacion_prenez_metodo: 'palpacion',
       };
       const r = derivarEstadoReproductivo(fila, CONFIG_BASE, '2024-03-31');
       expect(r.estado).toBe('preñada');
@@ -1457,6 +1462,105 @@ describe('derivarEstadoReproductivo', () => {
     });
   });
 
+  // ── D-D (dueño, 2026-08-13): 5 estados ──────────────────────────────
+  // "servida = preñada por presunción · confirmada = palpada". El método de
+  // la confirmación (migración 094) es lo único que las separa.
+  describe('método de la confirmación de preñez (D-D)', () => {
+    // Servicio suficientemente reciente para no caer en la ventana de
+    // secado: así el estado lo decide el método y nada más.
+    const filaConfirmada: EstadoActualHatoRow = {
+      ...filaBase,
+      ultimo_servicio_fecha: '2024-06-01',
+      ultima_confirmacion_prenez_fecha: '2024-07-15',
+      ultimo_evento_fecha: '2024-07-15',
+    };
+
+    it('palpación deja la vaca preñada (etiqueta "Confirmada")', () => {
+      const r = derivarEstadoReproductivo(
+        { ...filaConfirmada, ultima_confirmacion_prenez_metodo: 'palpacion' },
+        CONFIG_BASE,
+        '2024-08-09',
+      );
+      expect(r.estado).toBe('preñada');
+      expect(r.tiempo_prenez_dias).not.toBeNull();
+    });
+
+    it('presunción deja la vaca servida, no preñada', () => {
+      const r = derivarEstadoReproductivo(
+        { ...filaConfirmada, ultima_confirmacion_prenez_metodo: 'presuncion' },
+        CONFIG_BASE,
+        '2024-08-09',
+      );
+      expect(r.estado).toBe('servida');
+      // `servida` no es preñez confirmada: no se reporta tiempo de preñez.
+      expect(r.tiempo_prenez_dias).toBeNull();
+    });
+
+    it('método null se lee como PRESUNCIÓN, nunca como palpación', () => {
+      // La asimetría es deliberada: dar por palpada una vaca que nadie palpó
+      // lleva a secarla con datos que nadie verificó; el error contrario solo
+      // hace que se la vuelva a revisar.
+      const r = derivarEstadoReproductivo(filaConfirmada, CONFIG_BASE, '2024-08-09');
+      expect(r.estado).toBe('servida');
+    });
+
+    it('la misma regla aplica cuando no hay servicio que ancle la confirmación', () => {
+      const sinAncla: EstadoActualHatoRow = {
+        ...filaBase,
+        ultima_confirmacion_prenez_fecha: '2024-07-15',
+        ultimo_evento_fecha: '2024-07-15',
+      };
+      expect(derivarEstadoReproductivo(sinAncla, CONFIG_BASE, '2024-08-09').estado).toBe('servida');
+      expect(
+        derivarEstadoReproductivo(
+          { ...sinAncla, ultima_confirmacion_prenez_metodo: 'palpacion' },
+          CONFIG_BASE,
+          '2024-08-09',
+        ).estado,
+      ).toBe('preñada');
+    });
+  });
+
+  describe('señal de revisión: aborto vs. evento posterior sin tipificar (D-D)', () => {
+    const conServicio: EstadoActualHatoRow = { ...filaBase, ultimo_servicio_fecha: '2026-01-10' };
+
+    it('un aborto posterior deja la vaca VACÍA y explica el porqué en la señal', () => {
+      const r = derivarEstadoReproductivo(
+        { ...conServicio, ultimo_evento_fecha: '2026-06-30', ultimo_aborto_fecha: '2026-06-30' },
+        CONFIG_BASE,
+        '2026-07-09',
+      );
+      expect(r.estado).toBe('vacia_por_servir');
+      expect(r.senal_revision).toEqual({ tipo: 'aborto', fecha: '2026-06-30' });
+      // Nunca se proyecta un ciclo con datos que el aborto invalidó.
+      expect(r.fecha_probable_parto).toBeNull();
+      expect(r.fecha_secar).toBeNull();
+      // Un aborto no es un parto: no ancla el contador de días abiertos.
+      expect(r.dias_abiertos).toBeNull();
+    });
+
+    it('un evento posterior que NO es aborto sigue siendo indeterminado', () => {
+      const r = derivarEstadoReproductivo(
+        { ...conServicio, ultimo_evento_fecha: '2026-06-30' },
+        CONFIG_BASE,
+        '2026-07-09',
+      );
+      expect(r.estado).toBe('indeterminado');
+      expect(r.senal_revision).toEqual({ tipo: 'evento_posterior', fecha: '2026-06-30' });
+    });
+
+    it('un aborto VIEJO (anterior al último servicio) no produce señal alguna', () => {
+      // La vaca abortó, la volvieron a servir: el ciclo nuevo manda.
+      const r = derivarEstadoReproductivo(
+        { ...conServicio, ultimo_aborto_fecha: '2025-08-01', ultimo_evento_fecha: '2026-01-10' },
+        CONFIG_BASE,
+        '2026-02-09',
+      );
+      expect(r.estado).toBe('servida');
+      expect(r.senal_revision).toBeNull();
+    });
+  });
+
   it('servicio_sin_confirmacion se activa solo al pasar el umbral de config (45 días default)', () => {
     const fila: EstadoActualHatoRow = { ...filaBase, ultimo_servicio_fecha: '2024-05-14' };
     const antes = derivarEstadoReproductivo(fila, CONFIG_BASE, '2024-06-01'); // 18 días
@@ -1575,6 +1679,7 @@ describe('derivarEstadoReproductivo', () => {
         ...filaBase,
         ultimo_servicio_fecha: '2026-08-10',
         ultima_confirmacion_prenez_fecha: '2026-08-10',
+        ultima_confirmacion_prenez_metodo: 'palpacion',
       };
       const r = derivarEstadoReproductivo(fila, CONFIG_BASE, '2026-08-10');
       expect(r.estado).toBe('preñada');
@@ -1651,6 +1756,7 @@ describe('derivarEstadoReproductivo', () => {
         ...filaBase,
         ultimo_servicio_fecha: null,
         ultima_confirmacion_prenez_fecha: '2026-08-01',
+        ultima_confirmacion_prenez_metodo: 'palpacion',
       };
       const r = derivarEstadoReproductivo(fila, CONFIG_BASE, '2026-08-06');
       expect(r.estado).toBe('preñada');

--- a/src/__tests__/calculosHatoParidad.test.ts
+++ b/src/__tests__/calculosHatoParidad.test.ts
@@ -291,6 +291,8 @@ describe('paridad de comportamiento calculosHato ⇄ calculos-hato', () => {
       ultimo_secado_real_fecha: null,
       ultima_confirmacion_prenez_fecha: null,
       ultimo_evento_fecha: null,
+      ultima_confirmacion_prenez_metodo: null,
+      ultimo_aborto_fecha: null,
       ultimo_estado_chequeo: null,
     };
     const filas: frontend.EstadoActualHatoRow[] = [

--- a/src/__tests__/exportarPlanillaChequeo.test.ts
+++ b/src/__tests__/exportarPlanillaChequeo.test.ts
@@ -19,6 +19,7 @@ import {
   isoATextoDDMMYYYY,
   textoCeldaToro,
   textoCeldaEstado,
+  textoCeldaEstadoRegistrado,
   construirLibroPlanillaChequeo,
   type FilaPlanillaChequeo,
 } from '@/utils/hato/exportarPlanillaChequeo';
@@ -33,6 +34,7 @@ function filaVacia(overrides: Partial<FilaPlanillaChequeo> & { numero: number; n
     sexoCria: overrides.sexoCria ?? null,
     fechaServicio: overrides.fechaServicio ?? null,
     toro: overrides.toro ?? null,
+    estadoRegistrado: overrides.estadoRegistrado ?? null,
     estado: overrides.estado ?? null,
     secar: overrides.secar ?? null,
     partoProbable: overrides.partoProbable ?? null,
@@ -101,6 +103,22 @@ describe('textoCeldaEstado (Fase 1 de docs/plan_chequeo_captura_foto.md)', () =>
   });
 });
 
+describe('textoCeldaEstadoRegistrado (D-E, B5.4 -- N21/N22 del plan de agosto 2026)', () => {
+  it('devuelve la MISMA etiqueta de 5 estados que el resto de la app (chipEstadoReproductivo)', () => {
+    expect(textoCeldaEstadoRegistrado('servida')).toBe('Servida');
+    expect(textoCeldaEstadoRegistrado('preñada')).toBe('Confirmada');
+    expect(textoCeldaEstadoRegistrado('proxima_a_secar')).toBe('Por secar');
+    expect(textoCeldaEstadoRegistrado('seca')).toBe('Seca');
+    expect(textoCeldaEstadoRegistrado('vacia_por_servir')).toBe('Vacía');
+    expect(textoCeldaEstadoRegistrado('parida_reciente')).toBe('Vacía');
+  });
+
+  it('null/undefined -> celda vacía, nunca un texto inventado', () => {
+    expect(textoCeldaEstadoRegistrado(null)).toBeNull();
+    expect(textoCeldaEstadoRegistrado(undefined)).toBeNull();
+  });
+});
+
 describe('construirAOAPlanillaChequeo', () => {
   it('arma título (fila 0) + encabezado (fila 1, UNA sola vez) + filas de datos, una tabla continua', () => {
     const filas = [
@@ -124,9 +142,10 @@ describe('construirAOAPlanillaChequeo', () => {
     expect(filasQueSonElEncabezado).toHaveLength(1);
   });
 
-  it('el template tiene 12 columnas -- las 13 históricas menos TP (decisión del dueño)', () => {
-    expect(ENCABEZADOS_PLANILLA_CHEQUEO).toHaveLength(12);
+  it('el template tiene 13 columnas -- las 13 históricas menos TP, más "Estado registrado" (D-E, B5.4)', () => {
+    expect(ENCABEZADOS_PLANILLA_CHEQUEO).toHaveLength(13);
     expect(ENCABEZADOS_PLANILLA_CHEQUEO).not.toContain('TP');
+    expect(ENCABEZADOS_PLANILLA_CHEQUEO).toContain('Estado registrado');
   });
 });
 
@@ -170,8 +189,8 @@ describe('construirLibroPlanillaChequeo -- ensamblado real con xlsx', () => {
   });
 });
 
-describe('B5.3 -- grilla.ts reconoce los headers en palabra completa de nuestro propio formato', () => {
-  it('construirColmapConEncabezado mapea las 12 columnas del template sin ambigüedad y sin columna TP', () => {
+describe('B5.3/B5.4 -- grilla.ts reconoce los headers en palabra completa de nuestro propio formato', () => {
+  it('construirColmapConEncabezado mapea las 13 columnas del template sin ambigüedad y sin columna TP', () => {
     const { colmap, generacion, columnasExtra, notas } = construirColmapConEncabezado([...ENCABEZADOS_PLANILLA_CHEQUEO]);
 
     expect(colmap).toEqual({
@@ -183,11 +202,12 @@ describe('B5.3 -- grilla.ts reconoce los headers en palabra completa de nuestro 
       sx: 5,
       fechaServicio: 6,
       toro: 7,
+      estadoRegistrado: 8, // "Estado registrado" (D-E, B5.4) -- exclusiva de nuestro formato
       tp: null, // TP se elimina del template -- nunca se lee (regla dura del motor)
-      estado: 8,
-      secar: 9,
-      pp: 10,
-      ttto: 11,
+      estado: 9,
+      secar: 10,
+      pp: 11,
+      ttto: 12,
     });
     expect(generacion).toBe(3);
     expect(columnasExtra).toEqual([]);
@@ -204,5 +224,8 @@ describe('B5.3 -- grilla.ts reconoce los headers en palabra completa de nuestro 
     expect(colmap.tp).toBe(8);
     expect(colmap.estado).toBe(9);
     expect(generacion).toBe(2);
+    // Ninguna generación histórica trae "Estado registrado" (B5.4 es
+    // exclusiva de nuestro propio formato) -- alias aditivo, nunca inventado.
+    expect(colmap.estadoRegistrado).toBeNull();
   });
 });

--- a/src/__tests__/exportarPlanillaChequeoPDF.test.ts
+++ b/src/__tests__/exportarPlanillaChequeoPDF.test.ts
@@ -59,69 +59,61 @@ function fila(overrides: Partial<FilaPlanillaChequeo> & { numero: number; nombre
 }
 
 describe('etiquetaSexoCria (D-E: el PDF imprime lenguaje claro, no el código crudo)', () => {
-  it('macho vendido -> "M vendido" (el crudo era `OV`)', () => {
+  // Desde el 2026-08-14 esta etiqueta lleva SÓLO EL SEXO, por decisión del
+  // dueño viendo la planilla impresa ("reduce sexo cría a la mitad, sólo
+  // necesitamos que quepa Macho/Hembra o M/H"). Antes combinaba sexo + destino
+  // + chapeta de la cría, y por eso era la columna más ancha de la hoja.
+  // El destino y la chapeta NO se pierden: siguen en `hato_eventos` y en el
+  // `.xlsx`, que emite `sx_raw` verbatim. Ver la nota de la función.
+
+  it('macho -> "Macho", con o sin destino (el destino ya no se imprime)', () => {
     expect(
       etiquetaSexoCria({ sexoCria: 'macho', criaDestino: 'macho_vendido', sexoCriaRaw: 'OV' }),
-    ).toBe('M vendido');
+    ).toBe('Macho');
+    expect(etiquetaSexoCria({ sexoCria: 'macho', criaDestino: null, sexoCriaRaw: 'OV' })).toBe('Macho');
   });
 
-  it('hembra retenida con chapeta -> "H retenida #206" (el crudo era `A 206`)', () => {
+  it('hembra -> "Hembra", y la chapeta de la cría ya NO va al papel', () => {
     expect(
       etiquetaSexoCria({ sexoCria: 'hembra', criaDestino: 'retenida', sexoCriaRaw: 'A 206' }),
-    ).toBe('H retenida #206');
-  });
-
-  it('hembra retenida SIN número en la celda SX -> omite la chapeta, jamás la inventa', () => {
-    expect(etiquetaSexoCria({ sexoCria: 'hembra', criaDestino: 'retenida', sexoCriaRaw: 'A' })).toBe(
-      'H retenida',
-    );
-    expect(etiquetaSexoCria({ sexoCria: 'hembra', criaDestino: 'retenida', sexoCriaRaw: null })).toBe(
-      'H retenida',
-    );
-  });
-
-  it('hembra vendida -> "H vendida" (el crudo era `AV`)', () => {
+    ).toBe('Hembra');
     expect(
       etiquetaSexoCria({ sexoCria: 'hembra', criaDestino: 'hembra_vendida', sexoCriaRaw: 'AV' }),
-    ).toBe('H vendida');
-  });
-
-  it('cría muerta CON sexo legible (`A+` -> la letra sí dice hembra) -> "H murió"', () => {
+    ).toBe('Hembra');
     expect(etiquetaSexoCria({ sexoCria: 'hembra', criaDestino: 'muerta', sexoCriaRaw: 'A+' })).toBe(
-      'H murió',
+      'Hembra',
     );
-    expect(etiquetaSexoCria({ sexoCria: 'macho', criaDestino: 'muerta', sexoCriaRaw: 'O+' })).toBe(
-      'M murió',
-    );
-  });
-
-  it('cría muerta SIN sexo legible -> "Cría murió" (es el caso real: `cria_destino=muerta` viene tanto de A+ como de O+)', () => {
-    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'muerta', sexoCriaRaw: null })).toBe(
-      'Cría murió',
-    );
-  });
-
-  it('sexo conocido pero destino sin registrar -> solo el sexo (es dato real, no se rellena el resto)', () => {
-    expect(etiquetaSexoCria({ sexoCria: 'macho', criaDestino: null, sexoCriaRaw: 'OV' })).toBe('Macho');
     expect(etiquetaSexoCria({ sexoCria: 'hembra', criaDestino: null, sexoCriaRaw: null })).toBe('Hembra');
   });
 
-  it('destino conocido pero sexo no determinable -> se describe la cría sin inventarle sexo', () => {
-    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'retenida', sexoCriaRaw: 'A 206' })).toBe(
-      'Cría retenida #206',
-    );
-    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'hembra_vendida', sexoCriaRaw: null })).toBe(
-      'Cría vendida',
-    );
-    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'macho_vendido', sexoCriaRaw: null })).toBe(
-      'Cría vendido',
-    );
+  // Los tres casos SIN sexo no se borran junto con el destino: hubo un hecho
+  // real y una celda vacía diría "no hay dato". Van en una palabra corta para
+  // no volver a ensanchar la columna.
+  it('cría muerta SIN sexo legible -> "Murió" (`cria_destino=muerta` viene tanto de A+ como de O+)', () => {
+    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'muerta', sexoCriaRaw: null })).toBe('Murió');
   });
 
-  it('parto gemelar (`gem+`): no hay sexo de cada gemelo, pero el hecho SÍ es dato -> "Parto gemelar"', () => {
-    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: null, sexoCriaRaw: 'gem+' })).toBe(
-      'Parto gemelar',
-    );
+  it('destino conocido pero sexo no determinable -> "Cría": hubo cría, no se le inventa sexo', () => {
+    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'retenida', sexoCriaRaw: 'A 206' })).toBe('Cría');
+    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'hembra_vendida', sexoCriaRaw: null })).toBe('Cría');
+    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: 'macho_vendido', sexoCriaRaw: null })).toBe('Cría');
+  });
+
+  it('parto gemelar (`gem+`): no hay sexo de cada gemelo, pero el hecho SÍ es dato -> "Gemelar"', () => {
+    expect(etiquetaSexoCria({ sexoCria: null, criaDestino: null, sexoCriaRaw: 'gem+' })).toBe('Gemelar');
+  });
+
+  it('"Gemelar" es la etiqueta más larga y por eso fija el ancho de la columna', () => {
+    const todas = [
+      etiquetaSexoCria({ sexoCria: 'hembra', criaDestino: 'retenida', sexoCriaRaw: 'A 206' }),
+      etiquetaSexoCria({ sexoCria: 'macho', criaDestino: 'macho_vendido', sexoCriaRaw: 'OV' }),
+      etiquetaSexoCria({ sexoCria: null, criaDestino: 'muerta', sexoCriaRaw: null }),
+      etiquetaSexoCria({ sexoCria: null, criaDestino: 'retenida', sexoCriaRaw: 'A 206' }),
+      etiquetaSexoCria({ sexoCria: null, criaDestino: null, sexoCriaRaw: 'gem+' }),
+    ].filter((e): e is string => e !== null);
+    // Ninguna supera 7 caracteres: es lo que permite que la columna quepa en
+    // 14,5mm en vez de los 25,5 que necesitaba `H retenida #206`.
+    expect(Math.max(...todas.map((e) => e.length))).toBe('Gemelar'.length);
   });
 
   it('aborto: no hay cría que describir -> celda VACÍA', () => {

--- a/src/__tests__/exportarPlanillaChequeoPDF.test.ts
+++ b/src/__tests__/exportarPlanillaChequeoPDF.test.ts
@@ -20,6 +20,7 @@ import jsPDF from 'jspdf';
 import autoTable from 'jspdf-autotable';
 import {
   ENCABEZADOS_PLANILLA_CHEQUEO,
+  textoCeldaEstadoRegistrado,
   type FilaPlanillaChequeo,
 } from '@/utils/hato/exportarPlanillaChequeo';
 import {
@@ -36,6 +37,7 @@ import {
   FUENTE_DATOS_PT,
   ALTO_MINIMO_FILA_MM,
   NOTA_OPERATIVA_PLANILLA,
+  MARGENES_PDF_MM,
 } from '@/utils/hato/exportarPlanillaChequeoPDF';
 
 function fila(overrides: Partial<FilaPlanillaChequeo> & { numero: number; nombre: string }): FilaPlanillaChequeo {
@@ -48,6 +50,7 @@ function fila(overrides: Partial<FilaPlanillaChequeo> & { numero: number; nombre
     sexoCria: overrides.sexoCria ?? null,
     fechaServicio: overrides.fechaServicio ?? null,
     toro: overrides.toro ?? null,
+    estadoRegistrado: overrides.estadoRegistrado ?? null,
     estado: overrides.estado ?? null,
     secar: overrides.secar ?? null,
     partoProbable: overrides.partoProbable ?? null,
@@ -153,6 +156,7 @@ describe('construirFilasPlanillaPDF', () => {
         sexoCria: 'Hembra (retenida #206)',
         fechaServicio: '5/1/2026',
         toro: 'Ins Nitro',
+        estadoRegistrado: 'Servida',
         estado: 'ok',
         secar: '1/9/2026',
         partoProbable: '1/11/2026',
@@ -171,6 +175,7 @@ describe('construirFilasPlanillaPDF', () => {
       'Hembra (retenida #206)',
       '5/1/2026',
       'Ins Nitro',
+      'Servida',
       'ok',
       '1/9/2026',
       '1/11/2026',
@@ -183,7 +188,7 @@ describe('construirFilasPlanillaPDF', () => {
     expect(celdas[0]).toBe('101');
     expect(celdas[1]).toBe('LUCERO');
     // Todo lo demás sin dato previo: vacío, no cero.
-    expect(celdas.slice(2)).toEqual(['', '', '', '', '', '', '', '', '', '']);
+    expect(celdas.slice(2)).toEqual(['', '', '', '', '', '', '', '', '', '', '']);
     expect(celdas).not.toContain('0');
   });
 
@@ -203,6 +208,23 @@ describe('layout del PDF -- presupuesto de ancho y clasificación de columnas', 
     expect(suma).toBeGreaterThan(215.9 - 20);
   });
 
+  it('los márgenes no bajan del piso imprimible (el presupuesto de ancho NO protege esto)', () => {
+    // El test de arriba compara la suma de anchos contra `ANCHO_UTIL_CARTA_
+    // HORIZONTAL_MM`, que a su vez SE DERIVA de `MARGENES_PDF_MM`. O sea que
+    // encoger el margen sube el techo y el test sigue pasando: es
+    // autorreferencial en ese eje y no puede atrapar "los márgenes quedaron
+    // más chicos de lo que una impresora puede imprimir".
+    //
+    // Pasó de verdad al meter la 13ª columna ("Estado registrado", D-E): los
+    // márgenes bajaron de 10mm a 8mm y quedaron 0,2mm de holgura. 8mm sigue
+    // por encima del área no imprimible típica (~5mm, hasta 6,35mm en las
+    // más restrictivas), pero es el piso: por debajo, la planilla sale
+    // cortada en el papel aunque el PDF se vea bien en pantalla.
+    const PISO_IMPRIMIBLE_MM = 8;
+    expect(MARGENES_PDF_MM.left).toBeGreaterThanOrEqual(PISO_IMPRIMIBLE_MM);
+    expect(MARGENES_PDF_MM.right).toBeGreaterThanOrEqual(PISO_IMPRIMIBLE_MM);
+  });
+
   it('TODA columna del template está clasificada como "se diligencia" o "pre-llenada", sin solapamiento', () => {
     const total = COLUMNAS_A_DILIGENCIAR.size + COLUMNAS_PRELLENADAS.length;
     expect(total).toBe(ENCABEZADOS_PLANILLA_CHEQUEO.length);
@@ -218,8 +240,11 @@ describe('layout del PDF -- presupuesto de ancho y clasificación de columnas', 
       ['Estado', 'Fecha Servicio', 'PL', 'Sexo cría', 'Toro', 'Tratamiento'].sort(),
     );
     // Identidad/referencia: el sistema las calcula, nadie las escribe.
+    // "Estado registrado" (D-E, B5.4) es la más nueva de este grupo: gris,
+    // de solo referencia, nadie la diligencia -- la columna de al lado
+    // ("Estado") sigue siendo la que Martha verifica.
     expect([...COLUMNAS_PRELLENADAS].sort()).toEqual(
-      ['#', '# Partos', 'Nombre', 'Parto Probable', 'Secar', 'Última Cría'].sort(),
+      ['#', '# Partos', 'Estado registrado', 'Nombre', 'Parto Probable', 'Secar', 'Última Cría'].sort(),
     );
   });
 
@@ -269,6 +294,10 @@ describe('layout del PDF -- presupuesto de ancho y clasificación de columnas', 
       })!,
       'Fecha Servicio': '22/12/2026',
       Toro: 'Ins Holstein',
+      // "Confirmada" es la más larga de las 5 etiquetas del vocabulario de
+      // D-D -- derivada de la función REAL (`textoCeldaEstadoRegistrado`),
+      // mismo criterio que 'Sexo cría' arriba: nunca un literal desincronizable.
+      'Estado registrado': textoCeldaEstadoRegistrado('preñada')!,
       Estado: 'rech',
       Secar: '22/12/2026',
       'Parto Probable': '22/12/2026',

--- a/src/__tests__/exportarPlanillaChequeoPDF.test.ts
+++ b/src/__tests__/exportarPlanillaChequeoPDF.test.ts
@@ -259,10 +259,21 @@ describe('layout del PDF -- presupuesto de ancho y clasificación de columnas', 
     ]);
   });
 
-  it('la letra de los datos es >= 11pt (requisito duro del dueño) y el alto de fila deja espacio para escribir', () => {
-    expect(FUENTE_DATOS_PT).toBeGreaterThanOrEqual(11);
-    // Una línea de 11pt ocupa ~3,9mm: 9mm de fila dejan ~5mm libres dentro
-    // del recuadro para la escritura a mano.
+  it('la letra de los datos no baja de 9pt, y el alto de fila deja espacio para escribir', () => {
+    // Este test pedía >=11pt hasta el 2026-08-14, por un requisito explícito
+    // del dueño. Lo REVOCÓ él mismo viendo la planilla de 13 columnas
+    // renderizada ("el texto está muy grande, se puede condensar para abrir
+    // espacio"): a 11pt la planilla estaba sobre-suscrita y lo pagaban las dos
+    // columnas que se escriben a mano. Ver la nota de `FUENTE_DATOS_PT`.
+    //
+    // El piso pasa a 9pt, y sigue siendo un piso de verdad: por debajo la
+    // planilla deja de leerse en el corral, que es la razón original de la
+    // regla y no cambió. Si hiciera falta más espacio, la salida es una página
+    // más o una columna menos -- nunca letra más chica.
+    expect(FUENTE_DATOS_PT).toBeGreaterThanOrEqual(9);
+    // El alto NO es cuestión de que quepa el texto impreso sino la MANO de
+    // Martha: se queda en 9mm aunque la letra bajara, así que ahora hay más
+    // espacio libre dentro del recuadro, no menos.
     expect(ALTO_MINIMO_FILA_MM).toBeGreaterThanOrEqual(8);
   });
 

--- a/src/__tests__/exportarPlanillaChequeoRoundTrip.test.ts
+++ b/src/__tests__/exportarPlanillaChequeoRoundTrip.test.ts
@@ -241,10 +241,80 @@ describe('B5.3 -- round-trip: exportar un chequeo existente y volver a subirlo s
       cambios: 0,
       noReconocidos: 0,
       conIssues: 0,
+      conConflictoEstadoRegistrado: 0,
     });
     for (const fila of diff.filas) {
       expect(fila.clasificacion).toBe('sin_cambio');
       expect(fila.diferencias).toEqual([]);
+      // Sin `estadosRegistrados` (el 4º parámetro, opcional) el diff nunca
+      // fabrica un conflicto -- mismo contrato de "sin dato antes que dato
+      // inventado" del resto del módulo.
+      expect(fila.conflictoEstadoRegistrado).toBeNull();
     }
+  });
+
+  it('D-E/B5.4 -- "Estado registrado" (columna 13) round-tripea VERBATIM: exportar, re-leer, y compararlo contra lo que el sistema cree hoy detecta el conflicto explícito (N23)', () => {
+    const vaca = construirFixture({
+      id: 'animal-vaca',
+      numero: 300,
+      nombre: 'VACA',
+      plRaw: 15,
+      numPartosRaw: 2,
+      fechaServicioRaw: '10/8/2026',
+      toroRaw: 'Toro Jersey',
+      estadoRaw: null,
+      ultimaCriaRaw: null,
+      sxRaw: null,
+      tttoRaw: null,
+    });
+    // "Estado registrado" es la MISMA etiqueta que ve el resto de la app
+    // (chipEstadoReproductivo/etiquetaEstadoReproductivo) -- impresa cuando
+    // se exportó esta planilla.
+    const filaImpresa: FilaPlanillaChequeo = { ...vaca.fila, estadoRegistrado: 'Servida' };
+
+    const libro = construirLibroPlanillaChequeo(XLSX, {
+      tituloHoja: construirTituloHojaChequeo(FECHA_CHEQUEO_ACTUAL),
+      nombreHoja: construirNombreHojaChequeo(FECHA_CHEQUEO_ACTUAL),
+      filas: [filaImpresa],
+    });
+    const buf = XLSX.write(libro, { type: 'buffer', bookType: 'xlsx' }) as Buffer;
+    const libroLeido = XLSX.read(buf, { type: 'buffer', cellDates: false });
+    const nombreHojaLeida = libroLeido.SheetNames[0];
+    const hojaCruda: HojaCruda = {
+      archivo: ARCHIVO,
+      hoja: nombreHojaLeida,
+      filas: hojaAMatriz(libroLeido.Sheets[nombreHojaLeida]),
+    };
+
+    const salida = normalizarHojas([hojaCruda], '2026-08-20T00:00:00.000Z', CONFIG);
+    expect(salida.chequeos).toHaveLength(1);
+    // Round-trip VERBATIM: lo que se imprimió vuelve a leerse exactamente igual.
+    expect(salida.chequeos[0].estadoRegistrado).toBe('Servida');
+    expect(salida.chequeos[0].raw.estadoRegistrado).toBe('Servida');
+
+    // El sistema, al momento de aprobar, ahora cree OTRA cosa (p. ej. Martha
+    // ya la confirmó preñada por palpación en el ínterin) -- eso es
+    // exactamente el conflicto que N23 pide mostrar ANTES de aprobar.
+    const diffConConflicto = construirDiffChequeo(
+      salida.chequeos,
+      [vaca.animal],
+      [vaca.ultimo],
+      [{ animalId: 'animal-vaca', estado: 'Confirmada' }],
+    );
+    expect(diffConConflicto.filas[0].conflictoEstadoRegistrado).toEqual({
+      impreso: 'Servida',
+      actual: 'Confirmada',
+    });
+    expect(diffConConflicto.resumen.conConflictoEstadoRegistrado).toBe(1);
+
+    // Si en cambio el sistema sigue creyendo lo mismo que se imprimió, no hay
+    // conflicto que mostrar -- nunca se fabrica una alerta de la nada.
+    const diffSinConflicto = construirDiffChequeo(
+      salida.chequeos,
+      [vaca.animal],
+      [vaca.ultimo],
+      [{ animalId: 'animal-vaca', estado: 'Servida' }],
+    );
+    expect(diffSinConflicto.filas[0].conflictoEstadoRegistrado).toBeNull();
   });
 });

--- a/src/__tests__/fixtures/importHatoNormalizado.fixture.ts
+++ b/src/__tests__/fixtures/importHatoNormalizado.fixture.ts
@@ -61,6 +61,7 @@ function filaChequeo(datos: {
       sx: datos.sx ?? null,
       fechaServicio: null,
       toro: datos.toro ?? null,
+      estadoRegistrado: null,
       tp: null,
       estado: null,
       secar: null,
@@ -76,6 +77,7 @@ function filaChequeo(datos: {
     fechaProbableParto: null,
     toroNombre: datos.toroNombre !== undefined ? datos.toroNombre : (datos.toro ?? null),
     tipoServicio: null,
+    estadoRegistrado: null,
     issues: [],
   };
 }

--- a/src/__tests__/hatoAggregation.test.ts
+++ b/src/__tests__/hatoAggregation.test.ts
@@ -91,6 +91,8 @@ function estadoBase(overrides: Partial<HatoEstadoActualRow> = {}): HatoEstadoAct
     ultimo_secado_real_fecha: null,
     ultima_confirmacion_prenez_fecha: null,
     ultimo_evento_fecha: null,
+    ultima_confirmacion_prenez_metodo: null,
+    ultimo_aborto_fecha: null,
     ultimo_estado_chequeo: null,
     // Irrelevante para las filas con num_partos >= 1 (la regla D-13 las
     // clasifica "vaca" por el 1er parto, nunca por edad) -- mismo default

--- a/src/__tests__/hatoAlertas.test.ts
+++ b/src/__tests__/hatoAlertas.test.ts
@@ -55,6 +55,8 @@ function animalBase(overrides: Partial<AnimalHatoParaAlertas> = {}): AnimalHatoP
     ultimo_secado_real_fecha: null,
     ultima_confirmacion_prenez_fecha: null,
     ultimo_evento_fecha: null,
+    ultima_confirmacion_prenez_metodo: null,
+    ultimo_aborto_fecha: null,
     ultimo_estado_chequeo: null,
     ...overrides,
   };

--- a/src/__tests__/hatoAlertas.test.ts
+++ b/src/__tests__/hatoAlertas.test.ts
@@ -20,8 +20,14 @@ import {
   HORAS_MINIMAS_REENVIO,
   INTENTOS_MAXIMOS_REENVIO,
   DIAS_EXPIRACION_ALERTA,
+  claveAlertaCatalogo,
+  agruparSuscriptoresPorClave,
+  etiquetaRespuestaAlerta,
+  construirMensajeAlertaYaResuelta,
+  construirMensajeCierreAlertaBroadcast,
   type AnimalHatoParaAlertas,
   type PasoTratamientoPendienteInput,
+  type FilaSuscripcionAlerta,
 } from '@/utils/hatoAlertas';
 import type { HatoConfig } from '@/utils/calculosHato';
 
@@ -575,5 +581,103 @@ describe('decidirExpiracionTerminal — D-24 (docs/plan_hato_ronda_agosto_2026.m
       decidirExpiracionTerminal({ estado: 'escalada', escalada_at: escaladaHace5Dias, updated_at: escaladaHace5Dias }, AHORA, 3),
     ).toBe(true);
     expect(DIAS_EXPIRACION_ALERTA).toBe(14);
+  });
+});
+
+// ============================================================================
+// Suscripciones por usuario de Telegram (migración 096)
+// ============================================================================
+
+describe('claveAlertaCatalogo', () => {
+  it('concatena modulo.tipo', () => {
+    expect(claveAlertaCatalogo('hato', 'secado_due')).toBe('hato.secado_due');
+    expect(claveAlertaCatalogo('aguacate', 'algo')).toBe('aguacate.algo');
+  });
+});
+
+describe('agruparSuscriptoresPorClave', () => {
+  function fila(overrides: Partial<FilaSuscripcionAlerta> = {}): FilaSuscripcionAlerta {
+    return {
+      alerta_clave: 'hato.secado_due',
+      recibe: true,
+      escalamiento: false,
+      telegram_id: '8505349717',
+      ...overrides,
+    };
+  }
+
+  it('agrupa por clave, separando recibe de escalamiento', () => {
+    const filas: FilaSuscripcionAlerta[] = [
+      fila({ telegram_id: '111', recibe: true, escalamiento: true }),
+      fila({ telegram_id: '222', recibe: true, escalamiento: false }),
+      fila({ telegram_id: '333', recibe: false, escalamiento: true }),
+    ];
+    const mapa = agruparSuscriptoresPorClave(filas);
+    const entrada = mapa.get('hato.secado_due');
+    expect(entrada).toBeDefined();
+    expect(entrada!.recibe.sort()).toEqual(['111', '222']);
+    expect(entrada!.escalamiento.sort()).toEqual(['111', '333']);
+  });
+
+  it('un mismo telegram_id puede recibir y escalar a la vez', () => {
+    const mapa = agruparSuscriptoresPorClave([fila({ telegram_id: '111', recibe: true, escalamiento: true })]);
+    const entrada = mapa.get('hato.secado_due')!;
+    expect(entrada.recibe).toEqual(['111']);
+    expect(entrada.escalamiento).toEqual(['111']);
+  });
+
+  it('claves distintas no se mezclan', () => {
+    const mapa = agruparSuscriptoresPorClave([
+      fila({ alerta_clave: 'hato.secado_due', telegram_id: '111' }),
+      fila({ alerta_clave: 'hato.parto_proximo', telegram_id: '222' }),
+    ]);
+    expect(mapa.get('hato.secado_due')!.recibe).toEqual(['111']);
+    expect(mapa.get('hato.parto_proximo')!.recibe).toEqual(['222']);
+  });
+
+  it('ni recibe ni escalamiento -- la clave existe pero ambas listas quedan vacías', () => {
+    const mapa = agruparSuscriptoresPorClave([fila({ recibe: false, escalamiento: false })]);
+    expect(mapa.get('hato.secado_due')).toEqual({ recibe: [], escalamiento: [] });
+  });
+
+  it('lista vacía produce un mapa vacío', () => {
+    expect(agruparSuscriptoresPorClave([]).size).toBe(0);
+  });
+});
+
+describe('etiquetaRespuestaAlerta', () => {
+  it('traduce las 3 respuestas posibles', () => {
+    expect(etiquetaRespuestaAlerta('si')).toBe('Sí');
+    expect(etiquetaRespuestaAlerta('no')).toBe('Todavía no');
+    expect(etiquetaRespuestaAlerta('otro')).toBe('Otra cosa');
+  });
+});
+
+describe('construirMensajeAlertaYaResuelta — broadcast, cierre por el primero', () => {
+  it('con respondida_por y respuesta conocidos, nombra a quién y qué respondió', () => {
+    const texto = construirMensajeAlertaYaResuelta('confirmada', 'Fernando', 'si');
+    expect(texto).toContain('Fernando');
+    expect(texto).toContain('Sí');
+  });
+
+  it('sin respondida_por (dato legado o estado terminal sin respuesta), cae al genérico con el estado', () => {
+    const texto = construirMensajeAlertaYaResuelta('expirada', null, null);
+    expect(texto).toContain('expirada');
+    expect(texto).not.toContain('null');
+  });
+});
+
+describe('construirMensajeCierreAlertaBroadcast — edición del mensaje de los demás suscritos', () => {
+  it('conserva el mensaje original y antepone quién resolvió y cómo', () => {
+    const original = 'Vaca 47 (ESTRELLA) se debe secar hoy. ¿Ya se secó?';
+    const texto = construirMensajeCierreAlertaBroadcast(original, 'Martha', 'si');
+    expect(texto).toContain('Martha');
+    expect(texto).toContain('Sí');
+    expect(texto).toContain(original);
+  });
+
+  it('las 3 respuestas producen etiquetas distintas', () => {
+    const textos = (['si', 'no', 'otro'] as const).map((r) => construirMensajeCierreAlertaBroadcast('X', 'Martha', r));
+    expect(new Set(textos).size).toBe(3);
   });
 });

--- a/src/__tests__/hatoAlertasParidadServidor.test.ts
+++ b/src/__tests__/hatoAlertasParidadServidor.test.ts
@@ -84,6 +84,8 @@ const ANIMALES: frontend.AnimalHatoParaAlertas[] = [
     ultimo_secado_real_fecha: null,
     ultima_confirmacion_prenez_fecha: null,
     ultimo_evento_fecha: '2025-12-01',
+    ultima_confirmacion_prenez_metodo: null,
+    ultimo_aborto_fecha: null,
     ultimo_estado_chequeo: null,
   },
   // Chapeta provisional -- ejercita la regla "lidera con el nombre".
@@ -101,6 +103,8 @@ const ANIMALES: frontend.AnimalHatoParaAlertas[] = [
     ultimo_secado_real_fecha: null,
     ultima_confirmacion_prenez_fecha: null,
     ultimo_evento_fecha: '2025-10-25',
+    ultima_confirmacion_prenez_metodo: null,
+    ultimo_aborto_fecha: null,
     ultimo_estado_chequeo: null,
   },
 ];

--- a/src/__tests__/hatoAlertasTablero.test.ts
+++ b/src/__tests__/hatoAlertasTablero.test.ts
@@ -45,6 +45,7 @@ function animal(overrides: Partial<AnimalHatoDerivado> = {}): AnimalHatoDerivado
     numPartos: 0,
     ultimoChequeoFecha: null,
     ultimoPartoFecha: null,
+    fechaNacimiento: null,
     derivado: derivado(),
     categoria: 'hato',
     categoriaOrigen: 'calculado',

--- a/src/__tests__/hatoAlertasTablero.test.ts
+++ b/src/__tests__/hatoAlertasTablero.test.ts
@@ -26,6 +26,7 @@ function derivado(overrides: Partial<EstadoReproductivoDerivado> = {}): EstadoRe
     tiempo_secada_dias: null,
     proxima_a_reemplazo: false,
     vacia_es_problema: null,
+    senal_revision: null,
     alertas: { secado_due: false, rechequeo_due: false, servicio_sin_confirmacion: false, parto_proximo: false },
     ...overrides,
   };

--- a/src/__tests__/hatoCategorias.test.ts
+++ b/src/__tests__/hatoCategorias.test.ts
@@ -271,6 +271,8 @@ describe('clasificarAnimalHato', () => {
       ultimo_secado_real_fecha: null,
       ultima_confirmacion_prenez_fecha: null,
       ultimo_evento_fecha: null,
+      ultima_confirmacion_prenez_metodo: null,
+      ultimo_aborto_fecha: null,
       ultimo_estado_chequeo: null,
       fecha_nacimiento: null,
       etapa_forzada: false,

--- a/src/__tests__/hatoCicloManual.test.ts
+++ b/src/__tests__/hatoCicloManual.test.ts
@@ -42,6 +42,8 @@ function fila(datos: Partial<EstadoActualHatoRow> = {}): EstadoActualHatoRow {
     ultimo_secado_real_fecha: null,
     ultima_confirmacion_prenez_fecha: null,
     ultimo_evento_fecha: null,
+    ultima_confirmacion_prenez_metodo: null,
+    ultimo_aborto_fecha: null,
     ultimo_estado_chequeo: null,
     ...datos,
   };
@@ -330,12 +332,24 @@ describe('proyectarEstadoTrasMarca', () => {
       HOY,
     );
     expect(antes).toBe('novilla');
+    // D-D (2026-08-13) corrige D-20: la marca "preñada" es una PRESUNCIÓN, y
+    // una presunción deja a la vaca en `servida` (etiqueta "Servida"), no en
+    // `preñada`. Solo la palpación confirma.
+    expect(despues).toBe('servida');
+  });
+
+  it('vacía por servir -> marca confirmada (palpación) -> queda preñada', () => {
+    const { despues } = proyectarEstadoTrasMarca(fila(), 'confirmada', HOY, CONFIG, HOY);
     expect(despues).toBe('preñada');
   });
 
-  it('vacía por servir -> marca confirmada -> queda preñada (D-20: mismo estado que preñada)', () => {
-    const { despues } = proyectarEstadoTrasMarca(fila(), 'confirmada', HOY, CONFIG, HOY);
-    expect(despues).toBe('preñada');
+  it('la proyección lleva el MÉTODO, no solo la fecha: las dos marcas divergen', () => {
+    // Regresión de D-D: `aplicarMarcaAFilaHipotetica` actualizaba la fecha de
+    // confirmación sin el método, así que el "quedará" del diálogo prometía
+    // el mismo estado para las dos marcas.
+    const conPresuncion = proyectarEstadoTrasMarca(fila(), 'preñada', HOY, CONFIG, HOY);
+    const conPalpacion = proyectarEstadoTrasMarca(fila(), 'confirmada', HOY, CONFIG, HOY);
+    expect(conPresuncion.despues).not.toBe(conPalpacion.despues);
   });
 
   it('servida (ya con servicio) -> marca seca -> queda seca, cierra el lazo de ordeño (D-5)', () => {

--- a/src/__tests__/hatoCorreccionChequeo.test.ts
+++ b/src/__tests__/hatoCorreccionChequeo.test.ts
@@ -64,6 +64,7 @@ function fila(datos: Partial<FilaChequeoNormalizada> & { fila: number; numero: n
       sx: null,
       fechaServicio: null,
       toro: null,
+      estadoRegistrado: null,
       tp: null,
       estado: null,
       secar: null,
@@ -80,6 +81,7 @@ function fila(datos: Partial<FilaChequeoNormalizada> & { fila: number; numero: n
     fechaProbableParto: datos.fechaProbableParto ?? null,
     toroNombre: datos.toroNombre ?? null,
     tipoServicio: datos.tipoServicio ?? null,
+    estadoRegistrado: datos.estadoRegistrado ?? null,
     issues: datos.issues ?? [],
   };
 }
@@ -159,7 +161,7 @@ describe('aplicarCorreccionesFila — la capa cruda nunca se sobreescribe', () =
       fila: 5,
       numero: 157,
       pl: 1,
-      raw: { pl: '1', np: '3', ultimaCria: '2/12/2025', sx: 'OV', fechaServicio: null, toro: null, tp: null, estado: null, secar: null, pp: null, ttto: 'estrumate' },
+      raw: { pl: '1', np: '3', ultimaCria: '2/12/2025', sx: 'OV', fechaServicio: null, toro: null, estadoRegistrado: null, tp: null, estado: null, secar: null, pp: null, ttto: 'estrumate' },
     });
 
     const { fila: corregida, camposCorregidos, errores } = aplicarCorreccionesFila(original, { pl: '14' }, CONFIG);
@@ -176,7 +178,7 @@ describe('aplicarCorreccionesFila — la capa cruda nunca se sobreescribe', () =
   });
 
   it('registra la corrección como issue auditable con prefijo estable, citando crudo y ambos valores', () => {
-    const original = fila({ fila: 5, numero: 157, pl: 1, raw: { pl: '1', np: null, ultimaCria: null, sx: null, fechaServicio: null, toro: null, tp: null, estado: null, secar: null, pp: null, ttto: null } });
+    const original = fila({ fila: 5, numero: 157, pl: 1, raw: { pl: '1', np: null, ultimaCria: null, sx: null, fechaServicio: null, toro: null, estadoRegistrado: null, tp: null, estado: null, secar: null, pp: null, ttto: null } });
     const { fila: corregida } = aplicarCorreccionesFila(original, { pl: '14' }, CONFIG);
 
     const issue = corregida.issues.find((i) => i.motivo.startsWith(PREFIJO_ISSUE_CORRECCION_MANUAL));
@@ -192,7 +194,7 @@ describe('aplicarCorreccionesFila — la capa cruda nunca se sobreescribe', () =
       fila: 5,
       numero: 157,
       pl: null,
-      raw: { pl: '#VALUE!', np: null, ultimaCria: null, sx: null, fechaServicio: null, toro: null, tp: null, estado: null, secar: null, pp: null, ttto: null },
+      raw: { pl: '#VALUE!', np: null, ultimaCria: null, sx: null, fechaServicio: null, toro: null, estadoRegistrado: null, tp: null, estado: null, secar: null, pp: null, ttto: null },
       issues: [{ crudo: '#VALUE!', motivo: 'PL: error de fórmula de Excel propagado (no se reinterpreta aquí)' }],
     });
 
@@ -242,7 +244,7 @@ describe('aplicarCorreccionesFila — interpretación por campo (un solo parser,
       fila: 3,
       numero: 148,
       sx: parseSX('0V'),
-      raw: { pl: null, np: null, ultimaCria: null, sx: '0V', fechaServicio: null, toro: null, tp: null, estado: null, secar: null, pp: null, ttto: null },
+      raw: { pl: null, np: null, ultimaCria: null, sx: '0V', fechaServicio: null, toro: null, estadoRegistrado: null, tp: null, estado: null, secar: null, pp: null, ttto: null },
     });
     const { fila: corregida } = aplicarCorreccionesFila(original, { sx: 'A 206' }, CONFIG);
     expect(corregida.sx).toEqual(parseSX('A 206'));

--- a/src/__tests__/hatoListaHato.test.ts
+++ b/src/__tests__/hatoListaHato.test.ts
@@ -1,0 +1,125 @@
+// Tests de `utils/hato/listaHato.ts` -- columnas nuevas de la lista del hato
+// (N18 edad, N19 próximo evento) del plan
+// docs/plan_hato_telegram_estados_agosto_2026.md.
+
+import { describe, it, expect } from 'vitest';
+import {
+  edadEnAnios,
+  formatearEdadHato,
+  proximoEventoHato,
+  type EntradaProximoEvento,
+} from '@/utils/hato/listaHato';
+import type { EstadoReproductivoDerivado } from '@/utils/calculosHato';
+
+const HOY = '2026-08-13';
+
+function derivado(overrides: Partial<EstadoReproductivoDerivado> = {}): EstadoReproductivoDerivado {
+  return {
+    estado: 'servida',
+    fecha_secar: null,
+    fecha_probable_parto: null,
+    dias_abiertos: null,
+    tiempo_prenez_dias: null,
+    tiempo_secada_dias: null,
+    proxima_a_reemplazo: false,
+    vacia_es_problema: null,
+    senal_revision: null,
+    alertas: {
+      secado_due: false,
+      rechequeo_due: false,
+      servicio_sin_confirmacion: false,
+      parto_proximo: false,
+    },
+    ...overrides,
+  };
+}
+
+function entrada(d: Partial<EstadoReproductivoDerivado> = {}): EntradaProximoEvento {
+  return { derivado: derivado(d) };
+}
+
+describe('edadEnAnios', () => {
+  it('calcula años con un decimal', () => {
+    expect(edadEnAnios('2022-08-13', HOY)).toBe(4);
+    expect(edadEnAnios('2023-02-13', HOY)).toBe(3.5);
+  });
+
+  it('sin fecha de nacimiento devuelve null, nunca 0', () => {
+    // 20 de los 65 animales activos del hato real están así.
+    expect(edadEnAnios(null, HOY)).toBeNull();
+  });
+
+  it('una fecha de nacimiento futura se reporta como ausente, no como edad negativa', () => {
+    expect(edadEnAnios('2027-01-01', HOY)).toBeNull();
+  });
+});
+
+describe('formatearEdadHato', () => {
+  it('bajo el año se expresa en meses', () => {
+    expect(formatearEdadHato('2026-05-13', HOY)).toBe('3 meses');
+    expect(formatearEdadHato('2026-07-20', HOY)).toBe('1 mes');
+  });
+
+  it('desde el año, años con coma decimal (estándar colombiano)', () => {
+    expect(formatearEdadHato('2023-02-13', HOY)).toBe('3,5 años');
+  });
+
+  it('sin dato imprime guion', () => {
+    expect(formatearEdadHato(null, HOY)).toBe('—');
+  });
+});
+
+describe('proximoEventoHato', () => {
+  it('elige el hito con fecha más próximo que todavía no pasó', () => {
+    const r = proximoEventoHato(
+      entrada({ estado: 'preñada', fecha_secar: '2026-09-01', fecha_probable_parto: '2026-11-01' }),
+      HOY,
+    );
+    expect(r).toEqual({ tipo: 'secado', etiqueta: 'Secar', fecha: '2026-09-01', dias: 19 });
+  });
+
+  it('una vaca ya seca no vuelve a mostrar el secado: sigue el parto', () => {
+    const r = proximoEventoHato(
+      entrada({ estado: 'seca', fecha_secar: '2026-07-01', fecha_probable_parto: '2026-09-15' }),
+      HOY,
+    );
+    expect(r?.tipo).toBe('parto');
+  });
+
+  it('si todos los hitos ya vencieron, gana el más reciente y los días salen negativos', () => {
+    const r = proximoEventoHato(
+      entrada({ estado: 'preñada', fecha_secar: '2026-06-01', fecha_probable_parto: '2026-08-01' }),
+      HOY,
+    );
+    expect(r?.tipo).toBe('parto');
+    expect(r?.dias).toBe(-12);
+  });
+
+  it('sin ninguna fecha proyectada cae al rechequeo vencido, SIN inventarle fecha', () => {
+    const r = proximoEventoHato(entrada({ alertas: { ...derivado().alertas, rechequeo_due: true } }), HOY);
+    expect(r).toEqual({ tipo: 'rechequeo', etiqueta: 'Rechequeo', fecha: null, dias: null });
+  });
+
+  it('una vaca vacía sin rechequeo pendiente queda "por servir", también sin fecha', () => {
+    const r = proximoEventoHato(entrada({ estado: 'vacia_por_servir', vacia_es_problema: false }), HOY);
+    expect(r).toEqual({ tipo: 'servir', etiqueta: 'Servir', fecha: null, dias: null });
+  });
+
+  it('sin hito alguno devuelve null: la celda queda vacía, no dice "—" por defecto', () => {
+    // Cría: ni fechas proyectadas, ni rechequeo, ni "vacía" (la pregunta no
+    // aplica, así que `vacia_es_problema` es null).
+    expect(proximoEventoHato(entrada({ estado: 'cria' }), HOY)).toBeNull();
+  });
+
+  it('el rechequeo vencido NO desplaza a un hito con fecha real', () => {
+    const r = proximoEventoHato(
+      entrada({
+        estado: 'preñada',
+        fecha_probable_parto: '2026-09-01',
+        alertas: { ...derivado().alertas, rechequeo_due: true },
+      }),
+      HOY,
+    );
+    expect(r?.tipo).toBe('parto');
+  });
+});

--- a/src/__tests__/importHatoCommitChequeo.test.ts
+++ b/src/__tests__/importHatoCommitChequeo.test.ts
@@ -43,6 +43,7 @@ function filaBase(overrides: Partial<FilaChequeoNormalizada> = {}): FilaChequeoN
       sx: null,
       fechaServicio: '23/04/2026',
       toro: 'ins laredo',
+      estadoRegistrado: null,
       tp: null,
       estado: 'ok',
       secar: null,
@@ -58,6 +59,7 @@ function filaBase(overrides: Partial<FilaChequeoNormalizada> = {}): FilaChequeoN
     fechaProbableParto: '2027-01-23',
     toroNombre: 'ins laredo',
     tipoServicio: 'inseminacion',
+    estadoRegistrado: null,
     issues: [],
     ...overrides,
   };
@@ -184,7 +186,7 @@ describe('construirFilasVacas', () => {
     const fila = filaBase({
       raw: {
         pl: '16', np: '2', ultimaCria: '01/2025', sx: 'A210', fechaServicio: '23/04/2026',
-        toro: 'ins laredo', tp: '#VALUE!', estado: 'ok', secar: null, pp: null, ttto: 'penicilina',
+        toro: 'ins laredo', estadoRegistrado: null, tp: '#VALUE!', estado: 'ok', secar: null, pp: null, ttto: 'penicilina',
       },
     });
     const aprobadas: FilaChequeoAprobada[] = [{ fila, animalId: 'animal-1' }];
@@ -206,7 +208,7 @@ describe('construirFilasVacas', () => {
 
   it('#VALUE!/celdas vacías se preservan en la capa cruda y la normalizada queda null -- la fila nunca se descarta', () => {
     const fila = filaBase({
-      raw: { pl: '#VALUE!', np: null, ultimaCria: null, sx: null, fechaServicio: null, toro: null, tp: null, estado: null, secar: null, pp: null, ttto: null },
+      raw: { pl: '#VALUE!', np: null, ultimaCria: null, sx: null, fechaServicio: null, toro: null, estadoRegistrado: null, tp: null, estado: null, secar: null, pp: null, ttto: null },
       pl: null,
       numPartos: null,
       fechasServicio: [],

--- a/src/__tests__/importHatoCommitChequeo.test.ts
+++ b/src/__tests__/importHatoCommitChequeo.test.ts
@@ -14,6 +14,7 @@ import {
   construirPayloadCommit,
   seleccionarUltimaCriaAnteriorPorAnimal,
   seleccionarFechasServicioConocidasPorAnimal,
+  fusionarEventosManualesEnDedupe,
   type FilaChequeoAprobada,
   type FilaUltimaCriaHistorico,
 } from '@/utils/importHato/commitChequeo';
@@ -605,5 +606,97 @@ describe('construirPayloadCommit', () => {
     const payload2 = construirPayloadCommit({ fecha: '2026-07-09', veterinario: 'Dr. X' }, vacas, eventos, toroMapa);
     expect(payload1).toEqual(payload2);
     expect(JSON.stringify(payload1)).toEqual(JSON.stringify(payload2));
+  });
+});
+
+// ============================================================================
+// fusionarEventosManualesEnDedupe (N10) -- lo que impide que el chequeo
+// duplique lo que Fernando ya registró por Telegram.
+// ============================================================================
+
+describe('fusionarEventosManualesEnDedupe', () => {
+  it('una monta registrada por Telegram entra al set de fechas conocidas', () => {
+    // El caso literal de la visita de campo: Fernando monta el 10 de agosto,
+    // la veterinaria chequea el 20 y su planilla trae esa misma F Servicio.
+    const { fechasServicioPorAnimal } = fusionarEventosManualesEnDedupe(
+      new Map(),
+      new Map(),
+      [{ animalId: 'a1', tipo: 'servicio', fecha: '2026-08-10' }],
+      '2026-08-20',
+    );
+    expect(fechasServicioPorAnimal.get('a1')).toEqual(new Set(['2026-08-10']));
+  });
+
+  it('conserva las fechas que ya venían de chequeos anteriores', () => {
+    const { fechasServicioPorAnimal } = fusionarEventosManualesEnDedupe(
+      new Map([['a1', new Set(['2026-05-02'])]]),
+      new Map(),
+      [{ animalId: 'a1', tipo: 'servicio', fecha: '2026-08-10' }],
+      '2026-08-20',
+    );
+    expect(fechasServicioPorAnimal.get('a1')).toEqual(new Set(['2026-05-02', '2026-08-10']));
+  });
+
+  it('ignora lo registrado el mismo día del chequeo o después', () => {
+    // No es "lo ya conocido", es otro hecho -- mismo criterio estricto que
+    // los dos selectores que se alimentan de hato_chequeo_vacas.
+    const { fechasServicioPorAnimal } = fusionarEventosManualesEnDedupe(
+      new Map(),
+      new Map(),
+      [
+        { animalId: 'a1', tipo: 'servicio', fecha: '2026-08-20' },
+        { animalId: 'a1', tipo: 'servicio', fecha: '2026-08-25' },
+      ],
+      '2026-08-20',
+    );
+    expect(fechasServicioPorAnimal.has('a1')).toBe(false);
+  });
+
+  it('un parto manual reemplaza la última cría cuando es más reciente', () => {
+    const { ultimaCriaAnteriorPorAnimal } = fusionarEventosManualesEnDedupe(
+      new Map(),
+      new Map([['a1', '2026-01-15']]),
+      [{ animalId: 'a1', tipo: 'parto', fecha: '2026-07-30' }],
+      '2026-08-20',
+    );
+    expect(ultimaCriaAnteriorPorAnimal.get('a1')).toBe('2026-07-30');
+  });
+
+  it('un parto manual MÁS VIEJO no pisa la última cría del chequeo anterior', () => {
+    const { ultimaCriaAnteriorPorAnimal } = fusionarEventosManualesEnDedupe(
+      new Map(),
+      new Map([['a1', '2026-07-30']]),
+      [{ animalId: 'a1', tipo: 'parto', fecha: '2026-01-15' }],
+      '2026-08-20',
+    );
+    expect(ultimaCriaAnteriorPorAnimal.get('a1')).toBe('2026-07-30');
+  });
+
+  it('un parto manual llena el hueco cuando el chequeo anterior no pudo parsear la Última Cría', () => {
+    // `seleccionarUltimaCriaAnteriorPorAnimal` deja `null` cuando la celda
+    // cruda es ininterpretable; el evento manual sí tiene fecha real.
+    const { ultimaCriaAnteriorPorAnimal } = fusionarEventosManualesEnDedupe(
+      new Map(),
+      new Map([['a1', null]]),
+      [{ animalId: 'a1', tipo: 'parto', fecha: '2026-07-30' }],
+      '2026-08-20',
+    );
+    expect(ultimaCriaAnteriorPorAnimal.get('a1')).toBe('2026-07-30');
+  });
+
+  it('es puro: no muta los mapas que recibe', () => {
+    const servicios = new Map([['a1', new Set(['2026-05-02'])]]);
+    const crias = new Map<string, string | null>([['a1', '2026-01-15']]);
+    fusionarEventosManualesEnDedupe(
+      servicios,
+      crias,
+      [
+        { animalId: 'a1', tipo: 'servicio', fecha: '2026-08-10' },
+        { animalId: 'a1', tipo: 'parto', fecha: '2026-07-30' },
+      ],
+      '2026-08-20',
+    );
+    expect(servicios.get('a1')).toEqual(new Set(['2026-05-02']));
+    expect(crias.get('a1')).toBe('2026-01-15');
   });
 });

--- a/src/__tests__/importHatoDedupe.test.ts
+++ b/src/__tests__/importHatoDedupe.test.ts
@@ -12,7 +12,7 @@ import type { CrudoFilaChequeo, FilaChequeoNormalizada, ManifiestoHoja } from '@
 
 const RAW_VACIO: CrudoFilaChequeo = {
   pl: null, np: null, ultimaCria: null, sx: null, fechaServicio: null,
-  toro: null, tp: null, estado: null, secar: null, pp: null, ttto: null,
+  toro: null, estadoRegistrado: null, tp: null, estado: null, secar: null, pp: null, ttto: null,
 };
 
 function fila(overrides: Partial<FilaChequeoNormalizada> = {}): FilaChequeoNormalizada {
@@ -35,6 +35,7 @@ function fila(overrides: Partial<FilaChequeoNormalizada> = {}): FilaChequeoNorma
     fechaProbableParto: null,
     toroNombre: null,
     tipoServicio: null,
+    estadoRegistrado: null,
     issues: [],
     ...overrides,
   };

--- a/src/__tests__/importHatoDiffChequeo.test.ts
+++ b/src/__tests__/importHatoDiffChequeo.test.ts
@@ -12,6 +12,7 @@ import {
   construirDiffChequeo,
   seleccionarUltimoChequeoPorAnimal,
   type AnimalHatoActual,
+  type AnimalEstadoRegistradoActual,
   type UltimoChequeoVacaActual,
   type FilaChequeoVacaHistorico,
 } from '@/utils/importHato/diffChequeo';
@@ -37,6 +38,7 @@ function fila(datos: Partial<FilaChequeoNormalizada> & { fila: number; numero: n
       sx: null,
       fechaServicio: null,
       toro: null,
+      estadoRegistrado: datos.estadoRegistrado ?? null,
       tp: null,
       estado: null,
       secar: null,
@@ -52,6 +54,7 @@ function fila(datos: Partial<FilaChequeoNormalizada> & { fila: number; numero: n
     fechaProbableParto: datos.fechaProbableParto ?? null,
     toroNombre: datos.toroNombre ?? null,
     tipoServicio: datos.tipoServicio ?? null,
+    estadoRegistrado: datos.estadoRegistrado ?? null,
     issues: datos.issues ?? [],
   };
 }
@@ -242,7 +245,76 @@ describe('construirDiffChequeo — clasificación de filas', () => {
       cambios: 0,
       noReconocidos: 1,
       conIssues: 0,
+      conConflictoEstadoRegistrado: 0,
     });
+  });
+});
+
+describe('construirDiffChequeo — conflicto "registrado vs. papel" (D-E, N23, docs/plan_hato_telegram_estados_agosto_2026.md §3 Capa 5)', () => {
+  function estadoRegistrado(datos: AnimalEstadoRegistradoActual): AnimalEstadoRegistradoActual {
+    return datos;
+  }
+
+  it('lo impreso ("Estado registrado") difiere de lo que el sistema cree AHORA -> conflicto explícito', () => {
+    const animales = [animal({ id: 'a1', numero: 201, nombre: 'CAMPESINA' })];
+    const filas = [fila({ fila: 3, numero: 201, nombre: 'CAMPESINA', estadoRegistrado: 'Servida' })];
+
+    const resultado = construirDiffChequeo(filas, animales, [], [estadoRegistrado({ animalId: 'a1', estado: 'Confirmada' })]);
+
+    expect(resultado.filas[0].conflictoEstadoRegistrado).toEqual({ impreso: 'Servida', actual: 'Confirmada' });
+    expect(resultado.resumen.conConflictoEstadoRegistrado).toBe(1);
+  });
+
+  it('lo impreso coincide con lo que el sistema cree hoy -> sin conflicto', () => {
+    const animales = [animal({ id: 'a1', numero: 201, nombre: 'CAMPESINA' })];
+    const filas = [fila({ fila: 3, numero: 201, nombre: 'CAMPESINA', estadoRegistrado: 'Vacía' })];
+
+    const resultado = construirDiffChequeo(filas, animales, [], [estadoRegistrado({ animalId: 'a1', estado: 'Vacía' })]);
+
+    expect(resultado.filas[0].conflictoEstadoRegistrado).toBeNull();
+    expect(resultado.resumen.conConflictoEstadoRegistrado).toBe(0);
+  });
+
+  it('sin la columna (generación histórica, o celda vacía) -> nunca se fabrica un conflicto', () => {
+    const animales = [animal({ id: 'a1', numero: 201, nombre: 'CAMPESINA' })];
+    const filas = [fila({ fila: 3, numero: 201, nombre: 'CAMPESINA', estadoRegistrado: null })];
+
+    const resultado = construirDiffChequeo(filas, animales, [], [estadoRegistrado({ animalId: 'a1', estado: 'Servida' })]);
+
+    expect(resultado.filas[0].conflictoEstadoRegistrado).toBeNull();
+  });
+
+  it('sin `estadosRegistrados` (parámetro opcional, llamadas existentes) -> el diff se comporta exactamente igual que antes', () => {
+    const animales = [animal({ id: 'a1', numero: 201, nombre: 'CAMPESINA' })];
+    const filas = [fila({ fila: 3, numero: 201, nombre: 'CAMPESINA', estadoRegistrado: 'Servida' })];
+
+    const resultado = construirDiffChequeo(filas, animales, []);
+
+    expect(resultado.filas[0].conflictoEstadoRegistrado).toBeNull();
+  });
+
+  it('el animal no aparece en `estadosRegistrados` (mapa incompleto) -> nunca se fabrica un conflicto falso', () => {
+    const animales = [animal({ id: 'a1', numero: 201, nombre: 'CAMPESINA' })];
+    const filas = [fila({ fila: 3, numero: 201, nombre: 'CAMPESINA', estadoRegistrado: 'Servida' })];
+
+    const resultado = construirDiffChequeo(filas, animales, [], []);
+
+    expect(resultado.filas[0].conflictoEstadoRegistrado).toBeNull();
+  });
+
+  it('filas `nuevo`/`no_reconocido` nunca llevan conflicto -- no hay animal contra el cual recalcular', () => {
+    const filaNueva = fila({ fila: 2, numero: 500, nombre: 'NUEVA', estadoRegistrado: 'Servida' });
+    const filaSinNumero = fila({ fila: 5, numero: null, nombre: 'SIN NUMERO', estadoRegistrado: 'Servida' });
+
+    const resultado = construirDiffChequeo(
+      [filaNueva, filaSinNumero],
+      [],
+      [],
+      [estadoRegistrado({ animalId: 'no-existe', estado: 'Confirmada' })],
+    );
+
+    expect(resultado.filas[0].conflictoEstadoRegistrado).toBeNull();
+    expect(resultado.filas[1].conflictoEstadoRegistrado).toBeNull();
   });
 });
 

--- a/src/__tests__/importHatoOcrChequeo.test.ts
+++ b/src/__tests__/importHatoOcrChequeo.test.ts
@@ -122,6 +122,11 @@ describe('vocabulario de columnas', () => {
       expect(ENCABEZADO_POR_COLUMNA_OCR[col]).toBeTruthy();
     }
   });
+
+  it('"Estado registrado" (D-E, B5.4) es una columna OCR más -- el modelo también transcribe la referencia gris, no solo lo diligenciado', () => {
+    expect(COLUMNAS_OCR).toContain('estado_registrado');
+    expect(ENCABEZADO_POR_COLUMNA_OCR.estado_registrado).toBe('Estado registrado');
+  });
 });
 
 // ---------------------------------------------------------------------------
@@ -357,6 +362,23 @@ describe('procesarLecturaOcr', () => {
     // El texto dudoso NO se pierde: viaja en la respuesta para que el humano
     // lo vea en la ventana de corrección.
     expect(confirmada.celdas.toro).toEqual({ texto: 'NITRO?', confianza: 'baja' });
+  });
+
+  it('"Estado registrado" (D-E) viaja por la matriz igual que cualquier otra columna de referencia -- llega hasta el diff sin un segundo camino', () => {
+    const lectura = parsearRespuestaModeloOcr(
+      respuestaModelo([
+        {
+          numero_impreso: '101',
+          nombre_impreso: 'ALINA',
+          celdas: celdasJson({ estado_registrado: { texto: 'Servida', confianza: 'alta' } }),
+        },
+      ]),
+      1,
+    );
+
+    const resultado = procesarLecturaOcr([lectura], roster, OPCIONES_HOJA);
+    const idxEstadoRegistrado = ENCABEZADOS_HOJA_OCR.indexOf('Estado registrado');
+    expect(resultado.hoja.filas[2][idxEstadoRegistrado]).toBe('Servida');
   });
 
   it('una fila con ancla que no cuadra se reporta no leída y NO desplaza a las demás', () => {

--- a/src/__tests__/importHatoOcrPesajeCorreccion.test.ts
+++ b/src/__tests__/importHatoOcrPesajeCorreccion.test.ts
@@ -1,0 +1,339 @@
+// ARCHIVO: __tests__/importHatoOcrPesajeCorreccion.test.ts
+// DESCRIPCIÓN: N12 de `docs/plan_hato_telegram_estados_agosto_2026.md` --
+// decisión D-C: corrección de la lectura de pesaje en lenguaje natural.
+// `ocrPesajeCorreccion.ts` es puro: no llama al modelo ni toca Supabase.
+//
+// Lo que estos tests protegen, en orden de importancia:
+//   1. Un nombre que no ancla a UNA vaca del roster NUNCA se aplica -- se
+//      reporta como no entendido (mismo criterio que el ancla por foto).
+//   2. Una semana/AM-PM/valor que el texto no especifica NUNCA se adivina --
+//      también va a "no entendida", no se aplica a medias.
+//   3. "Sin dato" limpia la celda a null, nunca a 0.
+//   4. Aplicar correcciones sobre el diff es en memoria, nunca escribe nada.
+
+import { describe, it, expect } from 'vitest';
+import {
+  aplicarCorreccionesADiff,
+  construirPromptCorreccionPesaje,
+  esquemaJsonCorreccionPesaje,
+  interpretarCorreccionPesaje,
+  parsearRespuestaModeloCorreccionPesaje,
+  type CorreccionPesajeAplicable,
+  type ItemCorreccionModeloPesaje,
+} from '@/utils/importHato/ocrPesajeCorreccion';
+import { construirRosterPesaje, type AnimalRosterPesaje, type CeldaDiffPesaje, type SemanaPesaje } from '@/utils/importHato/ocrPesaje';
+
+const ROSTER_BASE: AnimalRosterPesaje[] = [
+  { id: 'uuid-monza', nombre: 'MONZA' },
+  { id: 'uuid-bonita', nombre: 'BONITA' },
+  { id: 'uuid-camila', nombre: 'CAMILA' },
+];
+const ROSTER = construirRosterPesaje(ROSTER_BASE);
+
+const FECHAS_5_SEMANAS: Record<SemanaPesaje, string | null> = {
+  1: '2026-08-05',
+  2: '2026-08-12',
+  3: '2026-08-19',
+  4: '2026-08-26',
+  5: null,
+};
+
+function item(parcial: Partial<ItemCorreccionModeloPesaje> & { nombreMencionado: string }): ItemCorreccionModeloPesaje {
+  return {
+    semana: null,
+    subcelda: null,
+    sinDato: false,
+    valorTexto: null,
+    ...parcial,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 1. parsearRespuestaModeloCorreccionPesaje -- tolerancia de forma
+// ---------------------------------------------------------------------------
+
+describe('parsearRespuestaModeloCorreccionPesaje', () => {
+  it('parsea una respuesta bien formada', () => {
+    const bruto = {
+      items: [
+        { nombre_mencionado: 'MONZA', semana: 2, subcelda: 'am', sin_dato: false, valor_texto: '6.5' },
+      ],
+    };
+    const { items, avisos } = parsearRespuestaModeloCorreccionPesaje(bruto);
+    expect(items).toHaveLength(1);
+    expect(items[0]).toEqual({
+      nombreMencionado: 'MONZA',
+      semana: 2,
+      subcelda: 'am',
+      sinDato: false,
+      valorTexto: '6.5',
+    });
+    expect(avisos).toEqual([]);
+  });
+
+  it('lanza si "items" no es un arreglo -- no hay nada que rescatar', () => {
+    expect(() => parsearRespuestaModeloCorreccionPesaje({})).toThrow(/items/);
+  });
+
+  it('lanza si la respuesta no es un objeto', () => {
+    expect(() => parsearRespuestaModeloCorreccionPesaje(null)).toThrow();
+    expect(() => parsearRespuestaModeloCorreccionPesaje('texto')).toThrow();
+  });
+
+  it('un ítem mal formado no aborta el resto -- queda vacío con aviso', () => {
+    const bruto = { items: [null, { nombre_mencionado: 'CAMILA', semana: 1, subcelda: 'pm', sin_dato: false, valor_texto: '5' }] };
+    const { items, avisos } = parsearRespuestaModeloCorreccionPesaje(bruto);
+    expect(items).toHaveLength(2);
+    expect(items[0].nombreMencionado).toBe('');
+    expect(avisos.some((a) => a.includes('ítem 1'))).toBe(true);
+  });
+
+  it('semana ausente/no numérica se lee como null, nunca 0', () => {
+    const bruto = { items: [{ nombre_mencionado: 'BONITA', semana: null, subcelda: null, sin_dato: true, valor_texto: null }] };
+    const { items } = parsearRespuestaModeloCorreccionPesaje(bruto);
+    expect(items[0].semana).toBeNull();
+  });
+
+  it('sin_dato=true fuerza valorTexto a null aunque el modelo mande algo', () => {
+    const bruto = { items: [{ nombre_mencionado: 'BONITA', semana: 2, subcelda: 'ambos', sin_dato: true, valor_texto: '6' }] };
+    const { items } = parsearRespuestaModeloCorreccionPesaje(bruto);
+    expect(items[0].valorTexto).toBeNull();
+  });
+
+  it('subcelda no reconocida se lee como null, nunca se adivina', () => {
+    const bruto = { items: [{ nombre_mencionado: 'MONZA', semana: 1, subcelda: 'mediodia', sin_dato: false, valor_texto: '5' }] };
+    const { items } = parsearRespuestaModeloCorreccionPesaje(bruto);
+    expect(items[0].subcelda).toBeNull();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. interpretarCorreccionPesaje -- las tres anclas (vaca, semana, valor)
+// ---------------------------------------------------------------------------
+
+describe('interpretarCorreccionPesaje', () => {
+  it('caso feliz: vaca + semana + AM + valor -> aplicable', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'MONZA', semana: 2, subcelda: 'am', valorTexto: '6.5' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(noEntendidas).toHaveLength(0);
+    expect(aplicables).toEqual([
+      { animalId: 'uuid-monza', nombre: 'MONZA', semana: 2, fecha: '2026-08-12', subcelda: 'am', valor: 6.5 },
+    ]);
+  });
+
+  it('"no se pesó" sin AM/PM limpia AMBAS sub-celdas a null, nunca 0', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'BONITA', semana: 3, sinDato: true })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(noEntendidas).toHaveLength(0);
+    expect(aplicables).toHaveLength(2);
+    expect(aplicables.map((a) => a.subcelda).sort()).toEqual(['am', 'pm']);
+    expect(aplicables.every((a) => a.valor === null)).toBe(true);
+  });
+
+  it('nombre que no ancla a NINGUNA vaca del roster -> no entendida, nunca se adivina', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'MOROCHA', semana: 1, subcelda: 'am', valorTexto: '7' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables).toHaveLength(0);
+    expect(noEntendidas).toHaveLength(1);
+    expect(noEntendidas[0].nombreMencionado).toBe('MOROCHA');
+  });
+
+  it('semana ausente -> no entendida, NUNCA se adivina cuál semana', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'BONITA', sinDato: true })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables).toHaveLength(0);
+    expect(noEntendidas).toHaveLength(1);
+    expect(noEntendidas[0].detalle).toMatch(/semana/);
+  });
+
+  it('semana fuera de 1-5 -> no entendida', () => {
+    const { noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'MONZA', semana: 7, subcelda: 'am', valorTexto: '6' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(noEntendidas).toHaveLength(1);
+  });
+
+  it('semana válida pero sin ocurrencia real ese mes (fecha null) -> no entendida', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'MONZA', semana: 5, subcelda: 'am', valorTexto: '6' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables).toHaveLength(0);
+    expect(noEntendidas).toHaveLength(1);
+    expect(noEntendidas[0].detalle).toMatch(/no existe/);
+  });
+
+  it('valor con AM/PM sin especificar y sin sin_dato -> no entendida, no se escribe en ambas a ciegas', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'CAMILA', semana: 1, valorTexto: '6' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables).toHaveLength(0);
+    expect(noEntendidas).toHaveLength(1);
+    expect(noEntendidas[0].detalle).toMatch(/AM, PM o ambos/);
+  });
+
+  it('valor no interpretable como número -> no entendida', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'CAMILA', semana: 1, subcelda: 'pm', valorTexto: 'no sé' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables).toHaveLength(0);
+    expect(noEntendidas).toHaveLength(1);
+  });
+
+  it('acepta fracciones manuscritas en el valor, igual que la lectura por foto', () => {
+    const { aplicables } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'MONZA', semana: 2, subcelda: 'am', valorTexto: '6 1/2' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables[0].valor).toBe(6.5);
+  });
+
+  it('una frase con varias correcciones produce varios ítems, cada uno evaluado por separado', () => {
+    const { aplicables, noEntendidas } = interpretarCorreccionPesaje(
+      [
+        item({ nombreMencionado: 'MONZA', semana: 2, subcelda: 'am', valorTexto: '6.5' }),
+        item({ nombreMencionado: 'BONITA', sinDato: true }), // sin semana -- no entendida
+      ],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables).toHaveLength(1);
+    expect(noEntendidas).toHaveLength(1);
+  });
+
+  it('nombre a una letra de diferencia se resuelve igual que en la foto (mismo cotejo)', () => {
+    const { aplicables } = interpretarCorreccionPesaje(
+      [item({ nombreMencionado: 'MONSA', semana: 2, subcelda: 'pm', valorTexto: '7' })],
+      ROSTER,
+      FECHAS_5_SEMANAS,
+    );
+    expect(aplicables).toHaveLength(1);
+    expect(aplicables[0].animalId).toBe('uuid-monza');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 3. aplicarCorreccionesADiff -- en memoria, nunca escribe nada
+// ---------------------------------------------------------------------------
+
+function celdaDiff(parcial: Partial<CeldaDiffPesaje> & { animalId: string; semana: SemanaPesaje }): CeldaDiffPesaje {
+  return {
+    nombre: 'X',
+    fecha: '2026-08-12',
+    litrosAm: null,
+    litrosPm: null,
+    litrosTotal: null,
+    soloUnOrdeno: false,
+    existenteId: null,
+    clasificacion: 'sin_dato',
+    noConfiable: false,
+    ...parcial,
+  };
+}
+
+describe('aplicarCorreccionesADiff', () => {
+  it('sin correcciones, devuelve una copia idéntica del diff', () => {
+    const diff = [celdaDiff({ animalId: 'uuid-monza', semana: 2, litrosAm: 6, litrosPm: 7, litrosTotal: 13, clasificacion: 'nuevo' })];
+    const resultado = aplicarCorreccionesADiff(diff, []);
+    expect(resultado).toEqual(diff);
+    expect(resultado).not.toBe(diff); // copia, no la misma referencia
+  });
+
+  it('corrige AM de una celda existente y recalcula el total', () => {
+    const diff = [celdaDiff({ animalId: 'uuid-monza', semana: 2, litrosAm: 6, litrosPm: 7, litrosTotal: 13, clasificacion: 'nuevo' })];
+    const correccion: CorreccionPesajeAplicable = { animalId: 'uuid-monza', nombre: 'MONZA', semana: 2, fecha: '2026-08-12', subcelda: 'am', valor: 6.5 };
+    const resultado = aplicarCorreccionesADiff(diff, [correccion]);
+    expect(resultado).toHaveLength(1);
+    expect(resultado[0].litrosAm).toBe(6.5);
+    expect(resultado[0].litrosPm).toBe(7);
+    expect(resultado[0].litrosTotal).toBe(13.5);
+  });
+
+  it('"sin dato" en ambas sub-celdas deja litrosTotal en null, nunca 0', () => {
+    const diff = [celdaDiff({ animalId: 'uuid-bonita', semana: 3, litrosAm: 5, litrosPm: 5, litrosTotal: 10, existenteId: 'x1', clasificacion: 'cambio' })];
+    const correcciones: CorreccionPesajeAplicable[] = [
+      { animalId: 'uuid-bonita', nombre: 'BONITA', semana: 3, fecha: '2026-08-19', subcelda: 'am', valor: null },
+      { animalId: 'uuid-bonita', nombre: 'BONITA', semana: 3, fecha: '2026-08-19', subcelda: 'pm', valor: null },
+    ];
+    const resultado = aplicarCorreccionesADiff(diff, correcciones);
+    expect(resultado[0].litrosAm).toBeNull();
+    expect(resultado[0].litrosPm).toBeNull();
+    expect(resultado[0].litrosTotal).toBeNull();
+    expect(resultado[0].clasificacion).toBe('sin_dato');
+  });
+
+  it('una corrección de una celda que NO estaba en el diff se agrega, nunca se descarta', () => {
+    const diff = [celdaDiff({ animalId: 'uuid-monza', semana: 2, litrosAm: 6, litrosPm: 7, litrosTotal: 13 })];
+    const correccion: CorreccionPesajeAplicable = { animalId: 'uuid-camila', nombre: 'CAMILA', semana: 1, fecha: '2026-08-05', subcelda: 'pm', valor: 5 };
+    const resultado = aplicarCorreccionesADiff(diff, [correccion]);
+    expect(resultado).toHaveLength(2);
+    const nueva = resultado.find((c) => c.animalId === 'uuid-camila')!;
+    expect(nueva.litrosPm).toBe(5);
+    expect(nueva.litrosTotal).toBe(5);
+    expect(nueva.clasificacion).toBe('nuevo');
+  });
+
+  it('una celda corregida con id existente se reclasifica como cambio, no sin_cambio (nunca se compara contra el valor viejo perdido)', () => {
+    const diff = [celdaDiff({ animalId: 'uuid-monza', semana: 2, litrosAm: 6, litrosPm: 7, litrosTotal: 13, existenteId: 'p-1', clasificacion: 'sin_cambio' })];
+    const correccion: CorreccionPesajeAplicable = { animalId: 'uuid-monza', nombre: 'MONZA', semana: 2, fecha: '2026-08-12', subcelda: 'am', valor: 6.5 };
+    const resultado = aplicarCorreccionesADiff(diff, [correccion]);
+    expect(resultado[0].clasificacion).toBe('cambio');
+  });
+
+  it('una corrección deja noConfiable en false -- un humano ya lo confirmó', () => {
+    const diff = [celdaDiff({ animalId: 'uuid-monza', semana: 2, litrosAm: 6, litrosPm: 7, litrosTotal: 13, noConfiable: true })];
+    const correccion: CorreccionPesajeAplicable = { animalId: 'uuid-monza', nombre: 'MONZA', semana: 2, fecha: '2026-08-12', subcelda: 'pm', valor: 8 };
+    const resultado = aplicarCorreccionesADiff(diff, [correccion]);
+    expect(resultado[0].noConfiable).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4. Esquema JSON y prompt
+// ---------------------------------------------------------------------------
+
+describe('esquemaJsonCorreccionPesaje', () => {
+  it('exige los 5 campos por ítem, sin roster de nombres embebido', () => {
+    const esquema = esquemaJsonCorreccionPesaje() as any;
+    const propsItem = esquema.properties.items.items.properties;
+    expect(Object.keys(propsItem).sort()).toEqual(['nombre_mencionado', 'semana', 'sin_dato', 'subcelda', 'valor_texto']);
+    expect(esquema.properties.items.items.required.sort()).toEqual(
+      ['nombre_mencionado', 'semana', 'sin_dato', 'subcelda', 'valor_texto'].sort(),
+    );
+  });
+});
+
+describe('construirPromptCorreccionPesaje', () => {
+  it('no recibe roster como parámetro -- no puede embeber una lista real de vacas', () => {
+    // La firma no toma argumentos: es estructuralmente imposible que el
+    // prompt cambie según el hato vigente. Esa es la garantía real (no un
+    // grep de nombres, que solo probaría que estos ejemplos en particular
+    // no colisionan con estos fixtures en particular).
+    expect(construirPromptCorreccionPesaje.length).toBe(0);
+  });
+
+  it('instruye a no adivinar semana/valor cuando el texto no los da', () => {
+    const prompt = construirPromptCorreccionPesaje();
+    expect(prompt).toMatch(/NUNCA inventes/);
+  });
+});

--- a/src/__tests__/ordenarAnimalesHato.test.ts
+++ b/src/__tests__/ordenarAnimalesHato.test.ts
@@ -20,6 +20,7 @@ function derivado(overrides: Partial<EstadoReproductivoDerivado> = {}): EstadoRe
     tiempo_secada_dias: null,
     proxima_a_reemplazo: false,
     vacia_es_problema: null,
+    senal_revision: null,
     alertas: { secado_due: false, rechequeo_due: false, servicio_sin_confirmacion: false, parto_proximo: false },
     ...overrides,
   };

--- a/src/__tests__/ordenarAnimalesHato.test.ts
+++ b/src/__tests__/ordenarAnimalesHato.test.ts
@@ -26,6 +26,8 @@ function derivado(overrides: Partial<EstadoReproductivoDerivado> = {}): EstadoRe
   };
 }
 
+const HOY = '2026-08-13';
+
 function animal(overrides: Partial<AnimalHatoDerivado> = {}): AnimalHatoDerivado {
   return {
     animalId: overrides.animalId ?? crypto.randomUUID(),
@@ -39,6 +41,7 @@ function animal(overrides: Partial<AnimalHatoDerivado> = {}): AnimalHatoDerivado
     numPartos: 0,
     ultimoChequeoFecha: null,
     ultimoPartoFecha: null,
+    fechaNacimiento: null,
     derivado: derivado(),
     categoria: 'hato',
     categoriaOrigen: 'calculado',
@@ -50,31 +53,31 @@ function animal(overrides: Partial<AnimalHatoDerivado> = {}): AnimalHatoDerivado
 describe('ordenarAnimalesHato — columna numero', () => {
   it('ordena numéricamente ascendente', () => {
     const animales = [animal({ animalId: 'a', numero: 30 }), animal({ animalId: 'b', numero: 5 }), animal({ animalId: 'c', numero: 12 })];
-    const resultado = ordenarAnimalesHato(animales, 'numero', 'asc').map((a) => a.numero);
+    const resultado = ordenarAnimalesHato(animales, 'numero', 'asc', HOY).map((a) => a.numero);
     expect(resultado).toEqual([5, 12, 30]);
   });
 
   it('ordena numéricamente descendente', () => {
     const animales = [animal({ animalId: 'a', numero: 30 }), animal({ animalId: 'b', numero: 5 }), animal({ animalId: 'c', numero: 12 })];
-    const resultado = ordenarAnimalesHato(animales, 'numero', 'desc').map((a) => a.numero);
+    const resultado = ordenarAnimalesHato(animales, 'numero', 'desc', HOY).map((a) => a.numero);
     expect(resultado).toEqual([30, 12, 5]);
   });
 
   it('deja "sin caravana" (numero null) al final en asc', () => {
     const animales = [animal({ animalId: 'a', numero: null }), animal({ animalId: 'b', numero: 5 })];
-    const resultado = ordenarAnimalesHato(animales, 'numero', 'asc').map((a) => a.numero);
+    const resultado = ordenarAnimalesHato(animales, 'numero', 'asc', HOY).map((a) => a.numero);
     expect(resultado).toEqual([5, null]);
   });
 
   it('deja "sin caravana" (numero null) al final TAMBIÉN en desc -- nunca se trata como "el más grande"', () => {
     const animales = [animal({ animalId: 'a', numero: null }), animal({ animalId: 'b', numero: 5 })];
-    const resultado = ordenarAnimalesHato(animales, 'numero', 'desc').map((a) => a.numero);
+    const resultado = ordenarAnimalesHato(animales, 'numero', 'desc', HOY).map((a) => a.numero);
     expect(resultado).toEqual([5, null]);
   });
 
   it('no muta el arreglo original', () => {
     const animales = [animal({ animalId: 'a', numero: 30 }), animal({ animalId: 'b', numero: 5 })];
-    ordenarAnimalesHato(animales, 'numero', 'asc');
+    ordenarAnimalesHato(animales, 'numero', 'asc', HOY);
     expect(animales.map((a) => a.numero)).toEqual([30, 5]);
   });
 });
@@ -86,8 +89,8 @@ describe('ordenarAnimalesHato — columna nombre', () => {
       animal({ animalId: 'b', nombre: null }),
       animal({ animalId: 'c', nombre: 'Estrella' }),
     ];
-    expect(ordenarAnimalesHato(animales, 'nombre', 'asc').map((a) => a.nombre)).toEqual(['Estrella', 'Zulema', null]);
-    expect(ordenarAnimalesHato(animales, 'nombre', 'desc').map((a) => a.nombre)).toEqual(['Zulema', 'Estrella', null]);
+    expect(ordenarAnimalesHato(animales, 'nombre', 'asc', HOY).map((a) => a.nombre)).toEqual(['Estrella', 'Zulema', null]);
+    expect(ordenarAnimalesHato(animales, 'nombre', 'desc', HOY).map((a) => a.nombre)).toEqual(['Zulema', 'Estrella', null]);
   });
 });
 
@@ -98,8 +101,8 @@ describe('ordenarAnimalesHato — columna pl', () => {
       animal({ animalId: 'b', pl: null }),
       animal({ animalId: 'c', pl: 8.2 }),
     ];
-    expect(ordenarAnimalesHato(animales, 'pl', 'asc').map((a) => a.pl)).toEqual([8.2, 12.5, null]);
-    expect(ordenarAnimalesHato(animales, 'pl', 'desc').map((a) => a.pl)).toEqual([12.5, 8.2, null]);
+    expect(ordenarAnimalesHato(animales, 'pl', 'asc', HOY).map((a) => a.pl)).toEqual([8.2, 12.5, null]);
+    expect(ordenarAnimalesHato(animales, 'pl', 'desc', HOY).map((a) => a.pl)).toEqual([12.5, 8.2, null]);
   });
 });
 
@@ -111,7 +114,7 @@ describe('ordenarAnimalesHato — columna estado', () => {
       animal({ animalId: 'a', derivado: derivado({ estado: 'servida' }) }),
       animal({ animalId: 'b', derivado: derivado({ estado: 'preñada' }) }),
     ];
-    const resultado = ordenarAnimalesHato(animales, 'estado', 'asc').map((a) => a.animalId);
+    const resultado = ordenarAnimalesHato(animales, 'estado', 'asc', HOY).map((a) => a.animalId);
     expect(resultado).toEqual(['b', 'a']);
   });
 });
@@ -123,7 +126,7 @@ describe('ordenarAnimalesHato — columna proximo', () => {
       animal({ animalId: 'b', derivado: derivado({ fecha_secar: '2026-08-01' }) }),
       animal({ animalId: 'c', derivado: derivado() }), // sin ninguna fecha
     ];
-    const resultado = ordenarAnimalesHato(animales, 'proximo', 'asc').map((a) => a.animalId);
+    const resultado = ordenarAnimalesHato(animales, 'proximo', 'asc', HOY).map((a) => a.animalId);
     expect(resultado).toEqual(['b', 'a', 'c']);
   });
 
@@ -132,7 +135,7 @@ describe('ordenarAnimalesHato — columna proximo', () => {
       animal({ animalId: 'a', derivado: derivado() }),
       animal({ animalId: 'b', derivado: derivado({ fecha_probable_parto: '2026-09-01' }) }),
     ];
-    const resultado = ordenarAnimalesHato(animales, 'proximo', 'desc').map((a) => a.animalId);
+    const resultado = ordenarAnimalesHato(animales, 'proximo', 'desc', HOY).map((a) => a.animalId);
     expect(resultado).toEqual(['b', 'a']);
   });
 });

--- a/src/__tests__/telegramAlertas.test.ts
+++ b/src/__tests__/telegramAlertas.test.ts
@@ -1,0 +1,276 @@
+// Tests de la lógica pura de suscripción a alertas por usuario de Telegram.
+// Precedente exacto: telegramUsuarios.ts / telegramUsuarios.test.ts.
+//
+// El catálogo (`alertas_catalogo`) vive en base de datos y hoy solo tiene
+// filas del módulo `hato` — mañana tendrá `aguacate` y `ganado` sin que el
+// código cambie. Estas pruebas cubren específicamente eso: agrupar y
+// etiquetar módulos desconocidos sin lista hard-codeada de alertas.
+
+import { describe, it, expect } from 'vitest';
+import {
+  agruparAlertasPorModulo,
+  labelModulo,
+  construirEstadoDesdeSuscripciones,
+  alternarRecibe,
+  alternarEscalamiento,
+  construirFilasParaGuardar,
+  contarSuscripcionesUsuario,
+  formatearResumenAlertas,
+  type AlertaCatalogoRow,
+  type AlertaSuscripcionRow,
+  type SuscripcionEstado,
+} from '@/utils/telegramAlertas';
+
+function alerta(overrides: Partial<AlertaCatalogoRow>): AlertaCatalogoRow {
+  return {
+    clave: 'hato.secado_due',
+    modulo: 'hato',
+    nombre: 'Secado próximo',
+    descripcion: 'Una vaca debe entrar a secado en los próximos días',
+    orden: 1,
+    activo: true,
+    ...overrides,
+  };
+}
+
+function suscripcion(overrides: Partial<AlertaSuscripcionRow>): AlertaSuscripcionRow {
+  return {
+    telegram_usuario_id: 'u1',
+    alerta_clave: 'hato.secado_due',
+    recibe: true,
+    escalamiento: false,
+    ...overrides,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// labelModulo
+// ---------------------------------------------------------------------------
+
+describe('labelModulo', () => {
+  it('etiqueta los módulos conocidos en español', () => {
+    expect(labelModulo('hato')).toBe('Hato Lechero');
+    expect(labelModulo('aguacate')).toBe('Aguacate');
+    expect(labelModulo('ganado')).toBe('Ganado');
+  });
+
+  it('para un módulo desconocido, capitaliza la clave en vez de reventar', () => {
+    expect(labelModulo('clima')).toBe('Clima');
+    expect(labelModulo('finanzas')).toBe('Finanzas');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// agruparAlertasPorModulo
+// ---------------------------------------------------------------------------
+
+describe('agruparAlertasPorModulo', () => {
+  it('agrupa por módulo y ordena las alertas dentro de cada grupo por orden', () => {
+    const catalogo = [
+      alerta({ clave: 'hato.b', modulo: 'hato', orden: 2 }),
+      alerta({ clave: 'hato.a', modulo: 'hato', orden: 1 }),
+    ];
+    const grupos = agruparAlertasPorModulo(catalogo);
+    expect(grupos).toHaveLength(1);
+    expect(grupos[0].alertas.map((a) => a.clave)).toEqual(['hato.a', 'hato.b']);
+  });
+
+  it('crea un grupo nuevo automáticamente para un módulo nunca visto (aguacate/ganado de mañana)', () => {
+    const catalogo = [
+      alerta({ clave: 'hato.a', modulo: 'hato', orden: 1 }),
+      alerta({ clave: 'aguacate.x', modulo: 'aguacate', orden: 1, nombre: 'Racimo listo' }),
+      alerta({ clave: 'ganado.y', modulo: 'ganado', orden: 1, nombre: 'Peso bajo' }),
+    ];
+    const grupos = agruparAlertasPorModulo(catalogo);
+    const modulos = grupos.map((g) => g.modulo).sort();
+    expect(modulos).toEqual(['aguacate', 'ganado', 'hato']);
+    const aguacate = grupos.find((g) => g.modulo === 'aguacate');
+    expect(aguacate?.label).toBe('Aguacate');
+    expect(aguacate?.alertas).toHaveLength(1);
+  });
+
+  it('excluye alertas inactivas', () => {
+    const catalogo = [
+      alerta({ clave: 'hato.activa', activo: true }),
+      alerta({ clave: 'hato.inactiva', activo: false }),
+    ];
+    const grupos = agruparAlertasPorModulo(catalogo);
+    const claves = grupos.flatMap((g) => g.alertas.map((a) => a.clave));
+    expect(claves).toEqual(['hato.activa']);
+  });
+
+  it('devuelve una lista vacía cuando el catálogo está vacío', () => {
+    expect(agruparAlertasPorModulo([])).toEqual([]);
+  });
+
+  it('ordena los grupos por el orden mínimo de sus alertas', () => {
+    const catalogo = [
+      alerta({ clave: 'ganado.y', modulo: 'ganado', orden: 5 }),
+      alerta({ clave: 'hato.a', modulo: 'hato', orden: 1 }),
+      alerta({ clave: 'aguacate.x', modulo: 'aguacate', orden: 3 }),
+    ];
+    const grupos = agruparAlertasPorModulo(catalogo);
+    expect(grupos.map((g) => g.modulo)).toEqual(['hato', 'aguacate', 'ganado']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// construirEstadoDesdeSuscripciones
+// ---------------------------------------------------------------------------
+
+describe('construirEstadoDesdeSuscripciones', () => {
+  it('construye un mapa clave -> {recibe, escalamiento}', () => {
+    const subs = [
+      suscripcion({ alerta_clave: 'hato.a', recibe: true, escalamiento: false }),
+      suscripcion({ alerta_clave: 'hato.b', recibe: false, escalamiento: true }),
+    ];
+    const estado = construirEstadoDesdeSuscripciones(subs);
+    expect(estado).toEqual({
+      'hato.a': { recibe: true, escalamiento: false },
+      'hato.b': { recibe: false, escalamiento: true },
+    });
+  });
+
+  it('devuelve un objeto vacío para una lista vacía', () => {
+    expect(construirEstadoDesdeSuscripciones([])).toEqual({});
+  });
+});
+
+// ---------------------------------------------------------------------------
+// alternarRecibe / alternarEscalamiento
+// ---------------------------------------------------------------------------
+
+describe('alternarRecibe', () => {
+  it('activa "recibe" para una clave sin estado previo', () => {
+    const resultado = alternarRecibe({}, 'hato.a');
+    expect(resultado).toEqual({ 'hato.a': { recibe: true, escalamiento: false } });
+  });
+
+  it('desactiva "recibe" si ya estaba activo, sin tocar escalamiento', () => {
+    const estado: SuscripcionEstado = { 'hato.a': { recibe: true, escalamiento: true } };
+    const resultado = alternarRecibe(estado, 'hato.a');
+    expect(resultado['hato.a']).toEqual({ recibe: false, escalamiento: true });
+  });
+
+  it('no muta el estado original (inmutable)', () => {
+    const estado: SuscripcionEstado = { 'hato.a': { recibe: false, escalamiento: false } };
+    const resultado = alternarRecibe(estado, 'hato.a');
+    expect(resultado).not.toBe(estado);
+    expect(estado['hato.a'].recibe).toBe(false);
+  });
+
+  it('no afecta el estado de otras claves', () => {
+    const estado: SuscripcionEstado = { 'hato.a': { recibe: true, escalamiento: false } };
+    const resultado = alternarRecibe(estado, 'hato.b');
+    expect(resultado['hato.a']).toEqual({ recibe: true, escalamiento: false });
+    expect(resultado['hato.b']).toEqual({ recibe: true, escalamiento: false });
+  });
+});
+
+describe('alternarEscalamiento', () => {
+  it('activa "escalamiento" sin requerir que "recibe" esté activo (estado legal)', () => {
+    const resultado = alternarEscalamiento({}, 'hato.a');
+    expect(resultado).toEqual({ 'hato.a': { recibe: false, escalamiento: true } });
+  });
+
+  it('desactiva "escalamiento" si ya estaba activo, sin tocar recibe', () => {
+    const estado: SuscripcionEstado = { 'hato.a': { recibe: true, escalamiento: true } };
+    const resultado = alternarEscalamiento(estado, 'hato.a');
+    expect(resultado['hato.a']).toEqual({ recibe: true, escalamiento: false });
+  });
+
+  it('no muta el estado original (inmutable)', () => {
+    const estado: SuscripcionEstado = { 'hato.a': { recibe: false, escalamiento: false } };
+    const resultado = alternarEscalamiento(estado, 'hato.a');
+    expect(resultado).not.toBe(estado);
+    expect(estado['hato.a'].escalamiento).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// construirFilasParaGuardar
+// ---------------------------------------------------------------------------
+
+describe('construirFilasParaGuardar', () => {
+  it('construye una fila por cada alerta del catálogo, con el estado actual', () => {
+    const catalogo = [
+      alerta({ clave: 'hato.a', orden: 1 }),
+      alerta({ clave: 'hato.b', orden: 2 }),
+    ];
+    const estado: SuscripcionEstado = {
+      'hato.a': { recibe: true, escalamiento: false },
+    };
+    const filas = construirFilasParaGuardar('u1', estado, catalogo);
+    expect(filas).toEqual([
+      { telegram_usuario_id: 'u1', alerta_clave: 'hato.a', recibe: true, escalamiento: false },
+      { telegram_usuario_id: 'u1', alerta_clave: 'hato.b', recibe: false, escalamiento: false },
+    ]);
+  });
+
+  it('una clave sin estado nunca tocada se guarda como false/false, no se omite', () => {
+    const catalogo = [alerta({ clave: 'hato.a' })];
+    const filas = construirFilasParaGuardar('u1', {}, catalogo);
+    expect(filas).toEqual([
+      { telegram_usuario_id: 'u1', alerta_clave: 'hato.a', recibe: false, escalamiento: false },
+    ]);
+  });
+
+  it('ignora claves del estado que ya no están en el catálogo', () => {
+    const catalogo = [alerta({ clave: 'hato.a' })];
+    const estado: SuscripcionEstado = {
+      'hato.a': { recibe: true, escalamiento: false },
+      'hato.ya_no_existe': { recibe: true, escalamiento: true },
+    };
+    const filas = construirFilasParaGuardar('u1', estado, catalogo);
+    expect(filas).toHaveLength(1);
+    expect(filas[0].alerta_clave).toBe('hato.a');
+  });
+
+  it('devuelve un arreglo vacío cuando el catálogo está vacío', () => {
+    expect(construirFilasParaGuardar('u1', {}, [])).toEqual([]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// contarSuscripcionesUsuario
+// ---------------------------------------------------------------------------
+
+describe('contarSuscripcionesUsuario', () => {
+  it('cuenta solo las filas del usuario indicado, solo las activas', () => {
+    const todas = [
+      suscripcion({ telegram_usuario_id: 'u1', alerta_clave: 'hato.a', recibe: true, escalamiento: false }),
+      suscripcion({ telegram_usuario_id: 'u1', alerta_clave: 'hato.b', recibe: false, escalamiento: true }),
+      suscripcion({ telegram_usuario_id: 'u1', alerta_clave: 'hato.c', recibe: false, escalamiento: false }),
+      suscripcion({ telegram_usuario_id: 'u2', alerta_clave: 'hato.a', recibe: true, escalamiento: true }),
+    ];
+    expect(contarSuscripcionesUsuario(todas, 'u1')).toEqual({ recibe: 1, escalamiento: 1 });
+    expect(contarSuscripcionesUsuario(todas, 'u2')).toEqual({ recibe: 1, escalamiento: 1 });
+  });
+
+  it('devuelve ceros cuando el usuario no tiene ninguna fila', () => {
+    expect(contarSuscripcionesUsuario([], 'u1')).toEqual({ recibe: 0, escalamiento: 0 });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatearResumenAlertas
+// ---------------------------------------------------------------------------
+
+describe('formatearResumenAlertas', () => {
+  it('sin ninguna suscripción activa', () => {
+    expect(formatearResumenAlertas({ recibe: 0, escalamiento: 0 })).toBe('Sin alertas');
+  });
+
+  it('singular vs. plural', () => {
+    expect(formatearResumenAlertas({ recibe: 1, escalamiento: 0 })).toBe('1 alerta');
+    expect(formatearResumenAlertas({ recibe: 3, escalamiento: 0 })).toBe('3 alertas');
+  });
+
+  it('agrega el conteo de escalamiento cuando hay alguno', () => {
+    expect(formatearResumenAlertas({ recibe: 3, escalamiento: 1 })).toBe('3 alertas (1 esc.)');
+  });
+
+  it('caso raro pero legal: escalamiento sin recibir ninguna alerta', () => {
+    expect(formatearResumenAlertas({ recibe: 0, escalamiento: 2 })).toBe('Sin alertas (2 esc.)');
+  });
+});

--- a/src/components/configuracion/TelegramConfig.tsx
+++ b/src/components/configuracion/TelegramConfig.tsx
@@ -1,15 +1,16 @@
-import { useState, useEffect } from 'react';
+import { useState, useEffect, useMemo } from 'react';
 import { Card } from '../ui/card';
 import { Button } from '../ui/button';
 import { Label } from '../ui/label';
 import { Input } from '../ui/input';
+import { Checkbox } from '../ui/checkbox';
 import { Dialog, DialogBody, DialogContent, DialogDescription, DialogFooter, DialogHeader, DialogTitle } from '../ui/dialog';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { toast } from 'sonner';
 import { useAuth } from '../../contexts/AuthContext';
 import { getSupabase } from '../../utils/supabase/client';
 import { formatearFechaHora } from '../../utils/fechas';
-import { Send, Plus, Edit, RotateCcw, Trash2, Copy, CheckCircle2, Clock, AlertTriangle, User } from 'lucide-react';
+import { Send, Plus, Edit, RotateCcw, Trash2, Copy, CheckCircle2, Clock, AlertTriangle, User, Bell } from 'lucide-react';
 import {
   TELEGRAM_MODULES,
   ROLES_BOT,
@@ -22,6 +23,18 @@ import {
   type RolBot,
   type EstadoVinculacion,
 } from '../../utils/telegramUsuarios';
+import {
+  agruparAlertasPorModulo,
+  construirEstadoDesdeSuscripciones,
+  alternarRecibe,
+  alternarEscalamiento,
+  construirFilasParaGuardar,
+  contarSuscripcionesUsuario,
+  formatearResumenAlertas,
+  type AlertaCatalogoRow,
+  type AlertaSuscripcionRow,
+  type SuscripcionEstado,
+} from '../../utils/telegramAlertas';
 
 interface UsuarioOption {
   id: string;
@@ -50,6 +63,16 @@ export function TelegramConfig() {
   const [rolBot, setRolBot] = useState<RolBot>('campo');
   const [modulosPermitidos, setModulosPermitidos] = useState<string[]>(['labores']);
   const [usuarioVinculadoId, setUsuarioVinculadoId] = useState<string | null>(null);
+  const [alertasEstado, setAlertasEstado] = useState<SuscripcionEstado>({});
+
+  // Catálogo de alertas (alertas_catalogo / telegram_alertas_suscripciones):
+  // tablas nuevas que puede que aún no existan en producción. Se degradan a
+  // "no disponible" en vez de romper el resto de la pantalla.
+  const [catalogoAlertas, setCatalogoAlertas] = useState<AlertaCatalogoRow[]>([]);
+  const [catalogoAlertasError, setCatalogoAlertasError] = useState(false);
+  const [todasSuscripciones, setTodasSuscripciones] = useState<AlertaSuscripcionRow[]>([]);
+
+  const gruposAlertas = useMemo(() => agruparAlertasPorModulo(catalogoAlertas), [catalogoAlertas]);
 
   useEffect(() => {
     if (profile && profile.rol !== 'Gerencia') {
@@ -58,7 +81,27 @@ export function TelegramConfig() {
     }
     cargarUsuarios();
     cargarUsuariosSistema();
+    cargarCatalogoAlertas();
+    cargarSuscripciones();
   }, [profile]);
+
+  // Corrige una carrera de carga: `cargarUsuarios`/`cargarSuscripciones` se
+  // disparan en paralelo al montar, así que si alguien abre "Editar" antes de
+  // que las suscripciones hayan llegado, `abrirModalEditar` habría sembrado
+  // el modal con casillas en falso -- y guardar así persiste "sin alertas"
+  // por encima de lo que el usuario sí tenía. Re-sincroniza en cuanto llegan,
+  // sin pisar ediciones en curso del usuario (solo corre cuando cambia el
+  // array de suscripciones, no en cada toggle de casilla).
+  useEffect(() => {
+    if (modalOpen && modalMode === 'editar' && usuarioActual) {
+      setAlertasEstado(
+        construirEstadoDesdeSuscripciones(
+          todasSuscripciones.filter((s) => s.telegram_usuario_id === usuarioActual.id),
+        ),
+      );
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [todasSuscripciones]);
 
   const cargarUsuarios = async () => {
     try {
@@ -96,6 +139,49 @@ export function TelegramConfig() {
     }
   };
 
+  // `alertas_catalogo`/`telegram_alertas_suscripciones` todavía no están en
+  // `src/types/database.ts` generado (tablas nuevas) -- mismo cast puntual
+  // que ya usan los hooks de hato/ganado (`getSupabase() as any`), nunca
+  // sobre el resto del archivo.
+  const cargarCatalogoAlertas = async () => {
+    try {
+      const supabase = getSupabase() as any;
+      const { data, error } = await supabase
+        .from('alertas_catalogo')
+        .select('*')
+        .eq('activo', true)
+        .order('orden', { ascending: true });
+
+      if (error) throw error;
+      setCatalogoAlertas((data ?? []) as AlertaCatalogoRow[]);
+      setCatalogoAlertasError(false);
+    } catch (err: unknown) {
+      // Secundario: la tabla puede no existir todavía en este entorno. La
+      // sección de Alertas se degrada a un mensaje explícito, nunca a una
+      // pantalla en blanco ni a una lista fantasma.
+      const msg = err instanceof Error ? err.message : 'Error desconocido';
+      console.error('Error al cargar catálogo de alertas:', msg);
+      setCatalogoAlertas([]);
+      setCatalogoAlertasError(true);
+    }
+  };
+
+  const cargarSuscripciones = async () => {
+    try {
+      const supabase = getSupabase() as any;
+      const { data, error } = await supabase
+        .from('telegram_alertas_suscripciones')
+        .select('*');
+
+      if (error) throw error;
+      setTodasSuscripciones((data ?? []) as AlertaSuscripcionRow[]);
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Error desconocido';
+      console.error('Error al cargar suscripciones de alertas:', msg);
+      setTodasSuscripciones([]);
+    }
+  };
+
   // ---- Modal open helpers ----
 
   const abrirModalCrear = () => {
@@ -105,6 +191,7 @@ export function TelegramConfig() {
     setRolBot('campo');
     setModulosPermitidos(['labores']);
     setUsuarioVinculadoId(null);
+    setAlertasEstado({});
     setModalOpen(true);
   };
 
@@ -115,6 +202,11 @@ export function TelegramConfig() {
     setRolBot(usuario.rol_bot);
     setModulosPermitidos([...(usuario.modulos_permitidos ?? [])]);
     setUsuarioVinculadoId(usuario.usuario_id);
+    setAlertasEstado(
+      construirEstadoDesdeSuscripciones(
+        todasSuscripciones.filter((s) => s.telegram_usuario_id === usuario.id),
+      ),
+    );
     setModalOpen(true);
   };
 
@@ -141,7 +233,7 @@ export function TelegramConfig() {
         const codigo = generarCodigoVinculacion();
         const expira = calcularExpiracion();
 
-        const { error } = await supabase
+        const { data: creado, error } = await supabase
           .from('telegram_usuarios')
           .insert({
             nombre_display: nombreDisplay.trim(),
@@ -151,9 +243,12 @@ export function TelegramConfig() {
             codigo_vinculacion: codigo,
             codigo_expira_at: expira,
             activo: true,
-          });
+          })
+          .select('id')
+          .single();
 
         if (error) throw error;
+        if (creado?.id) await guardarSuscripcionesAlertas(creado.id);
         setModalOpen(false);
         setCodigoModal({ codigo, nombre: nombreDisplay });
       } else if (usuarioActual) {
@@ -168,16 +263,42 @@ export function TelegramConfig() {
           .eq('id', usuarioActual.id);
 
         if (error) throw error;
+        await guardarSuscripcionesAlertas(usuarioActual.id);
         setModalOpen(false);
         toast.success('Usuario actualizado');
       }
 
       await cargarUsuarios();
+      await cargarSuscripciones();
     } catch (err: unknown) {
       const msg = err instanceof Error ? err.message : 'Error desconocido';
       toast.error('Error al guardar: ' + msg);
     } finally {
       setSavingId(null);
+    }
+  };
+
+  // Un solo upsert por (telegram_usuario_id, alerta_clave) -- se guarda junto
+  // con el resto del formulario, nunca por casilla. Si el catálogo está
+  // vacío o falló al cargar no hay nada que guardar. Un fallo aquí no debe
+  // tumbar el guardado del usuario, que ya se confirmó -- se avisa aparte.
+  const guardarSuscripcionesAlertas = async (usuarioId: string) => {
+    if (catalogoAlertas.length === 0) return;
+    try {
+      const filas = construirFilasParaGuardar(usuarioId, alertasEstado, catalogoAlertas);
+      // `updated_by` (migración 096) no tiene trigger que lo llene -- a
+      // diferencia del patrón `created_by` de 040/050/063/074, acá se
+      // espera que quien escribe lo declare.
+      const filasConAutor = filas.map((f) => ({ ...f, updated_by: profile?.id ?? null }));
+      const supabase = getSupabase() as any;
+      const { error } = await supabase
+        .from('telegram_alertas_suscripciones')
+        .upsert(filasConAutor, { onConflict: 'telegram_usuario_id,alerta_clave' });
+
+      if (error) throw error;
+    } catch (err: unknown) {
+      const msg = err instanceof Error ? err.message : 'Error desconocido';
+      toast.error('Usuario guardado, pero no se pudieron guardar sus alertas: ' + msg);
     }
   };
 
@@ -256,6 +377,25 @@ export function TelegramConfig() {
 
   // ---- Badge rendering ----
 
+  // Mismo estilo compacto que los chips de "Módulos permitidos" de arriba.
+  function renderAlertasIndicador(usuario: TelegramUsuarioRow) {
+    if (catalogoAlertasError) {
+      return <span className="text-xs text-brand-brown/40">—</span>;
+    }
+    const resumen = contarSuscripcionesUsuario(todasSuscripciones, usuario.id);
+    const activo = resumen.recibe > 0 || resumen.escalamiento > 0;
+    return (
+      <span
+        className={`inline-flex items-center gap-1 px-2 py-0.5 rounded text-xs ${
+          activo ? 'bg-primary/10 text-primary' : 'bg-secondary/10 text-brand-brown/50'
+        }`}
+      >
+        <Bell className="w-3 h-3" />
+        {formatearResumenAlertas(resumen)}
+      </span>
+    );
+  }
+
   function renderEstado(usuario: TelegramUsuarioRow) {
     const estado: EstadoVinculacion = getEstadoVinculacion(usuario);
 
@@ -333,6 +473,7 @@ export function TelegramConfig() {
                   <th className="px-4 py-3 text-left text-sm font-medium text-foreground">Nombre</th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-foreground">Rol</th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-foreground">Módulos</th>
+                  <th className="px-4 py-3 text-left text-sm font-medium text-foreground">Alertas</th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-foreground">Estado</th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-foreground">Activo</th>
                   <th className="px-4 py-3 text-left text-sm font-medium text-foreground">Acciones</th>
@@ -370,6 +511,7 @@ export function TelegramConfig() {
                         })}
                       </div>
                     </td>
+                    <td className="px-4 py-3 text-sm">{renderAlertasIndicador(usuario)}</td>
                     <td className="px-4 py-3 text-sm">{renderEstado(usuario)}</td>
                     <td className="px-4 py-3 text-sm">
                       <button
@@ -534,6 +676,67 @@ export function TelegramConfig() {
                     </label>
                   ))}
                 </div>
+              </div>
+
+              {/* Alertas -- catálogo dinámico (alertas_catalogo), agrupado por
+                  módulo. Hoy solo hay filas de `hato`; `aguacate`/`ganado`
+                  aparecerán solos cuando existan, sin tocar este código. */}
+              <div>
+                <Label>Alertas</Label>
+                {catalogoAlertasError ? (
+                  <p className="text-xs text-destructive mt-2">
+                    No se pudo cargar el catálogo de alertas. Intenta de nuevo más tarde.
+                  </p>
+                ) : gruposAlertas.length === 0 ? (
+                  <p className="text-xs text-brand-brown/60 mt-2">
+                    Todavía no hay alertas configuradas.
+                  </p>
+                ) : (
+                  <div className="mt-2 space-y-4">
+                    {gruposAlertas.map((grupo) => (
+                      <div key={grupo.modulo}>
+                        <p className="text-xs font-semibold text-brand-brown/70 uppercase tracking-wide mb-1.5">
+                          {grupo.label}
+                        </p>
+                        <div className="rounded-lg border border-secondary/30 divide-y divide-secondary/20">
+                          {grupo.alertas.map((alerta) => {
+                            const estado = alertasEstado[alerta.clave] ?? { recibe: false, escalamiento: false };
+                            return (
+                              <div key={alerta.clave} className="flex items-start justify-between gap-3 p-2.5">
+                                <div className="min-w-0">
+                                  <p className="text-sm font-medium text-foreground">{alerta.nombre}</p>
+                                  {alerta.descripcion && (
+                                    <p className="text-xs text-brand-brown/60 mt-0.5">{alerta.descripcion}</p>
+                                  )}
+                                </div>
+                                <div className="flex flex-shrink-0 gap-4">
+                                  <label className="flex flex-col items-center gap-1 text-xs text-brand-brown/70">
+                                    <Checkbox
+                                      checked={estado.recibe}
+                                      onCheckedChange={() =>
+                                        setAlertasEstado((prev) => alternarRecibe(prev, alerta.clave))
+                                      }
+                                    />
+                                    Recibe
+                                  </label>
+                                  <label className="flex flex-col items-center gap-1 text-xs text-brand-brown/70">
+                                    <Checkbox
+                                      checked={estado.escalamiento}
+                                      onCheckedChange={() =>
+                                        setAlertasEstado((prev) => alternarEscalamiento(prev, alerta.clave))
+                                      }
+                                    />
+                                    Escalamiento
+                                  </label>
+                                </div>
+                              </div>
+                            );
+                          })}
+                        </div>
+                      </div>
+                    ))}
+                  </div>
+                )}
               </div>
 
             </DialogBody>

--- a/src/components/hato/AnimalesList.tsx
+++ b/src/components/hato/AnimalesList.tsx
@@ -39,7 +39,14 @@ import { CrearAnimalDialog } from './components/CrearAnimalDialog';
 import { MarcarCicloDialog } from './components/MarcarCicloDialog';
 import { useHatoAnimales, type AnimalHatoDerivado } from './hooks/useHatoAnimales';
 import { usePesajesYPartos } from './hooks/usePesajesYPartos';
-import { chipEstadoReproductivo, chipProximaAReemplazo, chipNumeroProvisional, chipSubetapaTernera } from '@/utils/hatoUi';
+import {
+  chipEstadoReproductivo,
+  chipProximaAReemplazo,
+  chipNumeroProvisional,
+  chipSubetapaTernera,
+  chipSenalRevision,
+} from '@/utils/hatoUi';
+import { formatearEdadHato, proximoEventoHato } from '@/utils/hato/listaHato';
 import { LABEL_CATEGORIA_HATO, type CategoriaHato } from '@/utils/hatoCategorias';
 import {
   ordenarAnimalesHato,
@@ -59,14 +66,31 @@ function produccionTexto(animal: AnimalHatoDerivado, rendimientoPorAnimal: Map<s
   return actual != null ? `${formatNumber(actual, 1)} L/día` : '—';
 }
 
-function proximoEvento(animal: AnimalHatoDerivado): string {
-  if (animal.derivado.fecha_probable_parto) {
-    return `Parto: ${formatShortDate(animal.derivado.fecha_probable_parto)}`;
+/** Celda "Próximo evento". La ELECCIÓN del hito vive en
+ * `proximoEventoHato` (puro, testeado); acá solo se pinta. La versión
+ * anterior de esta función prefería SIEMPRE el parto sobre el secado, así
+ * que una vaca con secado en septiembre y parto en noviembre anunciaba
+ * noviembre -- el hito más lejano, y justamente el que no requiere acción
+ * todavía. */
+/** Señal de revisión de la fila (D-D): aborto o evento sin clasificar. El
+ * motor ya decidió si hay algo que revisar; acá solo se colorea. */
+function senalDeRevision(animal: AnimalHatoDerivado) {
+  return chipSenalRevision(animal.derivado.senal_revision);
+}
+
+function CeldaProximoEvento({ animal, hoy }: { animal: AnimalHatoDerivado; hoy: string }) {
+  const proximo = proximoEventoHato({ derivado: animal.derivado }, hoy);
+  if (!proximo) return <span className="text-gray-400">—</span>;
+  if (!proximo.fecha) {
+    // Rechequeo / servir: el sistema no tiene fecha objetivo para estos y no
+    // se la inventa. Se nombra el hito y nada más.
+    return <span>{proximo.etiqueta}</span>;
   }
-  if (animal.derivado.fecha_secar) {
-    return `Secar: ${formatShortDate(animal.derivado.fecha_secar)}`;
-  }
-  return '—';
+  return (
+    <span className={proximo.dias !== null && proximo.dias < 0 ? 'text-red-600' : undefined}>
+      {proximo.etiqueta}: {formatShortDate(proximo.fecha)}
+    </span>
+  );
 }
 
 function CabeceraOrdenable({
@@ -127,7 +151,15 @@ function TablaAnimales({
     );
   };
 
-  const animalesOrdenados = useMemo(() => ordenarAnimalesHato(animales, orden.columna, orden.direccion), [animales, orden]);
+  // Un solo "hoy" para toda la tabla: si cada celda llamara a
+  // `obtenerFechaHoy()` por su cuenta, una tabla renderizada a las 23:59:59
+  // podría mezclar dos días. Hora LOCAL, nunca UTC (ver CLAUDE.md).
+  const hoy = useMemo(() => obtenerFechaHoy(), []);
+
+  const animalesOrdenados = useMemo(
+    () => ordenarAnimalesHato(animales, orden.columna, orden.direccion, hoy),
+    [animales, orden, hoy],
+  );
 
   if (animales.length === 0) {
     return (
@@ -145,8 +177,11 @@ function TablaAnimales({
             <tr>
               <CabeceraOrdenable label="N.º" columna="numero" ordenActual={orden} onOrdenar={handleOrdenar} />
               <CabeceraOrdenable label="Nombre" columna="nombre" ordenActual={orden} onOrdenar={handleOrdenar} />
+              <CabeceraOrdenable label="Edad" columna="edad" ordenActual={orden} onOrdenar={handleOrdenar} align="right" />
+              <CabeceraOrdenable label="Partos" columna="partos" ordenActual={orden} onOrdenar={handleOrdenar} align="right" />
               <CabeceraOrdenable label="Estado" columna="estado" ordenActual={orden} onOrdenar={handleOrdenar} />
-              <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 whitespace-nowrap">Último parto</th>
+              <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 whitespace-nowrap">Señal</th>
+              <CabeceraOrdenable label="Última cría" columna="ultimaCria" ordenActual={orden} onOrdenar={handleOrdenar} />
               <CabeceraOrdenable label="Próximo evento" columna="proximo" ordenActual={orden} onOrdenar={handleOrdenar} />
               <th className="px-3 py-2 text-left text-xs font-semibold uppercase tracking-wide text-gray-500 whitespace-nowrap">Raza</th>
               <th className="px-3 py-2 text-right text-xs font-semibold uppercase tracking-wide text-gray-500 whitespace-nowrap">Producción</th>
@@ -173,6 +208,10 @@ function TablaAnimales({
                     {animal.nombre ?? '—'}
                   </Link>
                 </td>
+                <td className="px-3 py-1.5 whitespace-nowrap text-right text-gray-600">
+                  {formatearEdadHato(animal.fechaNacimiento, hoy)}
+                </td>
+                <td className="px-3 py-1.5 whitespace-nowrap text-right text-gray-600">{animal.numPartos}</td>
                 <td className="px-3 py-1.5 whitespace-nowrap">
                   <div className="flex flex-wrap items-center gap-1">
                     <EstadoChip chip={chipEstadoReproductivo(animal.derivado.estado)} />
@@ -183,10 +222,19 @@ function TablaAnimales({
                     {animal.derivado.proxima_a_reemplazo && <EstadoChip chip={chipProximaAReemplazo()} />}
                   </div>
                 </td>
+                <td className="px-3 py-1.5 whitespace-nowrap">
+                  {senalDeRevision(animal) ? (
+                    <EstadoChip chip={senalDeRevision(animal)!} />
+                  ) : (
+                    <span className="text-gray-300">—</span>
+                  )}
+                </td>
                 <td className="px-3 py-1.5 whitespace-nowrap text-gray-600">
                   {animal.ultimoPartoFecha ? formatShortDate(animal.ultimoPartoFecha) : '—'}
                 </td>
-                <td className="px-3 py-1.5 whitespace-nowrap text-gray-600">{proximoEvento(animal)}</td>
+                <td className="px-3 py-1.5 whitespace-nowrap text-gray-600">
+                  <CeldaProximoEvento animal={animal} hoy={hoy} />
+                </td>
                 <td className="px-3 py-1.5 whitespace-nowrap text-gray-600">{animal.raza ?? '—'}</td>
                 <td className="px-3 py-1.5 text-right whitespace-nowrap">
                   {produccionTexto(animal, rendimientoPorAnimal)}

--- a/src/components/hato/ChequeosList.tsx
+++ b/src/components/hato/ChequeosList.tsx
@@ -51,6 +51,7 @@ import {
   isoATextoDDMMYYYY,
   textoCeldaToro,
   textoCeldaEstado,
+  textoCeldaEstadoRegistrado,
   type FilaPlanillaChequeo,
 } from '@/utils/hato/exportarPlanillaChequeo';
 import {
@@ -95,6 +96,11 @@ function filaPlanillaPrellenada(animal: AnimalParaPlanillaChequeo): FilaPlanilla
     sexoCria: animal.sexoCriaRaw,
     fechaServicio: isoATextoDDMMYYYY(animal.ultimoServicioFecha),
     toro: textoCeldaToro(animal.toroNombre, animal.tipoServicio),
+    // "Estado registrado" (D-E, N22): lo que el motor de 5 estados cree HOY
+    // -- misma etiqueta en el `.xlsx` y en el PDF (a diferencia de `Sexo
+    // cría`, no hay un código crudo distinto que preservar: nadie escribe
+    // encima de esta columna).
+    estadoRegistrado: textoCeldaEstadoRegistrado(animal.estadoReproductivo),
     estado: textoCeldaEstado(animal.ultimoEstadoChequeo),
     secar: isoATextoDDMMYYYY(animal.fechaSecar),
     partoProbable: isoATextoDDMMYYYY(animal.fechaProbableParto),

--- a/src/components/hato/components/ChequeoDiffReview.tsx
+++ b/src/components/hato/components/ChequeoDiffReview.tsx
@@ -198,7 +198,8 @@ function FilaDiffEditable({
     diff.diferencias.length > 0 ||
     fila.issues.length > 0 ||
     erroresPorCampo.size > 0 ||
-    diff.clasificacion === 'nuevo';
+    diff.clasificacion === 'nuevo' ||
+    diff.conflictoEstadoRegistrado !== null;
 
   return (
     <>
@@ -244,6 +245,16 @@ function FilaDiffEditable({
         <tr className="bg-gray-50">
           <td colSpan={TOTAL_COLUMNAS} className="px-3 py-2">
             <div className="space-y-1">
+              {diff.conflictoEstadoRegistrado && (
+                <p className="text-xs text-red-700">
+                  <AlertTriangle className="w-4 h-4 inline-flex flex-shrink-0" /> "Estado registrado" impreso decía{' '}
+                  <span className="font-medium">{diff.conflictoEstadoRegistrado.impreso}</span>, pero el sistema cree
+                  ahora <span className="font-medium">{diff.conflictoEstadoRegistrado.actual}</span> -- algo cambió
+                  desde que se imprimió esta planilla (un evento de Telegram, una corrección). Verifica contra la vaca
+                  real antes de aprobar.
+                </p>
+              )}
+
               {diff.motivoNoReconocido && (
                 <p className="text-xs text-red-600">
                   <AlertTriangle className="w-4 h-4 inline-flex flex-shrink-0" /> {diff.motivoNoReconocido}
@@ -354,7 +365,10 @@ export function ChequeoDiffReview({
   const requiereAtencion = (f: FilaDiffChequeo) =>
     !esClasificacionAprobable(f.clasificacion) ||
     f.issues.length > 0 ||
-    erroresPorFila.has(f.fila);
+    erroresPorFila.has(f.fila) ||
+    // D-E/N23: lo impreso ya no coincide con lo que el sistema cree hoy --
+    // la contradicción tiene que verse ANTES de aprobar.
+    f.conflictoEstadoRegistrado !== null;
 
   const coincideFiltro = (f: FilaDiffChequeo, clasificacion: ClasificacionFilaDiff) => {
     switch (filtro) {
@@ -398,6 +412,15 @@ export function ChequeoDiffReview({
           <p className="text-xs text-red-600">No reconocidas</p>
         </div>
       </div>
+
+      {resumen.conConflictoEstadoRegistrado > 0 && (
+        <div className="flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
+          <AlertTriangle className="w-4 h-4 flex-shrink-0" />
+          {resumen.conConflictoEstadoRegistrado} fila(s) con "Estado registrado" desactualizado: el sistema cree algo
+          distinto de lo que estaba impreso cuando se exportó esta planilla. Revísalas antes de aprobar (filtro
+          "Requiere atención").
+        </div>
+      )}
 
       {cargandoEstado && (
         <div className="flex items-center gap-2 rounded-xl border border-gray-200 bg-gray-50 px-4 py-3 text-sm text-gray-600">

--- a/src/components/hato/components/HatoReproCard.tsx
+++ b/src/components/hato/components/HatoReproCard.tsx
@@ -31,7 +31,11 @@ export interface HatoReproCardProps {
 
 export function HatoReproCard({ enOrdeno, prenadas, servidas, vacias }: HatoReproCardProps) {
   const stats: StatRepro[] = [
-    { label: 'Preñadas', count: prenadas, color: 'var(--primary)' },
+    // D-D (2026-08-13): el vocabulario visible del módulo dice
+    // "Confirmada", no "Preñada". La REGLA de conteo no cambia (preñada +
+    // próxima a secar); solo la etiqueta, para que la card y la lista del
+    // hato no llamen distinto a lo mismo.
+    { label: 'Confirmadas', count: prenadas, color: 'var(--primary)' },
     { label: 'Servidas', count: servidas, color: '#2563eb' },
     { label: 'Vacías', count: vacias, color: '#d97706' },
   ];

--- a/src/components/hato/components/VacasPorEstadoCard.tsx
+++ b/src/components/hato/components/VacasPorEstadoCard.tsx
@@ -189,7 +189,7 @@ export function VacasPorEstadoCard({
           rightColor={HORRO}
         />
         <BarraNominal
-          leftLabel="Preñadas"
+          leftLabel="Confirmadas"
           leftValue={prenadas}
           leftColor={PRENADAS_COLOR}
           rightLabel="Por servir"

--- a/src/components/hato/hooks/useAnimalesParaPlanillaChequeo.ts
+++ b/src/components/hato/hooks/useAnimalesParaPlanillaChequeo.ts
@@ -33,6 +33,7 @@ import {
   derivarSexoCria,
   type EstadoActualHatoRow,
   type CriaDestino,
+  type EstadoReproductivo,
   type SexoCria,
   type TipoEstado,
 } from '@/utils/calculosHato';
@@ -83,6 +84,15 @@ export interface AnimalParaPlanillaChequeo {
    * mejor referencia disponible para que el veterinario la vea impresa. */
   fechaSecar: string | null;
   fechaProbableParto: string | null;
+  /** "Estado registrado" (D-E, N21/N22 -- docs/plan_hato_telegram_estados_agosto_2026.md
+   * §3 Capa 5): el `EstadoReproductivo` que el motor deriva HOY para esta
+   * vaca, la MISMA llamada a `derivarEstadoReproductivo` que ya se hacía
+   * para `fechaSecar`/`fechaProbableParto` -- ningún cálculo nuevo, solo se
+   * expone el campo `.estado` que antes se descartaba. Sale de
+   * `v_hato_estado_actual`, que fusiona TODO `hato_eventos` sin importar el
+   * origen -- incluye los manuales de Telegram (`chequeo_vaca_id IS NULL`),
+   * que es exactamente el mecanismo de sincronía que pide D-E. */
+  estadoReproductivo: EstadoReproductivo;
 }
 
 /** Lo que se necesita de un evento `parto` para resolver el sexo de la cría
@@ -257,6 +267,7 @@ export function useAnimalesParaPlanillaChequeo() {
             ultimoEstadoChequeo: fila.ultimo_estado_chequeo,
             fechaSecar: derivado.fecha_secar,
             fechaProbableParto: derivado.fecha_probable_parto,
+            estadoReproductivo: derivado.estado,
           };
         })
         .sort(ordenarPorNombreDeVaca);

--- a/src/components/hato/hooks/useAnimalesParaPlanillaChequeo.ts
+++ b/src/components/hato/hooks/useAnimalesParaPlanillaChequeo.ts
@@ -147,6 +147,8 @@ function filaVistaAFactRow(fila: EstadoActualHatoViewRow): EstadoActualHatoRow {
     ultimo_secado_real_fecha: fila.ultimo_secado_real_fecha,
     ultima_confirmacion_prenez_fecha: fila.ultima_confirmacion_prenez_fecha,
     ultimo_evento_fecha: fila.ultimo_evento_fecha,
+    ultima_confirmacion_prenez_metodo: fila.ultima_confirmacion_prenez_metodo,
+    ultimo_aborto_fecha: fila.ultimo_aborto_fecha,
     ultimo_estado_chequeo: fila.ultimo_estado_chequeo,
   };
 }

--- a/src/components/hato/hooks/useHatoAnimal.ts
+++ b/src/components/hato/hooks/useHatoAnimal.ts
@@ -74,6 +74,8 @@ function filaFactRow(
       ultimo_secado_real_fecha: null,
       ultima_confirmacion_prenez_fecha: null,
       ultimo_evento_fecha: null,
+      ultima_confirmacion_prenez_metodo: null,
+      ultimo_aborto_fecha: null,
       ultimo_estado_chequeo: null,
     };
   }
@@ -88,6 +90,8 @@ function filaFactRow(
     ultimo_secado_real_fecha: vista.ultimo_secado_real_fecha,
     ultima_confirmacion_prenez_fecha: vista.ultima_confirmacion_prenez_fecha,
     ultimo_evento_fecha: vista.ultimo_evento_fecha,
+    ultima_confirmacion_prenez_metodo: vista.ultima_confirmacion_prenez_metodo,
+    ultimo_aborto_fecha: vista.ultimo_aborto_fecha,
     ultimo_estado_chequeo: vista.ultimo_estado_chequeo,
   };
 }

--- a/src/components/hato/hooks/useHatoAnimales.ts
+++ b/src/components/hato/hooks/useHatoAnimales.ts
@@ -51,6 +51,10 @@ export interface AnimalHatoDerivado {
    * cruda, no este campo. `null` cuando `categoria` también es `null`
    * (estado terminal, no aplica ninguna de las dos). */
   categoriaOrigen: 'calculado' | 'override_manual' | null;
+  /** `fecha_nacimiento` de `hato_animales` vía la vista. `null` en 20 de
+   * los 65 animales activos del hato real -- la columna "Edad" muestra "—",
+   * nunca una edad inventada (`listaHato.ts::edadEnAnios`). */
+  fechaNacimiento: string | null;
   /** Subgrupo contable dentro de "ternera" (D-13: leche/concentrado),
    * `null` para toda categoría que no sea `ternera` o cuando la edad no se
    * pudo calcular. */
@@ -108,6 +112,7 @@ export function useHatoAnimales() {
           numPartos: fila.num_partos,
           ultimoChequeoFecha: fila.ultimo_chequeo_fecha,
           ultimoPartoFecha: fila.ultimo_parto_fecha,
+          fechaNacimiento: fila.fecha_nacimiento,
           derivado,
           categoria,
           categoriaOrigen,

--- a/src/components/hato/hooks/useMarcarCicloHato.ts
+++ b/src/components/hato/hooks/useMarcarCicloHato.ts
@@ -35,6 +35,8 @@ function filaDesdeVista(animal: HatoAnimalRow, vista: EstadoActualHatoViewRow | 
       ultimo_secado_real_fecha: null,
       ultima_confirmacion_prenez_fecha: null,
       ultimo_evento_fecha: null,
+      ultima_confirmacion_prenez_metodo: null,
+      ultimo_aborto_fecha: null,
       ultimo_estado_chequeo: null,
     };
   }
@@ -49,6 +51,8 @@ function filaDesdeVista(animal: HatoAnimalRow, vista: EstadoActualHatoViewRow | 
     ultimo_secado_real_fecha: vista.ultimo_secado_real_fecha,
     ultima_confirmacion_prenez_fecha: vista.ultima_confirmacion_prenez_fecha,
     ultimo_evento_fecha: vista.ultimo_evento_fecha,
+    ultima_confirmacion_prenez_metodo: vista.ultima_confirmacion_prenez_metodo,
+    ultimo_aborto_fecha: vista.ultimo_aborto_fecha,
     ultimo_estado_chequeo: vista.ultimo_estado_chequeo,
   };
 }

--- a/src/components/hato/hooks/useRevisionChequeo.ts
+++ b/src/components/hato/hooks/useRevisionChequeo.ts
@@ -103,7 +103,15 @@ export interface RevisionChequeo {
 
 const REVISION_VACIA_DIFF: ResultadoDiffChequeo = {
   filas: [],
-  resumen: { totalFilas: 0, nuevos: 0, sinCambio: 0, cambios: 0, noReconocidos: 0, conIssues: 0 },
+  resumen: {
+    totalFilas: 0,
+    nuevos: 0,
+    sinCambio: 0,
+    cambios: 0,
+    noReconocidos: 0,
+    conIssues: 0,
+    conConflictoEstadoRegistrado: 0,
+  },
   colisionesEnHoja: [],
 };
 

--- a/src/sql/migrations/094_hato_estado_actual_metodo_prenez_aborto.sql
+++ b/src/sql/migrations/094_hato_estado_actual_metodo_prenez_aborto.sql
@@ -1,0 +1,191 @@
+-- =====================================================================
+-- 094: Hato Lechero — `v_hato_estado_actual` expone el MÉTODO de la
+--      confirmación de preñez y la fecha del último aborto.
+-- Fecha: 2026-08-13
+-- Plan:  docs/plan_hato_telegram_estados_agosto_2026.md (N1)
+--
+-- POR QUÉ
+-- -------
+-- Decisión del dueño D-D (2026-08-13): el hato se lee con CINCO estados
+--   vacía · servida · confirmada · por secar · seca
+-- donde **"servida" incluye la preñez por PRESUNCIÓN y "confirmada"
+-- significa PALPADA**. Hasta hoy el motor (`derivarEstadoReproductivo`,
+-- `calculosHato.ts`) no podía distinguirlas: la migración 084/S3 guarda esa
+-- diferencia en `hato_eventos.datos->>'metodo'` ('presuncion' | 'palpacion',
+-- ver `hatoCicloManual.ts`), pero la vista solo exponía la FECHA de la
+-- última confirmación, nunca el método. Sin esta columna el motor no tiene
+-- de dónde leer y las dos marcas manuales del diálogo de ciclo colapsan en
+-- un único estado visible.
+--
+-- Segunda columna, misma decisión: D-D saca el aborto del ESTADO y lo manda
+-- a una columna de señales ("el estado ya no absorbe aborto/indeterminado").
+-- Hoy un aborto solo se ve como `ultimo_evento_fecha` más reciente que los 4
+-- eventos que el motor sabe clasificar, lo que tira al animal a
+-- `indeterminado` sin decir por qué — el comentario de la salvaguarda en
+-- `derivarEstadoReproductivo` lo dice con todas las letras: "casi siempre un
+-- aborto, venta o muerte... aunque no se sepa de qué tipo es". Con
+-- `ultimo_aborto_fecha` el motor SÍ puede tipificarlo: la vaca queda vacía
+-- (que es la verdad biológica después de un aborto) y la señal explica el
+-- porqué, en vez de un estado opaco.
+--
+-- CÓMO
+-- ----
+-- `CREATE OR REPLACE VIEW` **no admite reordenar ni insertar columnas en
+-- medio**: las dos nuevas van AL FINAL, después de `etapa_forzada` (mismo
+-- patrón que 062 con `ultimo_estado_chequeo`, 089 con `fecha_nacimiento` y
+-- 092 con `etapa_forzada`). El resto de la definición se reproduce VERBATIM
+-- desde `pg_get_viewdef` de producción — este archivo no aprovecha para
+-- cambiar nada más.
+--
+-- El único cambio de forma en las CTEs existentes: `ultima_confirmacion`
+-- pasa de `max(fecha) GROUP BY` a `DISTINCT ON (animal_id)`, porque ahora
+-- hay que traer un segundo campo (`datos->>'metodo'`) DE LA MISMA FILA que
+-- aporta esa fecha máxima — con `max()` + `GROUP BY` no hay forma de saber
+-- de cuál fila salió. El desempate `created_at DESC` replica exactamente el
+-- criterio que la CTE `ultimo_chequeo` ya usa en esta misma vista. Para una
+-- fecha única por animal el resultado es idéntico al anterior.
+--
+-- `security_invoker=true` se REAFIRMA explícitamente: `CREATE OR REPLACE
+-- VIEW` conserva las reloptions existentes, pero dejarlo escrito evita que
+-- una futura recreación desde cero pierda la propiedad (nota de 056 — nunca
+-- SECURITY DEFINER, mismo criterio que 033 aplicó a las vistas financieras).
+--
+-- Sin RLS propia: una vista `security_invoker` hereda las políticas de
+-- `hato_animales`/`hato_eventos`/`hato_chequeo_vacas`, que ya son el patrón
+-- 044. No se otorga ni revoca ningún grant aquí.
+--
+-- Idempotente: seguro de re-ejecutar.
+-- =====================================================================
+
+CREATE OR REPLACE VIEW v_hato_estado_actual
+WITH (security_invoker = true) AS
+WITH ultimo_chequeo AS (
+  SELECT DISTINCT ON (cv.animal_id)
+    cv.animal_id,
+    cv.id AS chequeo_vaca_id,
+    c.fecha AS chequeo_fecha,
+    cv.pl,
+    cv.meses_prenez,
+    cv.fecha_secar,
+    cv.fecha_probable_parto,
+    cv.estado
+  FROM hato_chequeo_vacas cv
+    JOIN hato_chequeos c ON c.id = cv.chequeo_id
+  ORDER BY cv.animal_id, c.fecha DESC, cv.created_at DESC
+), ultimo_servicio AS (
+  SELECT DISTINCT ON (e.animal_id)
+    e.animal_id,
+    e.fecha,
+    e.toro_id,
+    e.tipo_servicio
+  FROM hato_eventos e
+  WHERE e.tipo = 'servicio'::text
+  ORDER BY e.animal_id, e.fecha DESC
+), ultimo_parto AS (
+  SELECT e.animal_id,
+    max(e.fecha) AS fecha,
+    count(*) AS num_partos
+  FROM hato_eventos e
+  WHERE e.tipo = 'parto'::text
+  GROUP BY e.animal_id
+), ultimo_secado_real AS (
+  SELECT e.animal_id,
+    max(e.fecha) AS fecha
+  FROM hato_eventos e
+  WHERE e.tipo = 'secado_real'::text
+  GROUP BY e.animal_id
+), ultima_confirmacion AS (
+  -- DISTINCT ON, no max()+GROUP BY: `metodo` tiene que venir de LA MISMA
+  -- fila que aporta la fecha más reciente (ver cabecera).
+  SELECT DISTINCT ON (e.animal_id)
+    e.animal_id,
+    e.fecha,
+    e.datos ->> 'metodo'::text AS metodo
+  FROM hato_eventos e
+  WHERE e.tipo = 'confirmacion_prenez'::text
+  ORDER BY e.animal_id, e.fecha DESC, e.created_at DESC
+), ultimo_aborto AS (
+  SELECT e.animal_id,
+    max(e.fecha) AS fecha
+  FROM hato_eventos e
+  WHERE e.tipo = 'aborto'::text
+  GROUP BY e.animal_id
+), ultimo_evento AS (
+  SELECT e.animal_id,
+    max(e.fecha) AS fecha
+  FROM hato_eventos e
+  GROUP BY e.animal_id
+)
+SELECT a.id AS animal_id,
+  a.numero,
+  a.nombre,
+  a.etapa,
+  a.raza,
+  a.estado,
+  uc.chequeo_vaca_id AS ultimo_chequeo_vaca_id,
+  uc.chequeo_fecha AS ultimo_chequeo_fecha,
+  uc.pl,
+  uc.meses_prenez,
+  uc.fecha_secar,
+  uc.fecha_probable_parto,
+  us.fecha AS ultimo_servicio_fecha,
+  us.toro_id AS ultimo_servicio_toro_id,
+  us.tipo_servicio AS ultimo_tipo_servicio,
+  up.fecha AS ultimo_parto_fecha,
+  COALESCE(up.num_partos, 0::bigint) AS num_partos,
+  usr.fecha AS ultimo_secado_real_fecha,
+  ucp.fecha AS ultima_confirmacion_prenez_fecha,
+  ue.fecha AS ultimo_evento_fecha,
+  uc.estado AS ultimo_estado_chequeo,
+  a.fecha_nacimiento,
+  a.etapa_forzada,
+  -- ── columnas nuevas (094), siempre AL FINAL ──────────────────────
+  -- 'presuncion' | 'palpacion' | NULL. NULL = confirmación registrada sin
+  -- método (importación histórica o marca anterior a S3): el motor la trata
+  -- como PRESUNCIÓN, nunca como palpación — afirmar que un veterinario
+  -- palpó sin evidencia es la única lectura que no se puede deshacer.
+  ucp.metodo AS ultima_confirmacion_prenez_metodo,
+  uab.fecha AS ultimo_aborto_fecha
+FROM hato_animales a
+  LEFT JOIN ultimo_chequeo uc ON uc.animal_id = a.id
+  LEFT JOIN ultimo_servicio us ON us.animal_id = a.id
+  LEFT JOIN ultimo_parto up ON up.animal_id = a.id
+  LEFT JOIN ultimo_secado_real usr ON usr.animal_id = a.id
+  LEFT JOIN ultima_confirmacion ucp ON ucp.animal_id = a.id
+  LEFT JOIN ultimo_aborto uab ON uab.animal_id = a.id
+  LEFT JOIN ultimo_evento ue ON ue.animal_id = a.id;
+
+COMMENT ON VIEW v_hato_estado_actual IS
+  'Hechos por animal del hato (nunca cálculo): último chequeo, servicio, '
+  'parto, secado real, confirmación de preñez (+ método), aborto y evento. '
+  'Todo el cálculo de fechas/umbrales vive en calculosHato.ts, jamás aquí.';
+
+-- ---------------------------------------------------------------------
+-- Verificación (no muta nada; aborta si la vista quedó mal construida).
+-- ---------------------------------------------------------------------
+
+DO $$
+DECLARE
+  faltantes TEXT;
+BEGIN
+  SELECT string_agg(c, ', ') INTO faltantes
+  FROM unnest(ARRAY['ultima_confirmacion_prenez_metodo', 'ultimo_aborto_fecha']) AS c
+  WHERE NOT EXISTS (
+    SELECT 1 FROM information_schema.columns
+    WHERE table_schema = 'public'
+      AND table_name = 'v_hato_estado_actual'
+      AND column_name = c
+  );
+
+  IF faltantes IS NOT NULL THEN
+    RAISE EXCEPTION 'Migración 094: faltan columnas en v_hato_estado_actual: %', faltantes;
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_class
+    WHERE relname = 'v_hato_estado_actual'
+      AND 'security_invoker=true' = ANY (reloptions)
+  ) THEN
+    RAISE EXCEPTION 'Migración 094: v_hato_estado_actual perdió security_invoker';
+  END IF;
+END $$;

--- a/src/sql/migrations/095_hato_catalogo_toros_y_pajillas.sql
+++ b/src/sql/migrations/095_hato_catalogo_toros_y_pajillas.sql
@@ -1,0 +1,258 @@
+-- =====================================================================
+-- 095: Hato Lechero — catálogo de toros vigente + inventario de pajillas.
+-- Fecha: 2026-08-13
+-- Plan:  docs/plan_hato_telegram_estados_agosto_2026.md (N14 + N15)
+--
+-- DECISIÓN DEL DUEÑO (D-A, 2026-08-13)
+-- -----------------------------------
+-- "Borra todo el inventario de toros y pajillas y déjalo en: toros — Jersey
+-- y ternero Holstein, los dos de monta, luego agrega [las pajillas] como
+-- único inventario", resuelto en chips como **borrar los no usados,
+-- desactivar los usados**: el catálogo tiene 63 toros y 52 están
+-- referenciados por 232 eventos de servicio históricos. Borrarlos de verdad
+-- destruiría con qué toro se sirvió cada vaca en siete años de historia.
+--
+-- Estado final: 8 toros ACTIVOS (2 de monta + 6 de inseminación, uno por
+-- cada lote de pajillas) y todo lo demás inactivo o eliminado.
+--
+-- LO QUE ESTA MIGRACIÓN DESCUBRIÓ Y POR QUÉ IMPORTA
+-- ------------------------------------------------
+-- Verificado contra producción antes de escribir una sola línea:
+--
+-- 1. **`Ternero Holstein` YA EXISTE y está entre los "sin referencias"**
+--    (0 eventos), además de estar `activo = false`. Un `DELETE FROM
+--    hato_toros WHERE <sin referencias>` habría borrado exactamente el toro
+--    que el dueño pidió conservar. De ahí que la lista de sobrevivientes se
+--    excluya del borrado ANTES de cualquier otra condición.
+--
+-- 2. **`matt` y `marquez` YA EXISTEN, en minúscula y CON eventos** (1 y 6
+--    servicios): son los mismos toros del inventario de pajillas, cargados
+--    en su día desde la planilla sin raza ni tipo. Se REUSAN y se
+--    normalizan (nombre, raza, tipo), nunca se insertan de nuevo —
+--    `hato_toros` tiene `UNIQUE (lower(nombre))` y un INSERT habría
+--    fallado con 23505. Son también la excepción a "desactivar los usados":
+--    están referenciados Y siguen vigentes.
+--
+-- 3. **`Jersey` ya está exactamente como se necesita** (raza Jersey, tipo
+--    monta, activo) y arrastra 44 servicios. No se toca.
+--
+-- 4. La fila histórica **`Holstein` a secas (48 eventos) NO se fusiona con
+--    `Ternero Holstein`**. Viene de la importación, donde la planilla
+--    escribía solo la raza cuando el toro no tenía nombre; no hay forma de
+--    saber cuáles de esos 48 servicios fueron de este ternero, y fusionar
+--    sería inventar historia. Se desactiva como cualquier otro referenciado.
+--    Mismo criterio que la regla del módulo "dos nombres en la misma hoja
+--    son dos animales, nunca un rename".
+--
+-- RESPALDO
+-- --------
+-- El respaldo va al esquema `respaldos`, NUNCA a `public` (migración 081:
+-- Supabase concede `ALL` a `anon` por defecto sobre las tablas nuevas de
+-- `public`, que fue justo la alerta crítica del linter del 2026-08-03).
+--
+-- GUARDAS
+-- -------
+-- `RAISE EXCEPTION` aborta toda la transacción si los conteos previos o
+-- posteriores no cuadran exactamente (patrón 075/076/080/081). El incidente
+-- de corrupción del 2026-07-23 es la razón por la que esto no se hace con
+-- SQL ad hoc.
+--
+-- NO idempotente en su guarda de entrada: correrla dos veces aborta en la
+-- primera verificación (el catálogo ya no tendrá 63 toros). Eso es
+-- deliberado — un segundo pase silencioso es peor que un error ruidoso.
+-- =====================================================================
+
+BEGIN;
+
+-- ---------------------------------------------------------------------
+-- 0. Esquema de respaldos (creado por 081; se asegura por si acaso).
+-- ---------------------------------------------------------------------
+
+CREATE SCHEMA IF NOT EXISTS respaldos;
+REVOKE ALL ON SCHEMA respaldos FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------
+-- 1. Los 8 toros que sobreviven activos. Única fuente de verdad del
+--    resto de la migración: se usa para el UPSERT, para excluir del
+--    borrado y para excluir de la desactivación.
+-- ---------------------------------------------------------------------
+
+CREATE TEMP TABLE toros_vigentes (
+  clave   TEXT PRIMARY KEY,  -- lower(btrim(nombre)) con el que se busca
+  nombre  TEXT NOT NULL,     -- nombre de presentación final
+  raza    TEXT NOT NULL,
+  tipo    TEXT NOT NULL CHECK (tipo IN ('monta', 'inseminacion')),
+  pajillas INTEGER           -- NULL = toro de monta, no lleva lote
+) ON COMMIT DROP;
+
+INSERT INTO toros_vigentes (clave, nombre, raza, tipo, pajillas) VALUES
+  -- Los dos de monta. Todavía no tienen nombre propio (el dueño está
+  -- definiéndolo); estos son los nombres con los que ya viven en la base.
+  ('jersey',           'Jersey',           'Jersey',   'monta',        NULL),
+  ('ternero holstein', 'Ternero Holstein', 'Holstein', 'monta',        NULL),
+  -- Inventario de pajillas dictado por el dueño el 2026-08-13. 27 unidades.
+  ('matt',             'Matt',             'Jersey',   'inseminacion', 7),
+  ('daily double',     'Daily Double',     'Jersey',   'inseminacion', 5),
+  ('ulozon',           'Ulozon',           'Normando', 'inseminacion', 3),
+  ('hecker',           'Hecker',           'Holstein', 'inseminacion', 1),
+  ('marquez',          'Márquez',          'Holstein', 'inseminacion', 1),
+  ('valentino',        'Valentino',        'Simental', 'inseminacion', 10);
+
+-- ---------------------------------------------------------------------
+-- 2. Guarda de entrada: el catálogo tiene que estar como se verificó.
+-- ---------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_total INTEGER;
+  v_pajillas INTEGER;
+  v_usos INTEGER;
+BEGIN
+  SELECT count(*) INTO v_total FROM hato_toros;
+  SELECT count(*) INTO v_pajillas FROM hato_pajillas;
+  SELECT count(*) INTO v_usos FROM hato_pajillas_uso;
+
+  IF v_total <> 63 THEN
+    RAISE EXCEPTION 'Migración 095: se esperaban 63 toros en el catálogo, hay %. Verificar el estado antes de continuar.', v_total;
+  END IF;
+  -- El inventario de pajillas está en CERO (verificado 2026-08-13): no hay
+  -- nada que borrar, solo que sembrar. Si alguien cargó pajillas entre la
+  -- verificación y la ejecución, esta migración no debe pisarlas.
+  IF v_pajillas <> 0 OR v_usos <> 0 THEN
+    RAISE EXCEPTION 'Migración 095: hato_pajillas/hato_pajillas_uso ya tienen datos (% lotes, % usos). Esta migración solo siembra sobre inventario vacío.', v_pajillas, v_usos;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------
+-- 3. Respaldo forense del catálogo completo, antes de tocar nada.
+-- ---------------------------------------------------------------------
+
+DROP TABLE IF EXISTS respaldos.backup_095_hato_toros;
+CREATE TABLE respaldos.backup_095_hato_toros AS
+SELECT t.*,
+  (SELECT count(*) FROM hato_eventos e WHERE e.toro_id = t.id) AS eventos_al_respaldar,
+  (SELECT count(*) FROM hato_animales a WHERE a.padre_toro_id = t.id) AS hijos_al_respaldar
+FROM hato_toros t;
+
+ALTER TABLE respaldos.backup_095_hato_toros ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON respaldos.backup_095_hato_toros FROM PUBLIC, anon, authenticated;
+
+-- ---------------------------------------------------------------------
+-- 4. Alta o normalización de los 8 vigentes.
+--    SELECT-or-UPDATE por id, NUNCA upsert de PostgREST ni ON CONFLICT
+--    sobre el índice de expresión `lower(nombre)`.
+-- ---------------------------------------------------------------------
+
+UPDATE hato_toros t
+SET nombre = v.nombre,
+    raza   = v.raza,
+    tipo   = v.tipo,
+    activo = TRUE
+FROM toros_vigentes v
+WHERE lower(btrim(t.nombre)) = v.clave;
+
+INSERT INTO hato_toros (nombre, raza, tipo, activo)
+SELECT v.nombre, v.raza, v.tipo, TRUE
+FROM toros_vigentes v
+WHERE NOT EXISTS (
+  SELECT 1 FROM hato_toros t WHERE lower(btrim(t.nombre)) = lower(btrim(v.nombre))
+);
+
+-- ---------------------------------------------------------------------
+-- 5. Borrado de los toros sin uso alguno, EXCLUYENDO a los vigentes.
+--    El orden importa: los vigentes salen primero de la selección, y solo
+--    después se evalúa "no tiene referencias".
+-- ---------------------------------------------------------------------
+
+DELETE FROM hato_toros t
+WHERE NOT EXISTS (SELECT 1 FROM toros_vigentes v WHERE v.clave = lower(btrim(t.nombre)))
+  AND NOT EXISTS (SELECT 1 FROM hato_eventos   e WHERE e.toro_id = t.id)
+  AND NOT EXISTS (SELECT 1 FROM hato_animales  a WHERE a.padre_toro_id = t.id)
+  AND NOT EXISTS (SELECT 1 FROM hato_pajillas  p WHERE p.toro_id = t.id);
+
+-- ---------------------------------------------------------------------
+-- 6. Desactivación de todo lo demás (los referenciados que ya no se usan).
+--    Se conserva la fila entera: es lo que le da nombre a 232 servicios.
+-- ---------------------------------------------------------------------
+
+UPDATE hato_toros t
+SET activo = FALSE
+WHERE t.activo
+  AND NOT EXISTS (SELECT 1 FROM toros_vigentes v WHERE v.clave = lower(btrim(t.nombre)));
+
+-- ---------------------------------------------------------------------
+-- 7. Inventario de pajillas: un lote por toro de inseminación.
+-- ---------------------------------------------------------------------
+
+INSERT INTO hato_pajillas (toro_id, cantidad_inicial, activa)
+SELECT t.id, v.pajillas, TRUE
+FROM toros_vigentes v
+  JOIN hato_toros t ON lower(btrim(t.nombre)) = lower(btrim(v.nombre))
+WHERE v.pajillas IS NOT NULL;
+
+-- ---------------------------------------------------------------------
+-- 8. Guarda de salida. Cualquier desviación aborta TODO.
+-- ---------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_activos INTEGER;
+  v_monta INTEGER;
+  v_lotes INTEGER;
+  v_unidades INTEGER;
+  v_eventos_huerfanos INTEGER;
+  v_jersey_eventos INTEGER;
+BEGIN
+  SELECT count(*) INTO v_activos FROM hato_toros WHERE activo;
+  IF v_activos <> 8 THEN
+    RAISE EXCEPTION 'Migración 095: deberían quedar 8 toros activos, quedaron %.', v_activos;
+  END IF;
+
+  SELECT count(*) INTO v_monta FROM hato_toros WHERE activo AND tipo = 'monta';
+  IF v_monta <> 2 THEN
+    RAISE EXCEPTION 'Migración 095: deberían quedar 2 toros de monta activos, quedaron %.', v_monta;
+  END IF;
+
+  SELECT count(*), COALESCE(sum(cantidad_inicial), 0) INTO v_lotes, v_unidades FROM hato_pajillas;
+  IF v_lotes <> 6 OR v_unidades <> 27 THEN
+    RAISE EXCEPTION 'Migración 095: se esperaban 6 lotes de pajillas por 27 unidades, hay % lotes por % unidades.', v_lotes, v_unidades;
+  END IF;
+
+  -- Ningún evento puede haber perdido su toro: el borrado solo alcanzó
+  -- filas sin referencias, así que esto debe dar 0 siempre. Si da otra
+  -- cosa, el DELETE se llevó historia por delante.
+  SELECT count(*) INTO v_eventos_huerfanos
+  FROM hato_eventos e
+  WHERE e.toro_id IS NOT NULL
+    AND NOT EXISTS (SELECT 1 FROM hato_toros t WHERE t.id = e.toro_id);
+  IF v_eventos_huerfanos <> 0 THEN
+    RAISE EXCEPTION 'Migración 095: % eventos quedaron sin toro. Abortando.', v_eventos_huerfanos;
+  END IF;
+
+  -- Los 44 servicios de Jersey siguen colgando de la misma fila.
+  SELECT count(*) INTO v_jersey_eventos
+  FROM hato_eventos e JOIN hato_toros t ON t.id = e.toro_id
+  WHERE lower(btrim(t.nombre)) = 'jersey';
+  IF v_jersey_eventos <> 44 THEN
+    RAISE EXCEPTION 'Migración 095: Jersey debería conservar 44 servicios, tiene %.', v_jersey_eventos;
+  END IF;
+END $$;
+
+COMMIT;
+
+-- =====================================================================
+-- ROLLBACK (manual, desde el respaldo):
+--
+--   BEGIN;
+--   DELETE FROM hato_pajillas;                         -- el seed de esta migración
+--   UPDATE hato_toros t SET nombre = b.nombre, raza = b.raza,
+--          tipo = b.tipo, activo = b.activo
+--     FROM respaldos.backup_095_hato_toros b WHERE b.id = t.id;
+--   INSERT INTO hato_toros (id, nombre, tipo, raza, activo, created_at, created_by)
+--     SELECT b.id, b.nombre, b.tipo, b.raza, b.activo, b.created_at, b.created_by
+--     FROM respaldos.backup_095_hato_toros b
+--     WHERE NOT EXISTS (SELECT 1 FROM hato_toros t WHERE t.id = b.id);
+--   COMMIT;
+--
+-- El respaldo se deja en la base a propósito (misma decisión que 075/080).
+-- =====================================================================

--- a/src/sql/migrations/095_hato_catalogo_toros_y_pajillas.sql
+++ b/src/sql/migrations/095_hato_catalogo_toros_y_pajillas.sql
@@ -77,8 +77,14 @@ REVOKE ALL ON SCHEMA respaldos FROM PUBLIC, anon, authenticated;
 --    borrado y para excluir de la desactivación.
 -- ---------------------------------------------------------------------
 
+-- `clave` y `lower(btrim(nombre))` NO siempre coinciden: `marquez` vive en la
+-- base sin tilde y su nombre final es `Márquez`. Después del paso 4 esa fila
+-- ya no responde a su propia clave, así que todo lo que la busque DESPUÉS del
+-- renombre tiene que aceptar las dos grafías — es exactamente lo que hacía el
+-- paso 6 desactivar al toro que el paso 4 acababa de normalizar (7 activos en
+-- vez de 8, la guarda de salida lo atrapó).
 CREATE TEMP TABLE toros_vigentes (
-  clave   TEXT PRIMARY KEY,  -- lower(btrim(nombre)) con el que se busca
+  clave   TEXT PRIMARY KEY,  -- lower(btrim(nombre)) con el que se busca HOY
   nombre  TEXT NOT NULL,     -- nombre de presentación final
   raza    TEXT NOT NULL,
   tipo    TEXT NOT NULL CHECK (tipo IN ('monta', 'inseminacion')),
@@ -162,10 +168,13 @@ WHERE NOT EXISTS (
 -- 5. Borrado de los toros sin uso alguno, EXCLUYENDO a los vigentes.
 --    El orden importa: los vigentes salen primero de la selección, y solo
 --    después se evalúa "no tiene referencias".
+--    Se compara contra las DOS grafías (clave de búsqueda y nombre final)
+--    porque el paso 4 ya renombró: ver la nota de `toros_vigentes`.
 -- ---------------------------------------------------------------------
 
 DELETE FROM hato_toros t
-WHERE NOT EXISTS (SELECT 1 FROM toros_vigentes v WHERE v.clave = lower(btrim(t.nombre)))
+WHERE NOT EXISTS (SELECT 1 FROM toros_vigentes v
+                   WHERE lower(btrim(t.nombre)) IN (v.clave, lower(btrim(v.nombre))))
   AND NOT EXISTS (SELECT 1 FROM hato_eventos   e WHERE e.toro_id = t.id)
   AND NOT EXISTS (SELECT 1 FROM hato_animales  a WHERE a.padre_toro_id = t.id)
   AND NOT EXISTS (SELECT 1 FROM hato_pajillas  p WHERE p.toro_id = t.id);
@@ -173,12 +182,15 @@ WHERE NOT EXISTS (SELECT 1 FROM toros_vigentes v WHERE v.clave = lower(btrim(t.n
 -- ---------------------------------------------------------------------
 -- 6. Desactivación de todo lo demás (los referenciados que ya no se usan).
 --    Se conserva la fila entera: es lo que le da nombre a 232 servicios.
+--    Mismo cuidado que el paso 5 con las dos grafías: sin él, `Márquez`
+--    (renombrado en el paso 4) caía aquí y quedaban 7 activos en vez de 8.
 -- ---------------------------------------------------------------------
 
 UPDATE hato_toros t
 SET activo = FALSE
 WHERE t.activo
-  AND NOT EXISTS (SELECT 1 FROM toros_vigentes v WHERE v.clave = lower(btrim(t.nombre)));
+  AND NOT EXISTS (SELECT 1 FROM toros_vigentes v
+                   WHERE lower(btrim(t.nombre)) IN (v.clave, lower(btrim(v.nombre))));
 
 -- ---------------------------------------------------------------------
 -- 7. Inventario de pajillas: un lote por toro de inseminación.
@@ -202,7 +214,21 @@ DECLARE
   v_unidades INTEGER;
   v_eventos_huerfanos INTEGER;
   v_jersey_eventos INTEGER;
+  v_faltantes TEXT;
+  v_lotes_inactivos TEXT;
 BEGIN
+  -- Primero el diagnóstico preciso: QUÉ vigente no quedó activo. Un conteo
+  -- suelto ("quedaron 7") obliga a reconstruir a mano cuál se perdió.
+  SELECT string_agg(v.nombre, ', ' ORDER BY v.nombre) INTO v_faltantes
+  FROM toros_vigentes v
+  WHERE NOT EXISTS (
+    SELECT 1 FROM hato_toros t
+    WHERE t.activo AND lower(btrim(t.nombre)) = lower(btrim(v.nombre))
+  );
+  IF v_faltantes IS NOT NULL THEN
+    RAISE EXCEPTION 'Migración 095: estos toros vigentes no quedaron activos: %.', v_faltantes;
+  END IF;
+
   SELECT count(*) INTO v_activos FROM hato_toros WHERE activo;
   IF v_activos <> 8 THEN
     RAISE EXCEPTION 'Migración 095: deberían quedar 8 toros activos, quedaron %.', v_activos;
@@ -216,6 +242,16 @@ BEGIN
   SELECT count(*), COALESCE(sum(cantidad_inicial), 0) INTO v_lotes, v_unidades FROM hato_pajillas;
   IF v_lotes <> 6 OR v_unidades <> 27 THEN
     RAISE EXCEPTION 'Migración 095: se esperaban 6 lotes de pajillas por 27 unidades, hay % lotes por % unidades.', v_lotes, v_unidades;
+  END IF;
+
+  -- Un lote colgado de un toro inactivo es stock invisible: N16 filtra los
+  -- selectores por `activo`, así que esas pajillas existirían sin poder
+  -- usarse. Es la forma en que se manifestaba el bug de las dos grafías.
+  SELECT string_agg(t.nombre, ', ' ORDER BY t.nombre) INTO v_lotes_inactivos
+  FROM hato_pajillas p JOIN hato_toros t ON t.id = p.toro_id
+  WHERE NOT t.activo;
+  IF v_lotes_inactivos IS NOT NULL THEN
+    RAISE EXCEPTION 'Migración 095: hay pajillas asignadas a toros inactivos (%). Serían stock invisible.', v_lotes_inactivos;
   END IF;
 
   -- Ningún evento puede haber perdido su toro: el borrado solo alcanzó

--- a/src/sql/migrations/096_alertas_catalogo_y_suscripciones.sql
+++ b/src/sql/migrations/096_alertas_catalogo_y_suscripciones.sql
@@ -1,0 +1,415 @@
+-- =====================================================================
+-- 096: Suscripciones a alertas por usuario de Telegram -- catálogo
+--      genérico + suscripciones + cola de envíos del broadcast del hato.
+-- Fecha: 2026-08-14
+--
+-- CONTEXTO Y DECISIONES DEL DUEÑO (2026-08-14, contrato, no se negocian
+-- en esta migración):
+--   - "Broadcast con cierre por el primero": una alerta se manda a TODOS
+--     los suscritos de su tipo; la primera respuesta la cierra para
+--     todos, y los demás ven que ya se resolvió y por quién. NUNCA una
+--     alerta por persona.
+--   - El escalamiento es una segunda casilla POR TIPO DE ALERTA y por
+--     persona -- `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` (variable de
+--     entorno) deja de ser la fuente de verdad del escalamiento; el
+--     motor (`hato-alertas-tick.ts`, cambiado junto con esta migración,
+--     fuera del alcance de un archivo SQL) resuelve destinatarios y
+--     escalamiento desde las tablas de abajo.
+--
+-- POR QUÉ GENÉRICO A PROPÓSITO: el CATÁLOGO y las SUSCRIPCIONES sirven
+-- para cualquier módulo (`hato`, y lo que venga de `aguacate`/`ganado`
+-- más adelante) -- `alertas_catalogo.clave` es `modulo.tipo`. Las
+-- INSTANCIAS de alerta siguen siendo por módulo (`hato_alertas`, ya
+-- existente desde 056) -- no se generaliza eso, no es lo que se pidió.
+--
+-- QUÉ CREA:
+--   1. alertas_catalogo               -- catálogo de tipos de alerta,
+--                                         cualquier módulo.
+--   2. telegram_alertas_suscripciones -- quién recibe / quién escala,
+--                                         por usuario de Telegram y tipo.
+--   3. hato_alertas_envios            -- un envío por (alerta, suscrito)
+--                                         del broadcast del hato -- lo
+--                                         que permite editar el mensaje
+--                                         de cada suscrito cuando la
+--                                         alerta se cierra (guarda
+--                                         `message_id`). Es del hato
+--                                         porque referencia hato_alertas;
+--                                         cuando exista un motor de
+--                                         alertas de otro módulo, ese
+--                                         módulo tendrá su propia tabla
+--                                         de envíos con el mismo patrón.
+--
+-- SIEMBRA: las 5 claves salen de los `tipo` que hoy tiene
+-- `hato_alertas_config` (CHECK de la migración 056: secado_due,
+-- tratamiento_paso, rechequeo_due, servicio_sin_confirmacion,
+-- parto_proximo), con nombre/descripción en español pensados para una
+-- casilla que un humano marca, no para un log técnico.
+--
+-- Las suscripciones se siembran DERIVADAS DEL ESTADO ACTUAL de
+-- `hato_alertas_config.destinatario_telegram_id` (verificado en
+-- producción antes de escribir esta migración: las 5 filas apuntan a
+-- `8505349717`, Santiago -- migración 091, D-14): quien hoy está ahí
+-- queda con `recibe=true` y **`escalamiento=false`**, para que el día del
+-- despliegue el comportamiento del motor NO CAMBIE.
+--
+-- El `false` del escalamiento NO es un descuido, es el estado actual:
+-- verificado con `supabase secrets list` el 2026-08-14, la variable
+-- `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` **nunca se configuró**, así que
+-- hoy una alerta escalada no le llega a nadie -- se marca `escalada` y
+-- muere ahí. Sembrar `true` habría encendido, de refilón y dentro de una
+-- migración de andamiaje, una función apagada desde julio. Encenderla es
+-- una decisión del dueño, y a partir de esta migración tiene una casilla
+-- para tomarla.
+--
+-- `hato_alertas_config` NO SE TOCA en esta migración (ni su columna
+-- `destinatario_telegram_id`, ni `activo`, ni `horas_escalamiento`) --
+-- el motor sigue leyendo `activo`/`horas_escalamiento` de ahí (son
+-- ajustes por tipo, no de destinatario). `destinatario_telegram_id` en
+-- esa tabla queda VESTIGIAL desde el momento en que el motor deja de
+-- leerla para resolver a quién enviar (cambio de código, no de esquema)
+-- -- se documenta acá para que quede constancia, igual que se documenta
+-- abajo qué pasa con `hato_alertas.destinatario_telegram_id` (esa sí es
+-- una columna que el motor sigue escribiendo, con un significado nuevo:
+-- "a quién se le envió primero", ya no "el único destinatario" -- ver el
+-- reporte de la sesión que acompaña esta migración).
+--
+-- RLS: NO es el patrón 044/056 uniforme en las tres tablas -- corregido
+-- (mensaje del orquestador, verificado contra producción antes de escribir
+-- una sola política): `telegram_usuarios` no usa 044, tiene UNA sola policy
+-- `ALL` para `authenticated` Gerencia-only (lectura incluida). Como
+-- `telegram_alertas_suscripciones` se edita desde la MISMA pantalla
+-- (`TelegramConfig.tsx`) que ya gestiona `telegram_usuarios` con esa
+-- policy, la imita verbatim -- darle escritura a Administrador sería un
+-- permiso inalcanzable desde esa pantalla y dejaría el modelo de seguridad
+-- diciendo dos cosas distintas.
+--   - alertas_catalogo: SELECT authenticated (catálogo de NOMBRES, no de
+--     destinatarios -- lo puede leer cualquier pantalla, lo va a necesitar
+--     el futuro módulo de aguacate), escritura Gerencia-only.
+--   - telegram_alertas_suscripciones: UNA sola policy ALL, Gerencia-only
+--     (lectura incluida), mismo predicado que `telegram_usuarios`.
+--   - hato_alertas_envios: NINGUNA política para `authenticated`/`anon`,
+--     sin grants de navegador en absoluto -- es plomería del motor (quién
+--     recibió qué mensaje, con qué message_id), la escribe y la lee el
+--     `service_role` desde el tick y desde el callback del bot, igual que
+--     `telegram_mensajes` (026).
+--
+-- Todos los predicados de rol van envueltos `(SELECT auth.uid())`, nunca
+-- `auth.uid()` a secas -- mismo criterio que 077/093 y que la policy real
+-- de `telegram_usuarios`, que ya está así.
+--
+-- Trampa de la migración 081: Supabase concede `ALL` a `anon`/`authenticated`
+-- por defecto en tablas nuevas de `public` (`ALTER DEFAULT PRIVILEGES`) --
+-- eso es justo lo que dejó expuesto un backup el 2026-08-03. Con RLS
+-- habilitada y sin política `TO anon`, `anon` ya queda bloqueado por RLS
+-- sola, pero esta migración además REVOCA el grant por defecto de forma
+-- explícita (defensa en profundidad, mismo criterio que 084 aplicó sobre
+-- `hato_correcciones`) -- nunca se deja como decoración.
+--
+-- Guardas de entrada/salida con RAISE EXCEPTION (patrón 075/080/091/095):
+-- verifica que `hato_alertas_config` siga teniendo exactamente los 5
+-- tipos esperados antes de sembrar, y que la siembra deje exactamente
+-- las filas esperadas después -- un INNER JOIN que no encuentra a quién
+-- resolver un `telegram_id` se traga la fila en silencio si nadie lo
+-- comprueba, y eso es exactamente lo que este guard existe para atrapar.
+--
+-- NO SE APLICA por esta sesión -- la aplica el orquestador con el
+-- conector autenticado, igual que 086/091/095.
+-- =====================================================================
+
+-- ---------------------------------------------------------------------
+-- 1. alertas_catalogo -- genérico, cualquier módulo.
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS alertas_catalogo (
+  clave       TEXT PRIMARY KEY,            -- 'hato.secado_due' (modulo.tipo)
+  modulo      TEXT NOT NULL,               -- 'hato' | 'aguacate' | 'ganado' (sin CHECK: a propósito, ver cabecera)
+  nombre      TEXT NOT NULL,               -- lo que ve el humano en la casilla
+  descripcion TEXT,
+  orden       INTEGER NOT NULL DEFAULT 0,
+  activo      BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_alertas_catalogo_modulo ON alertas_catalogo(modulo);
+
+DROP TRIGGER IF EXISTS update_alertas_catalogo_updated_at ON alertas_catalogo;
+CREATE TRIGGER update_alertas_catalogo_updated_at
+  BEFORE UPDATE ON alertas_catalogo
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------
+-- 2. telegram_alertas_suscripciones -- quién recibe / quién escala.
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS telegram_alertas_suscripciones (
+  telegram_usuario_id UUID NOT NULL REFERENCES telegram_usuarios(id) ON DELETE CASCADE,
+  alerta_clave         TEXT NOT NULL REFERENCES alertas_catalogo(clave) ON DELETE CASCADE,
+  recibe                BOOLEAN NOT NULL DEFAULT TRUE,
+  escalamiento          BOOLEAN NOT NULL DEFAULT FALSE,
+  updated_at            TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  -- UUID pelado, SIN FK a `auth.users`: verificado 2026-08-14 contra
+  -- producción, en toda la base hay CERO claves foráneas hacia `auth.users`.
+  -- Las columnas de atribución del repo (`created_by` en tareas, fin_gastos,
+  -- fin_ingresos, monitoreos, registros_trabajo -- migraciones 040/050/063/074)
+  -- son todas `uuid` sin referencia. Introducir aquí la primera FK al esquema
+  -- `auth` acoplaría este módulo al ciclo de vida de la tabla de auth de
+  -- Supabase por una columna que sólo sirve de traza.
+  updated_by            UUID,
+  PRIMARY KEY (telegram_usuario_id, alerta_clave)
+);
+
+CREATE INDEX IF NOT EXISTS idx_telegram_alertas_suscripciones_clave ON telegram_alertas_suscripciones(alerta_clave);
+
+DROP TRIGGER IF EXISTS update_telegram_alertas_suscripciones_updated_at ON telegram_alertas_suscripciones;
+CREATE TRIGGER update_telegram_alertas_suscripciones_updated_at
+  BEFORE UPDATE ON telegram_alertas_suscripciones
+  FOR EACH ROW
+  EXECUTE FUNCTION update_updated_at_column();
+
+-- ---------------------------------------------------------------------
+-- 3. hato_alertas_envios -- un envío por (alerta, suscrito) del
+--    broadcast. `message_id` es lo que permite editar el mensaje de
+--    CADA suscrito cuando la alerta se cierra (Telegram no tiene forma
+--    de "cerrar para todos" de otro modo que editar cada mensaje que
+--    mandó). `telegram_id` (no el uuid de `telegram_usuarios`) porque es
+--    lo que la Bot API necesita para `editMessageText` (`chat_id`).
+-- ---------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS hato_alertas_envios (
+  alerta_id   UUID NOT NULL REFERENCES hato_alertas(id) ON DELETE CASCADE,
+  telegram_id TEXT NOT NULL,
+  message_id  BIGINT,
+  enviado_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (alerta_id, telegram_id)
+);
+
+-- ---------------------------------------------------------------------
+-- 4. RLS.
+-- ---------------------------------------------------------------------
+
+-- Corrección post-escritura (mensaje del orquestador, verificado contra
+-- producción antes de aplicar cualquier cambio): `telegram_usuarios` NO usa
+-- el patrón 044 -- tiene UNA sola policy `ALL` para `authenticated`,
+-- Gerencia-only (lectura incluida), predicado envuelto `(select auth.uid())`
+-- (077/093). Texto EXACTO copiado de `pg_policies` (2026-08-14):
+--
+--   cmd: ALL, roles: {authenticated}
+--   qual = with_check = EXISTS (
+--     SELECT 1 FROM usuarios
+--     WHERE usuarios.id = (SELECT auth.uid()) AND usuarios.rol = 'Gerencia'::rol_usuario
+--   )
+--
+-- `telegram_alertas_suscripciones` se edita desde la MISMA pantalla
+-- (Configuración -> Telegram, `TelegramConfig.tsx`) que ya gestiona
+-- `telegram_usuarios` con esa policy -- imita el MISMO predicado, verbatim,
+-- para que el modelo de seguridad de esa pantalla no diga dos cosas
+-- distintas (darle escritura a Administrador sería un permiso que nadie
+-- puede ejercer: la pantalla ya es inalcanzable para ese rol).
+--
+-- `alertas_catalogo` SÍ queda con SELECT abierto a `authenticated` -- es un
+-- catálogo de NOMBRES (no de destinatarios), lo puede leer cualquier
+-- pantalla del sistema y lo va a necesitar el futuro módulo de aguacate;
+-- solo la escritura es Gerencia-only, mismo predicado envuelto.
+
+-- 4.1 alertas_catalogo -- SELECT authenticated (catálogo de nombres, no de
+--     destinatarios), escritura Gerencia-only.
+ALTER TABLE alertas_catalogo ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "alertas_catalogo_select_authenticated" ON alertas_catalogo;
+CREATE POLICY "alertas_catalogo_select_authenticated" ON alertas_catalogo
+  FOR SELECT TO authenticated
+  USING (TRUE);
+
+DROP POLICY IF EXISTS "alertas_catalogo_write_gerencia" ON alertas_catalogo;
+CREATE POLICY "alertas_catalogo_write_gerencia" ON alertas_catalogo
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM usuarios
+      WHERE usuarios.id = (SELECT auth.uid())
+        AND usuarios.rol = 'Gerencia'::rol_usuario
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM usuarios
+      WHERE usuarios.id = (SELECT auth.uid())
+        AND usuarios.rol = 'Gerencia'::rol_usuario
+    )
+  );
+
+REVOKE ALL ON TABLE alertas_catalogo FROM anon;
+
+-- 4.2 telegram_alertas_suscripciones -- UNA sola policy ALL, Gerencia-only
+--     (lectura incluida), texto verbatim de la policy real de
+--     `telegram_usuarios` (ver nota arriba) -- misma pantalla, mismo dueño.
+ALTER TABLE telegram_alertas_suscripciones ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS "telegram_alertas_suscripciones_select_authenticated" ON telegram_alertas_suscripciones;
+DROP POLICY IF EXISTS "telegram_alertas_suscripciones_write_admin_gerencia" ON telegram_alertas_suscripciones;
+DROP POLICY IF EXISTS "Gerencia puede gestionar telegram_alertas_suscripciones" ON telegram_alertas_suscripciones;
+CREATE POLICY "Gerencia puede gestionar telegram_alertas_suscripciones"
+  ON telegram_alertas_suscripciones
+  FOR ALL TO authenticated
+  USING (
+    EXISTS (
+      SELECT 1 FROM usuarios
+      WHERE usuarios.id = (SELECT auth.uid())
+        AND usuarios.rol = 'Gerencia'::rol_usuario
+    )
+  )
+  WITH CHECK (
+    EXISTS (
+      SELECT 1 FROM usuarios
+      WHERE usuarios.id = (SELECT auth.uid())
+        AND usuarios.rol = 'Gerencia'::rol_usuario
+    )
+  );
+
+REVOKE ALL ON TABLE telegram_alertas_suscripciones FROM anon;
+
+-- 4.3 hato_alertas_envios -- deny-all para anon/authenticated, SIN grants
+--     de navegador en absoluto (ni siquiera SELECT) -- es traza del motor,
+--     no dato de pantalla, mismo criterio que `telegram_mensajes` (026). El
+--     tick y el callback del bot escriben/leen con la `service_role`, que
+--     ignora RLS.
+ALTER TABLE hato_alertas_envios ENABLE ROW LEVEL SECURITY;
+
+REVOKE ALL ON TABLE hato_alertas_envios FROM anon, authenticated;
+
+-- ---------------------------------------------------------------------
+-- 5. Guarda de entrada -- hato_alertas_config debe seguir teniendo
+--    exactamente los 5 tipos que la migración 056 sembró. Si esto
+--    cambió (una migración futura agregó/quitó un tipo sin actualizar
+--    esta), la siembra de abajo estaría incompleta o inventando una
+--    clave que no corresponde -- mejor abortar que sembrar mal.
+-- ---------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_tipos_esperados TEXT[] := ARRAY['secado_due', 'tratamiento_paso', 'rechequeo_due', 'servicio_sin_confirmacion', 'parto_proximo'];
+  v_tipos_actuales   TEXT[];
+BEGIN
+  SELECT array_agg(tipo ORDER BY tipo) INTO v_tipos_actuales FROM hato_alertas_config;
+  IF v_tipos_actuales IS DISTINCT FROM (SELECT array_agg(t ORDER BY t) FROM unnest(v_tipos_esperados) AS t) THEN
+    RAISE EXCEPTION '096 ABORTADA: hato_alertas_config.tipo no son los 5 esperados. Esperados: %, encontrados: %. Revisar antes de sembrar alertas_catalogo.', v_tipos_esperados, v_tipos_actuales;
+  END IF;
+END $$;
+
+-- ---------------------------------------------------------------------
+-- 6. Siembra de alertas_catalogo -- las 5 claves del hato, nombre y
+--    descripción en español para la UI de casillas.
+-- ---------------------------------------------------------------------
+
+INSERT INTO alertas_catalogo (clave, modulo, nombre, descripcion, orden, activo)
+VALUES
+  ('hato.secado_due', 'hato', 'Vaca por secar',
+   'La vaca llegó a la fecha programada de secado y todavía no se registró el secado real.',
+   1, TRUE),
+  ('hato.tratamiento_paso', 'hato', 'Paso de tratamiento pendiente',
+   'Un paso de un tratamiento veterinario tiene fecha programada para hoy y no se ha marcado como ejecutado.',
+   2, TRUE),
+  ('hato.rechequeo_due', 'hato', 'Rechequeo veterinario pendiente',
+   'Pasó el tiempo esperado desde el último chequeo de la vaca sin que se haya registrado uno nuevo.',
+   3, TRUE),
+  ('hato.servicio_sin_confirmacion', 'hato', 'Servicio sin confirmar preñez',
+   'La vaca fue servida hace tiempo y todavía no hay confirmación de preñez ni ninguna novedad registrada.',
+   4, TRUE),
+  ('hato.parto_proximo', 'hato', 'Parto próximo',
+   'La fecha probable de parto de la vaca está cerca.',
+   5, TRUE)
+ON CONFLICT (clave) DO NOTHING;
+
+-- ---------------------------------------------------------------------
+-- 7. Siembra de telegram_alertas_suscripciones -- derivada del estado
+--    actual de hato_alertas_config.destinatario_telegram_id, para que
+--    el despliegue no le cambie el comportamiento a nadie (ver cabecera).
+--
+--    El CAST a bigint puede fallar si algún día `destinatario_telegram_id`
+--    trae algo no numérico -- preferible un error de tipo ruidoso a un
+--    JOIN que descarta la fila en silencio.
+-- ---------------------------------------------------------------------
+
+-- `escalamiento = FALSE`, NO true. Corregido antes de aplicar: la versión
+-- anterior sembraba `TRUE` diciendo que así "el comportamiento no cambia", y
+-- es exactamente al revés. Verificado el 2026-08-14 con `supabase secrets
+-- list`: **`HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` NUNCA se configuró**, así
+-- que hoy el escalamiento no le manda mensaje a NADIE -- las alertas sin
+-- responder sólo se marcan `escalada` y ahí mueren (comportamiento
+-- documentado en CLAUDE.md: "unset -> escalated alerts are only marked
+-- escalada, no message sent"). Sembrar `TRUE` habría ENCENDIDO, como efecto
+-- colateral de una migración de andamiaje, una función que lleva apagada
+-- desde julio. Encenderla es una decisión del dueño y ahora tiene una casilla
+-- para tomarla.
+INSERT INTO telegram_alertas_suscripciones (telegram_usuario_id, alerta_clave, recibe, escalamiento)
+SELECT tu.id, 'hato.' || hac.tipo, TRUE, FALSE
+FROM hato_alertas_config hac
+JOIN telegram_usuarios tu ON tu.telegram_id = hac.destinatario_telegram_id::bigint
+WHERE hac.destinatario_telegram_id IS NOT NULL
+ON CONFLICT (telegram_usuario_id, alerta_clave) DO NOTHING;
+
+-- ---------------------------------------------------------------------
+-- 8. Guarda de salida -- todo lo esperado quedó sembrado, y nada se
+--    perdió en el JOIN del paso 7.
+-- ---------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_catalogo_hato       INTEGER;
+  v_config_con_destino  INTEGER;
+  v_config_resueltas    INTEGER;
+  v_suscripciones       INTEGER;
+  v_suscripciones_no_full INTEGER;
+BEGIN
+  SELECT count(*) INTO v_catalogo_hato FROM alertas_catalogo WHERE modulo = 'hato';
+  IF v_catalogo_hato <> 5 THEN
+    RAISE EXCEPTION '096 ABORTADA: se esperaban 5 filas en alertas_catalogo con modulo=''hato'', hay %.', v_catalogo_hato;
+  END IF;
+
+  SELECT count(*) INTO v_config_con_destino
+    FROM hato_alertas_config WHERE destinatario_telegram_id IS NOT NULL;
+
+  SELECT count(*) INTO v_config_resueltas
+    FROM hato_alertas_config hac
+    JOIN telegram_usuarios tu ON tu.telegram_id = hac.destinatario_telegram_id::bigint
+   WHERE hac.destinatario_telegram_id IS NOT NULL;
+
+  IF v_config_con_destino <> v_config_resueltas THEN
+    RAISE EXCEPTION '096 ABORTADA: % fila(s) de hato_alertas_config tienen destinatario_telegram_id que NO resuelve contra telegram_usuarios (de % con destinatario). Revisar telegram_usuarios antes de reintentar -- el JOIN de la siembra las habría descartado en silencio.',
+      (v_config_con_destino - v_config_resueltas), v_config_con_destino;
+  END IF;
+
+  SELECT count(*) INTO v_suscripciones FROM telegram_alertas_suscripciones;
+  IF v_suscripciones <> v_config_resueltas THEN
+    RAISE EXCEPTION '096 ABORTADA: se esperaban % suscripciones sembradas (una por hato_alertas_config con destinatario resuelto), hay %.', v_config_resueltas, v_suscripciones;
+  END IF;
+
+  -- El estado sembrado tiene que reproducir EXACTAMENTE lo de hoy: quien
+  -- recibía, recibe; y el escalamiento queda APAGADO porque hoy no le llega a
+  -- nadie (el secreto nunca se configuró -- ver la nota del paso 7). Si
+  -- alguna fila saliera con `escalamiento=true`, el despliegue estaría
+  -- encendiendo mensajes que hoy no existen.
+  SELECT count(*) INTO v_suscripciones_no_full
+    FROM telegram_alertas_suscripciones
+   WHERE NOT recibe OR escalamiento;
+  IF v_suscripciones_no_full <> 0 THEN
+    RAISE EXCEPTION '096 ABORTADA: % suscripción(es) sembradas no quedaron con recibe=true y escalamiento=false -- el despliegue le cambiaría el comportamiento a alguien.', v_suscripciones_no_full;
+  END IF;
+
+  RAISE NOTICE '096 OK: alertas_catalogo con 5 filas del hato, % suscripciones sembradas (recibe=true, escalamiento=false) reproduciendo el estado actual de hato_alertas_config.', v_suscripciones;
+END $$;
+
+-- =============================================================================
+-- ROLLBACK (manual)
+-- =============================================================================
+--   DROP TABLE IF EXISTS hato_alertas_envios;
+--   DROP TABLE IF EXISTS telegram_alertas_suscripciones;
+--   DROP TABLE IF EXISTS alertas_catalogo;
+-- Ninguna de las tres tiene historia que preservar todavía (son nuevas en
+-- esta migración) -- a diferencia de 075/080/095, un DROP directo no
+-- pierde nada que no se pueda volver a sembrar corriendo esta migración
+-- de nuevo, siempre que hato_alertas_config no haya cambiado mientras
+-- tanto.
+-- =============================================================================

--- a/src/supabase/functions/server/calculos-hato.ts
+++ b/src/supabase/functions/server/calculos-hato.ts
@@ -2143,6 +2143,55 @@ export function derivarEstadoReproductivo(
   };
 }
 
+/**
+ * Etiqueta legible de un `EstadoReproductivo`, en el vocabulario de CINCO
+ * estados de D-D (Vacía · Servida · Confirmada · Por secar · Seca) más los
+ * estados no-aplicables/terminales. Extraída de `hatoUi.ts::chipEstadoReproductivo`
+ * (S8) para que exista UNA sola fuente del TEXTO -- el color/className sigue
+ * viviendo en `hatoUi.ts` (browser-only), que ahora reusa esta función.
+ *
+ * Por qué vive acá y no solo en `hatoUi.ts`: la columna "Estado registrado"
+ * de la planilla de chequeo (D-E, docs/plan_hato_telegram_estados_agosto_2026.md
+ * N21-N23) imprime este mismo texto en el `.xlsx`/PDF (`exportarPlanillaChequeo*.ts`,
+ * browser) y el endpoint de diff (Deno, `hato-chequeo-preview.ts`) necesita
+ * calcular el MISMO texto para detectar cuándo lo impreso ya no coincide con
+ * lo que el sistema cree HOY -- y el lado Deno no puede importar `hatoUi.ts`
+ * (no es parte del trío espejado). Este archivo sí lo es, así que la etiqueta
+ * viaja gratis a los tres lados sin duplicar el vocabulario.
+ */
+export function etiquetaEstadoReproductivo(estado: EstadoReproductivo): string {
+  switch (estado) {
+    case 'preñada':
+      return 'Confirmada';
+    case 'parida_reciente':
+      return 'Vacía';
+    case 'servida':
+      return 'Servida';
+    case 'proxima_a_secar':
+      return 'Por secar';
+    case 'seca':
+      return 'Seca';
+    case 'vacia_por_servir':
+      return 'Vacía';
+    case 'novilla':
+      return 'Vacía';
+    case 'cria':
+      return 'Cría';
+    case 'indeterminado':
+      return '—';
+    case 'vendida':
+      return 'Vendida';
+    case 'muerta':
+      return 'Muerta';
+    case 'descartada':
+      return 'Descartada';
+    default: {
+      const _exhaustivo: never = estado;
+      return String(_exhaustivo);
+    }
+  }
+}
+
 // ============================================================================
 // BLOQUE 5 — PL / productividad
 // ============================================================================

--- a/src/supabase/functions/server/calculos-hato.ts
+++ b/src/supabase/functions/server/calculos-hato.ts
@@ -1639,9 +1639,31 @@ export function derivarSexoCria(input: InputSexoCria): SexoCria | null {
 // BLOQUE 4 — Derivación de estado reproductivo (v_hato_estado_actual + config)
 // ============================================================================
 
-/** Subconjunto de columnas de `v_hato_estado_actual` (migración 056) que
- * este motor consume. La vista expone solo hechos -- todo el cálculo de
- * fechas/umbrales vive aquí, nunca en la vista (plan §7.1, brief S1 Decisión 3). */
+/** Evidencia detrás de una confirmación de preñez (`hato_eventos.datos.metodo`,
+ * escrito por `hatoCicloManual.ts` desde S3). Es la ÚNICA diferencia entre
+ * los estados "servida" y "confirmada" de D-D. */
+export type MetodoConfirmacionPrenez = 'presuncion' | 'palpacion';
+
+/** Motivo por el que una vaca necesita revisión humana, para la columna de
+ * señales de la lista del hato (D-D, 2026-08-13: "el estado ya no absorbe
+ * aborto/indeterminado — eso vive en una columna de alertas aparte que dice
+ * qué pasó"). Nunca se mezcla con `estado`: el estado dice en qué punto del
+ * ciclo está la vaca, la señal dice por qué ese dato puede no ser confiable.
+ *
+ * - `aborto`: el evento más reciente del animal es un aborto. El estado SÍ
+ *   se conoce (queda vacía) -- la señal solo explica el porqué.
+ * - `evento_posterior`: hay un evento más nuevo que los 4 que este motor
+ *   sabe clasificar y NO es un aborto (celo, rechequeo, compra,
+ *   cambio_etapa...). Ahí el estado es genuinamente desconocido. */
+export interface SenalRevisionHato {
+  tipo: 'aborto' | 'evento_posterior';
+  fecha: string;
+}
+
+/** Subconjunto de columnas de `v_hato_estado_actual` (migración 056, ampliada
+ * por 062/089/092/094) que este motor consume. La vista expone solo hechos --
+ * todo el cálculo de fechas/umbrales vive aquí, nunca en la vista
+ * (plan §7.1, brief S1 Decisión 3). */
 export interface EstadoActualHatoRow {
   etapa: 'ternera' | 'novilla' | 'vaca' | 'toro';
   raza: string | null;
@@ -1659,6 +1681,21 @@ export interface EstadoActualHatoRow {
    * o muerte, no se proyecta un ciclo de preñez activo con datos que ese
    * evento puede haber invalidado -- ver `derivarEstadoReproductivo`. */
   ultimo_evento_fecha: string | null;
+  /** `datos->>'metodo'` del ÚLTIMO `confirmacion_prenez` (columna de la
+   * vista desde la migración 094). Decisión del dueño D-D (2026-08-13):
+   * "servida = preñada por presunción, confirmada = palpada", así que este
+   * campo es lo único que separa dos estados distintos a partir del MISMO
+   * tipo de evento. `null` = confirmación sin método registrado
+   * (importación histórica o marca anterior a S3) y se trata como
+   * PRESUNCIÓN: afirmar que un veterinario palpó sin evidencia es la única
+   * lectura de las dos que no se puede deshacer. */
+  ultima_confirmacion_prenez_metodo: MetodoConfirmacionPrenez | null;
+  /** MAX(fecha) de los eventos `aborto` del animal (columna de la vista
+   * desde la migración 094). Permite tipificar el caso que antes caía en
+   * `indeterminado` sin explicación: tras un aborto la vaca está VACÍA (eso
+   * es un hecho biológico, no una suposición) y el motivo viaja en
+   * `senal_revision`, no disfrazado dentro del `estado`. */
+  ultimo_aborto_fecha: string | null;
   /** `tipo` de `parseEstado` sobre el `ESTADO`/`OBS` del último chequeo
    * cerrado (`'vacia_apta' | 'vacia_problema' | 'fecha_heredada' |
    * 'desconocido' | 'vacio'`), o `null` si no hay ninguna señal disponible
@@ -1726,6 +1763,14 @@ export interface EstadoReproductivoDerivado {
    * no hay ninguna señal disponible -- nunca se adivina.
    */
   vacia_es_problema: boolean | null;
+  /**
+   * Motivo por el que este animal necesita una mirada humana (D-D). `null`
+   * = nada que revisar. Es información SEPARADA de `estado` a propósito: el
+   * vocabulario de 5 estados del dueño (vacía · servida · confirmada · por
+   * secar · seca) describe el punto del ciclo, y meter "abortó" o "hay algo
+   * raro" dentro de esa lista obligaría a mentir en uno de los dos ejes.
+   */
+  senal_revision: SenalRevisionHato | null;
   alertas: AlertasReproductivas;
 }
 
@@ -1792,6 +1837,22 @@ function clasificarVaciaProblema(
 }
 
 /**
+ * D-D (dueño, 2026-08-13): una confirmación de preñez vale como `preñada`
+ * (etiqueta "Confirmada") SOLO si viene de una palpación. Una confirmación
+ * por presunción deja a la vaca en `servida` -- que es exactamente lo que
+ * el dueño quiso decir con "servida = preñada por presunción".
+ *
+ * `null` (confirmación sin método: importación histórica o marca anterior a
+ * S3) se lee como presunción. Es la asimetría deliberada: dar por palpada
+ * una vaca que nadie palpó lleva a secarla y dejar de ordeñarla con datos
+ * que nadie verificó; el error contrario solo hace que se la vuelva a
+ * revisar.
+ */
+function estadoDeConfirmacion(fila: EstadoActualHatoRow): EstadoReproductivo {
+  return fila.ultima_confirmacion_prenez_metodo === 'palpacion' ? 'preñada' : 'servida';
+}
+
+/**
  * Deriva el estado reproductivo actual de un animal y las 4 alertas de
  * §7.3 (secado_due, rechequeo_due, servicio_sin_confirmacion, parto_proximo)
  * a partir de los hechos de `v_hato_estado_actual` + `HatoConfig`. Todos los
@@ -1830,6 +1891,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: false,
       vacia_es_problema: null,
+      senal_revision: null,
       alertas: SIN_ALERTAS,
     };
   }
@@ -1846,6 +1908,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
       vacia_es_problema: null,
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1888,6 +1951,7 @@ export function derivarEstadoReproductivo(
       // Una novilla nunca ha entrado al ciclo reproductivo: la pregunta
       // "¿normal o problema?" no aplica todavía.
       vacia_es_problema: esNovilla ? null : clasificarVaciaProblema(fila.ultimo_estado_chequeo, null, config),
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1898,26 +1962,44 @@ export function derivarEstadoReproductivo(
   });
   const masReciente = candidatos[0].tipo;
 
-  // Salvaguarda: `v_hato_estado_actual` no expone una columna dedicada de
-  // "último aborto" (a diferencia de parto/secado_real/confirmación), pero sí
-  // `ultimo_evento_fecha` (MAX sobre TODO `hato_eventos`, cualquier tipo). Si
-  // hay un evento más reciente que el más nuevo de los 4 que sí sabemos
-  // clasificar, algo pasó que este motor no puede tipificar aquí -- casi
-  // siempre un aborto, venta o muerte -- y proyectar SECAR/PP desde el
-  // servicio viejo sería exactamente el error real encontrado (QA, MONA:
-  // SX='aborto' con SECAR/PP de la fila cruda todavía "vigentes" en la
-  // planilla). Nunca se asume que el ciclo sigue activo cuando hay una señal
-  // de que no es así, aunque no se sepa de qué tipo es.
+  // Salvaguarda: `ultimo_evento_fecha` es MAX sobre TODO `hato_eventos`
+  // (cualquier tipo). Si hay un evento más reciente que el más nuevo de los 4
+  // que este motor sabe clasificar, algo pasó que invalida el ciclo -- y
+  // proyectar SECAR/PP desde el servicio viejo sería exactamente el error
+  // real encontrado (QA, MONA: SX='aborto' con SECAR/PP de la fila cruda
+  // todavía "vigentes" en la planilla). Nunca se asume que el ciclo sigue
+  // activo cuando hay una señal de que no es así.
+  //
+  // Desde la migración 094 esa señal se puede TIPIFICAR en el caso más
+  // frecuente. Si el evento más nuevo es un aborto, el estado no es
+  // desconocido: la vaca quedó VACÍA -- eso es un hecho biológico, no una
+  // suposición -- y el motivo viaja en `senal_revision`, que es justamente
+  // lo que pide D-D ("el estado ya no absorbe aborto/indeterminado"). Solo
+  // cuando el evento posterior NO es un aborto (celo, rechequeo, compra,
+  // cambio_etapa...) el estado sigue siendo genuinamente `indeterminado`.
   if (fila.ultimo_evento_fecha && fila.ultimo_evento_fecha > candidatos[0].fecha) {
+    const esAborto = fila.ultimo_aborto_fecha === fila.ultimo_evento_fecha;
     return {
-      estado: 'indeterminado',
+      estado: esAborto ? 'vacia_por_servir' : 'indeterminado',
       fecha_secar: null,
       fecha_probable_parto: null,
+      // `dias_abiertos` cuenta desde el ÚLTIMO PARTO, no desde cualquier fin
+      // de gestación: un aborto no es un parto y no ancla ese contador.
+      // Queda `null` -- nunca un número inventado desde otra fecha.
       dias_abiertos: null,
       tiempo_prenez_dias: null,
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
-      vacia_es_problema: null,
+      // Tras un aborto la vaca está vacía y la pregunta "¿normal o
+      // problema?" sí aplica -- pero sin ancla de tiempo utilizable (ver
+      // arriba) solo puede responderla la señal explícita del chequeo.
+      vacia_es_problema: esAborto
+        ? clasificarVaciaProblema(fila.ultimo_estado_chequeo, null, config)
+        : null,
+      senal_revision: {
+        tipo: esAborto ? 'aborto' : 'evento_posterior',
+        fecha: fila.ultimo_evento_fecha,
+      },
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1937,6 +2019,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
       vacia_es_problema: clasificarVaciaProblema(fila.ultimo_estado_chequeo, diasAbiertos, config),
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1953,7 +2036,8 @@ export function derivarEstadoReproductivo(
     // inventada -- pero el ESTADO real (`seca`/`preñada`) sí se conoce y se
     // devuelve. `tiempo_secada_dias` sí se puede calcular en `seca` porque
     // `ultimo_secado_real_fecha` es un dato real, no una proyección.
-    const estadoSinAncla: EstadoReproductivo = masReciente === 'secado_real' ? 'seca' : 'preñada';
+    const estadoSinAncla: EstadoReproductivo =
+      masReciente === 'secado_real' ? 'seca' : estadoDeConfirmacion(fila);
     const tiempoSecadaDiasSinAncla =
       estadoSinAncla === 'seca' && fila.ultimo_secado_real_fecha
         ? diferenciaDias(fila.ultimo_secado_real_fecha, fechaReferencia)
@@ -1970,6 +2054,7 @@ export function derivarEstadoReproductivo(
       // pregunta "¿normal o problema?" no aplica aquí, igual que en la rama
       // con ancla más abajo.
       vacia_es_problema: null,
+      senal_revision: null,
       // Sin ancla no hay `fecha_secar` que comparar, así que `secado_due` y
       // `parto_proximo` quedan en `false` (SIN_ALERTAS) -- no hay fecha
       // basura contra la que compararlas. `hatoAlertas.ts` además exige
@@ -2004,7 +2089,7 @@ export function derivarEstadoReproductivo(
   } else if (dentroVentanaSecar || secadoDue) {
     estado = 'proxima_a_secar';
   } else if (masReciente === 'confirmacion') {
-    estado = 'preñada';
+    estado = estadoDeConfirmacion(fila);
   } else {
     estado = 'servida';
   }
@@ -2048,6 +2133,7 @@ export function derivarEstadoReproductivo(
     // "servicios repetidos sin concepción" ya lo cubre la alerta
     // `servicio_sin_confirmacion` de arriba, sin necesidad de duplicarlo.
     vacia_es_problema: null,
+    senal_revision: null,
     alertas: {
       secado_due: secadoDue,
       rechequeo_due: rechequeoDue,

--- a/src/supabase/functions/server/hato-alertas-tick.ts
+++ b/src/supabase/functions/server/hato-alertas-tick.ts
@@ -29,21 +29,39 @@
 //                    `.upsert(..., { onConflict: 'regla_clave', ignoreDuplicates: true })`
 //                    -- el `ON CONFLICT ... DO NOTHING` real, PostgREST no
 //                    tiene otra forma de expresarlo.
-//   (b) Despachar -- para cada alerta activa (`pendiente`/`enviada`) cuyo
-//                    `tipo` está `activo` en `hato_alertas_config` Y tiene
-//                    `destinatario_telegram_id` configurado: primer envío
-//                    incondicional si `pendiente`; reenvío solo si
-//                    `debeReenviar(...)` (≥48h desde el último intento,
-//                    <3 intentos) si ya estaba `enviada`. Sin destinatario
-//                    configurado -> se deja `pendiente`, CERO mensajes
-//                    salientes -- este es el default "modo sombra" (el seed
-//                    de 056 no trae ningún destinatario): desplegar este
-//                    endpoint no dispara nada hasta que alguien configure
-//                    `hato_alertas_config` a mano.
+//   (b) Despachar -- BROADCAST (migración 096, 2026-08-14): para cada alerta
+//                    activa (`pendiente`/`enviada`) cuyo `tipo` está `activo`
+//                    en `hato_alertas_config`, se resuelve la lista de
+//                    suscritos con `recibe=true` para esa clave
+//                    (`telegram_alertas_suscripciones`, join
+//                    `telegram_usuarios` activos) y se manda UN mensaje POR
+//                    SUSCRITO -- no una alerta por persona, una sola alerta
+//                    que le llega a todos. Primer envío incondicional si
+//                    `pendiente`; reenvío (a la MISMA lista de suscritos)
+//                    solo si `debeReenviar(...)` (≥48h desde el último
+//                    intento, <3 intentos) si ya estaba `enviada` -- el
+//                    umbral de reenvío sigue siendo por ALERTA, no por
+//                    persona, mismo mecanismo de antes. Sin ningún suscrito
+//                    con `recibe=true` para esa clave -> se deja `pendiente`,
+//                    CERO mensajes salientes (mismo "modo sombra" de antes,
+//                    ahora gobernado por la tabla de suscripciones en vez de
+//                    `hato_alertas_config.destinatario_telegram_id`, que esta
+//                    fase YA NO LEE -- ver migración 096). Cada envío exitoso
+//                    se registra en `hato_alertas_envios` (alerta_id,
+//                    telegram_id, message_id) -- es lo que permite cerrar la
+//                    alerta para TODOS cuando el primero responde (ver
+//                    `telegram/bot.ts`).
 //   (c) Escalar/expirar -- `decidirAccionEscalamiento` sobre las alertas que
 //                    siguen activas tras (b). Telegram no permite
 //                    `editMessageText` pasadas 48h -- el escalamiento SIEMPRE
-//                    manda un mensaje NUEVO (nunca edita el original).
+//                    manda un mensaje NUEVO (nunca edita el original). El
+//                    escalamiento (096) también es broadcast: va a TODOS los
+//                    suscritos con `escalamiento=true` para esa clave, no a
+//                    la variable de entorno `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID`
+//                    (esa variable queda SIN USO por este handler desde
+//                    096 -- no se borra del entorno, ver CLAUDE.md). Sin
+//                    ningún suscrito con `escalamiento=true` -> se marca
+//                    `escalada` sin mandar nada, mismo contrato de antes.
 //
 // Nota de diseño (I/O, no cambia el motor puro): `hato_alertas` (migración
 // 056) no tiene una columna dedicada para "cuándo se envió por primera vez"
@@ -53,25 +71,25 @@
 // umbral de escalamiento sería incorrecto: cada reenvío correría el reloj de
 // escalamiento hacia adelante, retrasándolo exactamente cuando más urge (una
 // alerta que ya se reenvió varias veces sin respuesta). En vez de agregar
-// una columna nueva (fuera del alcance de esta sesión -- "no new migrations
-// needed"), el instante del primer envío se guarda dentro de la columna
-// `datos JSONB` ya existente (`datos.enviada_en`), que SÍ sobrevive
+// una columna nueva, el instante del primer envío se guarda dentro de la
+// columna `datos JSONB` ya existente (`datos.enviada_en`), que SÍ sobrevive
 // intacta a los reenvíos porque este handler nunca la sobreescribe una vez
 // puesta. `updated_at` sigue siendo la fuente correcta para "último intento"
 // (resend policy), porque ese valor SÍ debe correrse con cada intento -- es
 // exactamente lo que esa política mide.
 //
-// Recipiente de escalamiento: `hato_alertas_config` (migración 056) solo
-// declara UN destinatario por tipo -- no hay una columna separada para "a
-// quién escalar" (Martha) vs. "a quién se le manda primero" (Fernando,
-// habilitado por tipo tras el segundo checkpoint de confianza del plan §8).
-// Agregar esa columna sería un cambio de esquema fuera del alcance de esta
-// sesión. Solución sin migración: variable de entorno opcional
-// `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` (secreto de edge function, mismo
-// mecanismo que `HATO_ALERTAS_TICK_SECRET`). Si no está configurada, el
-// contrato explícito del plan aplica ("si no hay destinatario configurado,
-// solo se marca escalada"): se marca `escalada` sin enviar nada. Contar como
-// hallazgo a validar con el dueño -- ver el reporte de la sesión.
+// `hato_alertas.destinatario_telegram_id` (columna singular, existe desde
+// 056) sobrevive con un significado DISTINTO desde 096: ya no es "el único
+// destinatario" (el broadcast no tiene uno), es "a quién se le envió
+// primero" -- este handler la fija UNA sola vez, en el primer envío exitoso,
+// y nunca la vuelve a tocar (ni en reenvíos ni en despachos posteriores a
+// nuevos suscritos). Se conserva en vez de borrarse porque hay historia
+// real detrás (todas las filas hasta hoy la tienen puesta) -- decisión de
+// esta sesión, documentada en el reporte que acompaña la migración 096.
+// `hato_alertas_config.destinatario_telegram_id` (la columna singular de la
+// tabla de CONFIGURACIÓN, no de esta) queda VESTIGIAL desde el mismo cambio
+// -- este handler ya no la lee en absoluto (fase b/c de abajo), aunque la
+// columna sigue en la tabla (096 no la borra).
 //
 // I/O puro en este archivo: parseo/auth, consultas a Supabase, llamadas a
 // Telegram. Toda la lógica de negocio vive en el módulo puro `hatoAlertas.ts`
@@ -84,14 +102,21 @@ import {
   debeReenviar,
   decidirAccionEscalamiento,
   decidirExpiracionTerminal,
+  claveAlertaCatalogo,
+  agruparSuscriptoresPorClave,
   type AnimalHatoParaAlertas,
   type PasoTratamientoPendienteInput,
   type AlertaGenerada,
   type TipoAlertaHato,
   type EstadoAlertaHato,
+  type FilaSuscripcionAlerta,
 } from './hato-alertas.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
 import { enviarMensajeTelegram } from './telegram/enviar.ts';
+
+/** Módulo de este handler dentro de `alertas_catalogo` -- única fuente de
+ * la constante `'hato'` en todo el archivo (migración 096, `clave = modulo.tipo`). */
+const MODULO_ALERTAS = 'hato';
 
 function respuestaError(c: Context, status: 400 | 500 | 503, error: string) {
   return c.json({ success: false, error }, status);
@@ -124,9 +149,35 @@ function verificarSecretoTick(c: Context): Response | null {
 
 interface FilaAlertaConfig {
   tipo: TipoAlertaHato;
-  destinatario_telegram_id: string | null;
   horas_escalamiento: number;
   activo: boolean;
+}
+
+/** Fila cruda de `telegram_alertas_suscripciones` JOIN `telegram_usuarios`
+ * (migración 096) -- el embed de PostgREST puede venir como objeto o como
+ * array de un elemento según la versión del cliente, de ahí el `Array.isArray`
+ * en `resolverFilasSuscripcion`. Solo se listan suscritos ACTIVOS: la
+ * consulta filtra `telegram_usuarios.activo = true`. */
+interface FilaSuscripcionCruda {
+  alerta_clave: string;
+  recibe: boolean;
+  escalamiento: boolean;
+  telegram_usuarios: { telegram_id: number } | { telegram_id: number }[] | null;
+}
+
+function resolverFilasSuscripcion(filas: FilaSuscripcionCruda[]): FilaSuscripcionAlerta[] {
+  return filas
+    .map((f) => {
+      const usuario = Array.isArray(f.telegram_usuarios) ? f.telegram_usuarios[0] : f.telegram_usuarios;
+      if (usuario == null) return null;
+      return {
+        alerta_clave: f.alerta_clave,
+        recibe: f.recibe,
+        escalamiento: f.escalamiento,
+        telegram_id: String(usuario.telegram_id),
+      };
+    })
+    .filter((f): f is FilaSuscripcionAlerta => f !== null);
 }
 
 interface FilaAlertaActiva {
@@ -181,15 +232,33 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
   }
 
-  // --- hato_alertas_config -- destinatario/activo/horas por tipo ------
+  // --- hato_alertas_config -- activo/horas por tipo. Ya NO se lee
+  //     `destinatario_telegram_id` de aquí (096) -- los destinatarios salen
+  //     de `telegram_alertas_suscripciones`, abajo. La columna sigue en la
+  //     tabla (vestigial, ver cabecera del archivo). --------------------
   const { data: filasAlertasConfig, error: errorAlertasConfig } = await supabase
     .from('hato_alertas_config')
-    .select('tipo, destinatario_telegram_id, horas_escalamiento, activo');
+    .select('tipo, horas_escalamiento, activo');
   if (errorAlertasConfig) {
     return respuestaError(c, 500, `No se pudo leer hato_alertas_config: ${errorAlertasConfig.message}`);
   }
   const configPorTipo = new Map<TipoAlertaHato, FilaAlertaConfig>(
     ((filasAlertasConfig ?? []) as FilaAlertaConfig[]).map((f) => [f.tipo, f]),
+  );
+
+  // --- telegram_alertas_suscripciones -- quién recibe / quién escala, por
+  //     clave (`modulo.tipo`, migración 096). Solo suscritos ACTIVOS en
+  //     telegram_usuarios -- uno desactivado no debe recibir ni escalar
+  //     aunque su fila de suscripción siga con recibe/escalamiento=true. ---
+  const { data: filasSuscripcionesCrudas, error: errorSuscripciones } = await supabase
+    .from('telegram_alertas_suscripciones')
+    .select('alerta_clave, recibe, escalamiento, telegram_usuarios!inner(telegram_id, activo)')
+    .eq('telegram_usuarios.activo', true);
+  if (errorSuscripciones) {
+    return respuestaError(c, 500, `No se pudieron leer las suscripciones de alertas: ${errorSuscripciones.message}`);
+  }
+  const suscriptoresPorClave = agruparSuscriptoresPorClave(
+    resolverFilasSuscripcion((filasSuscripcionesCrudas ?? []) as FilaSuscripcionCruda[]),
   );
 
   // =========================================================================
@@ -284,12 +353,23 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
   }
   const activas = (filasActivas ?? []) as FilaAlertaActiva[];
 
-  let enviadas = 0;
+  let enviadas = 0; // # de ALERTAS con al menos un envío exitoso en este tick
+  let mensajesEnviados = 0; // # de mensajes de Telegram individuales enviados (broadcast)
   let saltadasSinDestinatario = 0;
 
   for (const alerta of activas) {
     const config = configPorTipo.get(alerta.tipo);
-    if (!config || !config.activo || !config.destinatario_telegram_id) {
+    if (!config || !config.activo) {
+      saltadasSinDestinatario += 1;
+      continue;
+    }
+
+    // Broadcast (096): TODOS los suscritos con recibe=true para esta clave,
+    // no un único destinatario. `hato_alertas_config.destinatario_telegram_id`
+    // ya no se lee -- ver cabecera del archivo.
+    const clave = claveAlertaCatalogo(MODULO_ALERTAS, alerta.tipo);
+    const destinatarios = suscriptoresPorClave.get(clave)?.recibe ?? [];
+    if (destinatarios.length === 0) {
       saltadasSinDestinatario += 1;
       continue;
     }
@@ -303,28 +383,65 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     if (!debeEnviar) continue;
 
     const mensaje = (alerta.datos?.mensaje as string | undefined) ?? 'Alerta del hato lechero (sin mensaje generado).';
-    const resultado = await enviarMensajeTelegram(supabase, {
-      telegramId: config.destinatario_telegram_id,
-      texto: mensaje,
-      tipoMensaje: 'alerta_hato',
-      flujo: alerta.tipo,
-      botones: [
-        { texto: 'Sí', callbackData: `hato_alerta:${alerta.id}:si` },
-        { texto: 'Todavía no', callbackData: `hato_alerta:${alerta.id}:no` },
-        { texto: 'Otra cosa', callbackData: `hato_alerta:${alerta.id}:otro` },
-      ],
-    });
+    const botones = [
+      { texto: 'Sí', callbackData: `hato_alerta:${alerta.id}:si` },
+      { texto: 'Todavía no', callbackData: `hato_alerta:${alerta.id}:no` },
+      { texto: 'Otra cosa', callbackData: `hato_alerta:${alerta.id}:otro` },
+    ];
 
-    const datosActualizados = resultado.ok && !alerta.datos?.enviada_en
+    // Un envío por suscrito -- un fallo puntual (chat bloqueado, etc.) NO
+    // debe tumbar el envío a los demás suscritos de la misma alerta.
+    let algunEnvioOk = false;
+    let primerDestinatarioOk: string | null = null;
+    const filasEnvios: Array<{ alerta_id: string; telegram_id: string; message_id: number | null; enviado_at: string }> = [];
+
+    for (const telegramId of destinatarios) {
+      const resultado = await enviarMensajeTelegram(supabase, {
+        telegramId,
+        texto: mensaje,
+        tipoMensaje: 'alerta_hato',
+        flujo: alerta.tipo,
+        botones,
+      });
+      if (resultado.ok) {
+        algunEnvioOk = true;
+        mensajesEnviados += 1;
+        if (!primerDestinatarioOk) primerDestinatarioOk = telegramId;
+        // `message_id` es lo que permite editar este mensaje puntual cuando
+        // otro suscrito cierre la alerta (telegram/bot.ts). Un reenvío
+        // pisa la fila anterior de este mismo (alerta, telegram_id) a
+        // propósito -- el mensaje viejo ya pasó los límites de edición de
+        // Telegram (48h), el nuevo es el único editable de aquí en más.
+        filasEnvios.push({
+          alerta_id: alerta.id,
+          telegram_id: telegramId,
+          message_id: resultado.telegramMessageId ?? null,
+          enviado_at: fechaHoraReferencia,
+        });
+      }
+    }
+
+    if (filasEnvios.length > 0) {
+      const { error: errorEnvios } = await supabase
+        .from('hato_alertas_envios')
+        .upsert(filasEnvios, { onConflict: 'alerta_id,telegram_id' });
+      if (errorEnvios) {
+        console.error(`[hato-alertas-tick] no se pudieron registrar los envíos de la alerta ${alerta.id}:`, errorEnvios.message);
+      }
+    }
+
+    const datosActualizados = algunEnvioOk && !alerta.datos?.enviada_en
       ? { ...alerta.datos, enviada_en: fechaHoraReferencia }
       : alerta.datos;
 
     const { error: errorUpdate } = await supabase
       .from('hato_alertas')
       .update({
-        estado: resultado.ok ? 'enviada' : alerta.estado,
+        estado: algunEnvioOk ? 'enviada' : alerta.estado,
         intentos: alerta.intentos + 1,
-        destinatario_telegram_id: config.destinatario_telegram_id,
+        // "A quién se le envió primero" (096) -- se fija UNA sola vez, nunca
+        // se pisa en reenvíos ni en despachos a suscritos nuevos.
+        destinatario_telegram_id: alerta.destinatario_telegram_id ?? primerDestinatarioOk,
         datos: datosActualizados,
       })
       .eq('id', alerta.id);
@@ -335,22 +452,27 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
 
     // Reflejar el cambio en memoria para que la fase (c) vea el estado
     // post-despacho sin una segunda consulta a la base.
-    alerta.estado = resultado.ok ? 'enviada' : alerta.estado;
+    alerta.estado = algunEnvioOk ? 'enviada' : alerta.estado;
     alerta.intentos += 1;
     alerta.datos = datosActualizados;
     alerta.updated_at = fechaHoraReferencia;
+    alerta.destinatario_telegram_id = alerta.destinatario_telegram_id ?? primerDestinatarioOk;
 
-    if (resultado.ok) enviadas += 1;
+    if (algunEnvioOk) enviadas += 1;
   }
 
   // =========================================================================
   // (c) ESCALAR / EXPIRAR
   // =========================================================================
 
-  const telegramIdEscalamiento = Deno.env.get('HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID') || null;
+  // `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` YA NO SE LEE -- desde 096 el
+  // escalamiento es broadcast a los suscritos con escalamiento=true de cada
+  // clave (ver cabecera del archivo). La variable de entorno queda sin uso
+  // en este handler; no se borra del entorno por si algo más la necesitara.
 
   let escaladas = 0;
   let expiradas = 0;
+  let mensajesEscalamiento = 0;
 
   for (const alerta of activas) {
     const config = configPorTipo.get(alerta.tipo);
@@ -380,16 +502,26 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     }
 
     // accion === 'escalar' -- Telegram no permite editar un mensaje pasadas
-    // 48h: se manda uno NUEVO, nunca se edita el original.
-    if (telegramIdEscalamiento) {
+    // 48h: se manda uno NUEVO, nunca se edita el original. Broadcast (096):
+    // a TODOS los suscritos con escalamiento=true para esta clave, no a un
+    // único destinatario de la variable de entorno.
+    const claveEscalamiento = claveAlertaCatalogo(MODULO_ALERTAS, alerta.tipo);
+    const destinatariosEscalamiento = suscriptoresPorClave.get(claveEscalamiento)?.escalamiento ?? [];
+    if (destinatariosEscalamiento.length > 0) {
       const mensajeBase = (alerta.datos?.mensaje as string | undefined) ?? 'Alerta del hato lechero (sin mensaje generado).';
-      await enviarMensajeTelegram(supabase, {
-        telegramId: telegramIdEscalamiento,
-        texto: `⏰ Sin respuesta hace más de ${horasEscalamiento}h -- ${mensajeBase}`,
-        tipoMensaje: 'alerta_hato_escalamiento',
-        flujo: alerta.tipo,
-      });
+      for (const telegramId of destinatariosEscalamiento) {
+        const resultado = await enviarMensajeTelegram(supabase, {
+          telegramId,
+          texto: `⏰ Sin respuesta hace más de ${horasEscalamiento}h -- ${mensajeBase}`,
+          tipoMensaje: 'alerta_hato_escalamiento',
+          flujo: alerta.tipo,
+        });
+        if (resultado.ok) mensajesEscalamiento += 1;
+      }
     }
+    // Sin ningún suscrito con escalamiento=true -- se marca `escalada` sin
+    // mandar nada, mismo contrato de antes (antes: sin la variable de
+    // entorno configurada).
     const { error } = await supabase
       .from('hato_alertas')
       .update({ estado: 'escalada', escalada_at: fechaHoraReferencia })
@@ -438,9 +570,11 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     success: true,
     fechaReferencia,
     generadas: alertasNuevas.length,
-    enviadas,
+    enviadas, // # de alertas con al menos un envío exitoso
+    mensajes_enviados: mensajesEnviados, // # de mensajes de Telegram individuales (broadcast, 096)
     saltadas_sin_destinatario: saltadasSinDestinatario,
     escaladas,
+    mensajes_escalamiento: mensajesEscalamiento,
     expiradas: expiradas + expiradasAtascadas,
     expiradas_atascadas: expiradasAtascadas,
   });

--- a/src/supabase/functions/server/hato-alertas-tick.ts
+++ b/src/supabase/functions/server/hato-alertas-tick.ts
@@ -199,7 +199,7 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
   const { data: filasEstado, error: errorEstado } = await supabase
     .from('v_hato_estado_actual')
     .select(
-      'animal_id, numero, nombre, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultimo_estado_chequeo',
+      'animal_id, numero, nombre, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultimo_estado_chequeo, ultima_confirmacion_prenez_metodo, ultimo_aborto_fecha',
     );
   if (errorEstado) {
     return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${errorEstado.message}`);

--- a/src/supabase/functions/server/hato-alertas.ts
+++ b/src/supabase/functions/server/hato-alertas.ts
@@ -533,3 +533,136 @@ export function decidirExpiracionTerminal(
   const ancla = alerta.escalada_at ?? alerta.updated_at;
   return diferenciaDiasIso(ancla, fechaHoraReferencia) > diasUmbral;
 }
+
+// ============================================================================
+// BLOQUE 8 — Suscripciones por usuario de Telegram (migración 096, plan
+// "Suscripciones a alertas por usuario de Telegram", 2026-08-14)
+//
+// Decisión del dueño (contrato, ver migración 096): BROADCAST con cierre por
+// el primero -- una alerta se manda a TODOS los suscritos de su tipo, y la
+// primera respuesta la cierra para todos. El escalamiento es una segunda
+// casilla POR TIPO y por persona (`telegram_alertas_suscripciones.escalamiento`)
+// -- la variable de entorno `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` deja de
+// ser la fuente de verdad (`hato-alertas-tick.ts` ya no la lee).
+//
+// Este bloque es deliberadamente GENÉRICO por módulo (`alertas_catalogo`
+// sirve a cualquiera, no solo al hato) -- `claveAlertaCatalogo`/
+// `agruparSuscriptoresPorClave` no importan nada de `calculosHato` ni saben
+// qué es una vaca. Los constructores de mensaje de "ya resuelta"/"cerrada
+// para todos" SÍ son específicos del hato porque forman parte del texto que
+// ve Fernando/Martha en el chat -- si mañana `aguacate`/`ganado` tienen su
+// propio motor de alertas, ese motor tendrá sus propios constructores de
+// mensaje (mismo criterio que ya separa `hato_alertas` de un futuro
+// `aguacate_alertas`).
+// ============================================================================
+
+/**
+ * Clave de `alertas_catalogo` para un tipo de alerta de un módulo dado
+ * (`modulo.tipo`, migración 096). Único punto que arma esa concatenación --
+ * tanto el tick (resolver destinatarios/escalamiento) como cualquier código
+ * futuro que necesite la misma clave la calculan aquí, nunca con un
+ * template string suelto en otro archivo.
+ */
+export function claveAlertaCatalogo(modulo: string, tipo: string): string {
+  return `${modulo}.${tipo}`;
+}
+
+/** Fila mínima de `telegram_alertas_suscripciones` JOIN `telegram_usuarios`
+ * que este motor necesita -- el caller (tick) ya resolvió `telegram_id`
+ * desde el embed y ya filtró `telegram_usuarios.activo = true` en la
+ * consulta (un suscrito desactivado no debe recibir ni escalar). */
+export interface FilaSuscripcionAlerta {
+  alerta_clave: string;
+  recibe: boolean;
+  escalamiento: boolean;
+  /** `telegram_usuarios.telegram_id`, como string -- mismo motivo que
+   * `OpcionesEnvioTelegram.telegramId` en `telegram/enviar.ts` (no arriesgar
+   * precisión de un `bigint` al pasar por un `number` de JS). */
+  telegram_id: string;
+}
+
+/** Destinatarios de un tipo de alerta, ya separados por las dos casillas. Un
+ * mismo `telegram_id` puede aparecer en ambas listas (recibe Y escala) o
+ * solo en una. */
+export interface SuscriptoresPorClave {
+  recibe: string[];
+  escalamiento: string[];
+}
+
+/**
+ * Agrupa las filas de suscripción (ya resueltas a `telegram_id`, JOIN hecho
+ * por el caller) por `alerta_clave`, separando quién recibe el envío normal
+ * de quién recibe el escalamiento. Pura -- ninguna llamada a Supabase ni a
+ * Telegram aquí, eso vive en `hato-alertas-tick.ts` (I/O).
+ */
+export function agruparSuscriptoresPorClave(filas: FilaSuscripcionAlerta[]): Map<string, SuscriptoresPorClave> {
+  const mapa = new Map<string, SuscriptoresPorClave>();
+  for (const fila of filas) {
+    let entrada = mapa.get(fila.alerta_clave);
+    if (!entrada) {
+      entrada = { recibe: [], escalamiento: [] };
+      mapa.set(fila.alerta_clave, entrada);
+    }
+    if (fila.recibe) entrada.recibe.push(fila.telegram_id);
+    if (fila.escalamiento) entrada.escalamiento.push(fila.telegram_id);
+  }
+  return mapa;
+}
+
+// ----------------------------------------------------------------------------
+// Mensajes de cierre (callback `hato_alerta:{id}:{si|no|otro}` en
+// `telegram/bot.ts`) -- broadcast con cierre por el primero.
+// ----------------------------------------------------------------------------
+
+/** Texto corto de cada respuesta posible, para componer los mensajes de
+ * cierre -- una sola definición, reutilizada por los dos constructores de
+ * abajo (antes había un riesgo real de que "Todavía no" se escribiera
+ * distinto en dos lugares). */
+export function etiquetaRespuestaAlerta(respuesta: 'si' | 'no' | 'otro'): string {
+  switch (respuesta) {
+    case 'si':
+      return 'Sí';
+    case 'no':
+      return 'Todavía no';
+    case 'otro':
+      return 'Otra cosa';
+    default: {
+      const _exhaustivo: never = respuesta;
+      return _exhaustivo;
+    }
+  }
+}
+
+/**
+ * Mensaje que reemplaza el de un suscrito que llega TARDE a responder una
+ * alerta que otro suscrito ya cerró (broadcast, cierre por el primero) --
+ * tanto para el popup de `answerCallbackQuery` de quien toca el botón dos
+ * veces como para editar el mensaje de los demás suscritos cuando alguno de
+ * ellos SÍ fue el primero. "Amablemente", no un error -- es el
+ * comportamiento esperado del diseño, no una falla.
+ */
+export function construirMensajeAlertaYaResuelta(
+  estado: EstadoAlertaHato,
+  respondidaPor: string | null,
+  respuesta: 'si' | 'no' | 'otro' | null,
+): string {
+  if (respondidaPor && respuesta) {
+    return `Esta alerta ya fue resuelta por ${respondidaPor} (respuesta: "${etiquetaRespuestaAlerta(respuesta)}"). No quedó nada más por hacer.`;
+  }
+  return `Esta alerta ya no está activa (estado: ${estado}).`;
+}
+
+/**
+ * Texto con el que se edita el mensaje de CADA suscrito al que se le envió
+ * la alerta (vía `hato_alertas_envios.message_id`), una vez que uno de ellos
+ * la cierra -- así todos ven que ya se resolvió y por quién, sin tener que
+ * abrir la app. `mensajeOriginal` es el mismo texto que ya recibieron (se
+ * conserva, no se reemplaza, para no perder el contexto de la alerta).
+ */
+export function construirMensajeCierreAlertaBroadcast(
+  mensajeOriginal: string,
+  respondidaPor: string,
+  respuesta: 'si' | 'no' | 'otro',
+): string {
+  return `✅ Resuelto por ${respondidaPor}: "${etiquetaRespuestaAlerta(respuesta)}"\n\n${mensajeOriginal}`;
+}

--- a/src/supabase/functions/server/hato-chequeo-commit.ts
+++ b/src/supabase/functions/server/hato-chequeo-commit.ts
@@ -50,6 +50,8 @@ import {
   construirPayloadCommit,
   seleccionarUltimaCriaAnteriorPorAnimal,
   seleccionarFechasServicioConocidasPorAnimal,
+  fusionarEventosManualesEnDedupe,
+  type EventoManualHistorico,
   type FilaUltimaCriaHistorico,
 } from './importHato/commitChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
@@ -283,7 +285,39 @@ export async function handleHatoChequeoCommit(c: Context): Promise<Response> {
   // trae `fechaServicio` por fila (ver `FilaChequeoVacaHistorico`), sin una
   // consulta adicional. Ver `derivarEventosDeChequeo`/`descomponerSX` para el
   // bug real que corrige (CAMILA #154).
-  const fechasServicioConocidasPorAnimal = seleccionarFechasServicioConocidasPorAnimal(historico, chequeo.fecha);
+  const fechasServicioBase = seleccionarFechasServicioConocidasPorAnimal(historico, chequeo.fecha);
+
+  // N10 -- Eventos registrados A MANO (`chequeo_vaca_id IS NULL`): la monta
+  // que Fernando marcó por Telegram el 10, el parto que Martha marcó en la
+  // Hoja de Vida. NO están en `hato_chequeo_vacas`, así que sin esta consulta
+  // los dos mapas de deduplicación de arriba no los ven y el chequeo emite un
+  // SEGUNDO evento para el mismo hecho -- la forma exacta del bug que costó
+  // tres rondas de limpieza en julio de 2026.
+  let eventosManuales: EventoManualHistorico[] = [];
+  if (animalIds.length > 0) {
+    const { data, error } = await supabase
+      .from('hato_eventos')
+      .select('animal_id, tipo, fecha')
+      .in('animal_id', animalIds)
+      .in('tipo', ['servicio', 'parto'])
+      .is('chequeo_vaca_id', null)
+      .lt('fecha', chequeo.fecha);
+    if (error) return respuestaError(c, 500, { error: `No se pudo leer hato_eventos: ${error.message}` });
+    eventosManuales = (data ?? []).map((fila: Record<string, unknown>) => ({
+      animalId: fila.animal_id as string,
+      tipo: fila.tipo as string,
+      fecha: fila.fecha as string,
+    }));
+  }
+
+  const fusionado = fusionarEventosManualesEnDedupe(
+    fechasServicioBase,
+    ultimaCriaAnteriorPorAnimal,
+    eventosManuales,
+    chequeo.fecha,
+  );
+  const fechasServicioConocidasPorAnimal = fusionado.fechasServicioPorAnimal;
+  const ultimaCriaAnteriorFusionada = fusionado.ultimaCriaAnteriorPorAnimal;
 
   // --- 4. Revalidar el ALCANCE contra el diff fresco --------------------
   const { aceptadas, rechazadas } = validarFilasCommit(filas, diffFresco);
@@ -296,7 +330,7 @@ export async function handleHatoChequeoCommit(c: Context): Promise<Response> {
 
   // --- 5. Derivar eventos + resolver toro_id (I/O: SELECT-o-INSERT) ----
   const vacas = construirFilasVacas(aceptadas);
-  const { eventos } = derivarEventosDeChequeo(aceptadas, ultimaCriaAnteriorPorAnimal, fechasServicioConocidasPorAnimal);
+  const { eventos } = derivarEventosDeChequeo(aceptadas, ultimaCriaAnteriorFusionada, fechasServicioConocidasPorAnimal);
 
   const nombresToro = [...new Set(eventos.map((e) => e.toro_nombre).filter((n): n is string => !!n && n.trim() !== ''))];
   const toroCache = new Map<string, string>();

--- a/src/supabase/functions/server/hato-chequeo-preview.ts
+++ b/src/supabase/functions/server/hato-chequeo-preview.ts
@@ -28,10 +28,12 @@ import { normalizarHojas } from './importHato/normalizar.ts';
 import { construirDiffChequeo, seleccionarUltimoChequeoPorAnimal } from './importHato/diffChequeo.ts';
 import type {
   AnimalHatoActual,
+  AnimalEstadoRegistradoActual,
   FilaChequeoVacaHistorico,
 } from './importHato/diffChequeo.ts';
 import type { HojaCruda } from './importHato/tipos.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { derivarEstadoReproductivo, etiquetaEstadoReproductivo, type EstadoActualHatoRow } from './calculos-hato.ts';
 
 const TAMANO_MAXIMO_BYTES = 20 * 1024 * 1024; // 20 MB -- una planilla real pesa unos pocos cientos de KB.
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053).
@@ -235,8 +237,40 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
     });
   }
 
+  // --- 4b. "Estado registrado" (D-E, N21/N23): lo que el motor de 5 estados
+  // cree AHORA para cada animal de la hoja -- recalculado en este mismo
+  // momento contra `v_hato_estado_actual` (que fusiona TODO `hato_eventos`
+  // sin importar `chequeo_vaca_id`, incluidos los eventos manuales de
+  // Telegram), nunca cacheado desde cuando se imprimió la planilla. Es la
+  // pieza que permite al diff marcar el conflicto explícito "registrado vs.
+  // papel" (docs/plan_hato_telegram_estados_agosto_2026.md §3 Capa 5).
+  let estadosRegistrados: AnimalEstadoRegistradoActual[] = [];
+  if (animalIds.length > 0) {
+    const { data, error } = await supabase
+      .from('v_hato_estado_actual')
+      .select(
+        'animal_id, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultima_confirmacion_prenez_metodo, ultimo_aborto_fecha, ultimo_estado_chequeo',
+      )
+      .in('animal_id', animalIds);
+    if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
+    // Mismo criterio de "hoy" que `hato-alertas-tick.ts` (UTC) -- las edge
+    // functions quedan deliberadamente fuera del arreglo de "hoy en hora
+    // local" (CLAUDE.md, "Hoy siempre se toma en hora LOCAL"): un desfase de
+    // un día en esta comparación de referencia no cambia la CLASIFICACIÓN
+    // reproductiva de una vaca de un día para otro salvo en el borde exacto
+    // de un umbral, y el conflicto que esto detecta ya es de días/semanas.
+    const hoy = new Date().toISOString().slice(0, 10);
+    estadosRegistrados = (data ?? []).map((fila: Record<string, unknown>) => {
+      const derivado = derivarEstadoReproductivo(fila as unknown as EstadoActualHatoRow, config, hoy);
+      return {
+        animalId: fila.animal_id as string,
+        estado: etiquetaEstadoReproductivo(derivado.estado),
+      };
+    });
+  }
+
   const ultimosChequeos = seleccionarUltimoChequeoPorAnimal(historico);
-  const diffChequeos = construirDiffChequeo(salida.chequeos, animales, ultimosChequeos);
+  const diffChequeos = construirDiffChequeo(salida.chequeos, animales, ultimosChequeos, estadosRegistrados);
 
   // Fecha del chequeo, para precargar el campo `chequeo.fecha` del commit
   // (`POST .../hato/chequeo/commit`, `hato-chequeo-commit.ts`) sin que el

--- a/src/supabase/functions/server/hato-pesaje-commit.ts
+++ b/src/supabase/functions/server/hato-pesaje-commit.ts
@@ -2,57 +2,41 @@
 // /make-server-1ccce916/hato/pesaje/commit`.
 //
 // El paso "Aprobar" que sigue al diff de `hato-pesaje-foto.ts` (ese endpoint
-// NUNCA comete un INSERT/UPDATE). Este SÍ escribe -- es el único camino de
-// escritura del commit de un pesaje por foto.
+// NUNCA comete un INSERT/UPDATE). Este SÍ escribe -- es uno de los dos
+// caminos de escritura del commit de un pesaje por foto (el otro es el bot
+// de Telegram, `telegram/conversations/pesajeLeche.ts`, N13 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md`, que llama a la MISMA
+// función de orquestación).
 //
 // Contrato: el cliente manda las CELDAS que quiere guardar (`celdas`, la
 // forma `CeldaDiffPesaje` que devolvió el preview -- posiblemente con
 // `litrosAm`/`litrosPm` CORREGIDOS a mano, D-6). Nunca reenvía la foto ni
 // pide que se vuelva a leer.
 //
-// REVALIDACIÓN CONTRA EL ESTADO FRESCO (mismo espíritu que
-// `hato-chequeo-commit.ts`, adaptado a que acá cada celda es un HECHO
-// INDEPENDIENTE, no partes de un mismo evento):
-//   - `animal_id` debe seguir siendo una vaca en ordeño ACTIVA en este
-//     instante -- si se vendió/murió entre la vista previa y la aprobación,
-//     esa celda se rechaza, nunca se escribe contra una identidad caducada.
-//   - `fecha` debe seguir siendo una ocurrencia real de
-//     `hato_config.dia_pesaje_semanal` para (anio, mes) -- si el ajuste
-//     cambió entre tanto, esa celda se rechaza en vez de escribir una fecha
-//     que ya no es la que la planilla impresa mostraba.
-//   - El `existenteId` (UPDATE vs INSERT) se RE-DERIVA de una consulta
-//     fresca a `hato_pesajes_leche` -- nunca se confía en el id que trae el
-//     cliente, que pudo quedar viejo si alguien más guardó ese mismo
-//     (vaca, fecha) mientras tanto.
+// REVALIDACIÓN CONTRA EL ESTADO FRESCO + escritura UPDATE-por-id/INSERT:
+// toda esa orquestación vive en `./hato-pesaje-pipeline.ts`
+// (`ejecutarCommitPesaje`), extraída para que el bot de Telegram reuse
+// EXACTAMENTE la misma revalidación (N13 del plan: "Reusa la revalidación
+// que ya existe en `hato-pesaje-commit.ts`") sin cambiar el comportamiento
+// observable de este endpoint. Este archivo queda como I/O puro: auth,
+// parseo/forma del body, y traducción del resultado a una respuesta HTTP.
 //
 // A DIFERENCIA del commit de chequeo (una sola RPC, todo o nada: un chequeo
 // es UN evento con varias filas relacionadas), acá cada celda es un hecho
 // independiente (`UNIQUE(animal_id, fecha)`, sin relación entre vacas ni
-// entre semanas) -- así que una celda inválida NO aborta las demás: se
-// escriben las que validan y se reportan las que no, para que una vaca
-// vendida entre medias no le cueste a Martha los otros 67 pesajes.
+// entre semanas) -- así que una celda inválida NO aborta las demás.
 //
-// Escritura vía UPDATE-por-id + INSERT (nunca upsert de PostgREST -- mismo
-// patrón que `useProduccionHato.guardarPesajes`, el camino de escritura
-// manual del grid semanal). `fuente: 'foto'` distingue esta vía de `'web'`
-// (grid manual) y `'telegram'`. `created_by` se setea EXPLÍCITO desde la
-// sesión verificada -- `hato_pesajes_leche` no tiene trigger de
-// `created_by` (a diferencia de `tareas`/`fin_gastos`/…, migraciones
-// 040/050/063/074) y este handler escribe con la service role
-// (`auth.uid()` sería NULL), así que sin esto la autoría se perdería.
-//
-// I/O puro en este archivo. Toda la lógica de clasificación/armado vive en
-// `./importHato/ocrPesaje.ts` (copia GENERADA, ver
-// docs/hato/regenerar-copias-importhato.py).
+// `fuente: 'foto'` distingue esta vía de `'web'` (grid manual) y
+// `'telegram'` (bot). `created_by` se setea EXPLÍCITO desde la sesión
+// verificada -- `hato_pesajes_leche` no tiene trigger de `created_by` (a
+// diferencia de `tareas`/`fin_gastos`/…, migraciones 040/050/063/074) y
+// este handler escribe con la service role (`auth.uid()` sería NULL), así
+// que sin esto la autoría se perdería.
 
 import { Context } from 'npm:hono';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
-import { fechasPesajeMensuales } from './calculos-hato.ts';
-import {
-  esCandidataRosterPesaje,
-  ETAPAS_ROSTER_PESAJE,
-  type CeldaDiffPesaje,
-} from './importHato/ocrPesaje.ts';
+import { ejecutarCommitPesaje, type CeldaCommitPesajeEntrada } from './hato-pesaje-pipeline.ts';
+import type { CeldaDiffPesaje } from './importHato/ocrPesaje.ts';
 
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053).
 
@@ -96,20 +80,13 @@ async function verificarAcceso(
 // Body esperado -- solo lo que el handler necesita para escribir; el resto
 // de `CeldaDiffPesaje` (nombre, clasificación) se ignora, nunca se confía.
 // ---------------------------------------------------------------------------
-interface CeldaCommitPesaje {
-  animalId: string;
-  fecha: string;
-  litrosAm: number | null;
-  litrosPm: number | null;
-}
-
 interface BodyCommitPesaje {
   anio?: number;
   mes?: number;
   celdas?: Array<Partial<CeldaDiffPesaje>>;
 }
 
-function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaCommitPesaje[] } | { error: string } {
+function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaCommitPesajeEntrada[] } | { error: string } {
   if (typeof body !== 'object' || body === null) {
     return { error: 'El cuerpo de la solicitud debe ser un objeto JSON.' };
   }
@@ -125,7 +102,7 @@ function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaC
     return { error: "'celdas' debe ser un arreglo no vacío -- no hay nada que aprobar." };
   }
 
-  const celdas: CeldaCommitPesaje[] = [];
+  const celdas: CeldaCommitPesajeEntrada[] = [];
   for (const c of b.celdas) {
     if (typeof c !== 'object' || c === null || typeof c.animalId !== 'string' || typeof c.fecha !== 'string') {
       return { error: 'Cada celda debe traer animalId (string) y fecha (AAAA-MM-DD).' };
@@ -144,12 +121,6 @@ function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaC
   }
 
   return { anio: b.anio as number, mes: b.mes as number, celdas };
-}
-
-interface CeldaRechazada {
-  animalId: string;
-  fecha: string;
-  motivo: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -175,121 +146,28 @@ export async function handleHatoPesajeCommit(c: Context): Promise<Response> {
   if ('error' in validado) return respuestaError(c, 400, { error: validado.error });
   const { anio, mes, celdas } = validado;
 
-  // --- 2. hato_config.dia_pesaje_semanal FRESCO -- recomputa las fechas
-  //    válidas para (anio, mes) EN ESTE INSTANTE, nunca las que vio el
-  //    cliente en la vista previa. --------------------------------------
-  const { data: configData, error: configError } = await supabase
-    .from('hato_config')
-    .select('valor')
-    .eq('clave', 'dia_pesaje_semanal')
-    .maybeSingle();
-  if (configError) return respuestaError(c, 500, { error: `No se pudo leer hato_config: ${configError.message}` });
-  const configValor = configData?.valor as { iso?: unknown } | undefined;
-  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
-    return respuestaError(c, 500, {
-      error: 'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064).',
-    });
-  }
-  const fechasValidasHoy = new Set(fechasPesajeMensuales(anio, mes, configValor.iso as number));
+  // --- 2. Revalidación + escritura, compartida con el bot (N13) -------------
+  const resultado = await ejecutarCommitPesaje({
+    supabase,
+    anio,
+    mes,
+    celdas,
+    createdBy: acceso.userId,
+    fuente: 'foto',
+  });
 
-  // --- 3. Roster FRESCO -- mismo criterio que imprimió la planilla y que usó
-  //    el OCR (`esCandidataRosterPesaje`), nunca uno propio: si acá fuera más
-  //    estrecho, los litros de una fila que Martha vio y aprobó se perderían
-  //    en silencio. Es también lo que acota el "agregar vaca" manual de la
-  //    grilla de revisión: se puede añadir cualquiera del roster, y nada más.
-  const animalIds = [...new Set(celdas.map((c) => c.animalId))];
-  const { data: animalesData, error: animalesError } = await supabase
-    .from('hato_animales')
-    .select('id, etapa, estado')
-    .in('id', animalIds)
-    .in('etapa', ETAPAS_ROSTER_PESAJE);
-  if (animalesError) {
-    return respuestaError(c, 500, { error: `No se pudo leer hato_animales: ${animalesError.message}` });
-  }
-  const activasAhora = new Set(
-    ((animalesData ?? []) as Array<{ id: string; etapa: string | null; estado: string | null }>)
-      .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
-      .map((a) => a.id),
-  );
-
-  // --- 4. Filtrar: solo celdas cuya vaca sigue activa y cuya fecha sigue
-  //    siendo una ocurrencia real del día de pesaje configurado. Cada celda
-  //    es un hecho independiente -- una inválida no bota a las demás. -----
-  const aceptadas: CeldaCommitPesaje[] = [];
-  const rechazadas: CeldaRechazada[] = [];
-  for (const celda of celdas) {
-    if (!activasAhora.has(celda.animalId)) {
-      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'El animal ya no está en el roster de la planilla -- puede haberse vendido o cambiado de etapa desde la vista previa.' });
-      continue;
+  if (!resultado.ok) {
+    if (resultado.status === 400) {
+      return respuestaError(c, 400, { error: resultado.error, celdasRechazadas: resultado.celdasRechazadas });
     }
-    if (!fechasValidasHoy.has(celda.fecha)) {
-      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'Esa fecha ya no corresponde a una semana de pesaje configurada para este mes.' });
-      continue;
-    }
-    aceptadas.push(celda);
-  }
-
-  if (aceptadas.length === 0) {
-    return respuestaError(c, 400, {
-      error: 'Ninguna celda pasó la revalidación -- el hato cambió desde la vista previa. No se escribió nada.',
-      celdasRechazadas: rechazadas,
-    });
-  }
-
-  // --- 5. Existentes FRESCOS -- decide UPDATE-por-id vs INSERT; nunca se
-  //    confía en el `existenteId` que trajo el cliente. -------------------
-  const fechasEnLote = [...new Set(aceptadas.map((c) => c.fecha))];
-  const { data: existentesData, error: existentesError } = await supabase
-    .from('hato_pesajes_leche')
-    .select('id, animal_id, fecha')
-    .in('animal_id', [...new Set(aceptadas.map((c) => c.animalId))])
-    .in('fecha', fechasEnLote);
-  if (existentesError) return respuestaError(c, 500, { error: `No se pudo leer hato_pesajes_leche: ${existentesError.message}` });
-  const idExistentePorClave = new Map<string, string>();
-  for (const fila of (existentesData ?? []) as Array<{ id: string; animal_id: string; fecha: string }>) {
-    idExistentePorClave.set(`${fila.animal_id}|${fila.fecha}`, fila.id);
-  }
-
-  // --- 6. Escritura: UPDATE-por-id + INSERT, nunca upsert de PostgREST
-  //    (mismo patrón que `useProduccionHato.guardarPesajes`). -------------
-  let actualizados = 0;
-  let creados = 0;
-  const nuevasFilas: Array<{ animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number; fuente: string; created_by: string }> = [];
-
-  for (const celda of aceptadas) {
-    const total = (celda.litrosAm ?? 0) + (celda.litrosPm ?? 0);
-    const existenteId = idExistentePorClave.get(`${celda.animalId}|${celda.fecha}`);
-    if (existenteId) {
-      const { error } = await supabase
-        .from('hato_pesajes_leche')
-        .update({ litros_am: celda.litrosAm, litros_pm: celda.litrosPm, litros_total: total, fuente: 'foto' })
-        .eq('id', existenteId);
-      if (error) return respuestaError(c, 500, { error: `No se pudo actualizar el pesaje de '${celda.animalId}' en ${celda.fecha}: ${error.message}` });
-      actualizados += 1;
-    } else {
-      nuevasFilas.push({
-        animal_id: celda.animalId,
-        fecha: celda.fecha,
-        litros_am: celda.litrosAm,
-        litros_pm: celda.litrosPm,
-        litros_total: total,
-        fuente: 'foto',
-        created_by: acceso.userId,
-      });
-    }
-  }
-
-  if (nuevasFilas.length > 0) {
-    const { error } = await supabase.from('hato_pesajes_leche').insert(nuevasFilas);
-    if (error) return respuestaError(c, 500, { error: `No se pudieron insertar los pesajes nuevos: ${error.message}` });
-    creados = nuevasFilas.length;
+    return respuestaError(c, 500, { error: resultado.error });
   }
 
   return c.json({
     success: true,
-    guardados: actualizados + creados,
-    actualizados,
-    creados,
-    celdasRechazadas: rechazadas,
+    guardados: resultado.guardados,
+    actualizados: resultado.actualizados,
+    creados: resultado.creados,
+    celdasRechazadas: resultado.celdasRechazadas,
   });
 }

--- a/src/supabase/functions/server/hato-pesaje-foto.ts
+++ b/src/supabase/functions/server/hato-pesaje-foto.ts
@@ -26,62 +26,32 @@
 // negocio. Los litros se interpretan con `parseValorNumerico`
 // (`calculos-hato.ts`), nunca un segundo parser numérico.
 //
-// I/O puro en este archivo: multipart, Storage, la llamada HTTP a
-// OpenRouter y las consultas a Supabase. Toda la lógica (roster, cotejo del
-// ancla, diff contra lo ya guardado, prompt y esquema) vive en el módulo
-// puro `./importHato/ocrPesaje.ts` (copia GENERADA de
-// `src/utils/importHato/ocrPesaje.ts`, ver
-// docs/hato/regenerar-copias-importhato.py) y está cubierta por Vitest.
+// I/O puro en este archivo: multipart y la traducción del resultado del
+// pipeline a una respuesta HTTP. TODA la orquestación (Storage, modelo de
+// visión, roster, diff) vive en `./hato-pesaje-pipeline.ts`
+// (`ejecutarPipelinePesajeFoto`, N11 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md`) -- extraída para que el
+// bot de Telegram (`telegram/conversations/pesajeLeche.ts`) use EXACTAMENTE
+// el mismo pipeline, sin cambiar el comportamiento observable de este
+// endpoint. La lógica pura (roster, cotejo del ancla, diff, prompt y
+// esquema) vive en `./importHato/ocrPesaje.ts` (copia GENERADA de
+// `src/utils/importHato/ocrPesaje.ts`) y está cubierta por Vitest.
 //
-// NUNCA escribe en tablas de dominio. Sí guarda las fotos en Storage: la
-// foto ES la capa cruda de esta ruta -- el equivalente del `*_raw` del
-// chequeo.
+// NUNCA escribe en tablas de dominio. Sí guarda las fotos en Storage (dentro
+// del pipeline): la foto ES la capa cruda de esta ruta -- el equivalente del
+// `*_raw` del chequeo.
 
 import { Context } from 'npm:hono';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
-import { fechasPesajeMensuales } from './calculos-hato.ts';
 import {
-  construirDiffPesaje,
-  construirPromptOcrPesaje,
-  construirRosterPesaje,
-  esCandidataRosterPesaje,
-  esquemaJsonOcrPesaje,
-  ETAPAS_ROSTER_PESAJE,
-  parsearRespuestaModeloOcrPesaje,
-  procesarLecturaOcrPesaje,
-  SEMANAS_PESAJE,
-  type AnimalRosterPesaje,
-  type LecturaOcrPesajePagina,
-  type PesajeExistente,
-  type SemanaPesaje,
-} from './importHato/ocrPesaje.ts';
+  ejecutarPipelinePesajeFoto,
+  MAXIMO_FOTOS_PESAJE,
+  TAMANO_MAXIMO_FOTO_PESAJE_BYTES,
+  TIPOS_ACEPTADOS_FOTO_PESAJE,
+  type FotoPesajeEntrada,
+} from './hato-pesaje-pipeline.ts';
 
-// --- Límites de entrada -----------------------------------------------------
-// El hato tiene 68 vacas activas (2026-08-06); a 16 columnas por fila, la
-// planilla real ocupa varias páginas (ver `exportarPlanillaPesajePDF.ts`,
-// 4 páginas medidas). Mismos límites que `hato-chequeo-foto.ts`.
-const MAXIMO_FOTOS = 6;
-const TAMANO_MAXIMO_FOTO_BYTES = 15 * 1024 * 1024;
-const TIPOS_ACEPTADOS = new Set([
-  'image/jpeg',
-  'image/jpg',
-  'image/png',
-  'image/webp',
-  'image/heic',
-  'image/heif',
-]);
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo set de escritura del módulo (053), igual que chequeo/foto.
-
-// --- Modelo de visión -------------------------------------------------------
-const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const MODELO_VISION = 'google/gemini-3-flash-preview';
-const TIMEOUT_MODELO_MS = 120_000;
-
-// --- Storage ----------------------------------------------------------------
-// Bucket privado propio (migración 086 -- patrón 072/085: RLS on, políticas
-// explícitas Administrador+Gerencia, DELETE Gerencia-only). Nunca se mezcla
-// con `chequeos-fotos` (otro dominio) ni con `hato-liquidaciones-fotos`.
-const BUCKET_FOTOS = 'hato-pesajes-fotos';
 
 function respuestaError(c: Context, status: 400 | 401 | 403 | 500 | 502 | 503, error: string) {
   return c.json({ success: false, error }, status);
@@ -122,125 +92,6 @@ async function verificarAcceso(
   }
 
   return { userId: userData.user.id };
-}
-
-// ---------------------------------------------------------------------------
-// Utilidades de I/O -- idénticas a `hato-chequeo-foto.ts` (cada handler es
-// autocontenido en su propio I/O, mismo patrón que el resto de `hato-*.ts`).
-// ---------------------------------------------------------------------------
-
-function bytesABase64(bytes: Uint8Array): string {
-  const TAMANO_BLOQUE = 0x8000;
-  let binario = '';
-  for (let i = 0; i < bytes.length; i += TAMANO_BLOQUE) {
-    binario += String.fromCharCode(...bytes.subarray(i, i + TAMANO_BLOQUE));
-  }
-  return btoa(binario);
-}
-
-function extensionDeTipo(tipo: string, nombre: string): string {
-  const porNombre = nombre.match(/\.([a-z0-9]{2,5})$/i)?.[1];
-  if (porNombre) return porNombre.toLowerCase();
-  const sufijo = tipo.split('/')[1];
-  return sufijo ? sufijo.toLowerCase() : 'jpg';
-}
-
-function extraerJson(contenido: string): unknown {
-  const limpio = contenido.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
-  return JSON.parse(limpio);
-}
-
-interface FotoRecibida {
-  pagina: number;
-  nombre: string;
-  tipo: string;
-  bytes: Uint8Array;
-}
-
-interface LlamadaModeloOk {
-  ok: true;
-  lectura: LecturaOcrPesajePagina;
-}
-interface LlamadaModeloError {
-  ok: false;
-  pagina: number;
-  error: string;
-}
-
-async function leerFotoConModelo(
-  foto: FotoRecibida,
-  totalFotos: number,
-  prompt: string,
-  esquema: Record<string, unknown>,
-  apiKey: string,
-): Promise<LlamadaModeloOk | LlamadaModeloError> {
-  const dataUrl = `data:${foto.tipo};base64,${bytesABase64(foto.bytes)}`;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MODELO_MS);
-
-  try {
-    const respuesta = await fetch(OPENROUTER_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: MODELO_VISION,
-        messages: [
-          { role: 'system', content: prompt },
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'text',
-                // "foto N de M", no "página N": desde 2026-08-11 la planilla
-                // cabe en UNA hoja y se fotografía por franjas, así que
-                // llamarla página inducía al modelo a esperar una planilla
-                // completa (con encabezados) en cada imagen.
-                text: `Transcribe la foto ${foto.pagina} de ${totalFotos} de la planilla de pesaje. Puede ser una franja de la hoja, no la hoja entera. Devuelve una entrada por cada fila de vaca visible, en el orden en que aparecen.`,
-              },
-              { type: 'image_url', image_url: { url: dataUrl } },
-            ],
-          },
-        ],
-        temperature: 0,
-        max_tokens: 12000,
-        response_format: {
-          type: 'json_schema',
-          json_schema: { name: 'planilla_pesaje', strict: true, schema: esquema },
-        },
-      }),
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-
-    if (!respuesta.ok) {
-      const detalle = await respuesta.text().catch(() => '');
-      return {
-        ok: false,
-        pagina: foto.pagina,
-        error: `el modelo de visión respondió ${respuesta.status}: ${detalle.slice(0, 300)}`,
-      };
-    }
-
-    const resultado = await respuesta.json();
-    const contenido = resultado?.choices?.[0]?.message?.content;
-    if (typeof contenido !== 'string' || contenido.trim() === '') {
-      return { ok: false, pagina: foto.pagina, error: 'el modelo de visión devolvió una respuesta vacía' };
-    }
-
-    return { ok: true, lectura: parsearRespuestaModeloOcrPesaje(extraerJson(contenido), foto.pagina) };
-  } catch (err) {
-    clearTimeout(timeoutId);
-    const mensaje =
-      err instanceof Error && err.name === 'AbortError'
-        ? `la lectura superó el tiempo máximo (${TIMEOUT_MODELO_MS / 1000}s)`
-        : err instanceof Error
-          ? err.message
-          : String(err);
-    return { ok: false, pagina: foto.pagina, error: mensaje };
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -297,25 +148,25 @@ export async function handleHatoPesajeFoto(c: Context): Promise<Response> {
   if (archivos.length === 0) {
     return respuestaError(c, 400, 'Faltan las fotos de la planilla (multipart/form-data, campo "fotos").');
   }
-  if (archivos.length > MAXIMO_FOTOS) {
-    return respuestaError(c, 400, `Se aceptan máximo ${MAXIMO_FOTOS} fotos por carga (llegaron ${archivos.length}).`);
+  if (archivos.length > MAXIMO_FOTOS_PESAJE) {
+    return respuestaError(c, 400, `Se aceptan máximo ${MAXIMO_FOTOS_PESAJE} fotos por carga (llegaron ${archivos.length}).`);
   }
 
-  const fotos: FotoRecibida[] = [];
+  const fotos: FotoPesajeEntrada[] = [];
   for (let i = 0; i < archivos.length; i++) {
     const archivo = archivos[i];
     if (archivo.size === 0) {
       return respuestaError(c, 400, `La foto ${i + 1} ('${archivo.name}') está vacía.`);
     }
-    if (archivo.size > TAMANO_MAXIMO_FOTO_BYTES) {
+    if (archivo.size > TAMANO_MAXIMO_FOTO_PESAJE_BYTES) {
       return respuestaError(
         c,
         400,
-        `La foto ${i + 1} ('${archivo.name}') supera el tamaño máximo de ${TAMANO_MAXIMO_FOTO_BYTES / 1024 / 1024} MB.`,
+        `La foto ${i + 1} ('${archivo.name}') supera el tamaño máximo de ${TAMANO_MAXIMO_FOTO_PESAJE_BYTES / 1024 / 1024} MB.`,
       );
     }
     const tipo = (archivo.type || '').toLowerCase();
-    if (!TIPOS_ACEPTADOS.has(tipo)) {
+    if (!TIPOS_ACEPTADOS_FOTO_PESAJE.has(tipo)) {
       return respuestaError(
         c,
         400,
@@ -330,153 +181,20 @@ export async function handleHatoPesajeFoto(c: Context): Promise<Response> {
     });
   }
 
-  const generadoEn = new Date().toISOString();
-
-  // --- 2. Guardar la capa cruda ANTES de leerla -----------------------------
-  const prefijoStorage = `pesaje-foto/${generadoEn.replace(/[:.]/g, '-')}-${crypto.randomUUID().slice(0, 8)}`;
-  const rutasStorage: Array<string | null> = [];
-  const erroresStorage: string[] = [];
-  for (const foto of fotos) {
-    const ruta = `${prefijoStorage}/pagina-${foto.pagina}.${extensionDeTipo(foto.tipo, foto.nombre)}`;
-    const { error } = await supabase.storage
-      .from(BUCKET_FOTOS)
-      .upload(ruta, foto.bytes, { contentType: foto.tipo, upsert: false });
-    if (error) {
-      rutasStorage.push(null);
-      erroresStorage.push(`página ${foto.pagina}: ${error.message}`);
-    } else {
-      rutasStorage.push(ruta);
-    }
+  // --- 2. Pipeline compartido con el bot de Telegram (N11) ------------------
+  const resultado = await ejecutarPipelinePesajeFoto({ supabase, apiKey, fotos, anio, mes });
+  if (!resultado.ok) {
+    return respuestaError(c, resultado.status, resultado.error);
   }
 
-  // --- 3. hato_config.dia_pesaje_semanal + roster VIGENTE de la planilla ----
-  const [configRes, rosterRes] = await Promise.all([
-    supabase.from('hato_config').select('valor').eq('clave', 'dia_pesaje_semanal').maybeSingle(),
-    // MISMO universo que exporta la planilla (`esCandidataRosterPesaje`,
-    // `importHato/ocrPesaje.ts` -- una sola definición espejada acá y usada
-    // igual por `useProduccionHato.fetchRosterPesaje` y por el commit).
-    supabase.from('hato_animales').select('id, nombre, etapa, estado').eq('estado', 'activa').in('etapa', ETAPAS_ROSTER_PESAJE),
-  ]);
-
-  if (configRes.error) return respuestaError(c, 500, `No se pudo leer hato_config: ${configRes.error.message}`);
-  const configValor = configRes.data?.valor as { iso?: unknown } | undefined;
-  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
-    return respuestaError(
-      c,
-      500,
-      'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064) -- no se puede resolver a qué fecha corresponde cada semana.',
-    );
-  }
-  const diaPesajeIso = configValor.iso;
-
-  if (rosterRes.error) return respuestaError(c, 500, `No se pudo leer hato_animales: ${rosterRes.error.message}`);
-  const animalesRoster: AnimalRosterPesaje[] = (
-    (rosterRes.data ?? []) as Array<{ id: string; nombre: string | null; etapa: string | null; estado: string | null }>
-  )
-    .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
-    .map((a) => ({ id: a.id, nombre: a.nombre ?? '' }));
-  const roster = construirRosterPesaje(animalesRoster);
-
-  if (roster.entradas.length === 0) {
-    return respuestaError(
-      c,
-      500,
-      'No hay vacas en ordeño activas con nombre en el hato: sin roster no se puede validar el ancla de ninguna fila.',
-    );
-  }
-
-  const fechasArr = fechasPesajeMensuales(anio, mes, diaPesajeIso);
-  const fechasPorSemana = {} as Record<SemanaPesaje, string | null>;
-  for (const semana of SEMANAS_PESAJE) fechasPorSemana[semana] = fechasArr[semana - 1] ?? null;
-
-  // --- 4. Lectura con el modelo de visión (una llamada por foto) -----------
-  const prompt = construirPromptOcrPesaje();
-  const esquema = esquemaJsonOcrPesaje();
-  const resultados = await Promise.all(
-    fotos.map((foto) => leerFotoConModelo(foto, fotos.length, prompt, esquema, apiKey)),
-  );
-
-  const lecturas: LecturaOcrPesajePagina[] = [];
-  const erroresLectura: string[] = [];
-  for (const resultado of resultados) {
-    if (resultado.ok) lecturas.push(resultado.lectura);
-    else erroresLectura.push(`página ${resultado.pagina}: ${resultado.error}`);
-  }
-
-  if (lecturas.length === 0) {
-    return respuestaError(
-      c,
-      502,
-      `No se pudo leer ninguna de las fotos. ${erroresLectura.join(' | ')}${
-        rutasStorage.some((r) => r !== null) ? ' Las fotos sí quedaron guardadas.' : ''
-      }`,
-    );
-  }
-
-  // --- 5. Anti-row-drift por nombre (lógica pura) ---------------------------
-  const ocr = procesarLecturaOcrPesaje(lecturas, roster);
-
-  // --- 6. Existentes en hato_pesajes_leche, para clasificar el diff --------
-  const animalIdsLeidos = ocr.filasConfirmadas.map((f) => f.animalId);
-  const fechasValidas = SEMANAS_PESAJE.map((s) => fechasPorSemana[s]).filter((f): f is string => f !== null);
-  const existentes = new Map<string, Map<string, PesajeExistente>>();
-  if (animalIdsLeidos.length > 0 && fechasValidas.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_pesajes_leche')
-      .select('id, animal_id, fecha, litros_am, litros_pm, litros_total')
-      .in('animal_id', animalIdsLeidos)
-      .in('fecha', fechasValidas);
-    if (error) return respuestaError(c, 500, `No se pudo leer hato_pesajes_leche: ${error.message}`);
-    for (const fila of (data ?? []) as Array<{ id: string; animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number }>) {
-      if (!existentes.has(fila.animal_id)) existentes.set(fila.animal_id, new Map());
-      existentes.get(fila.animal_id)!.set(fila.fecha, {
-        id: fila.id,
-        litrosAm: fila.litros_am,
-        litrosPm: fila.litros_pm,
-        litrosTotal: fila.litros_total,
-      });
-    }
-  }
-
-  const diff = construirDiffPesaje(ocr.filasConfirmadas, fechasPorSemana, existentes);
-  const celdasNoConfiables = ocr.filasConfirmadas.reduce((n, f) => n + f.celdasNoConfiables.length, 0);
-
-  // --- 7. Respuesta: NUNCA escribe -------------------------------------------
+  // --- 3. Respuesta: NUNCA escribe -------------------------------------------
   return c.json({
     success: true,
-    generadoEn,
-    anio,
-    mes,
-    fechasPorSemana,
-    diff,
-    ocr: {
-      modelo: MODELO_VISION,
-      fotos: fotos.map((f, i) => ({
-        pagina: f.pagina,
-        nombre: f.nombre,
-        tipo: f.tipo,
-        bytes: f.bytes.length,
-        rutaStorage: rutasStorage[i],
-      })),
-      almacenamiento: {
-        bucket: BUCKET_FOTOS,
-        prefijo: prefijoStorage,
-        ok: erroresStorage.length === 0,
-        errores: erroresStorage,
-      },
-      paginasNoLeidas: erroresLectura,
-      filasNoLeidas: ocr.filasNoLeidas,
-      vacasSinLeer: ocr.vacasSinLeer,
-      advertencias: ocr.advertencias,
-      resumen: {
-        vacasEnRoster: roster.entradas.length,
-        fotosRecibidas: fotos.length,
-        fotosLeidas: lecturas.length,
-        filasConfirmadas: ocr.filasConfirmadas.length,
-        filasNoLeidas: ocr.filasNoLeidas.length,
-        vacasSinLeer: ocr.vacasSinLeer.length,
-        celdasNoConfiables,
-      },
-    },
+    generadoEn: resultado.resultado.generadoEn,
+    anio: resultado.resultado.anio,
+    mes: resultado.resultado.mes,
+    fechasPorSemana: resultado.resultado.fechasPorSemana,
+    diff: resultado.resultado.diff,
+    ocr: resultado.resultado.ocr,
   });
 }

--- a/src/supabase/functions/server/hato-pesaje-pipeline.ts
+++ b/src/supabase/functions/server/hato-pesaje-pipeline.ts
@@ -1,0 +1,654 @@
+// hato-pesaje-pipeline.ts — N11-N13 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md` §3 Capa 2 / §8.2.
+//
+// POR QUÉ EXISTE ESTE ARCHIVO: hasta esta sesión, la lectura por foto
+// (`leerFotoConModelo` + el armado de roster/config/diff) vivía DENTRO del
+// handler de Hono de `hato-pesaje-foto.ts`, y la escritura (revalidación +
+// UPDATE-o-INSERT) vivía dentro del handler de `hato-pesaje-commit.ts` — ni
+// una ni otra eran reutilizables. El bot de Telegram (`/pesaje`,
+// `telegram/conversations/pesajeLeche.ts`) necesita EXACTAMENTE el mismo
+// pipeline (no un segundo lector de celdas, no una segunda revalidación),
+// así que este archivo extrae la orquestación a funciones puras-de-I/O
+// (reciben sus dependencias por parámetro, no leen `Context` de Hono) que
+// ambos consumidores llaman. `hato-pesaje-foto.ts` y `hato-pesaje-commit.ts`
+// quedan como I/O puro: parsean la petición HTTP, llaman a este módulo, y
+// traducen el resultado a una respuesta -- el comportamiento observable de
+// esos dos endpoints NO cambia.
+//
+// Tres funciones, una por nodo del plan:
+//   - `ejecutarPipelinePesajeFoto` (N11) -- guarda la capa cruda en Storage,
+//     lee cada foto con el modelo de visión, coteja el ancla por nombre
+//     (`ocrPesaje.ts`) y arma el diff contra `hato_pesajes_leche`. NUNCA
+//     escribe en tablas de dominio (mismo contrato que el endpoint).
+//   - `llamarModeloCorreccionPesaje` (N12) -- la ÚNICA llamada HTTP al
+//     modelo para interpretar una corrección en texto libre (D-C). El
+//     prompt/esquema y la VALIDACIÓN de lo que el modelo devuelve viven en
+//     `./importHato/ocrPesajeCorreccion.ts` (puro, espejado, testeado desde
+//     Vitest) -- acá solo se hace la llamada HTTP y se le pasa la respuesta
+//     cruda a `parsearRespuestaModeloCorreccionPesaje`.
+//   - `ejecutarCommitPesaje` (N13) -- la MISMA revalidación fresca que ya
+//     tenía `hato-pesaje-commit.ts` (vaca sigue activa, fecha sigue siendo
+//     una ocurrencia real del mes) + escritura UPDATE-por-id/INSERT, commit
+//     por CELDA (una inválida no bota a las demás).
+//
+// Los litros se interpretan con `parseValorNumerico` (`calculos-hato.ts`),
+// nunca un segundo parser. El cotejo de nombre reusa
+// `resolverNombreEnRosterPesaje`/`validarAnclaFilaPesaje` de `ocrPesaje.ts`.
+
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { fechasPesajeMensuales } from './calculos-hato.ts';
+import {
+  construirDiffPesaje,
+  construirRosterPesaje,
+  esCandidataRosterPesaje,
+  esquemaJsonOcrPesaje,
+  construirPromptOcrPesaje,
+  ETAPAS_ROSTER_PESAJE,
+  parsearRespuestaModeloOcrPesaje,
+  procesarLecturaOcrPesaje,
+  SEMANAS_PESAJE,
+  type AnimalRosterPesaje,
+  type CeldaDiffPesaje,
+  type FilaPesajeNoLeida,
+  type LecturaOcrPesajePagina,
+  type PesajeExistente,
+  type SemanaPesaje,
+  type VacaPesajeSinLeer,
+} from './importHato/ocrPesaje.ts';
+import {
+  construirPromptCorreccionPesaje,
+  esquemaJsonCorreccionPesaje,
+  parsearRespuestaModeloCorreccionPesaje,
+  type ItemCorreccionModeloPesaje,
+} from './importHato/ocrPesajeCorreccion.ts';
+
+type SupabaseAdmin = ReturnType<typeof createClient>;
+
+// ---------------------------------------------------------------------------
+// Límites/constantes compartidos -- ÚNICA definición para que el endpoint
+// HTTP y la conversación de Telegram acepten exactamente lo mismo (brief
+// N11: "mismo límite y mismos tipos MIME que el endpoint").
+// ---------------------------------------------------------------------------
+export const MAXIMO_FOTOS_PESAJE = 6;
+export const TAMANO_MAXIMO_FOTO_PESAJE_BYTES = 15 * 1024 * 1024;
+export const TIPOS_ACEPTADOS_FOTO_PESAJE = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+// Bucket privado propio (migración 086 -- patrón 072/085). Nunca se mezcla
+// con `chequeos-fotos` (otro dominio) ni con `hato-liquidaciones-fotos`.
+const BUCKET_FOTOS_PESAJE = 'hato-pesajes-fotos';
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const MODELO_VISION_PESAJE = 'google/gemini-3-flash-preview';
+const TIMEOUT_MODELO_MS = 120_000;
+
+// ---------------------------------------------------------------------------
+// Helpers de codificación -- idénticos a los que vivían en
+// `hato-pesaje-foto.ts` antes de esta extracción.
+// ---------------------------------------------------------------------------
+
+function bytesABase64(bytes: Uint8Array): string {
+  const TAMANO_BLOQUE = 0x8000;
+  let binario = '';
+  for (let i = 0; i < bytes.length; i += TAMANO_BLOQUE) {
+    binario += String.fromCharCode(...bytes.subarray(i, i + TAMANO_BLOQUE));
+  }
+  return btoa(binario);
+}
+
+function extensionDeTipo(tipo: string, nombre: string): string {
+  const porNombre = nombre.match(/\.([a-z0-9]{2,5})$/i)?.[1];
+  if (porNombre) return porNombre.toLowerCase();
+  const sufijo = tipo.split('/')[1];
+  return sufijo ? sufijo.toLowerCase() : 'jpg';
+}
+
+function extraerJson(contenido: string): unknown {
+  const limpio = contenido.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+  return JSON.parse(limpio);
+}
+
+// ---------------------------------------------------------------------------
+// N11 — Pipeline de lectura por foto (preview, nunca escribe en dominio).
+// ---------------------------------------------------------------------------
+
+export interface FotoPesajeEntrada {
+  /** 1-based, en el orden en que el caller recibió las fotos. */
+  pagina: number;
+  nombre: string;
+  tipo: string;
+  bytes: Uint8Array;
+}
+
+export interface PipelinePesajeFotoResultado {
+  generadoEn: string;
+  anio: number;
+  mes: number;
+  fechasPorSemana: Record<SemanaPesaje, string | null>;
+  diff: CeldaDiffPesaje[];
+  /** El roster que validó el ancla de esta lectura, como ARREGLO plano
+   * (nunca el `RosterPesaje` con su `Map` interno): N12 lo necesita para
+   * resolver el nombre de una corrección con el MISMO cotejo, pero el bot
+   * de Telegram persiste el resultado de este pipeline a través de
+   * `conversation.external()` -- eso pasa por el storage jsonb de
+   * `telegram_conversations`, y un `Map` no sobrevive un `JSON.stringify`.
+   * El caller reconstruye el `RosterPesaje` con `construirRosterPesaje`
+   * (puro, determinista) cada vez que lo necesita. */
+  rosterAnimales: AnimalRosterPesaje[];
+  ocr: {
+    modelo: string;
+    fotos: Array<{ pagina: number; nombre: string; tipo: string; bytes: number; rutaStorage: string | null }>;
+    almacenamiento: { bucket: string; prefijo: string; ok: boolean; errores: string[] };
+    paginasNoLeidas: string[];
+    filasNoLeidas: FilaPesajeNoLeida[];
+    vacasSinLeer: VacaPesajeSinLeer[];
+    advertencias: string[];
+    resumen: {
+      vacasEnRoster: number;
+      fotosRecibidas: number;
+      fotosLeidas: number;
+      filasConfirmadas: number;
+      filasNoLeidas: number;
+      vacasSinLeer: number;
+      celdasNoConfiables: number;
+    };
+  };
+}
+
+export type ResultadoPipelinePesajeFoto =
+  | { ok: true; resultado: PipelinePesajeFotoResultado }
+  | { ok: false; status: 500 | 502; error: string };
+
+interface LlamadaModeloOk {
+  ok: true;
+  lectura: LecturaOcrPesajePagina;
+}
+interface LlamadaModeloError {
+  ok: false;
+  pagina: number;
+  error: string;
+}
+
+async function leerFotoConModelo(
+  foto: FotoPesajeEntrada,
+  totalFotos: number,
+  prompt: string,
+  esquema: Record<string, unknown>,
+  apiKey: string,
+): Promise<LlamadaModeloOk | LlamadaModeloError> {
+  const dataUrl = `data:${foto.tipo};base64,${bytesABase64(foto.bytes)}`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MODELO_MS);
+
+  try {
+    const respuesta = await fetch(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODELO_VISION_PESAJE,
+        messages: [
+          { role: 'system', content: prompt },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                // "foto N de M", no "página N": desde 2026-08-11 la planilla
+                // cabe en UNA hoja y se fotografía por franjas, así que
+                // llamarla página inducía al modelo a esperar una planilla
+                // completa (con encabezados) en cada imagen.
+                text: `Transcribe la foto ${foto.pagina} de ${totalFotos} de la planilla de pesaje. Puede ser una franja de la hoja, no la hoja entera. Devuelve una entrada por cada fila de vaca visible, en el orden en que aparecen.`,
+              },
+              { type: 'image_url', image_url: { url: dataUrl } },
+            ],
+          },
+        ],
+        temperature: 0,
+        max_tokens: 12000,
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'planilla_pesaje', strict: true, schema: esquema },
+        },
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!respuesta.ok) {
+      const detalle = await respuesta.text().catch(() => '');
+      return {
+        ok: false,
+        pagina: foto.pagina,
+        error: `el modelo de visión respondió ${respuesta.status}: ${detalle.slice(0, 300)}`,
+      };
+    }
+
+    const resultado = await respuesta.json();
+    const contenido = resultado?.choices?.[0]?.message?.content;
+    if (typeof contenido !== 'string' || contenido.trim() === '') {
+      return { ok: false, pagina: foto.pagina, error: 'el modelo de visión devolvió una respuesta vacía' };
+    }
+
+    return { ok: true, lectura: parsearRespuestaModeloOcrPesaje(extraerJson(contenido), foto.pagina) };
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const mensaje =
+      err instanceof Error && err.name === 'AbortError'
+        ? `la lectura superó el tiempo máximo (${TIMEOUT_MODELO_MS / 1000}s)`
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, pagina: foto.pagina, error: mensaje };
+  }
+}
+
+/**
+ * N11: orquesta toda la ruta de lectura por foto -- guarda la capa cruda en
+ * Storage ANTES de leerla, resuelve `hato_config.dia_pesaje_semanal` y el
+ * roster vigente, llama al modelo (una vez por foto, en paralelo), coteja
+ * el ancla por nombre y arma el diff contra `hato_pesajes_leche`. NUNCA
+ * escribe en tablas de dominio -- ver `ejecutarCommitPesaje` para eso.
+ *
+ * Comparte esta orquestación el endpoint HTTP (`hato-pesaje-foto.ts`) y la
+ * conversación de Telegram (`pesajeLeche.ts`) -- es el pipeline que pedía
+ * N11 del plan, no un segundo lector de celdas ni un segundo armado de
+ * roster.
+ */
+export async function ejecutarPipelinePesajeFoto(params: {
+  supabase: SupabaseAdmin;
+  apiKey: string;
+  fotos: readonly FotoPesajeEntrada[];
+  anio: number;
+  mes: number;
+}): Promise<ResultadoPipelinePesajeFoto> {
+  const { supabase, apiKey, fotos, anio, mes } = params;
+  const generadoEn = new Date().toISOString();
+
+  // --- 1. Guardar la capa cruda ANTES de leerla -----------------------------
+  const prefijoStorage = `pesaje-foto/${generadoEn.replace(/[:.]/g, '-')}-${crypto.randomUUID().slice(0, 8)}`;
+  const rutasStorage: Array<string | null> = [];
+  const erroresStorage: string[] = [];
+  for (const foto of fotos) {
+    const ruta = `${prefijoStorage}/pagina-${foto.pagina}.${extensionDeTipo(foto.tipo, foto.nombre)}`;
+    const { error } = await supabase.storage
+      .from(BUCKET_FOTOS_PESAJE)
+      .upload(ruta, foto.bytes, { contentType: foto.tipo, upsert: false });
+    if (error) {
+      rutasStorage.push(null);
+      erroresStorage.push(`página ${foto.pagina}: ${error.message}`);
+    } else {
+      rutasStorage.push(ruta);
+    }
+  }
+
+  // --- 2. hato_config.dia_pesaje_semanal + roster VIGENTE de la planilla ----
+  const [configRes, rosterRes] = await Promise.all([
+    supabase.from('hato_config').select('valor').eq('clave', 'dia_pesaje_semanal').maybeSingle(),
+    supabase.from('hato_animales').select('id, nombre, etapa, estado').eq('estado', 'activa').in('etapa', ETAPAS_ROSTER_PESAJE),
+  ]);
+
+  if (configRes.error) return { ok: false, status: 500, error: `No se pudo leer hato_config: ${configRes.error.message}` };
+  const configValor = configRes.data?.valor as { iso?: unknown } | undefined;
+  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
+    return {
+      ok: false,
+      status: 500,
+      error: 'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064) -- no se puede resolver a qué fecha corresponde cada semana.',
+    };
+  }
+  const diaPesajeIso = configValor.iso;
+
+  if (rosterRes.error) return { ok: false, status: 500, error: `No se pudo leer hato_animales: ${rosterRes.error.message}` };
+  const animalesRoster: AnimalRosterPesaje[] = (
+    (rosterRes.data ?? []) as Array<{ id: string; nombre: string | null; etapa: string | null; estado: string | null }>
+  )
+    .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
+    .map((a) => ({ id: a.id, nombre: a.nombre ?? '' }));
+  const roster = construirRosterPesaje(animalesRoster);
+
+  if (roster.entradas.length === 0) {
+    return {
+      ok: false,
+      status: 500,
+      error: 'No hay vacas en ordeño activas con nombre en el hato: sin roster no se puede validar el ancla de ninguna fila.',
+    };
+  }
+
+  const fechasArr = fechasPesajeMensuales(anio, mes, diaPesajeIso);
+  const fechasPorSemana = {} as Record<SemanaPesaje, string | null>;
+  for (const semana of SEMANAS_PESAJE) fechasPorSemana[semana] = fechasArr[semana - 1] ?? null;
+
+  // --- 3. Lectura con el modelo de visión (una llamada por foto) -----------
+  const prompt = construirPromptOcrPesaje();
+  const esquema = esquemaJsonOcrPesaje();
+  const resultados = await Promise.all(
+    fotos.map((foto) => leerFotoConModelo(foto, fotos.length, prompt, esquema, apiKey)),
+  );
+
+  const lecturas: LecturaOcrPesajePagina[] = [];
+  const erroresLectura: string[] = [];
+  for (const resultado of resultados) {
+    if (resultado.ok) lecturas.push(resultado.lectura);
+    else erroresLectura.push(`página ${resultado.pagina}: ${resultado.error}`);
+  }
+
+  if (lecturas.length === 0) {
+    return {
+      ok: false,
+      status: 502,
+      error: `No se pudo leer ninguna de las fotos. ${erroresLectura.join(' | ')}${
+        rutasStorage.some((r) => r !== null) ? ' Las fotos sí quedaron guardadas.' : ''
+      }`,
+    };
+  }
+
+  // --- 4. Anti-row-drift por nombre (lógica pura) ---------------------------
+  const ocr = procesarLecturaOcrPesaje(lecturas, roster);
+
+  // --- 5. Existentes en hato_pesajes_leche, para clasificar el diff --------
+  const animalIdsLeidos = ocr.filasConfirmadas.map((f) => f.animalId);
+  const fechasValidas = SEMANAS_PESAJE.map((s) => fechasPorSemana[s]).filter((f): f is string => f !== null);
+  const existentes = new Map<string, Map<string, PesajeExistente>>();
+  if (animalIdsLeidos.length > 0 && fechasValidas.length > 0) {
+    const { data, error } = await supabase
+      .from('hato_pesajes_leche')
+      .select('id, animal_id, fecha, litros_am, litros_pm, litros_total')
+      .in('animal_id', animalIdsLeidos)
+      .in('fecha', fechasValidas);
+    if (error) return { ok: false, status: 500, error: `No se pudo leer hato_pesajes_leche: ${error.message}` };
+    for (const fila of (data ?? []) as Array<{ id: string; animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number }>) {
+      if (!existentes.has(fila.animal_id)) existentes.set(fila.animal_id, new Map());
+      existentes.get(fila.animal_id)!.set(fila.fecha, {
+        id: fila.id,
+        litrosAm: fila.litros_am,
+        litrosPm: fila.litros_pm,
+        litrosTotal: fila.litros_total,
+      });
+    }
+  }
+
+  const diff = construirDiffPesaje(ocr.filasConfirmadas, fechasPorSemana, existentes);
+  const celdasNoConfiables = ocr.filasConfirmadas.reduce((n, f) => n + f.celdasNoConfiables.length, 0);
+
+  return {
+    ok: true,
+    resultado: {
+      generadoEn,
+      anio,
+      mes,
+      fechasPorSemana,
+      diff,
+      rosterAnimales: animalesRoster,
+      ocr: {
+        modelo: MODELO_VISION_PESAJE,
+        fotos: fotos.map((f, i) => ({
+          pagina: f.pagina,
+          nombre: f.nombre,
+          tipo: f.tipo,
+          bytes: f.bytes.length,
+          rutaStorage: rutasStorage[i],
+        })),
+        almacenamiento: {
+          bucket: BUCKET_FOTOS_PESAJE,
+          prefijo: prefijoStorage,
+          ok: erroresStorage.length === 0,
+          errores: erroresStorage,
+        },
+        paginasNoLeidas: erroresLectura,
+        filasNoLeidas: ocr.filasNoLeidas,
+        vacasSinLeer: ocr.vacasSinLeer,
+        advertencias: ocr.advertencias,
+        resumen: {
+          vacasEnRoster: roster.entradas.length,
+          fotosRecibidas: fotos.length,
+          fotosLeidas: lecturas.length,
+          filasConfirmadas: ocr.filasConfirmadas.length,
+          filasNoLeidas: ocr.filasNoLeidas.length,
+          vacasSinLeer: ocr.vacasSinLeer.length,
+          celdasNoConfiables,
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// N12 — Interpretación de una corrección en texto libre (decisión D-C).
+// ---------------------------------------------------------------------------
+
+export type ResultadoLlamadaCorreccionPesaje =
+  | { ok: true; items: ItemCorreccionModeloPesaje[]; avisos: string[] }
+  | { ok: false; error: string };
+
+/**
+ * N12: la ÚNICA llamada HTTP al modelo para interpretar el texto libre de
+ * una corrección. El prompt y el esquema vienen de
+ * `ocrPesajeCorreccion.ts` (puro, espejado) -- acá solo se hace la
+ * petición y se le pasa la respuesta cruda a
+ * `parsearRespuestaModeloCorreccionPesaje`, que es quien decide la forma.
+ * Esta función NUNCA valida el contenido (nombre contra roster, semana
+ * contra la grilla del mes): eso es `interpretarCorreccionPesaje`, pura,
+ * llamada por el caller DESPUÉS de esto.
+ */
+export async function llamarModeloCorreccionPesaje(
+  texto: string,
+  apiKey: string,
+): Promise<ResultadoLlamadaCorreccionPesaje> {
+  const prompt = construirPromptCorreccionPesaje();
+  const esquema = esquemaJsonCorreccionPesaje();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MODELO_MS);
+
+  try {
+    const respuesta = await fetch(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODELO_VISION_PESAJE,
+        messages: [
+          { role: 'system', content: prompt },
+          { role: 'user', content: texto },
+        ],
+        temperature: 0,
+        max_tokens: 4000,
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'correccion_pesaje', strict: true, schema: esquema },
+        },
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!respuesta.ok) {
+      const detalle = await respuesta.text().catch(() => '');
+      return { ok: false, error: `el modelo respondió ${respuesta.status}: ${detalle.slice(0, 300)}` };
+    }
+
+    const resultado = await respuesta.json();
+    const contenido = resultado?.choices?.[0]?.message?.content;
+    if (typeof contenido !== 'string' || contenido.trim() === '') {
+      return { ok: false, error: 'el modelo devolvió una respuesta vacía' };
+    }
+
+    const { items, avisos } = parsearRespuestaModeloCorreccionPesaje(extraerJson(contenido));
+    return { ok: true, items, avisos };
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const mensaje =
+      err instanceof Error && err.name === 'AbortError'
+        ? `la interpretación superó el tiempo máximo (${TIMEOUT_MODELO_MS / 1000}s)`
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, error: mensaje };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// N13 — Commit por celda (revalidación fresca + escritura).
+// ---------------------------------------------------------------------------
+
+export interface CeldaCommitPesajeEntrada {
+  animalId: string;
+  fecha: string; // AAAA-MM-DD
+  litrosAm: number | null;
+  litrosPm: number | null;
+}
+
+export interface CeldaPesajeRechazada {
+  animalId: string;
+  fecha: string;
+  motivo: string;
+}
+
+export type ResultadoCommitPesaje =
+  | { ok: true; guardados: number; actualizados: number; creados: number; celdasRechazadas: CeldaPesajeRechazada[] }
+  | { ok: false; status: 400; error: string; celdasRechazadas: CeldaPesajeRechazada[] }
+  | { ok: false; status: 500; error: string };
+
+/**
+ * N13: la MISMA revalidación fresca que ya tenía `hato-pesaje-commit.ts`
+ * (la vaca sigue en el roster de la planilla EN ESTE INSTANTE; la fecha
+ * sigue siendo una ocurrencia real de `hato_config.dia_pesaje_semanal` para
+ * `(anio, mes)` EN ESTE INSTANTE) + escritura UPDATE-por-id/INSERT (nunca
+ * upsert de PostgREST). Commit por CELDA: una celda inválida se rechaza
+ * sola, el resto entra -- así una vaca vendida entre la vista previa y la
+ * aprobación no le cuesta a Martha/Fernando los demás pesajes.
+ *
+ * `createdBy` viaja EXPLÍCITO (riesgo R-6 del plan): el caller (endpoint
+ * HTTP o bot de Telegram) escribe con `service_role`, donde `auth.uid()` es
+ * NULL, así que sin este parámetro la autoría se perdería. `fuente` la
+ * decide el caller (`'foto'` para el endpoint web, `'telegram'` para el
+ * bot) -- no hay un valor por defecto acá a propósito, para que no se
+ * pueda commitear sin declarar de dónde vino.
+ */
+export async function ejecutarCommitPesaje(params: {
+  supabase: SupabaseAdmin;
+  anio: number;
+  mes: number;
+  celdas: readonly CeldaCommitPesajeEntrada[];
+  createdBy: string;
+  fuente: string;
+}): Promise<ResultadoCommitPesaje> {
+  const { supabase, anio, mes, celdas, createdBy, fuente } = params;
+
+  // --- 1. hato_config.dia_pesaje_semanal FRESCO -----------------------------
+  const { data: configData, error: configError } = await supabase
+    .from('hato_config')
+    .select('valor')
+    .eq('clave', 'dia_pesaje_semanal')
+    .maybeSingle();
+  if (configError) return { ok: false, status: 500, error: `No se pudo leer hato_config: ${configError.message}` };
+  const configValor = configData?.valor as { iso?: unknown } | undefined;
+  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
+    return {
+      ok: false,
+      status: 500,
+      error: 'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064).',
+    };
+  }
+  const fechasValidasHoy = new Set(fechasPesajeMensuales(anio, mes, configValor.iso as number));
+
+  // --- 2. Roster FRESCO -----------------------------------------------------
+  const animalIds = [...new Set(celdas.map((c) => c.animalId))];
+  const { data: animalesData, error: animalesError } = await supabase
+    .from('hato_animales')
+    .select('id, etapa, estado')
+    .in('id', animalIds)
+    .in('etapa', ETAPAS_ROSTER_PESAJE);
+  if (animalesError) {
+    return { ok: false, status: 500, error: `No se pudo leer hato_animales: ${animalesError.message}` };
+  }
+  const activasAhora = new Set(
+    ((animalesData ?? []) as Array<{ id: string; etapa: string | null; estado: string | null }>)
+      .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
+      .map((a) => a.id),
+  );
+
+  // --- 3. Filtrar: solo celdas cuya vaca sigue activa y cuya fecha sigue
+  //    siendo una ocurrencia real del día de pesaje configurado. ------------
+  const aceptadas: CeldaCommitPesajeEntrada[] = [];
+  const rechazadas: CeldaPesajeRechazada[] = [];
+  for (const celda of celdas) {
+    if (!activasAhora.has(celda.animalId)) {
+      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'El animal ya no está en el roster de la planilla -- puede haberse vendido o cambiado de etapa desde la vista previa.' });
+      continue;
+    }
+    if (!fechasValidasHoy.has(celda.fecha)) {
+      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'Esa fecha ya no corresponde a una semana de pesaje configurada para este mes.' });
+      continue;
+    }
+    aceptadas.push(celda);
+  }
+
+  if (aceptadas.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Ninguna celda pasó la revalidación -- el hato cambió desde la vista previa. No se escribió nada.',
+      celdasRechazadas: rechazadas,
+    };
+  }
+
+  // --- 4. Existentes FRESCOS -------------------------------------------------
+  const fechasEnLote = [...new Set(aceptadas.map((c) => c.fecha))];
+  const { data: existentesData, error: existentesError } = await supabase
+    .from('hato_pesajes_leche')
+    .select('id, animal_id, fecha')
+    .in('animal_id', [...new Set(aceptadas.map((c) => c.animalId))])
+    .in('fecha', fechasEnLote);
+  if (existentesError) return { ok: false, status: 500, error: `No se pudo leer hato_pesajes_leche: ${existentesError.message}` };
+  const idExistentePorClave = new Map<string, string>();
+  for (const fila of (existentesData ?? []) as Array<{ id: string; animal_id: string; fecha: string }>) {
+    idExistentePorClave.set(`${fila.animal_id}|${fila.fecha}`, fila.id);
+  }
+
+  // --- 5. Escritura: UPDATE-por-id + INSERT (nunca upsert de PostgREST) ----
+  let actualizados = 0;
+  let creados = 0;
+  const nuevasFilas: Array<{ animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number; fuente: string; created_by: string }> = [];
+
+  for (const celda of aceptadas) {
+    const total = (celda.litrosAm ?? 0) + (celda.litrosPm ?? 0);
+    const existenteId = idExistentePorClave.get(`${celda.animalId}|${celda.fecha}`);
+    if (existenteId) {
+      const { error } = await supabase
+        .from('hato_pesajes_leche')
+        .update({ litros_am: celda.litrosAm, litros_pm: celda.litrosPm, litros_total: total, fuente })
+        .eq('id', existenteId);
+      if (error) return { ok: false, status: 500, error: `No se pudo actualizar el pesaje de '${celda.animalId}' en ${celda.fecha}: ${error.message}` };
+      actualizados += 1;
+    } else {
+      nuevasFilas.push({
+        animal_id: celda.animalId,
+        fecha: celda.fecha,
+        litros_am: celda.litrosAm,
+        litros_pm: celda.litrosPm,
+        litros_total: total,
+        fuente,
+        created_by: createdBy,
+      });
+    }
+  }
+
+  if (nuevasFilas.length > 0) {
+    const { error } = await supabase.from('hato_pesajes_leche').insert(nuevasFilas);
+    if (error) return { ok: false, status: 500, error: `No se pudieron insertar los pesajes nuevos: ${error.message}` };
+    creados = nuevasFilas.length;
+  }
+
+  return { ok: true, guardados: actualizados + creados, actualizados, creados, celdasRechazadas: rechazadas };
+}

--- a/src/supabase/functions/server/importHato/chequeos.ts
+++ b/src/supabase/functions/server/importHato/chequeos.ts
@@ -82,6 +82,7 @@ const CRUDO_VACIO: CrudoFilaChequeo = {
   sx: null,
   fechaServicio: null,
   toro: null,
+  estadoRegistrado: null,
   tp: null,
   estado: null,
   secar: null,
@@ -207,6 +208,13 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
     const toroRes = parseToro(toroCruda, config);
     issues.push(...conCampo('Toro', toroRes.issues));
 
+    // "Estado registrado" (D-E, B5.4): texto de referencia, NUNCA
+    // interpretado -- se conserva verbatim para que el diff lo compare
+    // contra lo que el motor deriva hoy (N23). `null` cuando la hoja no trae
+    // esta columna (toda generación histórica, `colmap.estadoRegistrado ===
+    // null`) o la celda vino vacía.
+    const estadoRegistradoTexto = valorCeldaATexto(celda(filaFisica, colmap.estadoRegistrado));
+
     // D6 (decisión del dueño, 2026-07-22, resolution-report.md §6): un
     // código de ESTADO filtrado a la columna Toro NUNCA es un toro, "sin
     // excepción" -- incluso si la fila SÍ trae una fecha de servicio real.
@@ -272,6 +280,7 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
       sx: valorCeldaATexto(sxCruda),
       fechaServicio: fechaServicioTexto,
       toro: valorCeldaATexto(toroCruda),
+      estadoRegistrado: estadoRegistradoTexto,
       tp: tpTexto,
       estado: estadoTexto,
       secar: secarTexto,
@@ -298,6 +307,7 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
       fechaProbableParto,
       toroNombre: toroRes.toroNombre,
       tipoServicio: toroRes.tipoServicio,
+      estadoRegistrado: estadoRegistradoTexto,
       issues,
     });
   }

--- a/src/supabase/functions/server/importHato/commitChequeo.ts
+++ b/src/supabase/functions/server/importHato/commitChequeo.ts
@@ -309,6 +309,79 @@ export function seleccionarFechasServicioConocidasPorAnimal(
   return resultado;
 }
 
+/** Un evento del hato registrado A MANO (`chequeo_vaca_id IS NULL`): por
+ * Telegram (`/evento`, fuente `telegram`), por el diálogo de marcar ciclo
+ * (fuente `web`) o por venta/muerte. El caller lo trae ya filtrado. */
+export interface EventoManualHistorico {
+  animalId: string;
+  tipo: string;
+  fecha: string;
+}
+
+/**
+ * **N10 — el nodo que impide que el chequeo duplique lo que ya se registró a
+ * mano.** Fusiona los eventos manuales en los dos mapas de deduplicación que
+ * consume `derivarEventosDeChequeo`.
+ *
+ * Por qué existe: los dos mecanismos anti-duplicado del módulo
+ * (`fechasServicioConocidas` para servicios, `ultimaCriaAnterior` para
+ * partos) se alimentaban EXCLUSIVAMENTE de `hato_chequeo_vacas`, porque
+ * hasta ahora todos los eventos derivados venían de una planilla. Desde que
+ * Fernando registra la monta el mismo día en el corral, ese supuesto es
+ * falso: su monta del 10 de agosto no está en ninguna fila de chequeo, así
+ * que al aprobar el chequeo del 20 —que trae esa misma F Servicio, porque
+ * la veterinaria la copia de lo que ya sabe— el motor emitiría un SEGUNDO
+ * evento de servicio para la misma monta.
+ *
+ * Es exactamente la forma del bug que costó tres rondas de limpieza en julio
+ * de 2026 (385 servicios y 806 partos duplicados en producción). La
+ * diferencia es que aquel se descubrió con los datos ya corrompidos.
+ *
+ * Puro: devuelve mapas NUEVOS, no muta los que recibe.
+ */
+export function fusionarEventosManualesEnDedupe(
+  fechasServicioPorAnimal: Map<string, Set<string>>,
+  ultimaCriaAnteriorPorAnimal: Map<string, string | null>,
+  eventosManuales: EventoManualHistorico[],
+  chequeoNuevoFecha: string,
+): {
+  fechasServicioPorAnimal: Map<string, Set<string>>;
+  ultimaCriaAnteriorPorAnimal: Map<string, string | null>;
+} {
+  const servicios = new Map<string, Set<string>>();
+  for (const [animalId, fechas] of fechasServicioPorAnimal) {
+    servicios.set(animalId, new Set(fechas));
+  }
+  const crias = new Map<string, string | null>(ultimaCriaAnteriorPorAnimal);
+
+  for (const evento of eventosManuales) {
+    // Solo lo ESTRICTAMENTE anterior al chequeo que se aprueba -- mismo
+    // criterio que los dos selectores de arriba. Un evento manual del mismo
+    // día o posterior no es "lo ya conocido", es otro hecho.
+    if (evento.fecha >= chequeoNuevoFecha) continue;
+
+    if (evento.tipo === 'servicio') {
+      if (!servicios.has(evento.animalId)) servicios.set(evento.animalId, new Set());
+      servicios.get(evento.animalId)!.add(evento.fecha);
+      continue;
+    }
+
+    if (evento.tipo === 'parto') {
+      // `ultimaCriaAnterior` es UNA fecha (la última cría conocida), no un
+      // conjunto: `decidirEventoParto` agrupa por proximidad contra ella.
+      // Un parto manual solo la reemplaza si es MÁS RECIENTE que lo que ya
+      // había -- si el chequeo anterior reportó una cría posterior, esa
+      // sigue siendo la última.
+      const actual = crias.get(evento.animalId) ?? null;
+      if (actual === null || evento.fecha > actual) {
+        crias.set(evento.animalId, evento.fecha);
+      }
+    }
+  }
+
+  return { fechasServicioPorAnimal: servicios, ultimaCriaAnteriorPorAnimal: crias };
+}
+
 /**
  * Deriva los eventos de `hato_eventos` de cada fila aprobada, reusando
  * `descomponerSX` (mismo motor que `Load` y la captura en vivo). Una fila

--- a/src/supabase/functions/server/importHato/diffChequeo.ts
+++ b/src/supabase/functions/server/importHato/diffChequeo.ts
@@ -139,6 +139,27 @@ export interface CampoDiffChequeo {
   nuevo: unknown;
 }
 
+/**
+ * Conflicto explícito entre "lo registrado" y "lo impreso" (D-E, N23,
+ * docs/plan_hato_telegram_estados_agosto_2026.md §3 Capa 5). La planilla sale
+ * pre-impresa con la etiqueta del `EstadoReproductivo` que el motor creía
+ * cierta al momento de exportar ("Estado registrado", columna gris de solo
+ * referencia -- Martha nunca escribe ahí). Entre que se imprime y que se
+ * sube de vuelta puede haber pasado CUALQUIER COSA que cambie esa lectura: un
+ * evento de Telegram nuevo, una corrección manual, un chequeo distinto ya
+ * aprobado -- y eso tiene que verse ANTES de aprobar, no descubrirse después
+ * (la contradicción es justo lo que N23 pide mostrar). `actual` se recalcula
+ * SIEMPRE con el estado fresco de la base al momento del diff (mismo
+ * principio que el resto de este archivo: nunca el diff viejo que vio la
+ * pantalla).
+ */
+export interface ConflictoEstadoRegistrado {
+  /** Lo que decía la planilla cuando se exportó/imprimió. */
+  impreso: string;
+  /** Lo que el sistema cree AHORA, recién recalculado. */
+  actual: string;
+}
+
 export interface FilaDiffChequeo {
   fila: number;
   numero: number | null;
@@ -157,6 +178,25 @@ export interface FilaDiffChequeo {
   diferencias: CampoDiffChequeo[];
   motivoNoReconocido: string | null;
   issues: ParseIssue[];
+  /** `null` cuando no hay nada que contrastar: fila `nuevo`/`no_reconocido`
+   * (sin `animalId`), la hoja no trae la columna "Estado registrado" (toda
+   * generación anterior a B5.4), la celda vino vacía, o lo impreso SIGUE
+   * coincidiendo con lo que el sistema cree hoy. Ver `ConflictoEstadoRegistrado`. */
+  conflictoEstadoRegistrado: ConflictoEstadoRegistrado | null;
+}
+
+/** "Lo que el sistema cree HOY" para un animal -- la etiqueta de
+ * `EstadoReproductivo` (`etiquetaEstadoReproductivo`, calculosHato.ts),
+ * recalculada por el handler contra el estado FRESCO de `v_hato_estado_actual`
+ * en el momento del diff, nunca cacheada. El handler arma este arreglo; este
+ * módulo solo lo usa para comparar texto contra texto -- no conoce el motor
+ * de estados ni el vocabulario de 5 estados, mismo principio de capas que el
+ * resto de `importHato/`. */
+export interface AnimalEstadoRegistradoActual {
+  animalId: string;
+  /** Etiqueta YA calculada (`etiquetaEstadoReproductivo`), lista para
+   * comparar texto a texto contra `fila.estadoRegistrado`. */
+  estado: string;
 }
 
 export interface ResumenDiffChequeo {
@@ -169,6 +209,12 @@ export interface ResumenDiffChequeo {
    * clasificación -- independiente de `noReconocidos` (una fila puede tener
    * issues y aun así resolverse a un animal). */
   conIssues: number;
+  /** Filas cuyo "Estado registrado" impreso ya NO coincide con lo que el
+   * sistema cree hoy (N23, D-E) -- la señal que tiene que verse ANTES de
+   * aprobar. Independiente de `cambios`: una fila puede no traer ningún
+   * cambio de campo (Martha no tocó nada) y aun así tener este conflicto,
+   * porque lo que cambió fue el sistema, no el papel. */
+  conConflictoEstadoRegistrado: number;
 }
 
 export interface ResultadoDiffChequeo {
@@ -237,7 +283,33 @@ function filaNoReconocida(fila: FilaChequeoNormalizada, numeroEsProvisional: boo
     diferencias: [],
     motivoNoReconocido: motivo,
     issues: fila.issues,
+    // Sin animal resuelto no hay contra qué contrastar "lo que el sistema
+    // cree hoy" -- nunca se inventa un conflicto para una fila que ni
+    // siquiera se sabe de quién es.
+    conflictoEstadoRegistrado: null,
   };
+}
+
+/**
+ * N23: compara `estadoRegistrado` IMPRESO (crudo, tal como salió en la
+ * planilla) contra lo que el sistema cree AHORA (`estadosRegistrados`,
+ * recién recalculado por el handler). `null` cuando no hay nada que
+ * contrastar -- la hoja no trae la columna (generación anterior a B5.4), la
+ * celda vino vacía, o el animal no aparece en `estadosRegistrados` (no
+ * debería pasar para una fila con `animalId` resuelto, pero un mapa
+ * incompleto no debe fabricar un conflicto falso).
+ */
+function calcularConflictoEstadoRegistrado(
+  estadoRegistradoImpreso: string | null,
+  animalId: string,
+  estadosRegistradosPorAnimalId: Map<string, string>,
+): ConflictoEstadoRegistrado | null {
+  const impreso = estadoRegistradoImpreso?.trim();
+  if (!impreso) return null;
+  const actual = estadosRegistradosPorAnimalId.get(animalId);
+  if (actual === undefined) return null;
+  if (impreso === actual) return null;
+  return { impreso, actual };
 }
 
 /**
@@ -245,17 +317,28 @@ function filaNoReconocida(fila: FilaChequeoNormalizada, numeroEsProvisional: boo
  * actual del hato. `animales`/`ultimosChequeos` son la forma plana que el
  * handler del endpoint arma con dos consultas a Supabase (`hato_animales` +
  * `hato_chequeo_vacas` reducida vía `seleccionarUltimoChequeoPorAnimal`).
+ *
+ * `estadosRegistrados` (N23, D-E) es OPCIONAL y por defecto vacío -- sin él
+ * (llamadas existentes, o un handler que no lo calculó todavía) el diff se
+ * comporta exactamente igual que antes, solo que `conflictoEstadoRegistrado`
+ * sale siempre `null`. El handler lo arma recalculando `derivarEstadoReproductivo`
+ * contra `v_hato_estado_actual` FRESCA para los animales de esta hoja -- nunca
+ * un valor cacheado del momento en que se imprimió la planilla.
  */
 export function construirDiffChequeo(
   filas: FilaChequeoNormalizada[],
   animales: AnimalHatoActual[],
   ultimosChequeos: UltimoChequeoVacaActual[],
+  estadosRegistrados: AnimalEstadoRegistradoActual[] = [],
 ): ResultadoDiffChequeo {
   const animalesPorNumero = new Map<number, AnimalHatoActual>();
   for (const a of animales) animalesPorNumero.set(a.numero, a);
 
   const ultimoPorAnimalId = new Map<string, UltimoChequeoVacaActual>();
   for (const u of ultimosChequeos) ultimoPorAnimalId.set(u.animalId, u);
+
+  const estadosRegistradosPorAnimalId = new Map<string, string>();
+  for (const e of estadosRegistrados) estadosRegistradosPorAnimalId.set(e.animalId, e.estado);
 
   // Colisión DENTRO de la hoja subida (mismo número, nombres distintos) --
   // mismo motor que ya protege el pipeline histórico. `nombre` nunca es
@@ -305,6 +388,9 @@ export function construirDiffChequeo(
         diferencias: [],
         motivoNoReconocido: null,
         issues: fila.issues,
+        // Ficha nueva: no hay animal contra el cual recalcular "lo que el
+        // sistema cree hoy".
+        conflictoEstadoRegistrado: null,
       };
     }
 
@@ -322,6 +408,11 @@ export function construirDiffChequeo(
       diferencias,
       motivoNoReconocido: null,
       issues: fila.issues,
+      conflictoEstadoRegistrado: calcularConflictoEstadoRegistrado(
+        fila.estadoRegistrado,
+        animal.id,
+        estadosRegistradosPorAnimalId,
+      ),
     };
   });
 
@@ -332,6 +423,7 @@ export function construirDiffChequeo(
     cambios: filasDiff.filter((f) => f.clasificacion === 'cambio').length,
     noReconocidos: filasDiff.filter((f) => f.clasificacion === 'no_reconocido').length,
     conIssues: filasDiff.filter((f) => f.issues.length > 0).length,
+    conConflictoEstadoRegistrado: filasDiff.filter((f) => f.conflictoEstadoRegistrado !== null).length,
   };
 
   return { filas: filasDiff, resumen, colisionesEnHoja };

--- a/src/supabase/functions/server/importHato/grilla.ts
+++ b/src/supabase/functions/server/importHato/grilla.ts
@@ -41,6 +41,12 @@ export type ColumnaLogicaChequeo =
   | 'sx'
   | 'fechaServicio'
   | 'toro'
+  /** "Estado registrado" (D-E, plan agosto 2026 N21-N22): columna PRE-LLENADA
+   * y de solo referencia -- lo que el motor de 5 estados cree HOY, impreso
+   * para que la vet lo verifique contra la vaca real. Nunca se le pide nada
+   * a Martha en esta columna (esa es `estado`, la de al lado). Solo existe en
+   * el formato B5.3/B5.4 propio -- ninguna generación histórica la trae. */
+  | 'estadoRegistrado'
   | 'tp'
   | 'estado'
   | 'secar'
@@ -58,6 +64,7 @@ export const COLMAP_VACIO: ColmapChequeo = {
   sx: null,
   fechaServicio: null,
   toro: null,
+  estadoRegistrado: null,
   tp: null,
   estado: null,
   secar: null,
@@ -104,6 +111,10 @@ const ALIAS_ANCLA: Record<
   sx: ['SX', 'SEXO CRÍA'], // 'Sexo cría' es B5.3
   fechaServicio: ['F SERVICIO', 'FECHA SERVICIO'], // 'Fecha Servicio' es B5.3
   toro: ['T', 'TORO'],
+  // 'Estado registrado' es B5.4 (D-E, plan agosto 2026) -- exclusiva de
+  // nuestro propio formato, nunca ambigua con el alias 'ESTADO' del grupo
+  // final (comparación EXACTA de texto normalizado, ver `buscarColumnas`).
+  estadoRegistrado: ['ESTADO REGISTRADO'],
   ttto: ['TTTO', 'TRATAMIENTO'], // 'Tratamiento' es B5.3
 };
 
@@ -316,6 +327,11 @@ function colmapPosicional(offset: number): ColmapChequeo {
     sx: offset + 5,
     fechaServicio: offset + 6,
     toro: offset + 7,
+    // Ninguna de las 4 hojas headerless del corpus histórico trae 'Estado
+    // registrado' (B5.4, solo existe en nuestro propio formato exportado, que
+    // SIEMPRE lleva encabezado real) -- se deja sin columna, nunca se inventa
+    // una posición.
+    estadoRegistrado: null,
     tp: offset + 8,
     estado: offset + 9,
     secar: offset + 10,
@@ -380,6 +396,7 @@ const COLUMNAS_PARA_FILTRO_VACIO: ColumnaLogicaChequeo[] = [
   'sx',
   'fechaServicio',
   'toro',
+  'estadoRegistrado',
   'estado',
   'secar',
   'pp',

--- a/src/supabase/functions/server/importHato/ocrChequeo.ts
+++ b/src/supabase/functions/server/importHato/ocrChequeo.ts
@@ -78,6 +78,7 @@ export const COLUMNAS_OCR = [
   'sexo_cria',
   'fecha_servicio',
   'toro',
+  'estado_registrado',
   'estado',
   'secar',
   'parto_probable',
@@ -108,6 +109,7 @@ export const ENCABEZADO_POR_COLUMNA_OCR: Record<ColumnaOcr, string> = {
   sexo_cria: 'Sexo cría',
   fecha_servicio: 'Fecha Servicio',
   toro: 'Toro',
+  estado_registrado: 'Estado registrado',
   estado: 'Estado',
   secar: 'Secar',
   parto_probable: 'Parto Probable',
@@ -781,6 +783,21 @@ export const VOCABULARIO_SX: readonly string[] = [
 /** Códigos de la columna Estado que `parseEstado` reconoce. */
 export const VOCABULARIO_ESTADO: readonly string[] = ['ok', 'rech'];
 
+/** Etiquetas que puede traer la columna "Estado registrado" (D-E, B5.4) --
+ * las CINCO del vocabulario del dueño más el guion de "sin clasificar". Es
+ * una columna de REFERENCIA que el sistema pre-imprime; Martha nunca escribe
+ * ahí, así que el modelo solo necesita reconocer una de estas palabras (o
+ * transcribir lo que vea si algo salió distinto -- regla 3 del prompt sigue
+ * mandando). */
+export const VOCABULARIO_ESTADO_REGISTRADO: readonly string[] = [
+  'Vacía',
+  'Servida',
+  'Confirmada',
+  'Por secar',
+  'Seca',
+  '—',
+];
+
 export interface VocabularioOcr {
   /** Nombres de toro reales, de `hato_toros`. */
   toros: readonly string[];
@@ -882,6 +899,7 @@ export function construirPromptOcr(vocabulario: VocabularioOcr): string {
     'VOCABULARIO ESPERADO (úsalo para leer mejor la letra, NO para reemplazar lo que ves):',
     `- Fechas: formato día/mes/año, por ejemplo 5/11/2026. Transcríbelas tal cual estén escritas.`,
     `- Columna 'Sexo cría' (código SX): ${VOCABULARIO_SX.join(', ')}. La letra A es hembra, la O es macho, el signo + significa que la cría murió, y un número después de la letra es la chapeta de la cría.`,
+    `- Columna 'Estado registrado' (letra impresa, GRIS, de referencia -- nunca escrita a mano): una de estas palabras: ${VOCABULARIO_ESTADO_REGISTRADO.join(', ')}.`,
     `- Columna 'Estado': ${VOCABULARIO_ESTADO.join(', ')}.`,
     `- Columna 'Toro': nombres del catálogo real: ${toros}. A veces va precedido de 'Toro ' o 'Ins '. Si el nombre escrito no está en el catálogo, transcríbelo igual tal cual.`,
     `- Columnas 'PL' y '# Partos': números.`,

--- a/src/supabase/functions/server/importHato/ocrPesaje.ts
+++ b/src/supabase/functions/server/importHato/ocrPesaje.ts
@@ -320,13 +320,25 @@ export type ResultadoAnclaPesaje =
  * ambigüedad real. */
 const TOLERANCIA_EDICION_NOMBRE = 1;
 
-export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje): ResultadoAnclaPesaje {
-  const leido = normalizarNombrePesaje(fila.nombreImpreso);
+/**
+ * Cotejo de un nombre contra el roster de la planilla -- el corazón del
+ * anti-row-drift. Nace del ancla de la ruta FOTO (`validarAnclaFilaPesaje`,
+ * abajo, que solo le pasa `fila.nombreImpreso`), pero es la MISMA regla que
+ * necesita `ocrPesajeCorreccion.ts` para resolver el nombre que Fernando
+ * escribe en una corrección de texto libre (D-C): exacto único -> resuelto;
+ * exacto ambiguo -> nunca se adjudica; a una letra único -> resuelto con
+ * aviso; a una letra ambiguo -> nunca se adjudica; nada -> fuera del roster.
+ * Cotejar el nombre de una corrección con un algoritmo DISTINTO al que
+ * cotejó la foto original sería inconsistente sin motivo -- por eso una sola
+ * función, no dos parecidas.
+ */
+export function resolverNombreEnRosterPesaje(nombreCrudo: string, roster: RosterPesaje): ResultadoAnclaPesaje {
+  const leido = normalizarNombrePesaje(nombreCrudo);
   if (leido === '') {
     return {
       ok: false,
       motivo: 'nombre_ilegible',
-      detalle: `el nombre impreso se leyó como '${fila.nombreImpreso}', que no es un nombre -- la fila no se puede anclar`,
+      detalle: `'${nombreCrudo}' no es un nombre -- no se puede anclar`,
     };
   }
 
@@ -336,7 +348,7 @@ export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje
     return {
       ok: false,
       motivo: 'nombre_ambiguo_en_roster',
-      detalle: `${exactos.length} vacas en ordeño se llaman '${fila.nombreImpreso}' -- no se adjudica sola (regla del módulo), la fila queda para revisión humana`,
+      detalle: `${exactos.length} vacas en ordeño se llaman '${nombreCrudo}' -- no se adjudica sola (regla del módulo), queda para revisión humana`,
     };
   }
 
@@ -347,22 +359,26 @@ export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje
     return {
       ok: true,
       entrada: cercanos[0],
-      avisos: [`el nombre impreso se leyó como '${fila.nombreImpreso}' y el roster dice '${cercanos[0].nombre}' (una letra de diferencia) -- revisar`],
+      avisos: [`'${nombreCrudo}' y el roster dice '${cercanos[0].nombre}' (una letra de diferencia) -- revisar`],
     };
   }
   if (cercanos.length > 1) {
     return {
       ok: false,
       motivo: 'nombre_ambiguo_en_roster',
-      detalle: `'${fila.nombreImpreso}' está a una letra de ${cercanos.length} vacas en ordeño distintas -- no se adjudica sola`,
+      detalle: `'${nombreCrudo}' está a una letra de ${cercanos.length} vacas en ordeño distintas -- no se adjudica sola`,
     };
   }
 
   return {
     ok: false,
     motivo: 'nombre_fuera_del_roster',
-    detalle: `ninguna vaca en ordeño activa se llama '${fila.nombreImpreso}' -- puede ser una vaca vendida, una novilla anotada a mano, o un nombre mal leído`,
+    detalle: `ninguna vaca en ordeño activa se llama '${nombreCrudo}' -- puede ser una vaca vendida, una novilla anotada a mano, o un nombre mal escrito/leído`,
   };
+}
+
+export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje): ResultadoAnclaPesaje {
+  return resolverNombreEnRosterPesaje(fila.nombreImpreso, roster);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/supabase/functions/server/importHato/ocrPesajeCorreccion.ts
+++ b/src/supabase/functions/server/importHato/ocrPesajeCorreccion.ts
@@ -1,0 +1,419 @@
+// ARCHIVO: src/supabase/functions/server/importHato/ocrPesajeCorreccion.ts
+// GENERADO por docs/hato/regenerar-copias-importhato.py -- NUNCA edites este
+// archivo a mano. Editá `src/utils/importHato/ocrPesajeCorreccion.ts` y volvé a correr el script.
+//
+// POR QUÉ EXISTE ESTE DUPLICADO: el endpoint B0/V10 (`POST
+// .../hato/chequeo/preview`, `hato-chequeo-preview.ts`) corre en el árbol de
+// despliegue de la edge function y no puede importar desde `src/utils/` --
+// cruzaría la frontera del árbol de despliegue de Deno. Misma restricción
+// que ya produjo `priorizacion-scouting.ts` y `calculos-hato.ts`.
+//
+// Contenido idéntico al original salvo los especificadores de import
+// (reescritos para Deno: `@/utils/calculosHato` -> `../calculos-hato.ts`,
+// `./xxx` -> `./xxx.ts`). `src/__tests__/importHatoParidadServidor.test.ts`
+// corre este mismo script en modo `--check` y falla si alguien hand-editó
+// una copia en vez de regenerarla.
+
+// ARCHIVO: utils/importHato/ocrPesajeCorreccion.ts
+// DESCRIPCIÓN: N12 de `docs/plan_hato_telegram_estados_agosto_2026.md` --
+// decisión D-C del dueño: el bot de Telegram muestra en texto plano la
+// lectura de la planilla de pesaje (`ocrPesaje.ts`), Fernando responde en
+// LENGUAJE NATURAL ("MONZA sem 2 AM son 6.5 y BONITA no se pesó"), un modelo
+// traduce esa frase a celdas concretas y el bot vuelve a mostrar el resumen
+// YA CORREGIDO -- solo se persiste tras un "ok" explícito.
+//
+// LA MISMA SEPARACIÓN que el resto del módulo (`ocrChequeo.ts`,
+// `ocrPesaje.ts`): el modelo SOLO extrae entidades del texto (qué vaca, qué
+// semana, qué sub-celda, qué valor o "sin dato"); este archivo es quien
+// VALIDA esas entidades contra el roster y la grilla de semanas del mes --
+// nunca al revés. La llamada HTTP al modelo vive en el árbol Deno
+// (`hato-pesaje-pipeline.ts`); acá no hay I/O ni `Date.now()`.
+//
+// REGLA DURA (idéntica a la del ancla por foto): un ítem que el modelo no
+// logre anclar a UNA vaca del roster, a UNA semana válida de la grilla o a
+// UN valor de litros interpretable NUNCA se aplica -- se reporta como no
+// entendido para que Fernando lo aclare. Nunca se adivina.
+//
+// El cotejo de nombre reusa `resolverNombreEnRosterPesaje` de `./ocrPesaje`
+// -- el MISMO algoritmo que ancla la foto, para que un nombre se resuelva
+// igual sin importar si vino impreso o hablado. Los litros se interpretan
+// con `parseValorNumerico` (`calculosHato.ts`), el único parser numérico.
+//
+// Puro, cero I/O, cero Date.now().
+
+import { parseValorNumerico } from '../calculos-hato.ts';
+import {
+  resolverNombreEnRosterPesaje,
+  SEMANAS_PESAJE,
+  type CeldaDiffPesaje,
+  type ClasificacionCeldaPesaje,
+  type RosterPesaje,
+  type SemanaPesaje,
+} from './ocrPesaje.ts';
+
+// ---------------------------------------------------------------------------
+// 1. Lo que el modelo devuelve -- entidades extraídas del texto, SIN validar.
+// ---------------------------------------------------------------------------
+
+export type SubceldaCorreccionPesaje = 'am' | 'pm' | 'ambos';
+
+export interface ItemCorreccionModeloPesaje {
+  /** El nombre de vaca tal como el usuario lo escribió, verbatim -- para
+   * poder reportar "no encontré a X" con el texto real, nunca el
+   * normalizado. */
+  nombreMencionado: string;
+  /** Semana 1-5 mencionada en el texto, o `null` si el texto no la
+   * especifica. Nunca se infiere -- una corrección sin semana se reporta
+   * como no entendida (mismo criterio que un nombre sin ancla). */
+  semana: number | null;
+  /** Qué sub-celda(s) afecta. `'ambos'` cuando el texto habla de la vaca sin
+   * distinguir AM/PM (p. ej. "no se pesó"). `null` si el texto no lo dice. */
+  subcelda: SubceldaCorreccionPesaje | null;
+  /** `true` cuando el texto dice explícitamente que la vaca no se pesó / no
+   * hay dato para esa celda -- el valor resultante es `null`, nunca 0. */
+  sinDato: boolean;
+  /** Texto crudo del valor de litros, tal como lo dijo el usuario (puede
+   * traer coma, fracción, etc. -- se interpreta con `parseValorNumerico`).
+   * Vacío o ausente cuando `sinDato` es `true`. */
+  valorTexto: string | null;
+}
+
+function textoPlano(valor: unknown): string {
+  if (valor === null || valor === undefined) return '';
+  if (typeof valor === 'string') return valor.trim();
+  if (typeof valor === 'number' || typeof valor === 'boolean') return String(valor);
+  return '';
+}
+
+function semanaPlana(valor: unknown): number | null {
+  if (typeof valor === 'number' && Number.isInteger(valor)) return valor;
+  if (typeof valor === 'string' && valor.trim() !== '') {
+    const n = Number(valor.trim());
+    if (Number.isInteger(n)) return n;
+  }
+  return null;
+}
+
+function subceldaPlana(valor: unknown): SubceldaCorreccionPesaje | null {
+  return valor === 'am' || valor === 'pm' || valor === 'ambos' ? valor : null;
+}
+
+/**
+ * Convierte el JSON crudo que devolvió el modelo (ya des-serializado) en una
+ * lista de `ItemCorreccionModeloPesaje`. Tolerante por diseño, mismo
+ * criterio que `parsearRespuestaModeloOcrPesaje`: un ítem mal formado NUNCA
+ * aborta el resto -- se conserva con lo que se pueda leer (y lo demás en
+ * `null`, que `interpretarCorreccionPesaje` reportará como no entendido en
+ * vez de fallar en silencio). Solo `items` ausente/no-arreglo es fatal: ahí
+ * no hay nada que rescatar.
+ */
+export function parsearRespuestaModeloCorreccionPesaje(bruto: unknown): {
+  items: ItemCorreccionModeloPesaje[];
+  avisos: string[];
+} {
+  const avisos: string[] = [];
+  if (bruto === null || typeof bruto !== 'object') {
+    throw new Error('La respuesta del modelo de corrección no es un objeto JSON.');
+  }
+  const raiz = bruto as Record<string, unknown>;
+  const itemsBrutos = raiz.items;
+  if (!Array.isArray(itemsBrutos)) {
+    throw new Error("La respuesta del modelo de corrección no trae el arreglo 'items'.");
+  }
+
+  const items: ItemCorreccionModeloPesaje[] = itemsBrutos.map((itemBruto, i) => {
+    if (itemBruto === null || typeof itemBruto !== 'object') {
+      avisos.push(`ítem ${i + 1}: no es un objeto -- se descarta su contenido, queda como no entendido`);
+      return { nombreMencionado: '', semana: null, subcelda: null, sinDato: false, valorTexto: null };
+    }
+    const item = itemBruto as Record<string, unknown>;
+    return {
+      nombreMencionado: textoPlano(item.nombre_mencionado),
+      semana: semanaPlana(item.semana),
+      subcelda: subceldaPlana(item.subcelda),
+      sinDato: item.sin_dato === true,
+      valorTexto: item.sin_dato === true ? null : textoPlano(item.valor_texto) || null,
+    };
+  });
+
+  return { items, avisos };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Validación: entidades del modelo -> celdas concretas, o "no entendida".
+// ---------------------------------------------------------------------------
+
+export interface CorreccionPesajeAplicable {
+  animalId: string;
+  nombre: string;
+  semana: SemanaPesaje;
+  fecha: string;
+  subcelda: 'am' | 'pm';
+  /** `null` = limpia la celda ("no se pesó"), nunca 0. */
+  valor: number | null;
+}
+
+export interface CorreccionPesajeNoEntendida {
+  nombreMencionado: string;
+  semana: number | null;
+  detalle: string;
+}
+
+export interface ResultadoInterpretacionCorreccionPesaje {
+  aplicables: CorreccionPesajeAplicable[];
+  noEntendidas: CorreccionPesajeNoEntendida[];
+}
+
+/**
+ * Valida cada ítem que el modelo extrajo del texto libre contra el roster
+ * (nombre) y la grilla de semanas del mes (`fechasPorSemana`, la MISMA que
+ * ya resolvió `fechasPesajeMensuales` para la lectura por foto -- nunca se
+ * vuelve a derivar). Un ítem que falle CUALQUIERA de las tres anclas (vaca,
+ * semana, valor) va a `noEntendidas` -- nunca se aplica a medias ni se
+ * adivina la parte que falta.
+ */
+export function interpretarCorreccionPesaje(
+  items: readonly ItemCorreccionModeloPesaje[],
+  roster: RosterPesaje,
+  fechasPorSemana: Readonly<Record<SemanaPesaje, string | null>>,
+): ResultadoInterpretacionCorreccionPesaje {
+  const aplicables: CorreccionPesajeAplicable[] = [];
+  const noEntendidas: CorreccionPesajeNoEntendida[] = [];
+
+  for (const item of items) {
+    const ancla = resolverNombreEnRosterPesaje(item.nombreMencionado, roster);
+    if (!ancla.ok) {
+      noEntendidas.push({ nombreMencionado: item.nombreMencionado, semana: item.semana, detalle: ancla.detalle });
+      continue;
+    }
+    const nombre = ancla.entrada.nombre;
+
+    if (item.semana === null || !(SEMANAS_PESAJE as readonly number[]).includes(item.semana)) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana: item.semana,
+        detalle: `no especifica una semana válida (1 a 5) para ${nombre} -- dila explícita, p. ej. "semana 2"`,
+      });
+      continue;
+    }
+    const semana = item.semana as SemanaPesaje;
+
+    const fecha = fechasPorSemana[semana];
+    if (fecha === null) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `la semana ${semana} no existe en la planilla de este mes`,
+      });
+      continue;
+    }
+
+    // "no se pesó" sin AM/PM explícito limpia AMBAS -- ninguno de los dos
+    // ordeños pasó esa semana. Con valor (no sinDato) sí hace falta que el
+    // texto diga cuál de los dos: escribir el mismo número en AM y PM sin que
+    // el usuario lo haya dicho sería adivinar.
+    const subceldas: Array<'am' | 'pm'> =
+      item.subcelda === 'ambos' || (item.sinDato && item.subcelda === null)
+        ? ['am', 'pm']
+        : item.subcelda === 'am' || item.subcelda === 'pm'
+          ? [item.subcelda]
+          : [];
+
+    if (subceldas.length === 0) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `no especifica si es AM, PM o ambos para ${nombre} semana ${semana}`,
+      });
+      continue;
+    }
+
+    if (item.sinDato) {
+      for (const sub of subceldas) {
+        aplicables.push({ animalId: ancla.entrada.id, nombre, semana, fecha, subcelda: sub, valor: null });
+      }
+      continue;
+    }
+
+    const parseado = item.valorTexto ? parseValorNumerico(item.valorTexto, { fracciones: true }) : null;
+    if (!item.valorTexto || !parseado || parseado.valor === null) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `no pude interpretar '${item.valorTexto ?? ''}' como litros para ${nombre} semana ${semana}`,
+      });
+      continue;
+    }
+    for (const sub of subceldas) {
+      aplicables.push({ animalId: ancla.entrada.id, nombre, semana, fecha, subcelda: sub, valor: parseado.valor });
+    }
+  }
+
+  return { aplicables, noEntendidas };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Aplicar correcciones YA validadas sobre el diff en memoria.
+// ---------------------------------------------------------------------------
+
+/**
+ * Aplica correcciones validadas sobre el diff que ya se le mostró al
+ * usuario -- SIEMPRE en memoria, nunca contra la base de datos: el
+ * commit (N13) es un paso posterior y separado, gateado por el "ok"
+ * explícito. Una corrección que no toca una celda del diff (animal/semana
+ * que no vino en la lectura original) la agrega -- puede ser una vaca que
+ * el OCR no leyó y que Fernando corrige a mano en el mismo mensaje.
+ *
+ * `clasificacion` se recalcula con la MISMA regla que `construirDiffPesaje`
+ * (litrosTotal null -> 'sin_dato'; sin fila existente -> 'nuevo'; con fila
+ * existente -> 'cambio' -- nunca hace falta distinguir 'cambio' de
+ * 'sin_cambio' después de una corrección humana, ambas son escribibles por
+ * igual). `noConfiable` pasa a `false`: un humano confirmó la celda, ya no
+ * es "el modelo dudó".
+ */
+export function aplicarCorreccionesADiff(
+  diff: readonly CeldaDiffPesaje[],
+  aplicables: readonly CorreccionPesajeAplicable[],
+): CeldaDiffPesaje[] {
+  if (aplicables.length === 0) return [...diff];
+
+  type Cambio = { am?: number | null; pm?: number | null };
+  const porCelda = new Map<string, Cambio>();
+  for (const correccion of aplicables) {
+    const clave = `${correccion.animalId}|${correccion.semana}`;
+    const actual = porCelda.get(clave) ?? {};
+    if (correccion.subcelda === 'am') actual.am = correccion.valor;
+    else actual.pm = correccion.valor;
+    porCelda.set(clave, actual);
+  }
+
+  const resultado = diff.map((celda): CeldaDiffPesaje => {
+    const clave = `${celda.animalId}|${celda.semana}`;
+    const cambio = porCelda.get(clave);
+    if (!cambio) return celda;
+    porCelda.delete(clave); // lo que sobrevive al final son celdas NUEVAS (ver abajo)
+
+    const litrosAm = 'am' in cambio ? (cambio.am as number | null) : celda.litrosAm;
+    const litrosPm = 'pm' in cambio ? (cambio.pm as number | null) : celda.litrosPm;
+    return recalcularCelda({ ...celda, litrosAm, litrosPm });
+  });
+
+  // Correcciones que no calzaron con ninguna celda ya presente en el diff
+  // (p. ej. una vaca que la foto no leyó y que Fernando agrega a mano en la
+  // misma corrección) -- se agregan como celdas nuevas, nunca se descartan.
+  for (const [clave, cambio] of porCelda) {
+    const [animalId, semanaTexto] = clave.split('|');
+    const semana = Number(semanaTexto) as SemanaPesaje;
+    const nombre = aplicables.find((a) => a.animalId === animalId && a.semana === semana)?.nombre ?? '';
+    const fecha = aplicables.find((a) => a.animalId === animalId && a.semana === semana)?.fecha ?? '';
+    resultado.push(
+      recalcularCelda({
+        animalId,
+        nombre,
+        semana,
+        fecha,
+        litrosAm: 'am' in cambio ? (cambio.am as number | null) : null,
+        litrosPm: 'pm' in cambio ? (cambio.pm as number | null) : null,
+        litrosTotal: null,
+        soloUnOrdeno: false,
+        existenteId: null,
+        clasificacion: 'sin_dato',
+        noConfiable: false,
+      }),
+    );
+  }
+
+  return resultado;
+}
+
+function recalcularCelda(celda: CeldaDiffPesaje): CeldaDiffPesaje {
+  const litrosTotal = celda.litrosAm === null && celda.litrosPm === null ? null : (celda.litrosAm ?? 0) + (celda.litrosPm ?? 0);
+  const clasificacion: ClasificacionCeldaPesaje =
+    litrosTotal === null ? 'sin_dato' : celda.existenteId ? 'cambio' : 'nuevo';
+  return {
+    ...celda,
+    litrosTotal,
+    soloUnOrdeno: (celda.litrosAm === null) !== (celda.litrosPm === null),
+    clasificacion,
+    noConfiable: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Prompt y esquema de salida del modelo de interpretación.
+// ---------------------------------------------------------------------------
+
+/** Esquema JSON estricto -- mismo criterio que `esquemaJsonOcrPesaje`: sin
+ * uniones de tipo abiertas donde se pueda evitar, ausencia = `null`. */
+export function esquemaJsonCorreccionPesaje(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      items: {
+        type: 'array',
+        description: 'Una entrada por cada corrección/aclaración que el texto menciona.',
+        items: {
+          type: 'object',
+          properties: {
+            nombre_mencionado: {
+              type: 'string',
+              description: 'El nombre de la vaca tal como aparece en el texto, verbatim.',
+            },
+            semana: {
+              type: ['integer', 'null'],
+              description: 'Número de semana (1 a 5) que el texto menciona explícitamente. null si no lo dice.',
+            },
+            subcelda: {
+              type: ['string', 'null'],
+              enum: ['am', 'pm', 'ambos', null],
+              description:
+                "'am' u 'pm' si el texto distingue el ordeño; 'ambos' cuando habla de la vaca sin distinguir (p. ej. 'no se pesó'); null si no se puede determinar.",
+            },
+            sin_dato: {
+              type: 'boolean',
+              description: "true cuando el texto dice que la vaca NO se pesó / no hay dato para esa celda.",
+            },
+            valor_texto: {
+              type: ['string', 'null'],
+              description:
+                'El valor de litros tal como lo escribió el usuario (puede traer coma o fracción). null cuando sin_dato es true.',
+            },
+          },
+          required: ['nombre_mencionado', 'semana', 'subcelda', 'sin_dato', 'valor_texto'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['items'],
+    additionalProperties: false,
+  };
+}
+
+/**
+ * Prompt de interpretación. Deliberadamente NO incluye el roster de vacas
+ * activas (mismo criterio que `construirPromptOcrPesaje`): el modelo solo
+ * EXTRAE entidades del texto -- el nombre exacto que Fernando escribió, tal
+ * cual -- y es `interpretarCorreccionPesaje` quien lo valida contra el
+ * roster real. Pasarle el roster al modelo volvería la extracción un espejo
+ * de sí misma en vez de una lectura honesta del texto.
+ */
+export function construirPromptCorreccionPesaje(): string {
+  return [
+    'Eres un asistente que interpreta correcciones en español, dichas en lenguaje natural, sobre una planilla de pesaje de leche de un hato lechero en Colombia.',
+    '',
+    'El usuario acaba de ver un resumen de lo que se leyó de una foto de la planilla (vaca, semana, litros AM/PM) y ahora escribe correcciones o aclaraciones en texto libre. Tu único trabajo es EXTRAER, para cada corrección que menciona, estos datos: el nombre de la vaca (tal como lo escribió, sin corregirlo ni normalizarlo), la semana (1 a 5) si la menciona, si habla de AM, PM o de la vaca en general, si dice que la vaca NO se pesó, y el valor de litros si da uno.',
+    '',
+    'EJEMPLOS (los nombres son solo ilustrativos, no una lista real):',
+    '- "LUNA sem 2 AM son 6.5" -> {nombre_mencionado: "LUNA", semana: 2, subcelda: "am", sin_dato: false, valor_texto: "6.5"}',
+    '- "PRINCESA no se pesó" -> {nombre_mencionado: "PRINCESA", semana: null, subcelda: null, sin_dato: true, valor_texto: null} (semana null porque el texto no la menciona -- NO la adivines)',
+    '- "la vaca REINA semana 3 no se pesó" -> {nombre_mencionado: "REINA", semana: 3, subcelda: "ambos", sin_dato: true, valor_texto: null}',
+    '',
+    'REGLAS DURAS:',
+    '1. NUNCA inventes una semana, un AM/PM o un valor que el texto no diga explícita o inequívocamente. Si no está claro, deja ese campo en null (o sin_dato en false con valor_texto null) -- es preferible reportar que no se entendió a adivinar.',
+    '2. Copia el nombre EXACTAMENTE como aparece en el texto, sin corregir ortografía ni completar el nombre real de una vaca -- eso lo hace otro paso, no tú.',
+    '3. El valor de litros se copia tal cual está escrito (puede traer coma, punto o fracción como "6 1/2"); no lo conviertas ni lo redondees.',
+    '4. Una sola frase puede traer varias correcciones (una por vaca) -- devuelve un ítem por cada una.',
+    '',
+    'Responde ÚNICAMENTE con el JSON del esquema pedido. Sin explicaciones, sin markdown.',
+  ].join('\n');
+}

--- a/src/supabase/functions/server/importHato/tipos.ts
+++ b/src/supabase/functions/server/importHato/tipos.ts
@@ -55,6 +55,14 @@ export interface CrudoFilaChequeo {
   sx: string | null;
   fechaServicio: string | null;
   toro: string | null;
+  /** "Estado registrado" (D-E, B5.4): el texto VERBATIM impreso en la
+   * columna de referencia -- la etiqueta de `EstadoReproductivo`
+   * (`etiquetaEstadoReproductivo`, calculosHato.ts) que el sistema creía
+   * cierta al momento de exportar/imprimir la planilla. Nunca se interpreta
+   * acá (ni se convierte a un `EstadoReproductivo`): es evidencia cruda que
+   * el diff compara contra lo que el sistema cree AHORA (N23). `null` en
+   * cualquier generación histórica -- esa columna no existía. */
+  estadoRegistrado: string | null;
   /** Se conserva por trazabilidad pero NUNCA se interpreta: es una fórmula
    * `TODAY()` congelada, no un dato del chequeo (doc S2 QA §2.4). */
   tp: string | null;
@@ -99,6 +107,13 @@ export interface FilaChequeoNormalizada {
   fechaProbableParto: string | null;
   toroNombre: string | null;
   tipoServicio: 'monta' | 'inseminacion' | null;
+  /** Copia trimeada de `raw.estadoRegistrado` -- lo que estaba impreso en
+   * "Estado registrado" cuando se exportó esta planilla (D-E, B5.4). `null`
+   * cuando la hoja no trae esa columna (toda generación histórica) o la
+   * celda vino vacía. El diff (`diffChequeo.ts`) la compara contra el
+   * `EstadoReproductivo` que el sistema deriva HOY -- nunca contra otro
+   * campo, y nunca se reinterpreta a un tipo cerrado acá. */
+  estadoRegistrado: string | null;
 
   issues: ParseIssue[];
 }

--- a/src/supabase/functions/server/telegram/bot.ts
+++ b/src/supabase/functions/server/telegram/bot.ts
@@ -333,7 +333,7 @@ function getBot(): Bot<BotContext> {
         "/monitoreo — Registrar monitoreo",
         "/gasto — Registrar un gasto",
         "/ingreso — Registrar un ingreso",
-        "/pesaje — Pesaje semanal de leche por vaca",
+        "/pesaje — Cargar la planilla de pesaje de leche por foto",
         "/evento — Registrar monta, inseminación, secado, parto o aborto",
         "/cancelar — Cancelar operación actual",
         "/ayuda — Ver esta ayuda",
@@ -903,7 +903,8 @@ function getBot(): Bot<BotContext> {
     { command: "monitoreo", description: "Registrar monitoreo" },
     { command: "gasto", description: "Registrar un gasto" },
     { command: "ingreso", description: "Registrar un ingreso" },
-    { command: "pesaje", description: "Pesaje semanal de leche" },
+    { command: "pesaje", description: "Cargar pesaje de leche por foto" },
+    { command: "evento", description: "Registrar evento del hato" },
     { command: "cancelar", description: "Cancelar operación actual" },
     { command: "ayuda", description: "Ver ayuda" },
   ]).catch((err) => console.error("[Telegram] setMyCommands error:", err));

--- a/src/supabase/functions/server/telegram/bot.ts
+++ b/src/supabase/functions/server/telegram/bot.ts
@@ -18,6 +18,7 @@ import { monitoreoConversation } from "./conversations/monitoreo.ts";
 import { gastoConversation } from "./conversations/gasto.ts";
 import { ingresoConversation } from "./conversations/ingreso.ts";
 import { pesajeLecheConversation } from "./conversations/pesajeLeche.ts";
+import { eventoHatoConversation } from "./conversations/eventoHato.ts";
 // `produccionQuincenal` (litros al camión) se retiró del bot -- SOW 3 de
 // docs/plan_hato_produccion_rework.md §2.3: la quincena pasó a ser un
 // registro financiero (`fin_ingreso_id NOT NULL`, migración 070) y el bot
@@ -140,6 +141,7 @@ function getBot(): Bot<BotContext> {
   bot.use(createConversation(gastoConversation, "gasto"));
   bot.use(createConversation(ingresoConversation, "ingreso"));
   bot.use(createConversation(pesajeLecheConversation, "pesajeLeche"));
+  bot.use(createConversation(eventoHatoConversation, "eventoHato"));
 
   // ==========================================================================
   // HELPERS
@@ -163,6 +165,7 @@ function getBot(): Bot<BotContext> {
     }
     if (mods.includes("hato_produccion")) {
       kb.text("🐄 Pesaje semanal (leche)", "start_pesajeLeche").row();
+      kb.text("📋 Registrar evento del hato", "start_eventoHato").row();
     }
     if (mods.includes("consultas")) {
       kb.text("💬 Preguntarle a Esco", "start_consulta").row();
@@ -301,6 +304,20 @@ function getBot(): Bot<BotContext> {
     await ctx.conversation.enter("pesajeLeche");
   });
 
+  // /evento — registro en campo del ciclo reproductivo (monta, inseminación,
+  // secado, parto, aborto). Se gatea con el MISMO módulo que el pesaje
+  // (`hato_produccion`) a propósito: es el módulo que Fernando ya tiene, así
+  // que el flujo sirve desde el primer despliegue sin tocar configuración.
+  // Separarlo en un módulo propio es un cambio de `modulos_permitidos`, no
+  // de código.
+  bot.command("evento", async (ctx) => {
+    if (!ctx.telegramUser?.modulos_permitidos?.includes("hato_produccion")) {
+      await ctx.reply("No tienes acceso a este módulo.");
+      return;
+    }
+    await ctx.conversation.enter("eventoHato");
+  });
+
   bot.command("cancelar", async (ctx) => {
     await ctx.conversation.exit();
     await ctx.reply("Operación cancelada.");
@@ -317,6 +334,7 @@ function getBot(): Bot<BotContext> {
         "/gasto — Registrar un gasto",
         "/ingreso — Registrar un ingreso",
         "/pesaje — Pesaje semanal de leche por vaca",
+        "/evento — Registrar monta, inseminación, secado, parto o aborto",
         "/cancelar — Cancelar operación actual",
         "/ayuda — Ver esta ayuda",
         "",
@@ -372,6 +390,15 @@ function getBot(): Bot<BotContext> {
       return;
     }
     await ctx.conversation.enter("pesajeLeche");
+  });
+
+  bot.callbackQuery("start_eventoHato", async (ctx) => {
+    await ctx.answerCallbackQuery();
+    if (!ctx.telegramUser?.modulos_permitidos?.includes("hato_produccion")) {
+      await ctx.reply("No tienes acceso a este módulo.");
+      return;
+    }
+    await ctx.conversation.enter("eventoHato");
   });
 
   bot.callbackQuery("start_consulta", async (ctx) => {
@@ -470,6 +497,67 @@ function getBot(): Bot<BotContext> {
   // Toda respuesta escribe un evento auditado (quién, cuándo, qué) — plan
   // §6 Épica C "toda respuesta escribe evento auditado".
   // --------------------------------------------------------------------------
+
+  // --------------------------------------------------------------------------
+  // DESHACER un evento recién registrado por /evento (N9).
+  //
+  // Es la contraparte de la decisión D-B (Telegram escribe DIRECTO, sin cola
+  // de aprobación): el error probable en el corral no es inventarse un
+  // evento, es elegir la vaca equivocada de una lista de homónimas — y eso se
+  // ve en el resumen al instante. Sin este botón, corregirlo exigiría entrar
+  // a la app desde una finca sin internet.
+  //
+  // Solo borra eventos de `fuente='telegram'`: el id viaja en el callback, y
+  // un callback puede reenviarse. Nunca puede convertirse en una vía para
+  // borrar un evento derivado de un chequeo aprobado.
+  // --------------------------------------------------------------------------
+
+  bot.callbackQuery(/^hato_ev_undo:([0-9a-f-]+):([0-9a-f-]+|-)$/, async (ctx) => {
+    const eventoId = ctx.match?.[1];
+    const usoId = ctx.match?.[2];
+    if (!eventoId) {
+      await ctx.answerCallbackQuery({ text: "No se pudo procesar." });
+      return;
+    }
+
+    const sb = getSupabaseAdmin();
+    const { data: evento } = await sb
+      .from("hato_eventos")
+      .select("id, fuente")
+      .eq("id", eventoId)
+      .maybeSingle();
+
+    if (!evento) {
+      await ctx.answerCallbackQuery({ text: "Ese registro ya no existe." });
+      return;
+    }
+    if (evento.fuente !== "telegram") {
+      await ctx.answerCallbackQuery({ text: "Ese registro no se puede deshacer desde aquí." });
+      return;
+    }
+
+    // El uso de pajilla se borra PRIMERO: si fallara después del evento, el
+    // inventario quedaría descontado por un servicio que ya no existe.
+    if (usoId && usoId !== "-") {
+      const { error: errorUso } = await sb.from("hato_pajillas_uso").delete().eq("id", usoId);
+      if (errorUso) {
+        await ctx.answerCallbackQuery({ text: "No se pudo devolver la pajilla. No borré nada." });
+        return;
+      }
+    }
+
+    const { error } = await sb.from("hato_eventos").delete().eq("id", eventoId);
+    if (error) {
+      await ctx.answerCallbackQuery({ text: "No se pudo deshacer. Intenta de nuevo." });
+      return;
+    }
+
+    await ctx.answerCallbackQuery({ text: "Deshecho." });
+    // Se edita el mensaje para quitar el botón: un segundo toque sobre un id
+    // ya borrado solo diría "ya no existe", pero deja al usuario dudando de
+    // si borró dos cosas.
+    await ctx.editMessageText("↩️ Registro deshecho. No quedó nada guardado.\n\nUsa /evento para registrarlo de nuevo.");
+  });
 
   bot.callbackQuery(/^hato_alerta:(.+):(si|no|otro)$/, async (ctx) => {
     const alertaId = ctx.match?.[1];

--- a/src/supabase/functions/server/telegram/bot.ts
+++ b/src/supabase/functions/server/telegram/bot.ts
@@ -26,6 +26,8 @@ import { eventoHatoConversation } from "./conversations/eventoHato.ts";
 // ese NOT NULL ni restringirse a Gerencia (decisión 5 del dueño). `/pesaje`
 // no toca dinero y se mantiene intacto.
 import { llmToolLoop, getSystemPrompt } from "../chat.tsx";
+import { construirMensajeAlertaYaResuelta, construirMensajeCierreAlertaBroadcast } from "../hato-alertas.ts";
+import { cerrarAlertaEnEnvios } from "./enviar.ts";
 
 // ============================================================================
 // SUPABASE CLIENT (service role — same pattern as chat.ts)
@@ -496,6 +498,18 @@ function getBot(): Bot<BotContext> {
   // (`hato_alerta:{alertaId}:{si|no|otro}`), mismo patrón que `mem_save:`.
   // Toda respuesta escribe un evento auditado (quién, cuándo, qué) — plan
   // §6 Épica C "toda respuesta escribe evento auditado".
+  //
+  // BROADCAST CON CIERRE POR EL PRIMERO (migración 096, 2026-08-14): desde
+  // que una alerta se manda a TODOS los suscritos de su tipo
+  // (`hato_alertas_envios`, una fila por suscrito), este handler puede
+  // recibir el mismo `hato_alerta:{id}:...` de MÁS DE UNA persona. La
+  // primera respuesta cierra la alerta para todos; cualquier respuesta
+  // posterior a la misma alerta se trata "amablemente" (no es un error, es
+  // el diseño) y NUNCA repite el efecto de dominio ni el evento auditado.
+  // La atomicidad de "quién llegó primero" la da el propio UPDATE de abajo:
+  // solo tiene efecto si la alerta TODAVÍA está `pendiente`/`enviada`
+  // (`.in('estado', ...)` + `.select()` para saber si de verdad afectó una
+  // fila) — dos respuestas casi simultáneas no pueden colarse las dos.
   // --------------------------------------------------------------------------
 
   // --------------------------------------------------------------------------
@@ -568,40 +582,65 @@ function getBot(): Bot<BotContext> {
     }
 
     const sb = getSupabaseAdmin();
-    const { data: alerta, error: errorAlerta } = await sb
+    const respondidaPor = ctx.telegramUser?.nombre_display ?? String(ctx.from?.id ?? "desconocido");
+    const nuevoEstado = respuesta === "si" ? "confirmada" : "respondida";
+
+    // Reclamo atómico de "quién llegó primero" (096): el UPDATE solo afecta
+    // una fila si la alerta TODAVÍA está pendiente/enviada -- si otro
+    // suscrito ya la cerró (o la cerró este mismo dos veces, doble-tap),
+    // `.in('estado', ...)` no matchea nada y `actualizada` viene null. Un
+    // read-then-write habría dejado una ventana de carrera entre dos
+    // suscritos respondiendo casi a la vez; este single UPDATE no la tiene.
+    const { data: actualizada, error: errorUpdate } = await sb
       .from("hato_alertas")
-      .select("id, tipo, animal_id, paso_id, estado")
+      .update({ estado: nuevoEstado, respuesta, respondida_por: respondidaPor })
       .eq("id", alertaId)
+      .in("estado", ["pendiente", "enviada"])
+      .select("id, tipo, animal_id, paso_id, datos")
       .maybeSingle();
 
-    if (errorAlerta || !alerta) {
-      await ctx.answerCallbackQuery({ text: "No encontré esa alerta -- puede que ya no exista." });
+    if (errorUpdate) {
+      console.error("[Telegram] hato_alerta update error:", errorUpdate.message);
+      await ctx.answerCallbackQuery({ text: "No pude guardar tu respuesta. Intenta de nuevo." });
       return;
     }
 
-    const respondidaPor = ctx.telegramUser?.nombre_display ?? String(ctx.from?.id ?? "desconocido");
+    if (!actualizada) {
+      // O la alerta no existe, o ya la cerró otro suscrito (o este mismo,
+      // doble-tap) -- se distingue leyendo el estado actual, "amablemente",
+      // SIN repetir el efecto de dominio ni el evento auditado.
+      const { data: alertaExistente } = await sb
+        .from("hato_alertas")
+        .select("id, estado, respuesta, respondida_por")
+        .eq("id", alertaId)
+        .maybeSingle();
+      if (!alertaExistente) {
+        await ctx.answerCallbackQuery({ text: "No encontré esa alerta -- puede que ya no exista." });
+        return;
+      }
+      await ctx.answerCallbackQuery({
+        text: construirMensajeAlertaYaResuelta(
+          alertaExistente.estado,
+          alertaExistente.respondida_por,
+          alertaExistente.respuesta as "si" | "no" | "otro" | null,
+        ),
+      });
+      await ctx.editMessageReplyMarkup().catch(() => {});
+      return;
+    }
+
     const hoyIso = new Date().toISOString().slice(0, 10);
 
     if (respuesta === "si") {
-      const { error: errorUpdate } = await sb
-        .from("hato_alertas")
-        .update({ estado: "confirmada", respuesta: "si", respondida_por: respondidaPor })
-        .eq("id", alertaId);
-      if (errorUpdate) {
-        console.error("[Telegram] hato_alerta 'si' update error:", errorUpdate.message);
-        await ctx.answerCallbackQuery({ text: "No pude guardar tu respuesta. Intenta de nuevo." });
-        return;
-      }
-
       // Efectos de dominio, append-only -- nunca se borra ni se sobreescribe
       // evidencia. Solo dos tipos tienen un efecto de dominio definido más
       // allá de marcar la alerta -- el resto (rechequeo_due,
       // servicio_sin_confirmacion, parto_proximo) se resuelve con la sola
       // confirmación (Martha/Fernando ya lo dejan constar por otra vía --
       // chequeo, ficha -- este "sí" solo cierra el lazo de la alerta).
-      if (alerta.tipo === "secado_due" && alerta.animal_id) {
+      if (actualizada.tipo === "secado_due" && actualizada.animal_id) {
         const { error: errorEvento } = await sb.from("hato_eventos").insert({
-          animal_id: alerta.animal_id,
+          animal_id: actualizada.animal_id,
           tipo: "secado_real",
           fecha: hoyIso,
           fecha_confianza: "aproximada",
@@ -609,37 +648,45 @@ function getBot(): Bot<BotContext> {
           fuente: "alerta",
         });
         if (errorEvento) console.error("[Telegram] hato_eventos (secado_real) insert error:", errorEvento.message);
-      } else if (alerta.tipo === "tratamiento_paso" && alerta.paso_id) {
+      } else if (actualizada.tipo === "tratamiento_paso" && actualizada.paso_id) {
         // hato_eventos.tipo (CHECK de la migración 053) no tiene ninguna
         // variante de "tratamiento" -- no hay un evento que insertar aquí,
         // solo se marca ejecutado el paso mismo (055).
         const { error: errorPaso } = await sb
           .from("hato_tratamiento_pasos")
           .update({ fecha_ejecutada: hoyIso })
-          .eq("id", alerta.paso_id);
+          .eq("id", actualizada.paso_id);
         if (errorPaso) console.error("[Telegram] hato_tratamiento_pasos update error:", errorPaso.message);
       }
-
-      await ctx.answerCallbackQuery({ text: "Gracias, quedó registrado." });
-      await ctx.editMessageReplyMarkup().catch(() => {});
-      return;
     }
-
     // "no"/"otro" -- NUNCA se auto-resuelve: Martha lo revisa desde
     // AlertasView (plan §6 Épica C, C4 "supervisión por excepción").
-    const { error: errorUpdate } = await sb
-      .from("hato_alertas")
-      .update({ estado: "respondida", respuesta, respondida_por: respondidaPor })
-      .eq("id", alertaId);
-    if (errorUpdate) {
-      console.error("[Telegram] hato_alerta respuesta update error:", errorUpdate.message);
-      await ctx.answerCallbackQuery({ text: "No pude guardar tu respuesta. Intenta de nuevo." });
-      return;
-    }
+
     await ctx.answerCallbackQuery({
-      text: respuesta === "no" ? "Anotado, seguimos pendientes." : "Anotado -- Martha lo revisa.",
+      text: respuesta === "si"
+        ? "Gracias, quedó registrado."
+        : respuesta === "no"
+        ? "Anotado, seguimos pendientes."
+        : "Anotado -- Martha lo revisa.",
     });
     await ctx.editMessageReplyMarkup().catch(() => {});
+
+    // Broadcast (096): editar el mensaje de CADA OTRO suscrito al que se le
+    // mandó esta alerta, para que vea que ya se resolvió y por quién --
+    // `hato_alertas_envios` guarda el `message_id` de cada uno. El propio
+    // chat de quien respondió queda excluido (ya se editó arriba, vía ctx).
+    const mensajeOriginal = (actualizada.datos as { mensaje?: string } | null)?.mensaje ??
+      "Alerta del hato lechero (sin mensaje generado).";
+    const telegramIdRespondio = ctx.from?.id != null ? String(ctx.from.id) : null;
+    const { fallidos } = await cerrarAlertaEnEnvios(
+      sb,
+      alertaId,
+      telegramIdRespondio,
+      construirMensajeCierreAlertaBroadcast(mensajeOriginal, respondidaPor, respuesta),
+    );
+    if (fallidos > 0) {
+      console.error(`[Telegram] hato_alerta ${alertaId}: ${fallidos} mensaje(s) de otros suscritos no se pudieron editar al cerrar.`);
+    }
   });
 
   // ==========================================================================

--- a/src/supabase/functions/server/telegram/conversations/eventoHato.ts
+++ b/src/supabase/functions/server/telegram/conversations/eventoHato.ts
@@ -57,6 +57,28 @@ function hoyBogota(): string {
   return bogota.toISOString().slice(0, 10);
 }
 
+/**
+ * ¿El usuario está pidiendo salirse?
+ *
+ * Mientras una conversación está activa, el `bot.command("cancelar")` global de
+ * `bot.ts` **NUNCA se dispara**: el plugin de conversaciones consume el update
+ * antes de que llegue a los handlers de comandos. Así que cada paso que espera
+ * texto libre tiene que reconocer la cancelación por su cuenta, o el usuario
+ * queda encerrado sin más salida que bloquear el bot.
+ *
+ * No es hipotético: el dueño lo encontró el 2026-08-14 en el paso de fecha —
+ * `/cancelar`, `/pesaje` y "Cancelar" respondían "Formato inválido" en bucle.
+ *
+ * Se acepta con y sin barra a propósito. Con barra es lo que el usuario escribe
+ * por instinto (y lo que el propio mensaje del paso de la vaca le promete); sin
+ * barra es lo que escribe quien viene de tocar un botón "❌ Cancelar". Ninguna
+ * de las dos formas puede confundirse con una fecha DD/MM.
+ */
+function esCancelar(texto: string): boolean {
+  const t = texto.trim().toLowerCase();
+  return t === "/cancelar" || t === "cancelar" || t === "/cancel";
+}
+
 function parseDDMM(texto: string): string | null {
   const m = texto.trim().match(/^(\d{1,2})[/\-.](\d{1,2})$/);
   if (!m) return null;
@@ -253,6 +275,10 @@ export async function eventoHatoConversation(
     while (!vaca) {
       const txt = await conversation.waitFor("message:text");
       const consulta = txt.message.text.trim();
+      if (esCancelar(consulta)) {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
       if (consulta.startsWith("/")) {
         await txt.reply("Escribe el nombre o la chapeta, sin comandos. Usa /cancelar para salir.");
         continue;
@@ -308,15 +334,46 @@ export async function eventoHatoConversation(
 
     let fecha = hoy;
     if (cbFecha.callbackQuery.data === "fecha_otra") {
-      await cbFecha.editMessageText("📅 Escribe la fecha como DD/MM (ej: 12/08)");
+      // El `editMessageText` reemplaza el teclado anterior, así que sin esto el
+      // paso se queda SIN ningún botón de salida y el único escape es acertar
+      // una fecha válida. Se repone el "❌ Cancelar" y además se acepta la
+      // cancelación escrita (ver `esCancelar`).
+      const kbCancelarFecha = new InlineKeyboard().text("❌ Cancelar", "cancel_flow");
+      await cbFecha.editMessageText(
+        "📅 Escribe la fecha como DD/MM (ej: 12/08)\n\nO escribe /cancelar para salir.",
+        { reply_markup: kbCancelarFecha },
+      );
+      // `conversation.wait()` a secas, no un filtro: este paso tiene que poder
+      // atender DOS cosas (el texto de la fecha y el botón de cancelar) y es la
+      // única primitiva que el resto del bot ya usa de forma indiscutible. Lo
+      // que no sea ni una ni otra (una foto, un sticker) se ignora y se vuelve
+      // a preguntar, en vez de romper el flujo.
       while (true) {
-        const t = await conversation.waitFor("message:text");
-        const parsed = parseDDMM(t.message.text);
+        const paso = await conversation.wait();
+
+        const dataBoton = paso.callbackQuery?.data;
+        if (dataBoton) {
+          await paso.answerCallbackQuery();
+          if (dataBoton === "cancel_flow") {
+            await ctx.reply("Operación cancelada.");
+            return conversation.halt();
+          }
+          continue;
+        }
+
+        const texto = paso.message?.text;
+        if (!texto) continue;
+
+        if (esCancelar(texto)) {
+          await ctx.reply("Operación cancelada.");
+          return conversation.halt();
+        }
+        const parsed = parseDDMM(texto);
         if (parsed) {
           fecha = parsed;
           break;
         }
-        await t.reply("Formato inválido. Escribe DD/MM (ej: 12/08).");
+        await paso.reply("Formato inválido. Escribe DD/MM (ej: 12/08), o /cancelar para salir.");
       }
     } else {
       await cbFecha.editMessageText(`📅 Fecha: ${fechaLegible(fecha)}`);

--- a/src/supabase/functions/server/telegram/conversations/eventoHato.ts
+++ b/src/supabase/functions/server/telegram/conversations/eventoHato.ts
@@ -1,0 +1,538 @@
+// telegram/conversations/eventoHato.ts — Registro en campo de eventos del
+// ciclo reproductivo (N5-N9 del plan
+// docs/plan_hato_telegram_estados_agosto_2026.md).
+//
+// ORIGEN: visita del dueño a la finca, 2026-08-13. Fernando vio una vaca en
+// celo, llevó el toro y la montó — y no tenía ninguna forma de dejarlo
+// asentado hasta el chequeo bimensual de la veterinaria. Este flujo es esa
+// forma.
+//
+// DECISIÓN D-B (dueño, en chips): **Telegram escribe DIRECTO**, sin cola de
+// aprobación. El evento existe apenas Fernando lo registra y Martha lo
+// corrige después desde la Hoja de Vida. Lo que hace tolerable esa decisión
+// es el "Deshacer" del final: el error más probable no es inventarse un
+// evento, es elegir la vaca equivocada del listado, y eso se ve en el
+// resumen inmediatamente.
+//
+// CONTRATOS QUE ESTE ARCHIVO RESPETA
+// ----------------------------------
+// 1. **`created_by` explícito** desde `telegram_usuarios.usuario_id`. El bot
+//    escribe con `service_role`, donde `auth.uid()` es NULL: ni los triggers
+//    de atribución (040/050/063/074) ni la traza de `hato_correcciones`
+//    (084) se disparan solos. Sin esto, todo lo que registre Fernando queda
+//    sin autor, que es la brecha conocida del módulo.
+// 2. **`chequeo_vaca_id` queda en NULL** (no se toca). Es lo que hace estos
+//    eventos INTOCABLES por `fn_hato_commit_chequeo` (065): re-aprobar un
+//    chequeo borra y reinserta solo SUS propios eventos.
+// 3. **Nunca se inventa una fecha.** Por defecto hoy en hora de Bogotá
+//    (`hoyBogota()`), nunca `new Date().toISOString()` a secas: el servidor
+//    Deno corre en UTC y de 19:00 en adelante eso ya es mañana — la misma
+//    trampa que documenta el CLAUDE.md raíz para el navegador.
+// 4. **Advertir, nunca bloquear** (regla general del módulo): un secado
+//    antes de lo proyectado se avisa con los días de diferencia y se
+//    registra igual. Es justamente el caso que motivó este flujo (dos vacas
+//    con producción muy baja que hubo que secar antes de lo presupuestado).
+
+import { Conversation } from "npm:@grammyjs/conversations@2";
+import { InlineKeyboard } from "npm:grammy@1";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import type { BotContext } from "../types.ts";
+import {
+  derivarEstadoReproductivo,
+  type EstadoActualHatoRow,
+  type HatoConfig,
+} from "../../calculos-hato.ts";
+import { construirHatoConfigDesdeFilas } from "../../hato-config-desde-tabla.ts";
+
+function getSupabaseAdmin() {
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  return createClient(url, serviceKey, { auth: { persistSession: false } });
+}
+
+/** "Hoy" en Bogotá (UTC-5), no en UTC. Ver contrato 3 de la cabecera. */
+function hoyBogota(): string {
+  const ahora = new Date();
+  const bogota = new Date(ahora.getTime() - 5 * 60 * 60 * 1000);
+  return bogota.toISOString().slice(0, 10);
+}
+
+function parseDDMM(texto: string): string | null {
+  const m = texto.trim().match(/^(\d{1,2})[/\-.](\d{1,2})$/);
+  if (!m) return null;
+  const dia = parseInt(m[1], 10);
+  const mes = parseInt(m[2], 10);
+  if (mes < 1 || mes > 12 || dia < 1 || dia > 31) return null;
+  const anio = Number(hoyBogota().slice(0, 4));
+  const iso = `${anio}-${String(mes).padStart(2, "0")}-${String(dia).padStart(2, "0")}`;
+  // Una fecha futura casi siempre es el año pasado mal escrito (p. ej. "28/12"
+  // registrado en enero). Se corrige al año anterior en vez de guardar un
+  // hecho que todavía no ocurrió.
+  return iso > hoyBogota() ? `${anio - 1}-${iso.slice(5)}` : iso;
+}
+
+function fechaLegible(iso: string): string {
+  const [a, m, d] = iso.split("-").map(Number);
+  const meses = [
+    "enero", "febrero", "marzo", "abril", "mayo", "junio",
+    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+  ];
+  return `${d} de ${meses[m - 1]} ${a}`;
+}
+
+// ============================================================================
+// Tipos de evento que este flujo sabe registrar
+// ============================================================================
+
+type ClaveEvento = "monta" | "inseminacion" | "secado" | "parto" | "aborto";
+
+interface DefinicionEvento {
+  etiqueta: string;
+  /** `hato_eventos.tipo` real. `monta`/`inseminacion` son el MISMO tipo
+   * (`servicio`) distinguidos por `tipo_servicio` — el CHECK de la tabla ya
+   * lo modela así desde 053, no se agrega ningún tipo nuevo. */
+  tipo: "servicio" | "secado_real" | "parto" | "aborto";
+  tipoServicio?: "monta" | "inseminacion";
+  /** ¿Pide toro del catálogo? */
+  pideToro: boolean;
+}
+
+const EVENTOS: Record<ClaveEvento, DefinicionEvento> = {
+  monta: { etiqueta: "🐂 Monta", tipo: "servicio", tipoServicio: "monta", pideToro: true },
+  inseminacion: { etiqueta: "💉 Inseminación", tipo: "servicio", tipoServicio: "inseminacion", pideToro: true },
+  secado: { etiqueta: "🌾 Secado", tipo: "secado_real", pideToro: false },
+  parto: { etiqueta: "🐄 Parto", tipo: "parto", pideToro: false },
+  aborto: { etiqueta: "⚠️ Aborto", tipo: "aborto", pideToro: false },
+};
+
+/** Destinos de cría del CHECK de `hato_eventos.cria_destino` (053). */
+const DESTINOS_CRIA: Array<{ clave: string; etiqueta: string }> = [
+  { clave: "retenida", etiqueta: "Hembra, se queda" },
+  { clave: "hembra_vendida", etiqueta: "Hembra, se vende" },
+  { clave: "macho_vendido", etiqueta: "Macho, se vende" },
+  { clave: "muerta", etiqueta: "Nació muerta" },
+];
+
+// ============================================================================
+// Datos que el flujo lee de la base
+// ============================================================================
+
+interface VacaCandidata {
+  animal_id: string;
+  numero: number | null;
+  nombre: string | null;
+  fila: EstadoActualHatoRow;
+}
+
+interface ToroCatalogo {
+  id: string;
+  nombre: string;
+  raza: string | null;
+  /** Solo para inseminación: lote de pajillas y stock restante. */
+  pajillaId: string | null;
+  stock: number | null;
+}
+
+function etiquetaVaca(v: { numero: number | null; nombre: string | null }): string {
+  // Lidera con el NOMBRE, no con la chapeta: Fernando lee el nombre en el
+  // corral y una parte del hato carga números provisionales (800-999) que no
+  // corresponden a ninguna caravana física (migración 066).
+  const nombre = v.nombre ?? "sin nombre";
+  return v.numero != null ? `${nombre} (#${v.numero})` : `${nombre} (sin caravana)`;
+}
+
+/** Normaliza para buscar: sin acentos, sin mayúsculas, sin espacios extra. */
+function normalizar(texto: string): string {
+  return texto
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+/**
+ * N4 — búsqueda de la vaca por nombre o chapeta. Devuelve TODAS las
+ * coincidencias: dos vacas activas pueden llamarse igual (el caso real MOCA
+ * #177/#183 del módulo), y adjudicar una sola sería elegir por el usuario.
+ */
+export function buscarVacas(vacas: VacaCandidata[], consulta: string): VacaCandidata[] {
+  const q = normalizar(consulta);
+  if (!q) return [];
+  const comoNumero = /^#?\d+$/.test(q) ? Number(q.replace("#", "")) : null;
+  if (comoNumero !== null) {
+    const porNumero = vacas.filter((v) => v.numero === comoNumero);
+    if (porNumero.length > 0) return porNumero;
+  }
+  const exactas = vacas.filter((v) => normalizar(v.nombre ?? "") === q);
+  if (exactas.length > 0) return exactas;
+  return vacas.filter((v) => normalizar(v.nombre ?? "").includes(q));
+}
+
+// ============================================================================
+// Conversación
+// ============================================================================
+
+export async function eventoHatoConversation(
+  conversation: Conversation<BotContext>,
+  ctx: BotContext,
+) {
+  const usuarioId = ctx.telegramUser?.usuario_id ?? null;
+
+  try {
+    // ── Paso 1: ¿qué pasó? ────────────────────────────────────────────
+    const kbTipo = new InlineKeyboard()
+      .text(EVENTOS.monta.etiqueta, "ev_monta")
+      .text(EVENTOS.inseminacion.etiqueta, "ev_inseminacion")
+      .row()
+      .text(EVENTOS.secado.etiqueta, "ev_secado")
+      .text(EVENTOS.parto.etiqueta, "ev_parto")
+      .row()
+      .text(EVENTOS.aborto.etiqueta, "ev_aborto")
+      .text("❌ Cancelar", "cancel_flow");
+
+    await ctx.reply("📋 *Registrar evento del hato*\n\n¿Qué pasó?", {
+      reply_markup: kbTipo,
+      parse_mode: "Markdown",
+    });
+
+    const cbTipo = await conversation.waitForCallbackQuery([
+      "ev_monta", "ev_inseminacion", "ev_secado", "ev_parto", "ev_aborto", "cancel_flow",
+    ]);
+    await cbTipo.answerCallbackQuery();
+    if (cbTipo.callbackQuery.data === "cancel_flow") {
+      await ctx.reply("Operación cancelada.");
+      return conversation.halt();
+    }
+    const clave = cbTipo.callbackQuery.data.replace("ev_", "") as ClaveEvento;
+    const def = EVENTOS[clave];
+    await cbTipo.editMessageText(`📋 Evento: *${def.etiqueta}*`, { parse_mode: "Markdown" });
+
+    // ── Paso 2: cargar hato + config ──────────────────────────────────
+    const { vacas, config } = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      const [estadoRes, configRes] = await Promise.all([
+        sb
+          .from("v_hato_estado_actual")
+          .select(
+            "animal_id, numero, nombre, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, " +
+              "ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, " +
+              "ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultimo_estado_chequeo, " +
+              "ultima_confirmacion_prenez_metodo, ultimo_aborto_fecha",
+          )
+          .eq("estado", "activa")
+          .neq("etapa", "ternera"),
+        sb.from("hato_config").select("clave, valor"),
+      ]);
+      if (estadoRes.error) throw new Error(`Error cargando el hato: ${estadoRes.error.message}`);
+      if (configRes.error) throw new Error(`Error cargando configuración: ${configRes.error.message}`);
+
+      const filas = (estadoRes.data ?? []) as Array<Record<string, unknown>>;
+      const candidatas: VacaCandidata[] = filas.map((f) => ({
+        animal_id: f.animal_id as string,
+        numero: (f.numero as number | null) ?? null,
+        nombre: (f.nombre as string | null) ?? null,
+        fila: f as unknown as EstadoActualHatoRow,
+      }));
+      return {
+        vacas: candidatas,
+        config: construirHatoConfigDesdeFilas(
+          (configRes.data ?? []) as Array<{ clave: string; valor: unknown }>,
+        ) as HatoConfig,
+      };
+    });
+
+    if (vacas.length === 0) {
+      await ctx.reply("No hay vacas ni novillas activas en el hato.");
+      return;
+    }
+
+    // ── Paso 3: ¿cuál vaca? ───────────────────────────────────────────
+    await ctx.reply("🔎 Escribe el *nombre* o la *chapeta* de la vaca.", { parse_mode: "Markdown" });
+
+    let vaca: VacaCandidata | null = null;
+    while (!vaca) {
+      const txt = await conversation.waitFor("message:text");
+      const consulta = txt.message.text.trim();
+      if (consulta.startsWith("/")) {
+        await txt.reply("Escribe el nombre o la chapeta, sin comandos. Usa /cancelar para salir.");
+        continue;
+      }
+
+      const encontradas = buscarVacas(vacas, consulta);
+      if (encontradas.length === 0) {
+        await txt.reply(`No encontré ninguna vaca activa que coincida con "${consulta}". Intenta de nuevo.`);
+        continue;
+      }
+      if (encontradas.length === 1) {
+        vaca = encontradas[0];
+        break;
+      }
+
+      // Homónimas o coincidencias parciales: SIEMPRE elige el humano.
+      const kb = new InlineKeyboard();
+      encontradas.slice(0, 10).forEach((v, i) => {
+        kb.text(etiquetaVaca(v), `vaca_${i}`).row();
+      });
+      kb.text("❌ Cancelar", "cancel_flow");
+      await txt.reply(`Hay ${encontradas.length} coincidencias. ¿Cuál es?`, { reply_markup: kb });
+
+      const cbVaca = await conversation.waitForCallbackQuery(/^(vaca_\d+|cancel_flow)$/);
+      await cbVaca.answerCallbackQuery();
+      if (cbVaca.callbackQuery.data === "cancel_flow") {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      vaca = encontradas[Number(cbVaca.callbackQuery.data.replace("vaca_", ""))];
+    }
+
+    const estadoActual = derivarEstadoReproductivo(vaca.fila, config, hoyBogota());
+
+    // ── Paso 4: fecha ─────────────────────────────────────────────────
+    const hoy = hoyBogota();
+    const kbFecha = new InlineKeyboard()
+      .text(`✅ Hoy (${fechaLegible(hoy)})`, "fecha_hoy")
+      .row()
+      .text("📅 Otra fecha", "fecha_otra")
+      .text("❌ Cancelar", "cancel_flow");
+    await ctx.reply(`🐄 *${etiquetaVaca(vaca)}*\n¿Cuándo fue?`, {
+      reply_markup: kbFecha,
+      parse_mode: "Markdown",
+    });
+
+    const cbFecha = await conversation.waitForCallbackQuery(["fecha_hoy", "fecha_otra", "cancel_flow"]);
+    await cbFecha.answerCallbackQuery();
+    if (cbFecha.callbackQuery.data === "cancel_flow") {
+      await ctx.reply("Operación cancelada.");
+      return conversation.halt();
+    }
+
+    let fecha = hoy;
+    if (cbFecha.callbackQuery.data === "fecha_otra") {
+      await cbFecha.editMessageText("📅 Escribe la fecha como DD/MM (ej: 12/08)");
+      while (true) {
+        const t = await conversation.waitFor("message:text");
+        const parsed = parseDDMM(t.message.text);
+        if (parsed) {
+          fecha = parsed;
+          break;
+        }
+        await t.reply("Formato inválido. Escribe DD/MM (ej: 12/08).");
+      }
+    } else {
+      await cbFecha.editMessageText(`📅 Fecha: ${fechaLegible(fecha)}`);
+    }
+
+    // ── Paso 5: datos propios del tipo de evento ──────────────────────
+    let toro: ToroCatalogo | null = null;
+    let criaDestino: string | null = null;
+
+    if (def.pideToro) {
+      const toros = await conversation.external(async () => {
+        const sb = getSupabaseAdmin();
+        const { data: torosData, error } = await sb
+          .from("hato_toros")
+          .select("id, nombre, raza")
+          .eq("activo", true)
+          .eq("tipo", def.tipoServicio === "monta" ? "monta" : "inseminacion")
+          .order("nombre");
+        if (error) throw new Error(`Error cargando toros: ${error.message}`);
+
+        // Para inseminación se anexa el stock de pajillas del lote, que es lo
+        // que hay que descontar. La vista puede dar negativo: se avisa, NUNCA
+        // se bloquea (Épica G3).
+        let stockPorToro = new Map<string, { pajillaId: string; stock: number }>();
+        if (def.tipoServicio === "inseminacion") {
+          const { data: stockData, error: stockErr } = await sb
+            .from("v_hato_pajillas_stock")
+            .select("pajilla_id, toro_id, cantidad_actual");
+          if (stockErr) throw new Error(`Error cargando pajillas: ${stockErr.message}`);
+          for (const s of (stockData ?? []) as Array<Record<string, unknown>>) {
+            stockPorToro.set(s.toro_id as string, {
+              pajillaId: s.pajilla_id as string,
+              stock: Number(s.cantidad_actual ?? 0),
+            });
+          }
+        }
+
+        return ((torosData ?? []) as Array<Record<string, unknown>>).map((t): ToroCatalogo => {
+          const s = stockPorToro.get(t.id as string);
+          return {
+            id: t.id as string,
+            nombre: t.nombre as string,
+            raza: (t.raza as string | null) ?? null,
+            pajillaId: s?.pajillaId ?? null,
+            stock: s?.stock ?? null,
+          };
+        });
+      });
+
+      if (toros.length === 0) {
+        await ctx.reply(
+          `No hay toros de ${def.tipoServicio} activos en el catálogo. Avisa a un administrador.`,
+        );
+        return;
+      }
+
+      const kbToro = new InlineKeyboard();
+      toros.forEach((t, i) => {
+        const stock = t.stock !== null ? ` — ${t.stock} pajilla${t.stock === 1 ? "" : "s"}` : "";
+        const raza = t.raza ? ` (${t.raza})` : "";
+        kbToro.text(`${t.nombre}${raza}${stock}`, `toro_${i}`).row();
+      });
+      kbToro.text("❌ Cancelar", "cancel_flow");
+      await ctx.reply(def.tipoServicio === "monta" ? "🐂 ¿Con cuál toro?" : "💉 ¿Con cuál pajilla?", {
+        reply_markup: kbToro,
+      });
+
+      const cbToro = await conversation.waitForCallbackQuery(/^(toro_\d+|cancel_flow)$/);
+      await cbToro.answerCallbackQuery();
+      if (cbToro.callbackQuery.data === "cancel_flow") {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      toro = toros[Number(cbToro.callbackQuery.data.replace("toro_", ""))];
+      await cbToro.editMessageText(`🐂 ${toro.nombre}`);
+    }
+
+    if (clave === "parto") {
+      const kbCria = new InlineKeyboard();
+      DESTINOS_CRIA.forEach((d, i) => kbCria.text(d.etiqueta, `cria_${i}`).row());
+      kbCria.text("No sé todavía", "cria_none").text("❌ Cancelar", "cancel_flow");
+      await ctx.reply("🍼 ¿Cómo fue la cría?", { reply_markup: kbCria });
+
+      const cbCria = await conversation.waitForCallbackQuery(/^(cria_\d+|cria_none|cancel_flow)$/);
+      await cbCria.answerCallbackQuery();
+      if (cbCria.callbackQuery.data === "cancel_flow") {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      if (cbCria.callbackQuery.data !== "cria_none") {
+        criaDestino = DESTINOS_CRIA[Number(cbCria.callbackQuery.data.replace("cria_", ""))].clave;
+      }
+    }
+
+    // ── Paso 6: advertencias (nunca bloquean) ─────────────────────────
+    const advertencias: string[] = [];
+
+    if (clave === "secado" && estadoActual.fecha_secar) {
+      const dias = Math.round(
+        (Date.parse(`${estadoActual.fecha_secar}T00:00:00Z`) - Date.parse(`${fecha}T00:00:00Z`)) / 86400000,
+      );
+      if (dias > 7) {
+        // El caso que motivó este flujo: dos vacas de producción muy baja que
+        // hubo que secar antes de lo presupuestado.
+        advertencias.push(
+          `Se está secando ${dias} días antes de lo proyectado (${fechaLegible(estadoActual.fecha_secar)}).`,
+        );
+      }
+    }
+
+    if (clave === "parto" && vaca.fila.ultimo_parto_fecha) {
+      const diasEntrePartos = Math.round(
+        (Date.parse(`${fecha}T00:00:00Z`) - Date.parse(`${vaca.fila.ultimo_parto_fecha}T00:00:00Z`)) / 86400000,
+      );
+      if (Math.abs(diasEntrePartos) < 270) {
+        // 270 días es el mínimo biológico real, el mismo umbral de la
+        // migración 080 (partos biológicamente imposibles).
+        advertencias.push(
+          `Ya hay un parto registrado el ${fechaLegible(vaca.fila.ultimo_parto_fecha)}, hace ${Math.abs(diasEntrePartos)} días. Dos partos tan seguidos no son posibles.`,
+        );
+      }
+    }
+
+    if ((clave === "monta" || clave === "inseminacion") && estadoActual.estado === "preñada") {
+      advertencias.push("Esta vaca figura como preñez CONFIRMADA por palpación.");
+    }
+
+    if (toro && toro.stock !== null && toro.stock <= 0) {
+      advertencias.push(`El lote de ${toro.nombre} ya está en ${toro.stock} pajillas.`);
+    }
+
+    // ── Paso 7: confirmar ─────────────────────────────────────────────
+    const resumen = [
+      `📋 *${def.etiqueta.replace(/^\S+\s/, "")}*`,
+      `🐄 ${etiquetaVaca(vaca)}`,
+      `📅 ${fechaLegible(fecha)}`,
+      toro ? `🐂 ${toro.nombre}` : null,
+      criaDestino ? `🍼 ${DESTINOS_CRIA.find((d) => d.clave === criaDestino)?.etiqueta}` : null,
+      advertencias.length > 0 ? `\n⚠️ ${advertencias.join("\n⚠️ ")}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const kbConfirmar = new InlineKeyboard()
+      .text("✅ Guardar", "ok")
+      .text("❌ Cancelar", "cancel_flow");
+    await ctx.reply(`${resumen}\n\n¿Guardo?`, { reply_markup: kbConfirmar, parse_mode: "Markdown" });
+
+    const cbOk = await conversation.waitForCallbackQuery(["ok", "cancel_flow"]);
+    await cbOk.answerCallbackQuery();
+    if (cbOk.callbackQuery.data === "cancel_flow") {
+      await ctx.reply("Nada se guardó.");
+      return conversation.halt();
+    }
+
+    // ── Paso 8: escribir ──────────────────────────────────────────────
+    const guardado = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      const { data, error } = await sb
+        .from("hato_eventos")
+        .insert({
+          animal_id: vaca!.animal_id,
+          tipo: def.tipo,
+          fecha,
+          // El humano estuvo ahí: la fecha es exacta, no una reconstrucción
+          // a partir de una planilla.
+          fecha_confianza: "exacta",
+          tipo_servicio: def.tipoServicio ?? null,
+          toro_id: toro?.id ?? null,
+          cria_destino: criaDestino,
+          fuente: "telegram",
+          // chequeo_vaca_id se deja NULL: es lo que vuelve este evento
+          // intocable por fn_hato_commit_chequeo (065).
+          datos: { origen: "telegram", registrado_por: ctx.telegramUser?.nombre_display ?? null },
+          created_by: usuarioId,
+        })
+        .select("id")
+        .single();
+      if (error) throw new Error(`No se pudo guardar: ${error.message}`);
+
+      // Uso de pajilla: se registra DESPUÉS del evento y su fallo no tumba el
+      // evento — la preñez es el hecho importante, el descuento de inventario
+      // es contabilidad que Martha puede corregir.
+      let usoId: string | null = null;
+      if (toro?.pajillaId) {
+        const { data: uso, error: usoErr } = await sb
+          .from("hato_pajillas_uso")
+          .insert({
+            pajilla_id: toro.pajillaId,
+            fecha_uso: fecha,
+            animal_id: vaca!.animal_id,
+            created_by: usuarioId,
+          })
+          .select("id")
+          .single();
+        if (usoErr) {
+          console.error("[Telegram] No se pudo descontar la pajilla:", usoErr.message);
+        } else {
+          usoId = uso!.id as string;
+        }
+      }
+      return { eventoId: data!.id as string, usoId };
+    });
+
+    const kbDeshacer = new InlineKeyboard().text(
+      "↩️ Deshacer",
+      `hato_ev_undo:${guardado.eventoId}:${guardado.usoId ?? "-"}`,
+    );
+    await ctx.reply(
+      `✅ Registrado.\n\n${resumen}\n\nSi te equivocaste de vaca, usa Deshacer.\nUsa /start para volver al menú.`,
+      { reply_markup: kbDeshacer, parse_mode: "Markdown" },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "Conversation already halted") return;
+    const msg = err instanceof Error ? err.message : "Error desconocido";
+    console.error("[Telegram] Evento hato conversation error:", msg);
+    await ctx.reply(`Error registrando el evento: ${msg}\n\nUsa /start para volver al menú.`);
+  }
+}

--- a/src/supabase/functions/server/telegram/conversations/pesajeLeche.ts
+++ b/src/supabase/functions/server/telegram/conversations/pesajeLeche.ts
@@ -1,24 +1,76 @@
-// telegram/conversations/pesajeLeche.ts — Weekly per-cow milk weighing (S5,
-// Épica D1/V2 — docs/plan_hato_lechero_module.md §7.2/§7.5).
+// telegram/conversations/pesajeLeche.ts — N11-N13 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md` §3 Capa 2 / §8.2.
 //
-// Iterates active cows (hato_animales.etapa='vaca', estado='activa') asking
-// for ONE total figure per cow (litros_total — am+pm already summed,
-// migración 061; NEVER a split am/pm entry, that concept does not exist).
-// Each answer is saved immediately (UPDATE-by-id if the row already exists
-// for that date, INSERT otherwise) so a mid-conversation /cancelar never
-// loses what was already entered — the natural way "salteable, reanudable"
-// (plan §7.2) is honored without extra resume-state machinery: grammy
-// conversations already persist progress across webhook calls, and
-// per-answer saves mean there is nothing left to lose on exit.
+// REEMPLAZA la conversación anterior (vaca-por-vaca, ~65 preguntas por
+// chat: inviable en el corral) por el MISMO flujo de foto que ya usa la
+// ruta web (`SubirPesajeFoto.tsx` -> `POST /hato/pesaje/foto` ->
+// `POST /hato/pesaje/commit`): Fernando fotografía la planilla mensual (1
+// a 6 fotos, por franjas si hace falta), el bot muestra en texto plano lo
+// que leyó, Fernando corrige en LENGUAJE NATURAL (decisión D-C del dueño,
+// "MONZA sem 2 AM son 6.5 y BONITA no se pesó") y solo tras un "ok"
+// explícito se persiste -- por celda, no todo-o-nada.
 //
-// A cow the user skips gets NO row for that date — "no pesada", never 0
-// (regla D del plan §6 Épica D, misma que rige monitoreo/ganado).
+// N11 — NO es un segundo lector de celdas ni un segundo armado de roster:
+// toda la orquestación (Storage, modelo de visión, ancla por nombre, diff)
+// viene de `../../hato-pesaje-pipeline.ts::ejecutarPipelinePesajeFoto`, la
+// MISMA función que usa el endpoint HTTP. `anio`/`mes` se preguntan acá con
+// un default sensato al mes en curso -- nunca se adivinan del papel (la
+// planilla nunca trae fecha legible por sí sola sin ese dato).
+//
+// N12 — La interpretación de la corrección en texto libre es una llamada al
+// modelo (`../../hato-pesaje-pipeline.ts::llamarModeloCorreccionPesaje`)
+// seguida de la validación PURA `interpretarCorreccionPesaje`
+// (`../../importHato/ocrPesajeCorreccion.ts`, testeada desde Vitest): un
+// ítem que no ancla a una vaca del roster, a una semana válida o a un valor
+// interpretable NUNCA se aplica -- se reporta como no entendido y se vuelve
+// a preguntar. Nada se escribe antes del "ok" explícito; el loop
+// corregir/mostrar se puede repetir cuantas veces haga falta.
+//
+// N13 — El commit reusa la MISMA revalidación fresca de
+// `hato-pesaje-commit.ts` vía `ejecutarCommitPesaje` (vaca sigue activa,
+// fecha sigue siendo una ocurrencia real del mes) -- por CELDA, una celda
+// inválida se rechaza sola. `fuente: 'telegram'` y `created_by` EXPLÍCITO
+// desde `telegram_usuarios.usuario_id` (riesgo R-6 del plan: el bot escribe
+// con service_role, `auth.uid()` es NULL, ningún trigger de atribución se
+// dispara solo).
+//
+// REPLAY-SAFETY (grammy conversations): cada webhook es una invocación
+// nueva de la function serverless -- el estado de la conversación se
+// reconstruye REEJECUTANDO esta función desde el principio, reproduciendo
+// los resultados ya cacheados de cada `conversation.external()`/`wait()`.
+// Eso impone dos reglas that este archivo respeta:
+//   1. Todo resultado de `external()` debe ser JSON-serializable (viaja por
+//      el storage jsonb de `telegram_conversations`). Los bytes de las
+//      fotos NUNCA salen de un `external()` como valor de retorno -- se
+//      descargan y se consumen DENTRO del mismo `external()` que llama al
+//      pipeline, nunca por separado.
+//   2. Mientras una conversación está activa, `bot.command("cancelar")`
+//      global NUNCA se dispara (el plugin de conversaciones consume el
+//      update antes) -- cada paso que espera texto o foto reconoce
+//      "cancelar"/"/cancelar" por su cuenta (`esCancelacionTexto`).
 
 import { Conversation } from "npm:@grammyjs/conversations@2";
 import { InlineKeyboard } from "npm:grammy@1";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import type { BotContext } from "../types.ts";
-import { calcularFechaUltimoDiaPesaje } from "../../calculos-hato.ts";
+import {
+  ejecutarCommitPesaje,
+  ejecutarPipelinePesajeFoto,
+  llamarModeloCorreccionPesaje,
+  MAXIMO_FOTOS_PESAJE,
+  TIPOS_ACEPTADOS_FOTO_PESAJE,
+  type CeldaCommitPesajeEntrada,
+  type FotoPesajeEntrada,
+  type PipelinePesajeFotoResultado,
+} from "../../hato-pesaje-pipeline.ts";
+import {
+  construirFilasPesajeInsertables,
+  construirRosterPesaje,
+  SEMANAS_PESAJE,
+  type CeldaDiffPesaje,
+  type SemanaPesaje,
+} from "../../importHato/ocrPesaje.ts";
+import { aplicarCorreccionesADiff, interpretarCorreccionPesaje } from "../../importHato/ocrPesajeCorreccion.ts";
 
 function getSupabaseAdmin() {
   const url = Deno.env.get("SUPABASE_URL")!;
@@ -26,227 +78,443 @@ function getSupabaseAdmin() {
   return createClient(url, serviceKey, { auth: { persistSession: false } });
 }
 
-function todayISO(): string {
-  return new Date().toISOString().slice(0, 10);
+/** "Hoy" en Bogotá (UTC-5), no en UTC -- mismo criterio que `eventoHato.ts`. */
+function hoyBogota(): string {
+  const ahora = new Date();
+  const bogota = new Date(ahora.getTime() - 5 * 60 * 60 * 1000);
+  return bogota.toISOString().slice(0, 10);
 }
 
-function parseDDMM(text: string): string | null {
-  const match = text.trim().match(/^(\d{1,2})[/\-.](\d{1,2})$/);
-  if (!match) return null;
-  const day = parseInt(match[1], 10);
-  const month = parseInt(match[2], 10);
-  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
-  const year = new Date().getFullYear();
-  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+const MESES = [
+  "enero", "febrero", "marzo", "abril", "mayo", "junio",
+  "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+];
+
+function nombreMes(mes: number): string {
+  return MESES[mes - 1] ?? String(mes);
 }
 
-function formatDateSpanish(isoDate: string): string {
-  const [y, m, d] = isoDate.split("-").map(Number);
-  const months = [
-    "enero", "febrero", "marzo", "abril", "mayo", "junio",
-    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
-  ];
-  return `${d} de ${months[m - 1]} ${y}`;
+/** Reconoce la cancelación escrita a mano -- el `/cancelar` global NUNCA se
+ * dispara mientras esta conversación está activa (ver cabecera del
+ * archivo). Se comprueba en TODOS los pasos que esperan texto o foto. */
+function esCancelacionTexto(texto: string): boolean {
+  const t = texto.trim().toLowerCase();
+  return t === "cancelar" || t === "/cancelar";
 }
 
-interface VacaActiva {
-  id: string;
-  numero: number | null;
-  nombre: string | null;
+function esConfirmacionGuardar(texto: string): boolean {
+  const t = texto.trim().toLowerCase();
+  return t === "ok" || t === "listo" || t === "guardar" || t === "si" || t === "sí";
 }
+
+/** "MM/AAAA" o "MM-AAAA" -- formato numérico simple, sin adivinar nada que
+ * el usuario no haya escrito (mismo criterio que `parseDDMM` de
+ * `eventoHato.ts`). */
+function parseMesAnio(texto: string): { anio: number; mes: number } | null {
+  const m = texto.trim().match(/^(\d{1,2})[/\-](\d{4})$/);
+  if (!m) return null;
+  const mes = parseInt(m[1], 10);
+  const anio = parseInt(m[2], 10);
+  if (mes < 1 || mes > 12 || anio < 2020 || anio > 2100) return null;
+  return { anio, mes };
+}
+
+function partirTexto(texto: string, maximo = 3500): string[] {
+  if (texto.length <= maximo) return [texto];
+  const lineas = texto.split("\n");
+  const partes: string[] = [];
+  let actual = "";
+  for (const linea of lineas) {
+    if (actual && (actual + "\n" + linea).length > maximo) {
+      partes.push(actual);
+      actual = linea;
+    } else {
+      actual = actual ? `${actual}\n${linea}` : linea;
+    }
+  }
+  if (actual) partes.push(actual);
+  return partes;
+}
+
+/** Resumen en texto plano de la lectura -- lo que Fernando ve para corregir
+ * o confirmar (D-C). Agrupado por vaca, en orden alfabético; solo aparecen
+ * las vacas que SÍ se leyeron en alguna foto (`diff` viene de
+ * `ocr.filasConfirmadas`) -- las que faltaron van aparte, en
+ * `vacasSinLeer`. `—` para "sin dato", nunca 0 (regla del módulo). */
+function construirResumenPesajeTexto(diff: readonly CeldaDiffPesaje[]): string {
+  if (diff.length === 0) return "(ninguna vaca se pudo leer)";
+  const porAnimal = new Map<string, { nombre: string; celdas: Map<SemanaPesaje, CeldaDiffPesaje> }>();
+  for (const c of diff) {
+    if (!porAnimal.has(c.animalId)) porAnimal.set(c.animalId, { nombre: c.nombre, celdas: new Map() });
+    porAnimal.get(c.animalId)!.celdas.set(c.semana, c);
+  }
+  const filas = [...porAnimal.values()].sort((a, b) => a.nombre.localeCompare(b.nombre));
+  return filas
+    .map(({ nombre, celdas }) => {
+      const partes = SEMANAS_PESAJE.filter((s) => celdas.has(s)).map((s) => {
+        const c = celdas.get(s)!;
+        const am = c.litrosAm ?? "—";
+        const pm = c.litrosPm ?? "—";
+        return `S${s}:${am}/${pm}`;
+      });
+      return `• ${nombre} — ${partes.join("  ")}`;
+    })
+    .join("\n");
+}
+
+function construirAdvertenciasLectura(resultado: PipelinePesajeFotoResultado): string[] {
+  const advertencias: string[] = [];
+  if (resultado.ocr.filasNoLeidas.length > 0) {
+    const lista = resultado.ocr.filasNoLeidas
+      .slice(0, 10)
+      .map((f) => `"${f.nombreImpreso || "(sin nombre)"}"`)
+      .join(", ");
+    advertencias.push(
+      `⚠️ ${resultado.ocr.filasNoLeidas.length} fila(s) no se pudieron identificar: ${lista}${
+        resultado.ocr.filasNoLeidas.length > 10 ? "…" : ""
+      }`,
+    );
+  }
+  if (resultado.ocr.vacasSinLeer.length > 0) {
+    const lista = resultado.ocr.vacasSinLeer.slice(0, 15).map((v) => v.nombre).join(", ");
+    advertencias.push(
+      `⚠️ ${resultado.ocr.vacasSinLeer.length} vaca(s) no aparecen en ninguna foto: ${lista}${
+        resultado.ocr.vacasSinLeer.length > 15 ? "…" : ""
+      }`,
+    );
+  }
+  if (resultado.ocr.paginasNoLeidas.length > 0) {
+    advertencias.push(`⚠️ ${resultado.ocr.paginasNoLeidas.length} foto(s) no se pudieron leer.`);
+  }
+  return advertencias;
+}
+
+interface OpcionesEnvio {
+  reply_markup?: InlineKeyboard;
+  parse_mode?: "Markdown";
+}
+
+async function enviarPorPartes(ctx: BotContext, texto: string, opciones?: OpcionesEnvio) {
+  const partes = partirTexto(texto);
+  for (let i = 0; i < partes.length; i++) {
+    await ctx.reply(partes[i], i === partes.length - 1 ? opciones : undefined);
+  }
+}
+
+// ============================================================================
+// Descarga de fotos de Telegram (SIEMPRE dentro de un solo `external()` junto
+// al pipeline -- ver regla 1 de la cabecera: los bytes nunca salen solos de
+// un `external()`).
+// ============================================================================
+
+interface FotoTelegramReferencia {
+  fileId: string;
+  tipo: string;
+  nombre: string;
+}
+
+async function descargarBytesTelegram(fileId: string, botToken: string): Promise<Uint8Array> {
+  const fileRes = await fetch(`https://api.telegram.org/bot${botToken}/getFile?file_id=${fileId}`);
+  const fileData = await fileRes.json();
+  const filePath = fileData?.result?.file_path;
+  if (!filePath) throw new Error(`Telegram no devolvió la ruta del archivo ${fileId}`);
+  const descarga = await fetch(`https://api.telegram.org/file/bot${botToken}/${filePath}`);
+  if (!descarga.ok) throw new Error(`No se pudo descargar el archivo de Telegram (${descarga.status})`);
+  return new Uint8Array(await descarga.arrayBuffer());
+}
+
+// ============================================================================
+// Conversación
+// ============================================================================
 
 export async function pesajeLecheConversation(
   conversation: Conversation<BotContext>,
   ctx: BotContext,
 ) {
+  const usuarioId = ctx.telegramUser?.usuario_id ?? null;
+
   try {
-    // ── Step 1: hato_config.dia_pesaje_semanal (nunca hardcodeado) ──────
-
-    const config = await conversation.external(async () => {
-      const sb = getSupabaseAdmin();
-      const { data, error } = await sb
-        .from("hato_config")
-        .select("valor")
-        .eq("clave", "dia_pesaje_semanal")
-        .maybeSingle();
-      if (error) throw new Error(`Error leyendo configuración: ${error.message}`);
-      const valor = data?.valor as { iso?: unknown; nombre?: unknown } | undefined;
-      if (!valor || typeof valor.iso !== "number") {
-        throw new Error("CONFIG_FALTANTE");
-      }
-      return { iso: valor.iso, nombre: typeof valor.nombre === "string" ? valor.nombre : `día ISO ${valor.iso}` };
-    }).catch((err: unknown) => {
-      if (err instanceof Error && err.message === "CONFIG_FALTANTE") return null;
-      throw err;
-    });
-
-    if (!config) {
+    if (!usuarioId) {
       await ctx.reply(
-        "⚠️ No encontré la configuración del día de pesaje (hato_config.dia_pesaje_semanal). " +
-          "Avisa a un administrador antes de continuar.",
+        "Tu cuenta de Telegram no está vinculada a un usuario del sistema -- avisa a un administrador antes de registrar un pesaje.",
       );
       return;
     }
 
-    const fechaSugerida = calcularFechaUltimoDiaPesaje(todayISO(), config.iso);
+    const apiKey = Deno.env.get("OPENROUTER_API_KEY");
+    if (!apiKey) {
+      await ctx.reply("La lectura por foto no está disponible ahora mismo (falta configuración del servidor). Avisa a un administrador.");
+      return;
+    }
+    const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN")!;
 
-    // ── Step 2: confirmar/ajustar fecha ──────────────────────────────
+    // ── Paso 1: ¿qué mes es la planilla? ──────────────────────────────
+    const hoy = hoyBogota();
+    const anioActual = Number(hoy.slice(0, 4));
+    const mesActual = Number(hoy.slice(5, 7));
 
-    const fechaKb = new InlineKeyboard()
-      .text(`✅ ${formatDateSpanish(fechaSugerida)}`, "fecha_sugerida")
+    const kbMes = new InlineKeyboard()
+      .text(`✅ ${nombreMes(mesActual)} ${anioActual}`, "mes_actual")
       .row()
-      .text("📅 Otra fecha", "fecha_otra")
+      .text("📅 Otro mes", "mes_otro")
       .text("❌ Cancelar", "cancel_flow");
-
     await ctx.reply(
-      `🐄 *Pesaje semanal de leche*\n\nSe pesa los ${config.nombre}. Fecha sugerida: *${formatDateSpanish(fechaSugerida)}*.`,
-      { reply_markup: fechaKb, parse_mode: "Markdown" },
+      "🐄 *Pesaje de leche -- carga por foto*\n\n¿La planilla que vas a fotografiar es de qué mes?",
+      { reply_markup: kbMes, parse_mode: "Markdown" },
     );
 
-    const fechaCbCtx = await conversation.waitForCallbackQuery(["fecha_sugerida", "fecha_otra", "cancel_flow"]);
-    await fechaCbCtx.answerCallbackQuery();
+    let anio = anioActual;
+    let mes = mesActual;
+    while (true) {
+      const respuesta = await conversation.wait();
 
-    if (fechaCbCtx.callbackQuery.data === "cancel_flow") {
-      await ctx.reply("Operación cancelada.");
-      return conversation.halt();
-    }
-
-    let fecha = fechaSugerida;
-    if (fechaCbCtx.callbackQuery.data === "fecha_otra") {
-      await fechaCbCtx.editMessageText("📅 Escribe la fecha en formato DD/MM (ej: 22/07)");
-      while (true) {
-        const textCtx = await conversation.waitFor("message:text");
-        const parsed = parseDDMM(textCtx.message.text);
+      if (respuesta.callbackQuery?.data === "cancel_flow") {
+        await respuesta.answerCallbackQuery();
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      if (respuesta.callbackQuery?.data === "mes_actual") {
+        await respuesta.answerCallbackQuery();
+        await respuesta.editMessageText(`📅 Mes: ${nombreMes(mesActual)} ${anioActual}`);
+        break;
+      }
+      if (respuesta.callbackQuery?.data === "mes_otro") {
+        await respuesta.answerCallbackQuery();
+        await respuesta.editMessageText("📅 Escribe el mes como MM/AAAA (ej: 08/2026), o *cancelar*.", {
+          parse_mode: "Markdown",
+        });
+        continue;
+      }
+      const texto = respuesta.message?.text;
+      if (texto) {
+        if (esCancelacionTexto(texto)) {
+          await ctx.reply("Operación cancelada.");
+          return conversation.halt();
+        }
+        const parsed = parseMesAnio(texto);
         if (parsed) {
-          fecha = parsed;
+          anio = parsed.anio;
+          mes = parsed.mes;
+          await ctx.reply(`📅 Mes: ${nombreMes(mes)} ${anio}`);
           break;
         }
-        await textCtx.reply("Formato inválido. Escribe la fecha como DD/MM (ej: 22/07)");
+        await ctx.reply("Formato inválido. Escribe MM/AAAA (ej: 08/2026), o *cancelar*.", { parse_mode: "Markdown" });
+        continue;
       }
-    } else {
-      await fechaCbCtx.editMessageText(`📅 Fecha: ${formatDateSpanish(fecha)}`);
+      // callback/mensaje no reconocido -- se ignora, se sigue esperando.
     }
 
-    // ── Step 3: cargar vacas activas + pesajes existentes de esa fecha ──
+    // ── Paso 2: recolectar 1..6 fotos ─────────────────────────────────
+    const fotos: FotoTelegramReferencia[] = [];
+    const kbFotos = new InlineKeyboard()
+      .text("✅ Listo", "fotos_listo")
+      .text("❌ Cancelar", "cancel_flow");
+    await ctx.reply(
+      `📸 Envía las fotos de la planilla de *${nombreMes(mes)} ${anio}* (1 a ${MAXIMO_FOTOS_PESAJE}, puede ser por franjas si no cabe en una toma). Cuando termines, toca *Listo*.`,
+      { reply_markup: kbFotos, parse_mode: "Markdown" },
+    );
 
-    const { vacas, existentes } = await conversation.external(async () => {
-      const sb = getSupabaseAdmin();
-      const { data: vacasData, error: vacasErr } = await sb
-        .from("hato_animales")
-        .select("id, numero, nombre")
-        .eq("etapa", "vaca")
-        .eq("estado", "activa")
-        .order("numero", { ascending: true });
-      if (vacasErr) throw new Error(`Error cargando vacas: ${vacasErr.message}`);
+    while (true) {
+      const respuesta = await conversation.wait();
 
-      const { data: pesajesData, error: pesajesErr } = await sb
-        .from("hato_pesajes_leche")
-        .select("id, animal_id, litros_total")
-        .eq("fecha", fecha);
-      if (pesajesErr) throw new Error(`Error cargando pesajes existentes: ${pesajesErr.message}`);
-
-      const mapa = new Map<string, { id: string; litros_total: number }>();
-      for (const p of pesajesData ?? []) {
-        mapa.set(p.animal_id, { id: p.id, litros_total: p.litros_total });
+      if (respuesta.callbackQuery?.data === "cancel_flow") {
+        await respuesta.answerCallbackQuery();
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
       }
-      return { vacas: (vacasData ?? []) as VacaActiva[], existentes: mapa };
+      if (respuesta.callbackQuery?.data === "fotos_listo") {
+        await respuesta.answerCallbackQuery();
+        if (fotos.length === 0) {
+          await ctx.reply("Todavía no recibí ninguna foto. Envía al menos una, o toca Cancelar.");
+          continue;
+        }
+        break;
+      }
+
+      const texto = respuesta.message?.text;
+      if (texto && esCancelacionTexto(texto)) {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+
+      const photoSizes = respuesta.message?.photo;
+      if (photoSizes && photoSizes.length > 0) {
+        if (fotos.length >= MAXIMO_FOTOS_PESAJE) {
+          await ctx.reply(`Ya tengo ${MAXIMO_FOTOS_PESAJE} fotos, el máximo. Toca Listo para continuar.`);
+          continue;
+        }
+        const masGrande = photoSizes[photoSizes.length - 1];
+        fotos.push({ fileId: masGrande.file_id, tipo: "image/jpeg", nombre: `foto-${fotos.length + 1}.jpg` });
+        await ctx.reply(`📸 Foto ${fotos.length} recibida. Envía otra o toca Listo.`);
+        continue;
+      }
+
+      const documento = respuesta.message?.document;
+      if (documento) {
+        const tipo = (documento.mime_type ?? "").toLowerCase();
+        if (!TIPOS_ACEPTADOS_FOTO_PESAJE.has(tipo)) {
+          await ctx.reply(
+            `Ese archivo es de tipo '${documento.mime_type ?? "desconocido"}'. Envía JPEG, PNG, WEBP o HEIC, o toca Listo/Cancelar.`,
+          );
+          continue;
+        }
+        if (fotos.length >= MAXIMO_FOTOS_PESAJE) {
+          await ctx.reply(`Ya tengo ${MAXIMO_FOTOS_PESAJE} fotos, el máximo. Toca Listo para continuar.`);
+          continue;
+        }
+        fotos.push({ fileId: documento.file_id, tipo, nombre: documento.file_name ?? `foto-${fotos.length + 1}` });
+        await ctx.reply(`📸 Foto ${fotos.length} recibida. Envía otra o toca Listo.`);
+        continue;
+      }
+
+      await ctx.reply("No entendí. Envía una foto de la planilla, toca Listo, o escribe cancelar.");
+    }
+
+    // ── Paso 3: descargar + correr el pipeline (N11) ──────────────────
+    await ctx.replyWithChatAction("upload_photo");
+    const anioFinal = anio;
+    const mesFinal = mes;
+    const lectura = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      const fotosEntrada: FotoPesajeEntrada[] = [];
+      for (let i = 0; i < fotos.length; i++) {
+        const bytes = await descargarBytesTelegram(fotos[i].fileId, botToken);
+        fotosEntrada.push({ pagina: i + 1, nombre: fotos[i].nombre, tipo: fotos[i].tipo, bytes });
+      }
+      return await ejecutarPipelinePesajeFoto({ supabase: sb, apiKey, fotos: fotosEntrada, anio: anioFinal, mes: mesFinal });
     });
 
-    if (vacas.length === 0) {
-      await ctx.reply("No hay vacas activas registradas en el hato.");
+    if (!lectura.ok) {
+      await ctx.reply(`❌ No se pudo leer la planilla: ${lectura.error}\n\nUsa /pesaje para intentar de nuevo.`);
       return;
     }
 
-    // ── Step 4: iterar vacas ─────────────────────────────────────────
+    const roster = construirRosterPesaje(lectura.resultado.rosterAnimales);
+    const fechasPorSemana = lectura.resultado.fechasPorSemana;
+    let diffActual = lectura.resultado.diff;
 
-    let guardadas = 0;
-    let saltadas = 0;
-    let terminarTemprano = false;
+    // ── Paso 4/5: mostrar resumen + loop de corrección en texto libre (N12,
+    //    decisión D-C) hasta un "ok" explícito. Nada se escribe antes. ─────
+    const kbGuardar = new InlineKeyboard()
+      .text("✅ Guardar", "guardar_pesaje")
+      .text("❌ Cancelar", "cancel_flow");
 
-    for (const vaca of vacas) {
-      if (terminarTemprano) break;
+    const advertenciasIniciales = construirAdvertenciasLectura(lectura.resultado);
+    await enviarPorPartes(
+      ctx,
+      [
+        `📋 *Lectura de la planilla -- ${nombreMes(mesFinal)} ${anioFinal}*`,
+        "",
+        construirResumenPesajeTexto(diffActual),
+        ...(advertenciasIniciales.length > 0 ? ["", ...advertenciasIniciales] : []),
+        "",
+        'Escribe correcciones en lenguaje natural (ej: "MONZA sem 2 AM son 6.5" o "BONITA no se pesó"), o toca *Guardar* cuando esté bien.',
+      ].join("\n"),
+      { reply_markup: kbGuardar, parse_mode: "Markdown" },
+    );
 
-      const etiqueta = `#${vaca.numero ?? "?"} ${vaca.nombre ?? "sin nombre"}`;
-      const existente = existentes.get(vaca.id);
-      const actual = existente ? ` (actual: ${existente.litros_total} L)` : "";
+    while (true) {
+      const respuesta = await conversation.wait();
 
-      const kb = new InlineKeyboard()
-        .text("⏭ Saltar", "vaca_skip")
-        .text("✅ Terminar aquí", "vaca_finish")
-        .row()
-        .text("❌ Cancelar", "cancel_flow");
-
-      await ctx.reply(`🐄 *${etiqueta}*${actual}\n¿Cuántos litros dio?`, {
-        reply_markup: kb,
-        parse_mode: "Markdown",
-      });
-
-      // Loop until this cow resolves to skip/finish/cancel/valid-number —
-      // an invalid text answer re-prompts the SAME cow, it never silently
-      // advances to the next one.
-      while (true) {
-        const respuesta = await conversation.wait();
-
-        if (respuesta.callbackQuery?.data === "cancel_flow") {
-          await respuesta.answerCallbackQuery();
-          await ctx.reply(
-            `Operación cancelada. Los pesajes ya guardados (${guardadas}) quedan registrados — solo se descarta lo que faltaba.`,
-          );
-          return conversation.halt();
-        }
-
-        if (respuesta.callbackQuery?.data === "vaca_finish") {
-          await respuesta.answerCallbackQuery();
-          terminarTemprano = true;
-          break;
-        }
-
-        if (respuesta.callbackQuery?.data === "vaca_skip") {
-          await respuesta.answerCallbackQuery();
-          saltadas++;
-          break;
-        }
-
-        if (respuesta.message?.text) {
-          const litros = parseFloat(respuesta.message.text.trim().replace(",", "."));
-          if (isNaN(litros) || litros < 0) {
-            await respuesta.reply("Ingresa un número válido (0 o más), o usa los botones.");
-            continue;
-          }
-
-          const idGuardado = await conversation.external(async () => {
-            const sb = getSupabaseAdmin();
-            if (existente) {
-              const { error } = await sb
-                .from("hato_pesajes_leche")
-                .update({ litros_total: litros })
-                .eq("id", existente.id);
-              if (error) throw new Error(`Error guardando: ${error.message}`);
-              return existente.id;
-            }
-            const { data, error } = await sb
-              .from("hato_pesajes_leche")
-              .insert({ animal_id: vaca.id, fecha, litros_total: litros, fuente: "telegram" })
-              .select("id")
-              .single();
-            if (error) throw new Error(`Error guardando: ${error.message}`);
-            return data!.id as string;
-          });
-
-          existentes.set(vaca.id, { id: idGuardado, litros_total: litros });
-          guardadas++;
-          break;
-        }
-
-        await ctx.reply("No entendí la respuesta. Usa un número o los botones.");
+      if (respuesta.callbackQuery?.data === "cancel_flow") {
+        await respuesta.answerCallbackQuery();
+        await ctx.reply("Operación cancelada -- nada se guardó.");
+        return conversation.halt();
       }
+      if (respuesta.callbackQuery?.data === "guardar_pesaje") {
+        await respuesta.answerCallbackQuery();
+        break;
+      }
+
+      const texto = respuesta.message?.text;
+      if (!texto) {
+        await ctx.reply('No entendí. Escribe una corrección, "ok" para guardar, o toca los botones de arriba.');
+        continue;
+      }
+      if (esCancelacionTexto(texto)) {
+        await ctx.reply("Operación cancelada -- nada se guardó.");
+        return conversation.halt();
+      }
+      if (esConfirmacionGuardar(texto)) break;
+
+      // ── Interpretar la corrección: llamada al modelo (N12) + validación
+      //    PURA contra el roster y la grilla de semanas del mes. ──────────
+      await ctx.replyWithChatAction("typing");
+      const interpretacion = await conversation.external(() => llamarModeloCorreccionPesaje(texto, apiKey));
+
+      if (!interpretacion.ok) {
+        await ctx.reply(`No pude interpretar eso: ${interpretacion.error}\n\nIntenta de nuevo, o toca Guardar/Cancelar.`);
+        continue;
+      }
+
+      const { aplicables, noEntendidas } = interpretarCorreccionPesaje(interpretacion.items, roster, fechasPorSemana);
+
+      if (aplicables.length === 0 && noEntendidas.length === 0) {
+        await ctx.reply('No encontré ninguna corrección en ese mensaje. Intenta de nuevo, o escribe "ok" para guardar.');
+        continue;
+      }
+
+      diffActual = aplicarCorreccionesADiff(diffActual, aplicables);
+
+      const bloques = [
+        aplicables.length > 0 ? `✏️ Apliqué ${aplicables.length} corrección(es).` : null,
+        noEntendidas.length > 0
+          ? `⚠️ No entendí ${noEntendidas.length}:\n${noEntendidas.map((n) => `  - "${n.nombreMencionado}": ${n.detalle}`).join("\n")}`
+          : null,
+        "",
+        "📋 *Resumen actualizado*",
+        construirResumenPesajeTexto(diffActual),
+      ].filter((b): b is string => b !== null);
+
+      await enviarPorPartes(ctx, bloques.join("\n"), { reply_markup: kbGuardar, parse_mode: "Markdown" });
     }
 
-    await ctx.reply(
-      `✅ Pesaje del ${formatDateSpanish(fecha)} completado: ${guardadas} vaca${guardadas === 1 ? "" : "s"} pesada${guardadas === 1 ? "" : "s"}` +
-        (saltadas > 0 ? `, ${saltadas} saltada${saltadas === 1 ? "" : "s"}.` : ".") +
-        "\n\nUsa /start para volver al menú.",
-    );
+    // ── Paso 6: commit por celda (N13) ────────────────────────────────
+    const celdasParaGuardar: CeldaCommitPesajeEntrada[] = construirFilasPesajeInsertables(diffActual).map((f) => ({
+      animalId: f.animal_id,
+      fecha: f.fecha,
+      litrosAm: f.litros_am,
+      litrosPm: f.litros_pm,
+    }));
+
+    if (celdasParaGuardar.length === 0) {
+      await ctx.reply("No hay ninguna celda con datos para guardar (todo quedó en 'sin dato'). No se escribió nada.");
+      return;
+    }
+
+    const commit = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      return await ejecutarCommitPesaje({
+        supabase: sb,
+        anio: anioFinal,
+        mes: mesFinal,
+        celdas: celdasParaGuardar,
+        createdBy: usuarioId,
+        fuente: "telegram",
+      });
+    });
+
+    if (!commit.ok) {
+      const rechazadas = "celdasRechazadas" in commit ? commit.celdasRechazadas : [];
+      await ctx.reply(
+        `❌ No se pudo guardar: ${commit.error}${
+          rechazadas.length > 0 ? `\n\nRechazadas:\n${rechazadas.map((r) => `  - ${r.motivo}`).join("\n")}` : ""
+        }`,
+      );
+      return;
+    }
+
+    const resumenFinal = [
+      `✅ Pesaje de *${nombreMes(mesFinal)} ${anioFinal}* guardado: ${commit.guardados} celda(s) (${commit.actualizados} actualizadas, ${commit.creados} nuevas).`,
+      commit.celdasRechazadas.length > 0
+        ? `⚠️ ${commit.celdasRechazadas.length} celda(s) rechazadas al guardar:\n${commit.celdasRechazadas.map((r) => `  - ${r.motivo}`).join("\n")}`
+        : null,
+      "",
+      "Usa /pesaje para cargar otra planilla, o /start para el menú.",
+    ]
+      .filter((b): b is string => b !== null)
+      .join("\n");
+    await enviarPorPartes(ctx, resumenFinal, { parse_mode: "Markdown" });
   } catch (err: unknown) {
     if (err instanceof Error && err.message === "Conversation already halted") return;
     const msg = err instanceof Error ? err.message : "Error desconocido";

--- a/src/supabase/functions/server/telegram/enviar.ts
+++ b/src/supabase/functions/server/telegram/enviar.ts
@@ -5,6 +5,16 @@
 // escribe a alguien SIN que haya escrito primero (el tick diario cron ->
 // `hato-alertas-tick.ts`).
 //
+// Migración 096 (2026-08-14, suscripciones + broadcast con cierre por el
+// primero) agrega `editarMensajeTelegram`/`cerrarAlertaEnEnvios`: cuando un
+// suscrito responde una alerta que se mandó a VARIOS suscritos, los mensajes
+// de los DEMÁS hay que editarlos para que se vea que ya se resolvió y por
+// quién — pero esos mensajes viven en OTROS chats, no en el del que
+// respondió, así que `ctx.editMessageText` (que solo edita el mensaje del
+// `Context` actual) no alcanza. Estas dos funciones llaman directo a la Bot
+// API con el `chat_id`/`message_id` guardados en `hato_alertas_envios` (la
+// tabla de envíos del broadcast, una fila por (alerta, suscrito)).
+//
 // Deliberadamente NO reutiliza la instancia interna de `getBot()` de
 // `bot.ts` (no está exportada, y exportarla acoplaría el tick al ciclo de
 // vida completo del bot -- sesiones persistidas, plugin de conversations,
@@ -129,4 +139,102 @@ export async function enviarMensajeTelegram(
 
   await registrarEnvio(supabase, opciones, resultado);
   return resultado;
+}
+
+// ----------------------------------------------------------------------------
+// Edición de un mensaje YA enviado, en un chat que puede no ser el que
+// disparó el callback (migración 096, broadcast con cierre por el primero).
+// ----------------------------------------------------------------------------
+
+export interface OpcionesEdicionTelegram {
+  /** `chat_id` de Telegram del mensaje a editar -- NO necesariamente el chat
+   * de quien respondió la alerta (ese es el punto: se editan los mensajes de
+   * los DEMÁS suscritos). */
+  telegramId: string;
+  /** `message_id` devuelto por `sendMessage` en su momento (guardado en
+   * `hato_alertas_envios.message_id`). */
+  messageId: number;
+  texto: string;
+}
+
+/**
+ * Edita el texto de un mensaje ya enviado, vía la Bot API (`editMessageText`)
+ * -- nunca `ctx.editMessageText`, que solo sabe editar el mensaje del
+ * `Context` en curso. Mismo contrato duro que `enviarMensajeTelegram`: NUNCA
+ * lanza. Telegram rechaza editar un mensaje de más de 48h -- ese fallo (como
+ * cualquier otro: chat bloqueado, mensaje borrado por el usuario) se
+ * devuelve como `{ ok: false, error }` y el caller decide si sigue con el
+ * siguiente destinatario del broadcast.
+ *
+ * No se audita en `telegram_mensajes` (a diferencia de `enviarMensajeTelegram`):
+ * esa tabla registra mensajes NUEVOS, y una edición no es un mensaje nuevo --
+ * el mensaje original ya quedó auditado cuando se mandó.
+ */
+export async function editarMensajeTelegram(opciones: OpcionesEdicionTelegram): Promise<ResultadoEnvioTelegram> {
+  try {
+    const respuesta = await fetch(urlApiTelegram('editMessageText'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: opciones.telegramId,
+        message_id: opciones.messageId,
+        text: opciones.texto,
+      }),
+    });
+    const json = await respuesta.json().catch(() => null);
+    if (!respuesta.ok || !json?.ok) {
+      return { ok: false, error: json?.description ?? `Telegram respondió HTTP ${respuesta.status}` };
+    }
+    return { ok: true, telegramMessageId: opciones.messageId };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export interface ResultadoCierreAlertaEnvios {
+  editados: number;
+  fallidos: number;
+}
+
+/**
+ * Edita el mensaje de CADA suscrito al que se le mandó una alerta
+ * (`hato_alertas_envios`, una fila por (alerta_id, telegram_id)) para
+ * mostrar que ya se resolvió -- el corazón del broadcast "cierre por el
+ * primero" (migración 096). `excluirTelegramId` deja afuera el chat de quien
+ * ACABA de responder: ese mensaje ya lo edita el propio callback vía
+ * `ctx.editMessageReplyMarkup()` (más rápido, no necesita ir por la Bot API
+ * con un `chat_id` explícito) -- editarlo dos veces por dos caminos distintos
+ * es una carrera innecesaria contra el mismo mensaje.
+ *
+ * Un fallo puntual (mensaje ya editado más de 48h, chat bloqueado) no aborta
+ * el resto -- se cuenta en `fallidos` y el caller decide si lo loguea.
+ */
+export async function cerrarAlertaEnEnvios(
+  supabase: SupabaseClient,
+  alertaId: string,
+  excluirTelegramId: string | null,
+  texto: string,
+): Promise<ResultadoCierreAlertaEnvios> {
+  const { data: envios, error } = await supabase
+    .from('hato_alertas_envios')
+    .select('telegram_id, message_id')
+    .eq('alerta_id', alertaId);
+  if (error) {
+    console.error('[hato-alertas][hato_alertas_envios] no se pudieron leer los envíos para cerrar la alerta:', error.message);
+    return { editados: 0, fallidos: 0 };
+  }
+
+  let editados = 0;
+  let fallidos = 0;
+  for (const envio of (envios ?? []) as Array<{ telegram_id: string; message_id: number | null }>) {
+    if (excluirTelegramId && envio.telegram_id === excluirTelegramId) continue;
+    if (envio.message_id == null) {
+      fallidos += 1;
+      continue;
+    }
+    const resultado = await editarMensajeTelegram({ telegramId: envio.telegram_id, messageId: envio.message_id, texto });
+    if (resultado.ok) editados += 1;
+    else fallidos += 1;
+  }
+  return { editados, fallidos };
 }

--- a/src/types/hato.ts
+++ b/src/types/hato.ts
@@ -10,7 +10,12 @@
 // semanal + quincenal). Otras sesiones (S6, S10) añaden aquí sus propios
 // tipos según lo necesiten.
 
-import type { TipoEventoHato, CriaDestino, TipoEstado } from '@/utils/calculosHato';
+import type {
+  TipoEventoHato,
+  CriaDestino,
+  TipoEstado,
+  MetodoConfirmacionPrenez,
+} from '@/utils/calculosHato';
 
 export type { TipoEventoHato, CriaDestino, TipoEstado };
 
@@ -203,6 +208,15 @@ export interface EstadoActualHatoViewRow {
    * `fecha_nacimiento`. Cuando es `true`, `etapa` gana SIEMPRE sobre el
    * cálculo en `calcularEtapaHato`. */
   etapa_forzada: boolean;
+  /** `datos->>'metodo'` del último `confirmacion_prenez` (migración 094,
+   * D-D 2026-08-13) -- columna nueva AL FINAL, después de `etapa_forzada`.
+   * Separa "servida" (presunción) de "confirmada" (palpación); `null` se
+   * lee como presunción, nunca como palpación. */
+  ultima_confirmacion_prenez_metodo: MetodoConfirmacionPrenez | null;
+  /** MAX(fecha) de los eventos `aborto` (migración 094) -- columna nueva AL
+   * FINAL. Permite que el motor tipifique el aborto en vez de dejar al
+   * animal en `indeterminado` sin decir por qué. */
+  ultimo_aborto_fecha: string | null;
 }
 
 // ============================================================================

--- a/src/utils/calculosHato.ts
+++ b/src/utils/calculosHato.ts
@@ -2162,6 +2162,55 @@ export function derivarEstadoReproductivo(
   };
 }
 
+/**
+ * Etiqueta legible de un `EstadoReproductivo`, en el vocabulario de CINCO
+ * estados de D-D (Vacía · Servida · Confirmada · Por secar · Seca) más los
+ * estados no-aplicables/terminales. Extraída de `hatoUi.ts::chipEstadoReproductivo`
+ * (S8) para que exista UNA sola fuente del TEXTO -- el color/className sigue
+ * viviendo en `hatoUi.ts` (browser-only), que ahora reusa esta función.
+ *
+ * Por qué vive acá y no solo en `hatoUi.ts`: la columna "Estado registrado"
+ * de la planilla de chequeo (D-E, docs/plan_hato_telegram_estados_agosto_2026.md
+ * N21-N23) imprime este mismo texto en el `.xlsx`/PDF (`exportarPlanillaChequeo*.ts`,
+ * browser) y el endpoint de diff (Deno, `hato-chequeo-preview.ts`) necesita
+ * calcular el MISMO texto para detectar cuándo lo impreso ya no coincide con
+ * lo que el sistema cree HOY -- y el lado Deno no puede importar `hatoUi.ts`
+ * (no es parte del trío espejado). Este archivo sí lo es, así que la etiqueta
+ * viaja gratis a los tres lados sin duplicar el vocabulario.
+ */
+export function etiquetaEstadoReproductivo(estado: EstadoReproductivo): string {
+  switch (estado) {
+    case 'preñada':
+      return 'Confirmada';
+    case 'parida_reciente':
+      return 'Vacía';
+    case 'servida':
+      return 'Servida';
+    case 'proxima_a_secar':
+      return 'Por secar';
+    case 'seca':
+      return 'Seca';
+    case 'vacia_por_servir':
+      return 'Vacía';
+    case 'novilla':
+      return 'Vacía';
+    case 'cria':
+      return 'Cría';
+    case 'indeterminado':
+      return '—';
+    case 'vendida':
+      return 'Vendida';
+    case 'muerta':
+      return 'Muerta';
+    case 'descartada':
+      return 'Descartada';
+    default: {
+      const _exhaustivo: never = estado;
+      return String(_exhaustivo);
+    }
+  }
+}
+
 // ============================================================================
 // BLOQUE 5 — PL / productividad
 // ============================================================================

--- a/src/utils/calculosHato.ts
+++ b/src/utils/calculosHato.ts
@@ -1658,9 +1658,31 @@ export function derivarSexoCria(input: InputSexoCria): SexoCria | null {
 // BLOQUE 4 — Derivación de estado reproductivo (v_hato_estado_actual + config)
 // ============================================================================
 
-/** Subconjunto de columnas de `v_hato_estado_actual` (migración 056) que
- * este motor consume. La vista expone solo hechos -- todo el cálculo de
- * fechas/umbrales vive aquí, nunca en la vista (plan §7.1, brief S1 Decisión 3). */
+/** Evidencia detrás de una confirmación de preñez (`hato_eventos.datos.metodo`,
+ * escrito por `hatoCicloManual.ts` desde S3). Es la ÚNICA diferencia entre
+ * los estados "servida" y "confirmada" de D-D. */
+export type MetodoConfirmacionPrenez = 'presuncion' | 'palpacion';
+
+/** Motivo por el que una vaca necesita revisión humana, para la columna de
+ * señales de la lista del hato (D-D, 2026-08-13: "el estado ya no absorbe
+ * aborto/indeterminado — eso vive en una columna de alertas aparte que dice
+ * qué pasó"). Nunca se mezcla con `estado`: el estado dice en qué punto del
+ * ciclo está la vaca, la señal dice por qué ese dato puede no ser confiable.
+ *
+ * - `aborto`: el evento más reciente del animal es un aborto. El estado SÍ
+ *   se conoce (queda vacía) -- la señal solo explica el porqué.
+ * - `evento_posterior`: hay un evento más nuevo que los 4 que este motor
+ *   sabe clasificar y NO es un aborto (celo, rechequeo, compra,
+ *   cambio_etapa...). Ahí el estado es genuinamente desconocido. */
+export interface SenalRevisionHato {
+  tipo: 'aborto' | 'evento_posterior';
+  fecha: string;
+}
+
+/** Subconjunto de columnas de `v_hato_estado_actual` (migración 056, ampliada
+ * por 062/089/092/094) que este motor consume. La vista expone solo hechos --
+ * todo el cálculo de fechas/umbrales vive aquí, nunca en la vista
+ * (plan §7.1, brief S1 Decisión 3). */
 export interface EstadoActualHatoRow {
   etapa: 'ternera' | 'novilla' | 'vaca' | 'toro';
   raza: string | null;
@@ -1678,6 +1700,21 @@ export interface EstadoActualHatoRow {
    * o muerte, no se proyecta un ciclo de preñez activo con datos que ese
    * evento puede haber invalidado -- ver `derivarEstadoReproductivo`. */
   ultimo_evento_fecha: string | null;
+  /** `datos->>'metodo'` del ÚLTIMO `confirmacion_prenez` (columna de la
+   * vista desde la migración 094). Decisión del dueño D-D (2026-08-13):
+   * "servida = preñada por presunción, confirmada = palpada", así que este
+   * campo es lo único que separa dos estados distintos a partir del MISMO
+   * tipo de evento. `null` = confirmación sin método registrado
+   * (importación histórica o marca anterior a S3) y se trata como
+   * PRESUNCIÓN: afirmar que un veterinario palpó sin evidencia es la única
+   * lectura de las dos que no se puede deshacer. */
+  ultima_confirmacion_prenez_metodo: MetodoConfirmacionPrenez | null;
+  /** MAX(fecha) de los eventos `aborto` del animal (columna de la vista
+   * desde la migración 094). Permite tipificar el caso que antes caía en
+   * `indeterminado` sin explicación: tras un aborto la vaca está VACÍA (eso
+   * es un hecho biológico, no una suposición) y el motivo viaja en
+   * `senal_revision`, no disfrazado dentro del `estado`. */
+  ultimo_aborto_fecha: string | null;
   /** `tipo` de `parseEstado` sobre el `ESTADO`/`OBS` del último chequeo
    * cerrado (`'vacia_apta' | 'vacia_problema' | 'fecha_heredada' |
    * 'desconocido' | 'vacio'`), o `null` si no hay ninguna señal disponible
@@ -1745,6 +1782,14 @@ export interface EstadoReproductivoDerivado {
    * no hay ninguna señal disponible -- nunca se adivina.
    */
   vacia_es_problema: boolean | null;
+  /**
+   * Motivo por el que este animal necesita una mirada humana (D-D). `null`
+   * = nada que revisar. Es información SEPARADA de `estado` a propósito: el
+   * vocabulario de 5 estados del dueño (vacía · servida · confirmada · por
+   * secar · seca) describe el punto del ciclo, y meter "abortó" o "hay algo
+   * raro" dentro de esa lista obligaría a mentir en uno de los dos ejes.
+   */
+  senal_revision: SenalRevisionHato | null;
   alertas: AlertasReproductivas;
 }
 
@@ -1811,6 +1856,22 @@ function clasificarVaciaProblema(
 }
 
 /**
+ * D-D (dueño, 2026-08-13): una confirmación de preñez vale como `preñada`
+ * (etiqueta "Confirmada") SOLO si viene de una palpación. Una confirmación
+ * por presunción deja a la vaca en `servida` -- que es exactamente lo que
+ * el dueño quiso decir con "servida = preñada por presunción".
+ *
+ * `null` (confirmación sin método: importación histórica o marca anterior a
+ * S3) se lee como presunción. Es la asimetría deliberada: dar por palpada
+ * una vaca que nadie palpó lleva a secarla y dejar de ordeñarla con datos
+ * que nadie verificó; el error contrario solo hace que se la vuelva a
+ * revisar.
+ */
+function estadoDeConfirmacion(fila: EstadoActualHatoRow): EstadoReproductivo {
+  return fila.ultima_confirmacion_prenez_metodo === 'palpacion' ? 'preñada' : 'servida';
+}
+
+/**
  * Deriva el estado reproductivo actual de un animal y las 4 alertas de
  * §7.3 (secado_due, rechequeo_due, servicio_sin_confirmacion, parto_proximo)
  * a partir de los hechos de `v_hato_estado_actual` + `HatoConfig`. Todos los
@@ -1849,6 +1910,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: false,
       vacia_es_problema: null,
+      senal_revision: null,
       alertas: SIN_ALERTAS,
     };
   }
@@ -1865,6 +1927,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
       vacia_es_problema: null,
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1907,6 +1970,7 @@ export function derivarEstadoReproductivo(
       // Una novilla nunca ha entrado al ciclo reproductivo: la pregunta
       // "¿normal o problema?" no aplica todavía.
       vacia_es_problema: esNovilla ? null : clasificarVaciaProblema(fila.ultimo_estado_chequeo, null, config),
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1917,26 +1981,44 @@ export function derivarEstadoReproductivo(
   });
   const masReciente = candidatos[0].tipo;
 
-  // Salvaguarda: `v_hato_estado_actual` no expone una columna dedicada de
-  // "último aborto" (a diferencia de parto/secado_real/confirmación), pero sí
-  // `ultimo_evento_fecha` (MAX sobre TODO `hato_eventos`, cualquier tipo). Si
-  // hay un evento más reciente que el más nuevo de los 4 que sí sabemos
-  // clasificar, algo pasó que este motor no puede tipificar aquí -- casi
-  // siempre un aborto, venta o muerte -- y proyectar SECAR/PP desde el
-  // servicio viejo sería exactamente el error real encontrado (QA, MONA:
-  // SX='aborto' con SECAR/PP de la fila cruda todavía "vigentes" en la
-  // planilla). Nunca se asume que el ciclo sigue activo cuando hay una señal
-  // de que no es así, aunque no se sepa de qué tipo es.
+  // Salvaguarda: `ultimo_evento_fecha` es MAX sobre TODO `hato_eventos`
+  // (cualquier tipo). Si hay un evento más reciente que el más nuevo de los 4
+  // que este motor sabe clasificar, algo pasó que invalida el ciclo -- y
+  // proyectar SECAR/PP desde el servicio viejo sería exactamente el error
+  // real encontrado (QA, MONA: SX='aborto' con SECAR/PP de la fila cruda
+  // todavía "vigentes" en la planilla). Nunca se asume que el ciclo sigue
+  // activo cuando hay una señal de que no es así.
+  //
+  // Desde la migración 094 esa señal se puede TIPIFICAR en el caso más
+  // frecuente. Si el evento más nuevo es un aborto, el estado no es
+  // desconocido: la vaca quedó VACÍA -- eso es un hecho biológico, no una
+  // suposición -- y el motivo viaja en `senal_revision`, que es justamente
+  // lo que pide D-D ("el estado ya no absorbe aborto/indeterminado"). Solo
+  // cuando el evento posterior NO es un aborto (celo, rechequeo, compra,
+  // cambio_etapa...) el estado sigue siendo genuinamente `indeterminado`.
   if (fila.ultimo_evento_fecha && fila.ultimo_evento_fecha > candidatos[0].fecha) {
+    const esAborto = fila.ultimo_aborto_fecha === fila.ultimo_evento_fecha;
     return {
-      estado: 'indeterminado',
+      estado: esAborto ? 'vacia_por_servir' : 'indeterminado',
       fecha_secar: null,
       fecha_probable_parto: null,
+      // `dias_abiertos` cuenta desde el ÚLTIMO PARTO, no desde cualquier fin
+      // de gestación: un aborto no es un parto y no ancla ese contador.
+      // Queda `null` -- nunca un número inventado desde otra fecha.
       dias_abiertos: null,
       tiempo_prenez_dias: null,
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
-      vacia_es_problema: null,
+      // Tras un aborto la vaca está vacía y la pregunta "¿normal o
+      // problema?" sí aplica -- pero sin ancla de tiempo utilizable (ver
+      // arriba) solo puede responderla la señal explícita del chequeo.
+      vacia_es_problema: esAborto
+        ? clasificarVaciaProblema(fila.ultimo_estado_chequeo, null, config)
+        : null,
+      senal_revision: {
+        tipo: esAborto ? 'aborto' : 'evento_posterior',
+        fecha: fila.ultimo_evento_fecha,
+      },
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1956,6 +2038,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
       vacia_es_problema: clasificarVaciaProblema(fila.ultimo_estado_chequeo, diasAbiertos, config),
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1972,7 +2055,8 @@ export function derivarEstadoReproductivo(
     // inventada -- pero el ESTADO real (`seca`/`preñada`) sí se conoce y se
     // devuelve. `tiempo_secada_dias` sí se puede calcular en `seca` porque
     // `ultimo_secado_real_fecha` es un dato real, no una proyección.
-    const estadoSinAncla: EstadoReproductivo = masReciente === 'secado_real' ? 'seca' : 'preñada';
+    const estadoSinAncla: EstadoReproductivo =
+      masReciente === 'secado_real' ? 'seca' : estadoDeConfirmacion(fila);
     const tiempoSecadaDiasSinAncla =
       estadoSinAncla === 'seca' && fila.ultimo_secado_real_fecha
         ? diferenciaDias(fila.ultimo_secado_real_fecha, fechaReferencia)
@@ -1989,6 +2073,7 @@ export function derivarEstadoReproductivo(
       // pregunta "¿normal o problema?" no aplica aquí, igual que en la rama
       // con ancla más abajo.
       vacia_es_problema: null,
+      senal_revision: null,
       // Sin ancla no hay `fecha_secar` que comparar, así que `secado_due` y
       // `parto_proximo` quedan en `false` (SIN_ALERTAS) -- no hay fecha
       // basura contra la que compararlas. `hatoAlertas.ts` además exige
@@ -2023,7 +2108,7 @@ export function derivarEstadoReproductivo(
   } else if (dentroVentanaSecar || secadoDue) {
     estado = 'proxima_a_secar';
   } else if (masReciente === 'confirmacion') {
-    estado = 'preñada';
+    estado = estadoDeConfirmacion(fila);
   } else {
     estado = 'servida';
   }
@@ -2067,6 +2152,7 @@ export function derivarEstadoReproductivo(
     // "servicios repetidos sin concepción" ya lo cubre la alerta
     // `servicio_sin_confirmacion` de arriba, sin necesidad de duplicarlo.
     vacia_es_problema: null,
+    senal_revision: null,
     alertas: {
       secado_due: secadoDue,
       rechequeo_due: rechequeoDue,

--- a/src/utils/hato/exportarPlanillaChequeo.ts
+++ b/src/utils/hato/exportarPlanillaChequeo.ts
@@ -55,12 +55,20 @@
 // continua (requisito duro de B5.1: "nunca repetir el header, rompe la
 // extracción del parser de subida").
 
-import type { TipoEstado } from '@/utils/calculosHato';
+import { etiquetaEstadoReproductivo, type EstadoReproductivo, type TipoEstado } from '@/utils/calculosHato';
 
-/** Las 12 columnas del template (13 históricas menos `TP`), en orden, con
- * las abreviaturas desarrolladas (decisión del dueño). Única fuente de
- * verdad del header -- tanto el armado del AOA como los tests la reutilizan,
- * nunca se repite el arreglo literal en dos sitios. */
+/** Las 13 columnas del template (13 históricas menos `TP`, más "Estado
+ * registrado" de B5.4 -- D-E, docs/plan_hato_telegram_estados_agosto_2026.md
+ * N21-N22), en orden, con las abreviaturas desarrolladas (decisión del
+ * dueño). Única fuente de verdad del header -- tanto el armado del AOA como
+ * los tests la reutilizan, nunca se repite el arreglo literal en dos sitios.
+ *
+ * "Estado registrado" va ANTES de "Estado" a propósito: primero lo que el
+ * sistema cree (referencia, gris), después la columna donde Martha lo
+ * verifica (ok/rech/nota). Es el mecanismo de sincronía de D-E -- la monta
+ * que Fernando registró por Telegram en agosto llega impresa al papel de la
+ * vet en agosto, para que lo confirme o lo corrija en vez de transcribirlo
+ * de memoria. */
 export const ENCABEZADOS_PLANILLA_CHEQUEO = [
   '#',
   'Nombre',
@@ -70,6 +78,7 @@ export const ENCABEZADOS_PLANILLA_CHEQUEO = [
   'Sexo cría',
   'Fecha Servicio',
   'Toro',
+  'Estado registrado',
   'Estado',
   'Secar',
   'Parto Probable',
@@ -100,6 +109,15 @@ export interface FilaPlanillaChequeo {
   sexoCria: string | null;
   fechaServicio: string | null;
   toro: string | null;
+  /** "Estado registrado" (D-E, B5.4): la etiqueta de `EstadoReproductivo`
+   * que el sistema creía cierta al exportar (`textoCeldaEstadoRegistrado`),
+   * gris/de solo referencia -- Martha nunca escribe acá, `estado` (la
+   * columna de al lado) es su verificación. OPCIONAL: el B5.2
+   * record-keeping (`ChequeoDetalle.tsx`, un chequeo YA CARGADO) no la trae
+   * -- esa columna no existía cuando ese chequeo se capturó, así que su
+   * ausencia en el objeto se traduce a celda vacía igual que `null`, nunca
+   * a un valor inventado retroactivamente. */
+  estadoRegistrado?: string | null;
   estado: string | null;
   /** Referencia de solo-lectura calculada por la app -- el parser de
    * subida JAMÁS la lee de vuelta (Secar/PP siempre se RE-DERIVAN desde
@@ -124,6 +142,7 @@ function filaAOA(fila: FilaPlanillaChequeo): CeldaAOA[] {
     fila.sexoCria,
     fila.fechaServicio,
     fila.toro,
+    fila.estadoRegistrado ?? null,
     fila.estado,
     fila.secar,
     fila.partoProbable,
@@ -231,12 +250,38 @@ export function textoCeldaEstado(tipo: TipoEstado | null | undefined): string | 
   return null;
 }
 
-/** Anchos de columna (`!cols`, caracteres) -- angostos a propósito: 12
+/**
+ * Texto de la celda "Estado registrado" (D-E, B5.4) -- la etiqueta de
+ * `EstadoReproductivo` (`etiquetaEstadoReproductivo`, calculosHato.ts), la
+ * MISMA que ve el resto de la app (`chipEstadoReproductivo`, `hatoUi.ts`).
+ *
+ * A diferencia de `textoCeldaToro`/`textoCeldaEstado` (que escriben códigos
+ * CRUDOS re-parseables porque esas dos columnas son DILIGENCIADAS), esta
+ * columna es de solo REFERENCIA -- nadie la vuelve a escribir a mano, así que
+ * no hay razón para que el `.xlsx` y el PDF muestren textos distintos como sí
+ * ocurre con `Sexo cría` (ver `exportarPlanillaChequeoPDF.ts`). El diff
+ * (`importHato/diffChequeo.ts`, N23) compara esta MISMA etiqueta -- impresa
+ * vs. recalculada al momento de aprobar -- para marcar el conflicto explícito
+ * que pide D-E.
+ *
+ * `null` -> celda vacía, nunca un texto inventado: sin `EstadoReproductivo`
+ * conocido (la fila no tiene animal resuelto, p. ej. B5.2 de un chequeo
+ * histórico que no guardó este dato) no hay nada que imprimir.
+ */
+export function textoCeldaEstadoRegistrado(estado: EstadoReproductivo | null | undefined): string | null {
+  if (!estado) return null;
+  return etiquetaEstadoReproductivo(estado);
+}
+
+/** Anchos de columna (`!cols`, caracteres) -- angostos a propósito: las 13
  * columnas deben caber en el ANCHO de una página impresa tamaño carta/oficio
  * en orientación horizontal sin que Excel corte la tabla por la mitad al
  * paginar (ver nota de `construirLibroPlanillaChequeo` sobre las
- * limitaciones reales de paginación de esta librería). */
-const ANCHOS_COLUMNAS_PLANILLA: readonly number[] = [6, 20, 6, 8, 11, 12, 13, 14, 9, 11, 13, 18];
+ * limitaciones reales de paginación de esta librería). El .xlsx es el
+ * artefacto de MÁQUINA (nunca se imprime tal cual -- para eso está el PDF),
+ * así que este ancho es cosmético para quien lo abra en Excel, no un
+ * presupuesto físico como el de `exportarPlanillaChequeoPDF.ts`. */
+const ANCHOS_COLUMNAS_PLANILLA: readonly number[] = [6, 20, 6, 8, 11, 12, 13, 14, 16, 9, 11, 13, 18];
 
 export type XLSXModule = typeof import('xlsx');
 

--- a/src/utils/hato/exportarPlanillaChequeoPDF.ts
+++ b/src/utils/hato/exportarPlanillaChequeoPDF.ts
@@ -251,7 +251,7 @@ export function hayNumerosProvisionales(filas: readonly FilaPlanillaChequeo[]): 
 
 export function construirFilasPlanillaPDF(filas: readonly FilaPlanillaChequeo[]): string[][] {
   return filas.map((f) => {
-    const celdas: (string | number | null)[] = [
+    const celdas: (string | number | null | undefined)[] = [
       textoCeldaNumero(f.numero),
       f.nombre,
       f.pl,
@@ -260,6 +260,7 @@ export function construirFilasPlanillaPDF(filas: readonly FilaPlanillaChequeo[])
       f.sexoCria,
       f.fechaServicio,
       f.toro,
+      f.estadoRegistrado,
       f.estado,
       f.secar,
       f.partoProbable,
@@ -275,48 +276,65 @@ export function construirFilasPlanillaPDF(filas: readonly FilaPlanillaChequeo[])
 
 /**
  * Anchos de columna en MILÍMETROS. Presupuesto real de carta HORIZONTAL:
- * 279,4mm de ancho − 10mm de margen a cada lado = **259,4mm útiles**. La suma
- * de abajo es 254,5mm, con holgura deliberada para que un redondeo de jsPDF
- * nunca empuje la tabla fuera de la página (hay un test que fija el techo).
+ * 279,4mm de ancho − 8mm de margen a cada lado = **263,4mm útiles**. El
+ * margen bajó de 10 a 8mm en D-E/N22 (docs/plan_hato_telegram_estados_agosto_2026.md)
+ * para financiar la columna 13 ("Estado registrado") sin comerse la del
+ * resto -- 8mm sigue siendo un margen imprimible normal en cualquier
+ * impresora de oficina.
  *
  * El reparto NO es uniforme y no se eligió a ojo: cada ancho se midió con
  * `doc.getTextWidth` contra el contenido REAL más largo de esa columna a
- * 11pt, más 3mm de padding horizontal, para que **ninguna celda se envuelva a
- * dos líneas** (una tabla de altos uniformes es más fácil de leer, de escribir
- * y de anclar para el OCR de la Fase 3):
+ * 11pt (datos) O la palabra más larga del encabezado a 9pt bold (lo que sea
+ * mayor) más 3mm de padding horizontal. Las celdas de DATOS nunca se
+ * envuelven a dos líneas (requisito duro); un encabezado de dos palabras SÍ
+ * puede partirse en dos líneas entre palabras (p. ej. "Fecha" / "Servicio"),
+ * pero ninguna palabra individual se parte a la mitad -- por eso el piso de
+ * cada columna es el MAYOR de los dos:
  * - Fechas (`Última Cría`, `Fecha Servicio`, `Secar`, `Parto Probable`):
  *   `22/12/2026` mide 19,25mm -> 22,5mm de columna.
  * - `Nombre`: `BRILLANTINA` (el nombre más largo del hato) mide 24,87mm -> 28mm.
  * - `Toro`: `Ins Holstein` (raza-como-nombre-de-toro, el caso más largo) mide
- *   20,18mm -> 24mm.
+ *   20,18mm -> 23,4mm.
  * - `Sexo cría` lleva una FRASE, no un dato corto: `H retenida #206` (el caso
- *   real más largo) mide 27,40mm -> 31mm de columna.
- * - `Tratamiento` es la columna donde Martha MÁS escribe y por eso recibe el
- *   ancho liberado por la etiqueta compacta: 37mm. El reparto no se eligió a
- *   ojo sino midiendo el histórico de `hato_chequeo_vacas` (2026-07-29): SX
- *   promedia 3 caracteres escritos a mano y `TTTO` promedia 12 con máximos de
- *   54. La versión anterior asignaba 44mm a SX y 21mm a TTTO -- exactamente al
- *   revés de la necesidad real. Ver la nota de `textoSexo`.
- * - Las de referencia pura (`#`, `# Partos`) llevan lo justo para su contenido
- *   conocido: nadie escribe ahí.
+ *   real más largo) mide 27,40mm -> 30,6mm de columna.
+ * - `Estado registrado` (D-E, B5.4, N22): la etiqueta más larga del
+ *   vocabulario de 5 estados es `Confirmada` (19,91mm de dato) -- pero la
+ *   palabra suelta del encabezado, `registrado`, mide 15,46mm a 9pt bold, así
+ *   que el dato manda -> 23,4mm de columna.
+ * - `Estado`/`PL`/`# Partos` son códigos cortos (`ok`/`rech`, números de 1-2
+ *   dígitos), pero cada uno respeta el piso de su propia palabra de
+ *   encabezado ("Estado" 10,51mm, "Partos" 9,81mm) para no partirla:
+ *   `Estado` -> 13,7mm, `PL` -> 7,5mm, `# Partos` -> 13mm.
+ * - `Tratamiento` es la columna donde Martha MÁS escribe y por eso sigue
+ *   recibiendo el resto del presupuesto disponible -- 22,5mm, medido contra
+ *   el histórico de `hato_chequeo_vacas` (2026-07-29): SX promedia 3
+ *   caracteres escritos a mano y TTTO promedia 12 (máx. 54). Encogió frente
+ *   a la versión anterior (35mm) para financiar la columna 13; sigue
+ *   cubriendo con holgura el caso promedio, no el máximo histórico extremo.
+ * - Las de referencia pura (`#`) lleva lo justo para su contenido conocido:
+ *   nadie escribe ahí.
  *
- * El total queda en 257,5mm de los 259,4 útiles: 1,9mm de holgura. Cualquier
- * columna nueva o más ancha exige quitar de otra, ir a oficio, o aceptar una
- * 3ª página -- no hay margen escondido.
+ * El total queda en 263,1mm de los 263,4 útiles: 0,3mm de holgura --
+ * deliberadamente angosta (cada columna ya trae su propio colchón de
+ * redondeo, ver el test que mide contra `doc.getTextWidth` real) para poder
+ * financiar la columna 13 sin ir a tamaño oficio ni sacrificar el requisito
+ * de letra ≥11pt. Cualquier columna nueva o más ancha exige quitar de otra o
+ * aceptar una página más -- no hay margen escondido.
  */
 export const ANCHOS_COLUMNAS_PDF_MM: readonly number[] = [
-  12, // # (cabe `999*`: la marca de provisional suma un carácter)
+  11.1, // # (cabe `999*`: la marca de provisional suma un carácter)
   28, // Nombre
-  10, // PL
-  13.5, // # Partos
+  7.5, // PL
+  13, // # Partos
   22.5, // Última Cría
-  31, // Sexo cría
+  30.6, // Sexo cría
   22.5, // Fecha Servicio
-  24, // Toro
-  14, // Estado
+  23.4, // Toro
+  23.4, // Estado registrado
+  13.7, // Estado
   22.5, // Secar
   22.5, // Parto Probable
-  35, // Tratamiento
+  22.5, // Tratamiento
 ];
 
 /** Ancho total de la tabla = suma exacta de los anchos de columna. Se le pasa
@@ -330,8 +348,10 @@ export const ANCHO_TABLA_PDF_MM = ANCHOS_COLUMNAS_PDF_MM.reduce((a, b) => a + b,
 
 /** Márgenes de la página, en mm. `top` reserva la banda del título, que se
  * redibuja en CADA página (ver `dibujarEncabezadoPagina`); `bottom` reserva la
- * banda del pie (nota operativa + "Página i de N"). */
-export const MARGENES_PDF_MM = { top: 20, right: 10, bottom: 12, left: 10 } as const;
+ * banda del pie (nota operativa + "Página i de N"). `right`/`left` bajaron de
+ * 10 a 8mm en D-E/N22 para financiar la columna 13 ("Estado registrado") --
+ * ver la nota de `ANCHOS_COLUMNAS_PDF_MM`. */
+export const MARGENES_PDF_MM = { top: 20, right: 8, bottom: 12, left: 8 } as const;
 
 /** Ancho útil de una hoja carta horizontal con estos márgenes. Constante
  * explícita para que el test de presupuesto de ancho no repita la aritmética. */

--- a/src/utils/hato/exportarPlanillaChequeoPDF.ts
+++ b/src/utils/hato/exportarPlanillaChequeoPDF.ts
@@ -283,58 +283,47 @@ export function construirFilasPlanillaPDF(filas: readonly FilaPlanillaChequeo[])
  * impresora de oficina.
  *
  * El reparto NO es uniforme y no se eligió a ojo: cada ancho se midió con
- * `doc.getTextWidth` contra el contenido REAL más largo de esa columna a
- * 11pt (datos) O la palabra más larga del encabezado a 9pt bold (lo que sea
- * mayor) más 3mm de padding horizontal. Las celdas de DATOS nunca se
- * envuelven a dos líneas (requisito duro); un encabezado de dos palabras SÍ
- * puede partirse en dos líneas entre palabras (p. ej. "Fecha" / "Servicio"),
- * pero ninguna palabra individual se parte a la mitad -- por eso el piso de
- * cada columna es el MAYOR de los dos:
- * - Fechas (`Última Cría`, `Fecha Servicio`, `Secar`, `Parto Probable`):
- *   `22/12/2026` mide 19,25mm -> 22,5mm de columna.
- * - `Nombre`: `BRILLANTINA` (el nombre más largo del hato) mide 24,87mm -> 28mm.
- * - `Toro`: `Ins Holstein` (raza-como-nombre-de-toro, el caso más largo) mide
- *   20,18mm -> 23,4mm.
- * - `Sexo cría` lleva una FRASE, no un dato corto: `H retenida #206` (el caso
- *   real más largo) mide 27,40mm -> 30,6mm de columna.
- * - `Estado registrado` (D-E, B5.4, N22): la etiqueta más larga del
- *   vocabulario de 5 estados es `Confirmada` (19,91mm de dato) -- pero la
- *   palabra suelta del encabezado, `registrado`, mide 15,46mm a 9pt bold, así
- *   que el dato manda -> 23,4mm de columna.
- * - `Estado`/`PL`/`# Partos` son códigos cortos (`ok`/`rech`, números de 1-2
- *   dígitos), pero cada uno respeta el piso de su propia palabra de
- *   encabezado ("Estado" 10,51mm, "Partos" 9,81mm) para no partirla:
- *   `Estado` -> 13,7mm, `PL` -> 7,5mm, `# Partos` -> 13mm.
- * - `Tratamiento` es la columna donde Martha MÁS escribe y por eso sigue
- *   recibiendo el resto del presupuesto disponible -- 22,5mm, medido contra
- *   el histórico de `hato_chequeo_vacas` (2026-07-29): SX promedia 3
- *   caracteres escritos a mano y TTTO promedia 12 (máx. 54). Encogió frente
- *   a la versión anterior (35mm) para financiar la columna 13; sigue
- *   cubriendo con holgura el caso promedio, no el máximo histórico extremo.
- * - Las de referencia pura (`#`) lleva lo justo para su contenido conocido:
- *   nadie escribe ahí.
+ * `doc.getTextWidth` contra el contenido REAL más largo de esa columna a 9pt
+ * (datos) O la palabra más larga del encabezado a 8pt bold (lo que sea mayor),
+ * más 3,4mm de padding real (`cellPadding` 1,5+1,5 y el borde). Un encabezado
+ * de dos palabras SÍ puede partirse entre palabras ("Fecha" / "Servicio"),
+ * pero ninguna palabra individual se parte a la mitad.
  *
- * El total queda en 263,1mm de los 263,4 útiles: 0,3mm de holgura --
- * deliberadamente angosta (cada columna ya trae su propio colchón de
- * redondeo, ver el test que mide contra `doc.getTextWidth` real) para poder
- * financiar la columna 13 sin ir a tamaño oficio ni sacrificar el requisito
- * de letra ≥11pt. Cualquier columna nueva o más ancha exige quitar de otra o
- * aceptar una página más -- no hay margen escondido.
+ * **Rehecho el 2026-08-14, después de ver la planilla impresa.** El reparto
+ * anterior tenía tres defectos que sólo se ven en el papel:
+ * - `Tratamiento`, la columna donde Martha MÁS escribe, había bajado a 22,5mm
+ *   para financiar la columna 13. Vuelve a 36mm -- por encima incluso de los
+ *   35mm que tenía antes de que existiera "Estado registrado".
+ * - `Sexo cría` tenía 30,6mm, más que `Nombre`. Baja a 24mm: cubre `H
+ *   retenida` con holgura, y el caso extremo `H retenida #206` se parte en dos
+ *   líneas, que es aceptable en una columna de referencia dentro de una fila
+ *   de 9mm de alto.
+ * - `Nombre` (28mm) y `Toro` (23,4mm) NO alcanzaban a 11pt: `BRILLANTINA`, el
+ *   nombre más largo del hato real, se partía por 0,3mm, y `Ternero Holstein`
+ *   se partía siempre. A 9pt miden 20,4 y 22,9mm y ahora caben enteros.
+ *
+ * `Estado` sube de 13,7 a 18mm por la misma razón que `Tratamiento`: es de las
+ * que se escriben a mano. Las de referencia pura (`#`, las 4 de fecha,
+ * `Estado registrado`) llevan lo justo para su contenido conocido.
+ *
+ * El total queda en 255,5mm de los 259,4 útiles (márgenes de vuelta en 10mm,
+ * no en los 8mm de emergencia): **3,9mm de holgura**. Cualquier columna nueva
+ * exige quitar de otra, bajar más la letra o aceptar una página más.
  */
 export const ANCHOS_COLUMNAS_PDF_MM: readonly number[] = [
-  11.1, // # (cabe `999*`: la marca de provisional suma un carácter)
-  28, // Nombre
-  7.5, // PL
-  13, // # Partos
-  22.5, // Última Cría
-  30.6, // Sexo cría
-  22.5, // Fecha Servicio
-  23.4, // Toro
-  23.4, // Estado registrado
-  13.7, // Estado
-  22.5, // Secar
-  22.5, // Parto Probable
-  22.5, // Tratamiento
+  10, // # (cabe `999*`: la marca de provisional suma un carácter)
+  24, // Nombre (BRILLANTINA, el más largo del hato, mide 20,4mm a 9pt)
+  7, // PL
+  12, // # Partos
+  19.5, // Última Cría
+  25.5, // Sexo cría (cabe entero `H retenida #206`, el caso real más largo)
+  19.5, // Fecha Servicio
+  26.5, // Toro ("Ternero Holstein", 22,9mm a 9pt: deja de partirse)
+  20, // Estado registrado
+  18, // Estado -- SE ESCRIBE A MANO
+  19.5, // Secar
+  19.5, // Parto Probable
+  36, // Tratamiento -- SE ESCRIBE A MANO, la que más
 ];
 
 /** Ancho total de la tabla = suma exacta de los anchos de columna. Se le pasa
@@ -351,16 +340,32 @@ export const ANCHO_TABLA_PDF_MM = ANCHOS_COLUMNAS_PDF_MM.reduce((a, b) => a + b,
  * banda del pie (nota operativa + "Página i de N"). `right`/`left` bajaron de
  * 10 a 8mm en D-E/N22 para financiar la columna 13 ("Estado registrado") --
  * ver la nota de `ANCHOS_COLUMNAS_PDF_MM`. */
-export const MARGENES_PDF_MM = { top: 20, right: 8, bottom: 12, left: 8 } as const;
+export const MARGENES_PDF_MM = { top: 20, right: 10, bottom: 12, left: 10 } as const;
 
 /** Ancho útil de una hoja carta horizontal con estos márgenes. Constante
  * explícita para que el test de presupuesto de ancho no repita la aritmética. */
 export const ANCHO_UTIL_CARTA_HORIZONTAL_MM = 279.4 - MARGENES_PDF_MM.left - MARGENES_PDF_MM.right;
 
-/** Tamaño de letra de las celdas de DATOS. Requisito duro del dueño (plan §6
- * y §8.3): **≥11pt** es lo que hace legible la planilla en papel. Si el
- * layout no cupiera, la salida son más páginas -- NUNCA letra más chica. */
-export const FUENTE_DATOS_PT = 11;
+/** Tamaño de letra de las celdas de DATOS.
+ *
+ * **Historia de esta constante, porque cambió una regla del dueño.** Valía 11pt
+ * por un requisito suyo explícito ("≥11pt es lo que hace legible la planilla en
+ * papel; si el layout no cupiera, la salida son más páginas, NUNCA letra más
+ * chica"). El dueño la REVOCÓ el 2026-08-14 viendo la planilla de 13 columnas
+ * ya renderizada: *"el texto está muy grande, se puede condensar para abrir
+ * espacio"*.
+ *
+ * No fue una preferencia estética: a 11pt la planilla estaba **sobre-suscrita**.
+ * El mínimo medido con `getTextWidth` era 261,4mm contra 259,4mm útiles, y eso
+ * se pagaba encogiendo `Tratamiento` (donde Martha más escribe) y partiendo en
+ * dos líneas tanto `Ternero Holstein` como `BRILLANTINA` -- el nombre más largo
+ * del hato real, que no cabía por 0,3mm. A 9pt el mínimo baja a 218mm, y esos
+ * ~41mm liberados son los que financian las dos columnas manuscritas y
+ * devuelven los márgenes a 10mm.
+ *
+ * Si vuelve a subir, hay que rehacer el reparto: a 11pt NO cabe con 13
+ * columnas. */
+export const FUENTE_DATOS_PT = 9;
 
 /** El encabezado va más pequeño que los datos, y es una decisión de
  * presupuesto, no un descuido: el requisito de ≥11pt es sobre las CELDAS DE
@@ -368,10 +373,13 @@ export const FUENTE_DATOS_PT = 11;
  * impreso, fijo y en negrilla, y bajarlo a 9pt es lo que permite que
  * `Tratamiento` (17,85mm a 9pt bold) y `# Partos` quepan en su columna sin
  * partir la palabra a mitad. A 10pt no caben. */
-export const FUENTE_ENCABEZADO_PT = 9;
+export const FUENTE_ENCABEZADO_PT = 8;
 
 /** Alto mínimo de fila en mm -- espacio real para escribir a mano DENTRO del
- * recuadro (una línea de 11pt ocupa ~3,9mm, así que quedan ~5mm libres). */
+ * recuadro. Se mantiene en 9mm aunque la letra bajara a 9pt: el alto no es
+ * cuestión de que quepa el texto impreso, sino de que quepa la MANO de Martha.
+ * Al ocupar la línea ~3,2mm en vez de ~3,9mm, la baja de fuente además dejó
+ * MÁS espacio libre para escribir, no menos. */
 export const ALTO_MINIMO_FILA_MM = 9;
 
 const COLOR_PRIMARIO: [number, number, number] = [115, 153, 28]; // #73991C

--- a/src/utils/hato/exportarPlanillaChequeoPDF.ts
+++ b/src/utils/hato/exportarPlanillaChequeoPDF.ts
@@ -124,46 +124,49 @@ function textoDestino(destino: CriaDestino | null, numeroCria: number | null): s
  * re-parseable, y esta etiqueta NO lo es (ni tiene que serlo, el PDF nunca se
  * vuelve a leer con un parser).
  *
- * Tabla de decisión (sexo y destino son ejes INDEPENDIENTES -- se conoce uno,
- * el otro, ambos o ninguno):
+ * **SÓLO EL SEXO desde el 2026-08-14, por decisión del dueño** viendo la
+ * planilla impresa: *"reduce sexo cría a la mitad, sólo necesitamos que quepa
+ * Macho/Hembra o M/H"*. Antes la etiqueta combinaba sexo + destino + chapeta
+ * de la cría (`H retenida #206`), y eso la volvía la columna más ancha de la
+ * planilla -- más que `Nombre`. No era un caso raro: contra producción
+ * (2026-08-14), de las 35 vacas activas con parto, ~15 daban `H retenida
+ * #NNN` y ~15 `M vendido`.
  *
- * | sexo | destino | etiqueta |
+ * **Lo que se deja de imprimir EN EL PAPEL**: el destino (`retenida`,
+ * `vendido`, `murió`) y la chapeta de la cría. No se pierde el dato: el
+ * `.xlsx` sigue emitiendo `sx_raw` verbatim (es re-parseable, esta etiqueta
+ * nunca lo fue) y `hato_eventos` conserva `cria_destino` intacto. Es una
+ * decisión de qué cabe en una hoja, no de qué se guarda.
+ *
+ * Tabla de decisión:
+ *
+ * | sexo | otros hechos | etiqueta |
  * |---|---|---|
- * | Macho | vendido | `M vendido` |
- * | Hembra | retenida + chapeta | `H retenida #206` |
- * | Hembra | vendida | `H vendida` |
- * | Hembra | murió | `H murió` |
- * | Macho/Hembra | — | `Macho` / `Hembra` (sin destino que lo acompañe, la
- * |   |   | inicial sola sería críptica: aquí sí va la palabra completa) |
- * | — | murió | `Cría murió` (es el caso real: `cria_destino='muerta'` NO
- * |   |   | determina el sexo, viene tanto de `A+` como de `O+`) |
- * | — | retenida/vendida | `Cría retenida #206` / `Cría vendida` |
- * | — | (SX = `gem+`) | `Parto gemelar` (la planilla no dice el sexo de cada
- * |   |   | gemelo, así que no hay sexo que imprimir -- pero el hecho sí es
- * |   |   | dato y perderlo sería descartar en silencio) |
+ * | Macho / Hembra | (da igual el destino) | `Macho` / `Hembra` |
+ * | — | SX = `gem+` | `Gemelar` |
+ * | — | destino = murió | `Murió` |
+ * | — | destino conocido | `Cría` (hubo cría; el sexo no se sabe) |
  * | — | — | `null` -> **celda vacía** |
  *
- * REGLA DURA: sin sexo Y sin destino la celda va VACÍA. Nunca "N/D", nunca
- * "—" dentro del texto, nunca un valor por defecto -- mismo contrato de "sin
+ * Las tres filas sin sexo NO se borran junto con el destino: son los casos en
+ * que hubo un hecho real y la celda vacía mentiría diciendo "no hay dato".
+ * Van en una sola palabra corta para no volver a ensanchar la columna.
+ *
+ * REGLA DURA, sin cambios: sin sexo Y sin ningún hecho, la celda va VACÍA.
+ * Nunca "N/D", nunca "—", nunca un valor por defecto -- mismo contrato de "sin
  * dato, nunca 0" del resto del módulo.
  */
 export function etiquetaSexoCria(input: InputEtiquetaSexoCria): string | null {
   const sx = input.sexoCriaRaw ? parseSX(input.sexoCriaRaw) : null;
-  const numeroCria = sx?.numeroCria ?? null;
 
   const sexo = textoSexo(input.sexoCria);
-  const destino = textoDestino(input.criaDestino, numeroCria);
+  const destino = textoDestino(input.criaDestino, null);
 
-  // Sin paréntesis: con el sexo abreviado a inicial, `H retenida #206` se lee
-  // igual de claro que `Hembra (retenida #206)` y ahorra dos caracteres más.
-  if (sexo && destino) return `${sexo} ${destino}`;
   if (sexo) return sexo === 'M' ? 'Macho' : 'Hembra';
-  if (destino === 'murió') return 'Cría murió';
-  if (destino) return `Cría ${destino}`;
-  // Parto gemelar: no hay sexo (son dos crías) ni destino registrado, pero el
-  // código SX sí dice que fue gemelar -- dato real, leído por el único parser
-  // de SX del repo.
-  if (sx?.tipo === 'gemelar') return 'Parto gemelar';
+  // Sin sexo. El hecho igual es real y la celda vacía diría "no hay dato".
+  if (sx?.tipo === 'gemelar') return 'Gemelar';
+  if (destino === 'murió') return 'Murió';
+  if (destino) return 'Cría';
   return null;
 }
 
@@ -294,10 +297,11 @@ export function construirFilasPlanillaPDF(filas: readonly FilaPlanillaChequeo[])
  * - `Tratamiento`, la columna donde Martha MÁS escribe, había bajado a 22,5mm
  *   para financiar la columna 13. Vuelve a 36mm -- por encima incluso de los
  *   35mm que tenía antes de que existiera "Estado registrado".
- * - `Sexo cría` tenía 30,6mm, más que `Nombre`. Baja a 24mm: cubre `H
- *   retenida` con holgura, y el caso extremo `H retenida #206` se parte en dos
- *   líneas, que es aceptable en una columna de referencia dentro de una fila
- *   de 9mm de alto.
+ * - `Sexo cría` tenía 30,6mm, más que `Nombre`. Baja a **14,5mm** (-53%)
+ *   porque el dueño acotó su CONTENIDO el 2026-08-14: ya no imprime destino
+ *   ni chapeta de la cría, sólo el sexo. El piso ya no lo pone `H retenida
+ *   #206` (25,42mm) sino `Gemelar` (14,21mm), la más larga de las etiquetas
+ *   que quedan. Ver la nota de `etiquetaSexoCria`.
  * - `Nombre` (28mm) y `Toro` (23,4mm) NO alcanzaban a 11pt: `BRILLANTINA`, el
  *   nombre más largo del hato real, se partía por 0,3mm, y `Ternero Holstein`
  *   se partía siempre. A 9pt miden 20,4 y 22,9mm y ahora caben enteros.
@@ -306,9 +310,12 @@ export function construirFilasPlanillaPDF(filas: readonly FilaPlanillaChequeo[])
  * que se escriben a mano. Las de referencia pura (`#`, las 4 de fecha,
  * `Estado registrado`) llevan lo justo para su contenido conocido.
  *
- * El total queda en 255,5mm de los 259,4 útiles (márgenes de vuelta en 10mm,
- * no en los 8mm de emergencia): **3,9mm de holgura**. Cualquier columna nueva
- * exige quitar de otra, bajar más la letra o aceptar una página más.
+ * El total queda en 256mm de los 259,4 útiles (márgenes de vuelta en 10mm, no
+ * en los 8mm de emergencia): **3,4mm de holgura**. Los 11mm que liberó
+ * `Sexo cría` fueron completos a las dos columnas que se escriben a mano
+ * (`Tratamiento` 36 -> 44, `Estado` 18 -> 20), que es de donde habían salido.
+ * Cualquier columna nueva exige quitar de otra, bajar más la letra o aceptar
+ * una página más.
  */
 export const ANCHOS_COLUMNAS_PDF_MM: readonly number[] = [
   10, // # (cabe `999*`: la marca de provisional suma un carácter)
@@ -316,14 +323,14 @@ export const ANCHOS_COLUMNAS_PDF_MM: readonly number[] = [
   7, // PL
   12, // # Partos
   19.5, // Última Cría
-  25.5, // Sexo cría (cabe entero `H retenida #206`, el caso real más largo)
+  14.5, // Sexo cría -- sólo el sexo (D-2026-08-14); el piso lo pone `Gemelar`
   19.5, // Fecha Servicio
   26.5, // Toro ("Ternero Holstein", 22,9mm a 9pt: deja de partirse)
   20, // Estado registrado
-  18, // Estado -- SE ESCRIBE A MANO
+  20, // Estado -- SE ESCRIBE A MANO
   19.5, // Secar
   19.5, // Parto Probable
-  36, // Tratamiento -- SE ESCRIBE A MANO, la que más
+  44, // Tratamiento -- SE ESCRIBE A MANO, la que más (histórico: máx. 54 caracteres)
 ];
 
 /** Ancho total de la tabla = suma exacta de los anchos de columna. Se le pasa

--- a/src/utils/hato/listaHato.ts
+++ b/src/utils/hato/listaHato.ts
@@ -1,0 +1,165 @@
+// ARCHIVO: utils/hato/listaHato.ts
+// DESCRIPCIÓN: Lógica pura de las columnas nuevas de la lista del hato
+// (N17/N18/N19 del plan docs/plan_hato_telegram_estados_agosto_2026.md).
+// Pedido del dueño tras la visita de campo del 2026-08-13: "mostrar edad en
+// años y números de partos a primera vista, fecha de última cría y próximo
+// evento".
+//
+// Vive fuera de `calculosHato.ts` a propósito (mismo criterio que
+// `hatoCategorias.ts` y `hatoCicloManual.ts`): es composición de producto
+// sobre lo que el motor YA calculó, no una regla nueva del ciclo. Nada de
+// esto necesita entrar al trío protegido por paridad byte-idéntica con el
+// servidor.
+//
+// Cero imports de Supabase o React. Toda función que dependa de "hoy" lo
+// recibe como parámetro (`hoyISO`), nunca lo lee del reloj -- misma regla
+// que el motor.
+
+import type { EstadoReproductivoDerivado } from '@/utils/calculosHato';
+
+// ============================================================================
+// Aritmética de fecha local, CON SIGNO.
+//
+// `diferenciaEnDias` (utils/fechas.ts) devuelve el valor ABSOLUTO
+// (`Math.abs` + `Math.ceil`), así que no sirve para ninguno de los dos usos
+// de este archivo: no distingue una fecha de nacimiento futura (dato mal
+// digitado) de una pasada, ni un hito vencido de uno por venir. Se duplica
+// la FÓRMULA, nunca la responsabilidad -- mismo criterio que ya aplican
+// `hatoUi.ts::diasHastaFecha` y `hatoCicloManual.ts::diferenciaDiasIso`.
+// ============================================================================
+
+/** `hasta - desde` en días enteros. Negativo = `hasta` quedó en el pasado. */
+function diasEntre(desdeISO: string, hastaISO: string): number {
+  const [a1, m1, d1] = desdeISO.split('-').map(Number);
+  const [a2, m2, d2] = hastaISO.split('-').map(Number);
+  return Math.round((Date.UTC(a2, m2 - 1, d2) - Date.UTC(a1, m1 - 1, d1)) / 86400000);
+}
+
+// ============================================================================
+// N18 -- Edad
+// ============================================================================
+
+/** Días de un año medio, incluyendo bisiestos. La misma convención de
+ * "año calendario promedio" que ya usa el módulo con los 30.44 días/mes. */
+const DIAS_POR_ANIO = 365.25;
+
+/**
+ * Edad en años con un decimal, o `null` cuando no se puede afirmar.
+ *
+ * `null` en dos casos, y ninguno se rellena con un valor por defecto:
+ * - **Sin `fecha_nacimiento`** -- son 20 de los 65 animales activos del hato
+ *   real (verificado 2026-08-13). La columna muestra "—", nunca 0: una edad
+ *   inventada es peor que una edad ausente, porque se ve igual de creíble.
+ * - **Fecha de nacimiento futura** -- dato mal digitado. Se reporta como
+ *   ausente en vez de una edad negativa.
+ */
+export function edadEnAnios(fechaNacimiento: string | null, hoyISO: string): number | null {
+  if (!fechaNacimiento) return null;
+  const dias = diasEntre(fechaNacimiento, hoyISO);
+  if (dias < 0) return null;
+  return Math.round((dias / DIAS_POR_ANIO) * 10) / 10;
+}
+
+/**
+ * Edad lista para pintar. Bajo el año se expresa en MESES: "0,4 años" no es
+ * una edad con la que nadie razone sobre una ternera, y el hato tiene
+ * terneras justamente por eso (la categoría existe). A partir del año, años
+ * con un decimal y coma decimal (estándar colombiano, igual que el resto de
+ * la app).
+ */
+export function formatearEdadHato(fechaNacimiento: string | null, hoyISO: string): string {
+  const anios = edadEnAnios(fechaNacimiento, hoyISO);
+  if (anios === null) return '—';
+  if (anios < 1) {
+    const meses = Math.max(0, Math.round((diasEntre(fechaNacimiento as string, hoyISO) / DIAS_POR_ANIO) * 12));
+    return meses === 1 ? '1 mes' : `${meses} meses`;
+  }
+  return `${anios.toFixed(1).replace('.', ',')} años`;
+}
+
+// ============================================================================
+// N19 -- Próximo evento
+// ============================================================================
+
+export type TipoProximoEvento = 'secado' | 'parto' | 'rechequeo' | 'servir';
+
+export interface ProximoEventoHato {
+  tipo: TipoProximoEvento;
+  /** Etiqueta corta para la celda ("Secar", "Parto", "Rechequeo", "Servir"). */
+  etiqueta: string;
+  /** Fecha objetivo real, o `null` cuando el evento no tiene una fecha
+   * honesta que mostrar (rechequeo y servir -- ver abajo). */
+  fecha: string | null;
+  /** Días desde hoy hasta `fecha`. Negativo = vencido. `null` cuando no hay
+   * fecha. */
+  dias: number | null;
+}
+
+const ETIQUETA_PROXIMO_EVENTO: Record<TipoProximoEvento, string> = {
+  secado: 'Secar',
+  parto: 'Parto',
+  rechequeo: 'Rechequeo',
+  servir: 'Servir',
+};
+
+/** Entrada mínima: lo que la lista ya tiene por fila, sin consultas nuevas. */
+export interface EntradaProximoEvento {
+  derivado: EstadoReproductivoDerivado;
+}
+
+/**
+ * El siguiente hito de la vaca, para la columna "Próximo evento".
+ *
+ * **Solo dos de los cuatro hitos tienen una fecha real**: `fecha_secar` y
+ * `fecha_probable_parto`, ambas proyectadas por el motor desde el último
+ * servicio. "Rechequeo" y "servir" NO tienen fecha objetivo en ninguna parte
+ * del sistema -- el motor solo sabe si están vencidos (`alertas.rechequeo_due`)
+ * o si la vaca está vacía. Inventarles una fecha sería exactamente lo que
+ * `PILL_ALERTA_TABLERO` ya se negó a hacer para el Dashboard, así que aquí
+ * tampoco: entran como hito SIN fecha, y solo cuando no hay ninguno con
+ * fecha que mostrar.
+ *
+ * Elección entre los hitos con fecha: gana el **más próximo que todavía no
+ * pasó**; si todos ya pasaron, gana el **más reciente**, que es la
+ * obligación vigente (una vaca con el secado vencido hace un mes y el parto
+ * vencido ayer necesita que se le hable del parto). El secado se descarta
+ * en cuanto la vaca ya está seca -- ese hito ya se cumplió.
+ */
+export function proximoEventoHato(entrada: EntradaProximoEvento, hoyISO: string): ProximoEventoHato | null {
+  const { derivado } = entrada;
+
+  const candidatos: Array<{ tipo: TipoProximoEvento; fecha: string }> = [];
+  if (derivado.fecha_secar && derivado.estado !== 'seca') {
+    candidatos.push({ tipo: 'secado', fecha: derivado.fecha_secar });
+  }
+  if (derivado.fecha_probable_parto) {
+    candidatos.push({ tipo: 'parto', fecha: derivado.fecha_probable_parto });
+  }
+
+  if (candidatos.length > 0) {
+    const futuros = candidatos.filter((c) => c.fecha >= hoyISO).sort((a, b) => (a.fecha < b.fecha ? -1 : 1));
+    const pasados = candidatos.filter((c) => c.fecha < hoyISO).sort((a, b) => (a.fecha > b.fecha ? -1 : 1));
+    const elegido = futuros[0] ?? pasados[0];
+    return {
+      tipo: elegido.tipo,
+      etiqueta: ETIQUETA_PROXIMO_EVENTO[elegido.tipo],
+      fecha: elegido.fecha,
+      dias: diasEntre(hoyISO, elegido.fecha),
+    };
+  }
+
+  if (derivado.alertas.rechequeo_due) {
+    return { tipo: 'rechequeo', etiqueta: ETIQUETA_PROXIMO_EVENTO.rechequeo, fecha: null, dias: null };
+  }
+
+  // "Por servir" solo se afirma de una vaca efectivamente vacía. El motor ya
+  // marcó cuáles lo están con `vacia_es_problema !== null` (V14): ese campo
+  // es `null` en todo estado donde la pregunta no aplica (preñez activa,
+  // seca, cría, terminal), así que sirve de discriminador sin repetir aquí
+  // la lista de estados.
+  if (derivado.vacia_es_problema !== null) {
+    return { tipo: 'servir', etiqueta: ETIQUETA_PROXIMO_EVENTO.servir, fecha: null, dias: null };
+  }
+
+  return null;
+}

--- a/src/utils/hatoAlertas.ts
+++ b/src/utils/hatoAlertas.ts
@@ -516,3 +516,136 @@ export function decidirExpiracionTerminal(
   const ancla = alerta.escalada_at ?? alerta.updated_at;
   return diferenciaDiasIso(ancla, fechaHoraReferencia) > diasUmbral;
 }
+
+// ============================================================================
+// BLOQUE 8 — Suscripciones por usuario de Telegram (migración 096, plan
+// "Suscripciones a alertas por usuario de Telegram", 2026-08-14)
+//
+// Decisión del dueño (contrato, ver migración 096): BROADCAST con cierre por
+// el primero -- una alerta se manda a TODOS los suscritos de su tipo, y la
+// primera respuesta la cierra para todos. El escalamiento es una segunda
+// casilla POR TIPO y por persona (`telegram_alertas_suscripciones.escalamiento`)
+// -- la variable de entorno `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` deja de
+// ser la fuente de verdad (`hato-alertas-tick.ts` ya no la lee).
+//
+// Este bloque es deliberadamente GENÉRICO por módulo (`alertas_catalogo`
+// sirve a cualquiera, no solo al hato) -- `claveAlertaCatalogo`/
+// `agruparSuscriptoresPorClave` no importan nada de `calculosHato` ni saben
+// qué es una vaca. Los constructores de mensaje de "ya resuelta"/"cerrada
+// para todos" SÍ son específicos del hato porque forman parte del texto que
+// ve Fernando/Martha en el chat -- si mañana `aguacate`/`ganado` tienen su
+// propio motor de alertas, ese motor tendrá sus propios constructores de
+// mensaje (mismo criterio que ya separa `hato_alertas` de un futuro
+// `aguacate_alertas`).
+// ============================================================================
+
+/**
+ * Clave de `alertas_catalogo` para un tipo de alerta de un módulo dado
+ * (`modulo.tipo`, migración 096). Único punto que arma esa concatenación --
+ * tanto el tick (resolver destinatarios/escalamiento) como cualquier código
+ * futuro que necesite la misma clave la calculan aquí, nunca con un
+ * template string suelto en otro archivo.
+ */
+export function claveAlertaCatalogo(modulo: string, tipo: string): string {
+  return `${modulo}.${tipo}`;
+}
+
+/** Fila mínima de `telegram_alertas_suscripciones` JOIN `telegram_usuarios`
+ * que este motor necesita -- el caller (tick) ya resolvió `telegram_id`
+ * desde el embed y ya filtró `telegram_usuarios.activo = true` en la
+ * consulta (un suscrito desactivado no debe recibir ni escalar). */
+export interface FilaSuscripcionAlerta {
+  alerta_clave: string;
+  recibe: boolean;
+  escalamiento: boolean;
+  /** `telegram_usuarios.telegram_id`, como string -- mismo motivo que
+   * `OpcionesEnvioTelegram.telegramId` en `telegram/enviar.ts` (no arriesgar
+   * precisión de un `bigint` al pasar por un `number` de JS). */
+  telegram_id: string;
+}
+
+/** Destinatarios de un tipo de alerta, ya separados por las dos casillas. Un
+ * mismo `telegram_id` puede aparecer en ambas listas (recibe Y escala) o
+ * solo en una. */
+export interface SuscriptoresPorClave {
+  recibe: string[];
+  escalamiento: string[];
+}
+
+/**
+ * Agrupa las filas de suscripción (ya resueltas a `telegram_id`, JOIN hecho
+ * por el caller) por `alerta_clave`, separando quién recibe el envío normal
+ * de quién recibe el escalamiento. Pura -- ninguna llamada a Supabase ni a
+ * Telegram aquí, eso vive en `hato-alertas-tick.ts` (I/O).
+ */
+export function agruparSuscriptoresPorClave(filas: FilaSuscripcionAlerta[]): Map<string, SuscriptoresPorClave> {
+  const mapa = new Map<string, SuscriptoresPorClave>();
+  for (const fila of filas) {
+    let entrada = mapa.get(fila.alerta_clave);
+    if (!entrada) {
+      entrada = { recibe: [], escalamiento: [] };
+      mapa.set(fila.alerta_clave, entrada);
+    }
+    if (fila.recibe) entrada.recibe.push(fila.telegram_id);
+    if (fila.escalamiento) entrada.escalamiento.push(fila.telegram_id);
+  }
+  return mapa;
+}
+
+// ----------------------------------------------------------------------------
+// Mensajes de cierre (callback `hato_alerta:{id}:{si|no|otro}` en
+// `telegram/bot.ts`) -- broadcast con cierre por el primero.
+// ----------------------------------------------------------------------------
+
+/** Texto corto de cada respuesta posible, para componer los mensajes de
+ * cierre -- una sola definición, reutilizada por los dos constructores de
+ * abajo (antes había un riesgo real de que "Todavía no" se escribiera
+ * distinto en dos lugares). */
+export function etiquetaRespuestaAlerta(respuesta: 'si' | 'no' | 'otro'): string {
+  switch (respuesta) {
+    case 'si':
+      return 'Sí';
+    case 'no':
+      return 'Todavía no';
+    case 'otro':
+      return 'Otra cosa';
+    default: {
+      const _exhaustivo: never = respuesta;
+      return _exhaustivo;
+    }
+  }
+}
+
+/**
+ * Mensaje que reemplaza el de un suscrito que llega TARDE a responder una
+ * alerta que otro suscrito ya cerró (broadcast, cierre por el primero) --
+ * tanto para el popup de `answerCallbackQuery` de quien toca el botón dos
+ * veces como para editar el mensaje de los demás suscritos cuando alguno de
+ * ellos SÍ fue el primero. "Amablemente", no un error -- es el
+ * comportamiento esperado del diseño, no una falla.
+ */
+export function construirMensajeAlertaYaResuelta(
+  estado: EstadoAlertaHato,
+  respondidaPor: string | null,
+  respuesta: 'si' | 'no' | 'otro' | null,
+): string {
+  if (respondidaPor && respuesta) {
+    return `Esta alerta ya fue resuelta por ${respondidaPor} (respuesta: "${etiquetaRespuestaAlerta(respuesta)}"). No quedó nada más por hacer.`;
+  }
+  return `Esta alerta ya no está activa (estado: ${estado}).`;
+}
+
+/**
+ * Texto con el que se edita el mensaje de CADA suscrito al que se le envió
+ * la alerta (vía `hato_alertas_envios.message_id`), una vez que uno de ellos
+ * la cierra -- así todos ven que ya se resolvió y por quién, sin tener que
+ * abrir la app. `mensajeOriginal` es el mismo texto que ya recibieron (se
+ * conserva, no se reemplaza, para no perder el contexto de la alerta).
+ */
+export function construirMensajeCierreAlertaBroadcast(
+  mensajeOriginal: string,
+  respondidaPor: string,
+  respuesta: 'si' | 'no' | 'otro',
+): string {
+  return `✅ Resuelto por ${respondidaPor}: "${etiquetaRespuestaAlerta(respuesta)}"\n\n${mensajeOriginal}`;
+}

--- a/src/utils/hatoCicloManual.ts
+++ b/src/utils/hatoCicloManual.ts
@@ -385,9 +385,23 @@ function aplicarMarcaAFilaHipotetica(
 
   switch (marca) {
     case 'preñada':
-    case 'confirmada':
-      siguiente.ultima_confirmacion_prenez_fecha = fechaMasReciente(fila.ultima_confirmacion_prenez_fecha, fecha);
+    case 'confirmada': {
+      const anterior = fila.ultima_confirmacion_prenez_fecha;
+      siguiente.ultima_confirmacion_prenez_fecha = fechaMasReciente(anterior, fecha);
+      // D-D (2026-08-13): el MÉTODO viaja con la fecha, no aparte. Desde que
+      // `estadoDeConfirmacion` (calculosHato.ts) decide "servida" vs
+      // "preñada" leyendo este campo, proyectar la fecha sin el método haría
+      // que el diálogo prometiera un estado que la marca no produce -- la
+      // marca "confirmada" se vería como "servida" en el "quedará".
+      // Solo se pisa el método cuando la marca es efectivamente la
+      // confirmación más reciente: una marca con fecha anterior a una
+      // confirmación ya registrada no cambia el hecho agregado (igual que
+      // la fecha, y consistente con la advertencia A3).
+      if (!anterior || fecha >= anterior) {
+        siguiente.ultima_confirmacion_prenez_metodo = marca === 'confirmada' ? 'palpacion' : 'presuncion';
+      }
       break;
+    }
     case 'seca':
       siguiente.ultimo_secado_real_fecha = fechaMasReciente(fila.ultimo_secado_real_fecha, fecha);
       break;

--- a/src/utils/hatoProduccion.ts
+++ b/src/utils/hatoProduccion.ts
@@ -1161,6 +1161,16 @@ export function reconstruirEstadoAFecha(
         eventosAnimal.filter((e) => e.tipo === 'confirmacion_prenez').map((e) => e.fecha),
       ),
       ultimo_evento_fecha: maxFecha(eventosAnimal.map((e) => e.fecha)),
+      ultimo_aborto_fecha: maxFecha(eventosAnimal.filter((e) => e.tipo === 'aborto').map((e) => e.fecha)),
+      // `EventoHistorico` no carga `datos`, así que el método de la
+      // confirmación no está disponible en este corte histórico. `null` se
+      // lee como PRESUNCIÓN (`estadoDeConfirmacion`, calculosHato.ts), y eso
+      // no altera lo que esta función mide: `servida` y `preñada` caen ambas
+      // en la categoría `hato` (en ordeño) de `clasificarCategoriaHato`, que
+      // es el único consumo de estas filas. Ampliar `EventoHistorico` con
+      // `datos` solo para esto agregaría peso a la consulta sin cambiar
+      // ningún número.
+      ultima_confirmacion_prenez_metodo: null,
       ultimo_estado_chequeo: ultimoChequeo?.estado ?? null,
       presente,
       cobertura,

--- a/src/utils/hatoUi.ts
+++ b/src/utils/hatoUi.ts
@@ -16,7 +16,7 @@
 // alterarlo (V1 del plan -- los componentes nuevos del mock no tocan
 // definiciones globales del sistema de diseño).
 
-import type { EstadoReproductivo, SenalRevisionHato, TipoEstado } from '@/utils/calculosHato';
+import { etiquetaEstadoReproductivo, type EstadoReproductivo, type SenalRevisionHato, type TipoEstado } from '@/utils/calculosHato';
 import type { ClasificacionFilaDiff } from '@/utils/importHato/diffChequeo';
 import type { CategoriaHato, SubetapaTernera } from '@/utils/hatoCategorias';
 import type { EstadoAlertaHato } from '@/utils/hatoAlertas';
@@ -64,31 +64,32 @@ const ROJO = 'bg-red-50 text-red-700 border-red-200';
  *   escribe "—", nunca un valor por defecto.
  */
 export function chipEstadoReproductivo(estado: EstadoReproductivo): ChipEstilo {
+  const label = etiquetaEstadoReproductivo(estado);
   switch (estado) {
     case 'preñada':
-      return { label: 'Confirmada', className: VERDE, title: 'Preñez confirmada por palpación' };
+      return { label, className: VERDE, title: 'Preñez confirmada por palpación' };
     case 'parida_reciente':
-      return { label: 'Vacía', className: AMBAR, title: 'Parió y todavía no ha sido servida' };
+      return { label, className: AMBAR, title: 'Parió y todavía no ha sido servida' };
     case 'servida':
-      return { label: 'Servida', className: AZUL, title: 'Montada o inseminada, preñez sin confirmar por palpación' };
+      return { label, className: AZUL, title: 'Montada o inseminada, preñez sin confirmar por palpación' };
     case 'proxima_a_secar':
-      return { label: 'Por secar', className: AMBAR };
+      return { label, className: AMBAR };
     case 'seca':
-      return { label: 'Seca', className: GRIS };
+      return { label, className: GRIS };
     case 'vacia_por_servir':
-      return { label: 'Vacía', className: AMBAR };
+      return { label, className: AMBAR };
     case 'novilla':
-      return { label: 'Vacía', className: AMBAR, title: 'Novilla: todavía no ha entrado al ciclo reproductivo' };
+      return { label, className: AMBAR, title: 'Novilla: todavía no ha entrado al ciclo reproductivo' };
     case 'cria':
-      return { label: 'Cría', className: GRIS };
+      return { label, className: GRIS };
     case 'indeterminado':
-      return { label: '—', className: GRIS, title: 'Sin dato: hay un evento posterior sin clasificar — ver la señal de revisión' };
+      return { label, className: GRIS, title: 'Sin dato: hay un evento posterior sin clasificar — ver la señal de revisión' };
     case 'vendida':
-      return { label: 'Vendida', className: GRIS };
+      return { label, className: GRIS };
     case 'muerta':
-      return { label: 'Muerta', className: GRIS };
+      return { label, className: GRIS };
     case 'descartada':
-      return { label: 'Descartada', className: GRIS };
+      return { label, className: GRIS };
     default: {
       const _exhaustivo: never = estado;
       return { label: String(_exhaustivo), className: GRIS };

--- a/src/utils/hatoUi.ts
+++ b/src/utils/hatoUi.ts
@@ -16,7 +16,7 @@
 // alterarlo (V1 del plan -- los componentes nuevos del mock no tocan
 // definiciones globales del sistema de diseño).
 
-import type { EstadoReproductivo, TipoEstado } from '@/utils/calculosHato';
+import type { EstadoReproductivo, SenalRevisionHato, TipoEstado } from '@/utils/calculosHato';
 import type { ClasificacionFilaDiff } from '@/utils/importHato/diffChequeo';
 import type { CategoriaHato, SubetapaTernera } from '@/utils/hatoCategorias';
 import type { EstadoAlertaHato } from '@/utils/hatoAlertas';
@@ -38,27 +38,51 @@ const AZUL = 'bg-blue-50 text-blue-700 border-blue-200';
 const GRIS = 'bg-gray-100 text-gray-600 border-gray-200';
 const ROJO = 'bg-red-50 text-red-700 border-red-200';
 
-/** Chip para `EstadoReproductivo` (lista del hato, hoja de vida). */
+/**
+ * Chip para `EstadoReproductivo` (lista del hato, hoja de vida).
+ *
+ * **D-D (dueño, 2026-08-13): el vocabulario visible es de CINCO estados** --
+ * Vacía · Servida · Confirmada · Por secar · Seca -- y esta función es
+ * donde los 13 estados internos del motor se traducen a esos cinco. Las
+ * equivalencias que no son 1:1, y por qué:
+ *
+ * - `parida_reciente` -> **Vacía**. Parió y todavía no la sirven: está
+ *   vacía. La fecha del parto se muestra en su propia columna, así que no
+ *   se pierde nada al no repetirla en el estado.
+ * - `novilla` -> **Vacía**. Nunca entró al ciclo; "vacía" es exactamente su
+ *   situación. La pestaña Novillas ya la separa por etapa.
+ * - `preñada` -> **Confirmada**. El motor solo devuelve `preñada` cuando la
+ *   confirmación vino de una palpación (`estadoDeConfirmacion`); una
+ *   presunción ya sale de ahí como `servida`.
+ * - `cria` -> **Cría**, y NO uno de los cinco: una ternera no tiene estado
+ *   reproductivo, y rotularla "Vacía" sería absurdo. El vocabulario de D-D
+ *   aplica a novillas y vacas.
+ * - `indeterminado` -> **guion**, no un estado inventado. Hay un evento que
+ *   el motor no puede clasificar, así que el estado es genuinamente
+ *   desconocido; el porqué viaja en `chipSenalRevision`, que se muestra en
+ *   la columna de alertas. Misma regla que rige todo el módulo: sin dato se
+ *   escribe "—", nunca un valor por defecto.
+ */
 export function chipEstadoReproductivo(estado: EstadoReproductivo): ChipEstilo {
   switch (estado) {
     case 'preñada':
-      return { label: 'Preñada', className: VERDE };
+      return { label: 'Confirmada', className: VERDE, title: 'Preñez confirmada por palpación' };
     case 'parida_reciente':
-      return { label: 'Parida reciente', className: VERDE };
+      return { label: 'Vacía', className: AMBAR, title: 'Parió y todavía no ha sido servida' };
     case 'servida':
-      return { label: 'Servida', className: AZUL };
+      return { label: 'Servida', className: AZUL, title: 'Montada o inseminada, preñez sin confirmar por palpación' };
     case 'proxima_a_secar':
-      return { label: 'Próxima a secar', className: AMBAR };
+      return { label: 'Por secar', className: AMBAR };
     case 'seca':
-      return { label: 'Seca (horro)', className: GRIS };
+      return { label: 'Seca', className: GRIS };
     case 'vacia_por_servir':
-      return { label: 'Vacía por servir', className: AMBAR };
+      return { label: 'Vacía', className: AMBAR };
     case 'novilla':
-      return { label: 'Novilla', className: AZUL };
+      return { label: 'Vacía', className: AMBAR, title: 'Novilla: todavía no ha entrado al ciclo reproductivo' };
     case 'cria':
       return { label: 'Cría', className: GRIS };
     case 'indeterminado':
-      return { label: 'Indeterminado — revisar', className: AMBAR };
+      return { label: '—', className: GRIS, title: 'Sin dato: hay un evento posterior sin clasificar — ver la señal de revisión' };
     case 'vendida':
       return { label: 'Vendida', className: GRIS };
     case 'muerta':
@@ -70,6 +94,32 @@ export function chipEstadoReproductivo(estado: EstadoReproductivo): ChipEstilo {
       return { label: String(_exhaustivo), className: GRIS };
     }
   }
+}
+
+/**
+ * Chip de la **columna de señales** de la lista del hato (D-D, 2026-08-13:
+ * "5 estados + columna de alertas que digan cuál — si es aborto o algo
+ * diferente"). `null` = nada que revisar, la celda queda vacía.
+ *
+ * Deliberadamente separado de `chipEstadoReproductivo`: el estado dice en
+ * qué punto del ciclo está la vaca, la señal dice por qué ese dato puede no
+ * ser confiable. Meter las dos cosas en una sola etiqueta obligaría a
+ * mentir en uno de los dos ejes.
+ */
+export function chipSenalRevision(senal: SenalRevisionHato | null): ChipEstilo | null {
+  if (!senal) return null;
+  if (senal.tipo === 'aborto') {
+    return {
+      label: `Aborto ${formatShortDate(senal.fecha)}`,
+      className: ROJO,
+      title: 'El último evento registrado es un aborto: la vaca quedó vacía',
+    };
+  }
+  return {
+    label: 'Revisar',
+    className: AMBAR,
+    title: `Hay un evento del ${formatShortDate(senal.fecha)} que el sistema no puede clasificar. Registra qué pasó para que el estado vuelva a ser confiable.`,
+  };
 }
 
 /** Chip para "¿esta vacía es normal o un problema?" (D-2/V14). `null` =

--- a/src/utils/importHato/chequeos.ts
+++ b/src/utils/importHato/chequeos.ts
@@ -66,6 +66,7 @@ const CRUDO_VACIO: CrudoFilaChequeo = {
   sx: null,
   fechaServicio: null,
   toro: null,
+  estadoRegistrado: null,
   tp: null,
   estado: null,
   secar: null,
@@ -191,6 +192,13 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
     const toroRes = parseToro(toroCruda, config);
     issues.push(...conCampo('Toro', toroRes.issues));
 
+    // "Estado registrado" (D-E, B5.4): texto de referencia, NUNCA
+    // interpretado -- se conserva verbatim para que el diff lo compare
+    // contra lo que el motor deriva hoy (N23). `null` cuando la hoja no trae
+    // esta columna (toda generación histórica, `colmap.estadoRegistrado ===
+    // null`) o la celda vino vacía.
+    const estadoRegistradoTexto = valorCeldaATexto(celda(filaFisica, colmap.estadoRegistrado));
+
     // D6 (decisión del dueño, 2026-07-22, resolution-report.md §6): un
     // código de ESTADO filtrado a la columna Toro NUNCA es un toro, "sin
     // excepción" -- incluso si la fila SÍ trae una fecha de servicio real.
@@ -256,6 +264,7 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
       sx: valorCeldaATexto(sxCruda),
       fechaServicio: fechaServicioTexto,
       toro: valorCeldaATexto(toroCruda),
+      estadoRegistrado: estadoRegistradoTexto,
       tp: tpTexto,
       estado: estadoTexto,
       secar: secarTexto,
@@ -282,6 +291,7 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
       fechaProbableParto,
       toroNombre: toroRes.toroNombre,
       tipoServicio: toroRes.tipoServicio,
+      estadoRegistrado: estadoRegistradoTexto,
       issues,
     });
   }

--- a/src/utils/importHato/commitChequeo.ts
+++ b/src/utils/importHato/commitChequeo.ts
@@ -293,6 +293,79 @@ export function seleccionarFechasServicioConocidasPorAnimal(
   return resultado;
 }
 
+/** Un evento del hato registrado A MANO (`chequeo_vaca_id IS NULL`): por
+ * Telegram (`/evento`, fuente `telegram`), por el diálogo de marcar ciclo
+ * (fuente `web`) o por venta/muerte. El caller lo trae ya filtrado. */
+export interface EventoManualHistorico {
+  animalId: string;
+  tipo: string;
+  fecha: string;
+}
+
+/**
+ * **N10 — el nodo que impide que el chequeo duplique lo que ya se registró a
+ * mano.** Fusiona los eventos manuales en los dos mapas de deduplicación que
+ * consume `derivarEventosDeChequeo`.
+ *
+ * Por qué existe: los dos mecanismos anti-duplicado del módulo
+ * (`fechasServicioConocidas` para servicios, `ultimaCriaAnterior` para
+ * partos) se alimentaban EXCLUSIVAMENTE de `hato_chequeo_vacas`, porque
+ * hasta ahora todos los eventos derivados venían de una planilla. Desde que
+ * Fernando registra la monta el mismo día en el corral, ese supuesto es
+ * falso: su monta del 10 de agosto no está en ninguna fila de chequeo, así
+ * que al aprobar el chequeo del 20 —que trae esa misma F Servicio, porque
+ * la veterinaria la copia de lo que ya sabe— el motor emitiría un SEGUNDO
+ * evento de servicio para la misma monta.
+ *
+ * Es exactamente la forma del bug que costó tres rondas de limpieza en julio
+ * de 2026 (385 servicios y 806 partos duplicados en producción). La
+ * diferencia es que aquel se descubrió con los datos ya corrompidos.
+ *
+ * Puro: devuelve mapas NUEVOS, no muta los que recibe.
+ */
+export function fusionarEventosManualesEnDedupe(
+  fechasServicioPorAnimal: Map<string, Set<string>>,
+  ultimaCriaAnteriorPorAnimal: Map<string, string | null>,
+  eventosManuales: EventoManualHistorico[],
+  chequeoNuevoFecha: string,
+): {
+  fechasServicioPorAnimal: Map<string, Set<string>>;
+  ultimaCriaAnteriorPorAnimal: Map<string, string | null>;
+} {
+  const servicios = new Map<string, Set<string>>();
+  for (const [animalId, fechas] of fechasServicioPorAnimal) {
+    servicios.set(animalId, new Set(fechas));
+  }
+  const crias = new Map<string, string | null>(ultimaCriaAnteriorPorAnimal);
+
+  for (const evento of eventosManuales) {
+    // Solo lo ESTRICTAMENTE anterior al chequeo que se aprueba -- mismo
+    // criterio que los dos selectores de arriba. Un evento manual del mismo
+    // día o posterior no es "lo ya conocido", es otro hecho.
+    if (evento.fecha >= chequeoNuevoFecha) continue;
+
+    if (evento.tipo === 'servicio') {
+      if (!servicios.has(evento.animalId)) servicios.set(evento.animalId, new Set());
+      servicios.get(evento.animalId)!.add(evento.fecha);
+      continue;
+    }
+
+    if (evento.tipo === 'parto') {
+      // `ultimaCriaAnterior` es UNA fecha (la última cría conocida), no un
+      // conjunto: `decidirEventoParto` agrupa por proximidad contra ella.
+      // Un parto manual solo la reemplaza si es MÁS RECIENTE que lo que ya
+      // había -- si el chequeo anterior reportó una cría posterior, esa
+      // sigue siendo la última.
+      const actual = crias.get(evento.animalId) ?? null;
+      if (actual === null || evento.fecha > actual) {
+        crias.set(evento.animalId, evento.fecha);
+      }
+    }
+  }
+
+  return { fechasServicioPorAnimal: servicios, ultimaCriaAnteriorPorAnimal: crias };
+}
+
 /**
  * Deriva los eventos de `hato_eventos` de cada fila aprobada, reusando
  * `descomponerSX` (mismo motor que `Load` y la captura en vivo). Una fila

--- a/src/utils/importHato/diffChequeo.ts
+++ b/src/utils/importHato/diffChequeo.ts
@@ -123,6 +123,27 @@ export interface CampoDiffChequeo {
   nuevo: unknown;
 }
 
+/**
+ * Conflicto explícito entre "lo registrado" y "lo impreso" (D-E, N23,
+ * docs/plan_hato_telegram_estados_agosto_2026.md §3 Capa 5). La planilla sale
+ * pre-impresa con la etiqueta del `EstadoReproductivo` que el motor creía
+ * cierta al momento de exportar ("Estado registrado", columna gris de solo
+ * referencia -- Martha nunca escribe ahí). Entre que se imprime y que se
+ * sube de vuelta puede haber pasado CUALQUIER COSA que cambie esa lectura: un
+ * evento de Telegram nuevo, una corrección manual, un chequeo distinto ya
+ * aprobado -- y eso tiene que verse ANTES de aprobar, no descubrirse después
+ * (la contradicción es justo lo que N23 pide mostrar). `actual` se recalcula
+ * SIEMPRE con el estado fresco de la base al momento del diff (mismo
+ * principio que el resto de este archivo: nunca el diff viejo que vio la
+ * pantalla).
+ */
+export interface ConflictoEstadoRegistrado {
+  /** Lo que decía la planilla cuando se exportó/imprimió. */
+  impreso: string;
+  /** Lo que el sistema cree AHORA, recién recalculado. */
+  actual: string;
+}
+
 export interface FilaDiffChequeo {
   fila: number;
   numero: number | null;
@@ -141,6 +162,25 @@ export interface FilaDiffChequeo {
   diferencias: CampoDiffChequeo[];
   motivoNoReconocido: string | null;
   issues: ParseIssue[];
+  /** `null` cuando no hay nada que contrastar: fila `nuevo`/`no_reconocido`
+   * (sin `animalId`), la hoja no trae la columna "Estado registrado" (toda
+   * generación anterior a B5.4), la celda vino vacía, o lo impreso SIGUE
+   * coincidiendo con lo que el sistema cree hoy. Ver `ConflictoEstadoRegistrado`. */
+  conflictoEstadoRegistrado: ConflictoEstadoRegistrado | null;
+}
+
+/** "Lo que el sistema cree HOY" para un animal -- la etiqueta de
+ * `EstadoReproductivo` (`etiquetaEstadoReproductivo`, calculosHato.ts),
+ * recalculada por el handler contra el estado FRESCO de `v_hato_estado_actual`
+ * en el momento del diff, nunca cacheada. El handler arma este arreglo; este
+ * módulo solo lo usa para comparar texto contra texto -- no conoce el motor
+ * de estados ni el vocabulario de 5 estados, mismo principio de capas que el
+ * resto de `importHato/`. */
+export interface AnimalEstadoRegistradoActual {
+  animalId: string;
+  /** Etiqueta YA calculada (`etiquetaEstadoReproductivo`), lista para
+   * comparar texto a texto contra `fila.estadoRegistrado`. */
+  estado: string;
 }
 
 export interface ResumenDiffChequeo {
@@ -153,6 +193,12 @@ export interface ResumenDiffChequeo {
    * clasificación -- independiente de `noReconocidos` (una fila puede tener
    * issues y aun así resolverse a un animal). */
   conIssues: number;
+  /** Filas cuyo "Estado registrado" impreso ya NO coincide con lo que el
+   * sistema cree hoy (N23, D-E) -- la señal que tiene que verse ANTES de
+   * aprobar. Independiente de `cambios`: una fila puede no traer ningún
+   * cambio de campo (Martha no tocó nada) y aun así tener este conflicto,
+   * porque lo que cambió fue el sistema, no el papel. */
+  conConflictoEstadoRegistrado: number;
 }
 
 export interface ResultadoDiffChequeo {
@@ -221,7 +267,33 @@ function filaNoReconocida(fila: FilaChequeoNormalizada, numeroEsProvisional: boo
     diferencias: [],
     motivoNoReconocido: motivo,
     issues: fila.issues,
+    // Sin animal resuelto no hay contra qué contrastar "lo que el sistema
+    // cree hoy" -- nunca se inventa un conflicto para una fila que ni
+    // siquiera se sabe de quién es.
+    conflictoEstadoRegistrado: null,
   };
+}
+
+/**
+ * N23: compara `estadoRegistrado` IMPRESO (crudo, tal como salió en la
+ * planilla) contra lo que el sistema cree AHORA (`estadosRegistrados`,
+ * recién recalculado por el handler). `null` cuando no hay nada que
+ * contrastar -- la hoja no trae la columna (generación anterior a B5.4), la
+ * celda vino vacía, o el animal no aparece en `estadosRegistrados` (no
+ * debería pasar para una fila con `animalId` resuelto, pero un mapa
+ * incompleto no debe fabricar un conflicto falso).
+ */
+function calcularConflictoEstadoRegistrado(
+  estadoRegistradoImpreso: string | null,
+  animalId: string,
+  estadosRegistradosPorAnimalId: Map<string, string>,
+): ConflictoEstadoRegistrado | null {
+  const impreso = estadoRegistradoImpreso?.trim();
+  if (!impreso) return null;
+  const actual = estadosRegistradosPorAnimalId.get(animalId);
+  if (actual === undefined) return null;
+  if (impreso === actual) return null;
+  return { impreso, actual };
 }
 
 /**
@@ -229,17 +301,28 @@ function filaNoReconocida(fila: FilaChequeoNormalizada, numeroEsProvisional: boo
  * actual del hato. `animales`/`ultimosChequeos` son la forma plana que el
  * handler del endpoint arma con dos consultas a Supabase (`hato_animales` +
  * `hato_chequeo_vacas` reducida vía `seleccionarUltimoChequeoPorAnimal`).
+ *
+ * `estadosRegistrados` (N23, D-E) es OPCIONAL y por defecto vacío -- sin él
+ * (llamadas existentes, o un handler que no lo calculó todavía) el diff se
+ * comporta exactamente igual que antes, solo que `conflictoEstadoRegistrado`
+ * sale siempre `null`. El handler lo arma recalculando `derivarEstadoReproductivo`
+ * contra `v_hato_estado_actual` FRESCA para los animales de esta hoja -- nunca
+ * un valor cacheado del momento en que se imprimió la planilla.
  */
 export function construirDiffChequeo(
   filas: FilaChequeoNormalizada[],
   animales: AnimalHatoActual[],
   ultimosChequeos: UltimoChequeoVacaActual[],
+  estadosRegistrados: AnimalEstadoRegistradoActual[] = [],
 ): ResultadoDiffChequeo {
   const animalesPorNumero = new Map<number, AnimalHatoActual>();
   for (const a of animales) animalesPorNumero.set(a.numero, a);
 
   const ultimoPorAnimalId = new Map<string, UltimoChequeoVacaActual>();
   for (const u of ultimosChequeos) ultimoPorAnimalId.set(u.animalId, u);
+
+  const estadosRegistradosPorAnimalId = new Map<string, string>();
+  for (const e of estadosRegistrados) estadosRegistradosPorAnimalId.set(e.animalId, e.estado);
 
   // Colisión DENTRO de la hoja subida (mismo número, nombres distintos) --
   // mismo motor que ya protege el pipeline histórico. `nombre` nunca es
@@ -289,6 +372,9 @@ export function construirDiffChequeo(
         diferencias: [],
         motivoNoReconocido: null,
         issues: fila.issues,
+        // Ficha nueva: no hay animal contra el cual recalcular "lo que el
+        // sistema cree hoy".
+        conflictoEstadoRegistrado: null,
       };
     }
 
@@ -306,6 +392,11 @@ export function construirDiffChequeo(
       diferencias,
       motivoNoReconocido: null,
       issues: fila.issues,
+      conflictoEstadoRegistrado: calcularConflictoEstadoRegistrado(
+        fila.estadoRegistrado,
+        animal.id,
+        estadosRegistradosPorAnimalId,
+      ),
     };
   });
 
@@ -316,6 +407,7 @@ export function construirDiffChequeo(
     cambios: filasDiff.filter((f) => f.clasificacion === 'cambio').length,
     noReconocidos: filasDiff.filter((f) => f.clasificacion === 'no_reconocido').length,
     conIssues: filasDiff.filter((f) => f.issues.length > 0).length,
+    conConflictoEstadoRegistrado: filasDiff.filter((f) => f.conflictoEstadoRegistrado !== null).length,
   };
 
   return { filas: filasDiff, resumen, colisionesEnHoja };

--- a/src/utils/importHato/grilla.ts
+++ b/src/utils/importHato/grilla.ts
@@ -25,6 +25,12 @@ export type ColumnaLogicaChequeo =
   | 'sx'
   | 'fechaServicio'
   | 'toro'
+  /** "Estado registrado" (D-E, plan agosto 2026 N21-N22): columna PRE-LLENADA
+   * y de solo referencia -- lo que el motor de 5 estados cree HOY, impreso
+   * para que la vet lo verifique contra la vaca real. Nunca se le pide nada
+   * a Martha en esta columna (esa es `estado`, la de al lado). Solo existe en
+   * el formato B5.3/B5.4 propio -- ninguna generación histórica la trae. */
+  | 'estadoRegistrado'
   | 'tp'
   | 'estado'
   | 'secar'
@@ -42,6 +48,7 @@ export const COLMAP_VACIO: ColmapChequeo = {
   sx: null,
   fechaServicio: null,
   toro: null,
+  estadoRegistrado: null,
   tp: null,
   estado: null,
   secar: null,
@@ -88,6 +95,10 @@ const ALIAS_ANCLA: Record<
   sx: ['SX', 'SEXO CRÍA'], // 'Sexo cría' es B5.3
   fechaServicio: ['F SERVICIO', 'FECHA SERVICIO'], // 'Fecha Servicio' es B5.3
   toro: ['T', 'TORO'],
+  // 'Estado registrado' es B5.4 (D-E, plan agosto 2026) -- exclusiva de
+  // nuestro propio formato, nunca ambigua con el alias 'ESTADO' del grupo
+  // final (comparación EXACTA de texto normalizado, ver `buscarColumnas`).
+  estadoRegistrado: ['ESTADO REGISTRADO'],
   ttto: ['TTTO', 'TRATAMIENTO'], // 'Tratamiento' es B5.3
 };
 
@@ -300,6 +311,11 @@ function colmapPosicional(offset: number): ColmapChequeo {
     sx: offset + 5,
     fechaServicio: offset + 6,
     toro: offset + 7,
+    // Ninguna de las 4 hojas headerless del corpus histórico trae 'Estado
+    // registrado' (B5.4, solo existe en nuestro propio formato exportado, que
+    // SIEMPRE lleva encabezado real) -- se deja sin columna, nunca se inventa
+    // una posición.
+    estadoRegistrado: null,
     tp: offset + 8,
     estado: offset + 9,
     secar: offset + 10,
@@ -364,6 +380,7 @@ const COLUMNAS_PARA_FILTRO_VACIO: ColumnaLogicaChequeo[] = [
   'sx',
   'fechaServicio',
   'toro',
+  'estadoRegistrado',
   'estado',
   'secar',
   'pp',

--- a/src/utils/importHato/ocrChequeo.ts
+++ b/src/utils/importHato/ocrChequeo.ts
@@ -62,6 +62,7 @@ export const COLUMNAS_OCR = [
   'sexo_cria',
   'fecha_servicio',
   'toro',
+  'estado_registrado',
   'estado',
   'secar',
   'parto_probable',
@@ -92,6 +93,7 @@ export const ENCABEZADO_POR_COLUMNA_OCR: Record<ColumnaOcr, string> = {
   sexo_cria: 'Sexo cría',
   fecha_servicio: 'Fecha Servicio',
   toro: 'Toro',
+  estado_registrado: 'Estado registrado',
   estado: 'Estado',
   secar: 'Secar',
   parto_probable: 'Parto Probable',
@@ -765,6 +767,21 @@ export const VOCABULARIO_SX: readonly string[] = [
 /** Códigos de la columna Estado que `parseEstado` reconoce. */
 export const VOCABULARIO_ESTADO: readonly string[] = ['ok', 'rech'];
 
+/** Etiquetas que puede traer la columna "Estado registrado" (D-E, B5.4) --
+ * las CINCO del vocabulario del dueño más el guion de "sin clasificar". Es
+ * una columna de REFERENCIA que el sistema pre-imprime; Martha nunca escribe
+ * ahí, así que el modelo solo necesita reconocer una de estas palabras (o
+ * transcribir lo que vea si algo salió distinto -- regla 3 del prompt sigue
+ * mandando). */
+export const VOCABULARIO_ESTADO_REGISTRADO: readonly string[] = [
+  'Vacía',
+  'Servida',
+  'Confirmada',
+  'Por secar',
+  'Seca',
+  '—',
+];
+
 export interface VocabularioOcr {
   /** Nombres de toro reales, de `hato_toros`. */
   toros: readonly string[];
@@ -866,6 +883,7 @@ export function construirPromptOcr(vocabulario: VocabularioOcr): string {
     'VOCABULARIO ESPERADO (úsalo para leer mejor la letra, NO para reemplazar lo que ves):',
     `- Fechas: formato día/mes/año, por ejemplo 5/11/2026. Transcríbelas tal cual estén escritas.`,
     `- Columna 'Sexo cría' (código SX): ${VOCABULARIO_SX.join(', ')}. La letra A es hembra, la O es macho, el signo + significa que la cría murió, y un número después de la letra es la chapeta de la cría.`,
+    `- Columna 'Estado registrado' (letra impresa, GRIS, de referencia -- nunca escrita a mano): una de estas palabras: ${VOCABULARIO_ESTADO_REGISTRADO.join(', ')}.`,
     `- Columna 'Estado': ${VOCABULARIO_ESTADO.join(', ')}.`,
     `- Columna 'Toro': nombres del catálogo real: ${toros}. A veces va precedido de 'Toro ' o 'Ins '. Si el nombre escrito no está en el catálogo, transcríbelo igual tal cual.`,
     `- Columnas 'PL' y '# Partos': números.`,

--- a/src/utils/importHato/ocrPesaje.ts
+++ b/src/utils/importHato/ocrPesaje.ts
@@ -304,13 +304,25 @@ export type ResultadoAnclaPesaje =
  * ambigüedad real. */
 const TOLERANCIA_EDICION_NOMBRE = 1;
 
-export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje): ResultadoAnclaPesaje {
-  const leido = normalizarNombrePesaje(fila.nombreImpreso);
+/**
+ * Cotejo de un nombre contra el roster de la planilla -- el corazón del
+ * anti-row-drift. Nace del ancla de la ruta FOTO (`validarAnclaFilaPesaje`,
+ * abajo, que solo le pasa `fila.nombreImpreso`), pero es la MISMA regla que
+ * necesita `ocrPesajeCorreccion.ts` para resolver el nombre que Fernando
+ * escribe en una corrección de texto libre (D-C): exacto único -> resuelto;
+ * exacto ambiguo -> nunca se adjudica; a una letra único -> resuelto con
+ * aviso; a una letra ambiguo -> nunca se adjudica; nada -> fuera del roster.
+ * Cotejar el nombre de una corrección con un algoritmo DISTINTO al que
+ * cotejó la foto original sería inconsistente sin motivo -- por eso una sola
+ * función, no dos parecidas.
+ */
+export function resolverNombreEnRosterPesaje(nombreCrudo: string, roster: RosterPesaje): ResultadoAnclaPesaje {
+  const leido = normalizarNombrePesaje(nombreCrudo);
   if (leido === '') {
     return {
       ok: false,
       motivo: 'nombre_ilegible',
-      detalle: `el nombre impreso se leyó como '${fila.nombreImpreso}', que no es un nombre -- la fila no se puede anclar`,
+      detalle: `'${nombreCrudo}' no es un nombre -- no se puede anclar`,
     };
   }
 
@@ -320,7 +332,7 @@ export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje
     return {
       ok: false,
       motivo: 'nombre_ambiguo_en_roster',
-      detalle: `${exactos.length} vacas en ordeño se llaman '${fila.nombreImpreso}' -- no se adjudica sola (regla del módulo), la fila queda para revisión humana`,
+      detalle: `${exactos.length} vacas en ordeño se llaman '${nombreCrudo}' -- no se adjudica sola (regla del módulo), queda para revisión humana`,
     };
   }
 
@@ -331,22 +343,26 @@ export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje
     return {
       ok: true,
       entrada: cercanos[0],
-      avisos: [`el nombre impreso se leyó como '${fila.nombreImpreso}' y el roster dice '${cercanos[0].nombre}' (una letra de diferencia) -- revisar`],
+      avisos: [`'${nombreCrudo}' y el roster dice '${cercanos[0].nombre}' (una letra de diferencia) -- revisar`],
     };
   }
   if (cercanos.length > 1) {
     return {
       ok: false,
       motivo: 'nombre_ambiguo_en_roster',
-      detalle: `'${fila.nombreImpreso}' está a una letra de ${cercanos.length} vacas en ordeño distintas -- no se adjudica sola`,
+      detalle: `'${nombreCrudo}' está a una letra de ${cercanos.length} vacas en ordeño distintas -- no se adjudica sola`,
     };
   }
 
   return {
     ok: false,
     motivo: 'nombre_fuera_del_roster',
-    detalle: `ninguna vaca en ordeño activa se llama '${fila.nombreImpreso}' -- puede ser una vaca vendida, una novilla anotada a mano, o un nombre mal leído`,
+    detalle: `ninguna vaca en ordeño activa se llama '${nombreCrudo}' -- puede ser una vaca vendida, una novilla anotada a mano, o un nombre mal escrito/leído`,
   };
+}
+
+export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje): ResultadoAnclaPesaje {
+  return resolverNombreEnRosterPesaje(fila.nombreImpreso, roster);
 }
 
 // ---------------------------------------------------------------------------

--- a/src/utils/importHato/ocrPesajeCorreccion.ts
+++ b/src/utils/importHato/ocrPesajeCorreccion.ts
@@ -1,0 +1,403 @@
+// ARCHIVO: utils/importHato/ocrPesajeCorreccion.ts
+// DESCRIPCIÓN: N12 de `docs/plan_hato_telegram_estados_agosto_2026.md` --
+// decisión D-C del dueño: el bot de Telegram muestra en texto plano la
+// lectura de la planilla de pesaje (`ocrPesaje.ts`), Fernando responde en
+// LENGUAJE NATURAL ("MONZA sem 2 AM son 6.5 y BONITA no se pesó"), un modelo
+// traduce esa frase a celdas concretas y el bot vuelve a mostrar el resumen
+// YA CORREGIDO -- solo se persiste tras un "ok" explícito.
+//
+// LA MISMA SEPARACIÓN que el resto del módulo (`ocrChequeo.ts`,
+// `ocrPesaje.ts`): el modelo SOLO extrae entidades del texto (qué vaca, qué
+// semana, qué sub-celda, qué valor o "sin dato"); este archivo es quien
+// VALIDA esas entidades contra el roster y la grilla de semanas del mes --
+// nunca al revés. La llamada HTTP al modelo vive en el árbol Deno
+// (`hato-pesaje-pipeline.ts`); acá no hay I/O ni `Date.now()`.
+//
+// REGLA DURA (idéntica a la del ancla por foto): un ítem que el modelo no
+// logre anclar a UNA vaca del roster, a UNA semana válida de la grilla o a
+// UN valor de litros interpretable NUNCA se aplica -- se reporta como no
+// entendido para que Fernando lo aclare. Nunca se adivina.
+//
+// El cotejo de nombre reusa `resolverNombreEnRosterPesaje` de `./ocrPesaje`
+// -- el MISMO algoritmo que ancla la foto, para que un nombre se resuelva
+// igual sin importar si vino impreso o hablado. Los litros se interpretan
+// con `parseValorNumerico` (`calculosHato.ts`), el único parser numérico.
+//
+// Puro, cero I/O, cero Date.now().
+
+import { parseValorNumerico } from '@/utils/calculosHato';
+import {
+  resolverNombreEnRosterPesaje,
+  SEMANAS_PESAJE,
+  type CeldaDiffPesaje,
+  type ClasificacionCeldaPesaje,
+  type RosterPesaje,
+  type SemanaPesaje,
+} from './ocrPesaje';
+
+// ---------------------------------------------------------------------------
+// 1. Lo que el modelo devuelve -- entidades extraídas del texto, SIN validar.
+// ---------------------------------------------------------------------------
+
+export type SubceldaCorreccionPesaje = 'am' | 'pm' | 'ambos';
+
+export interface ItemCorreccionModeloPesaje {
+  /** El nombre de vaca tal como el usuario lo escribió, verbatim -- para
+   * poder reportar "no encontré a X" con el texto real, nunca el
+   * normalizado. */
+  nombreMencionado: string;
+  /** Semana 1-5 mencionada en el texto, o `null` si el texto no la
+   * especifica. Nunca se infiere -- una corrección sin semana se reporta
+   * como no entendida (mismo criterio que un nombre sin ancla). */
+  semana: number | null;
+  /** Qué sub-celda(s) afecta. `'ambos'` cuando el texto habla de la vaca sin
+   * distinguir AM/PM (p. ej. "no se pesó"). `null` si el texto no lo dice. */
+  subcelda: SubceldaCorreccionPesaje | null;
+  /** `true` cuando el texto dice explícitamente que la vaca no se pesó / no
+   * hay dato para esa celda -- el valor resultante es `null`, nunca 0. */
+  sinDato: boolean;
+  /** Texto crudo del valor de litros, tal como lo dijo el usuario (puede
+   * traer coma, fracción, etc. -- se interpreta con `parseValorNumerico`).
+   * Vacío o ausente cuando `sinDato` es `true`. */
+  valorTexto: string | null;
+}
+
+function textoPlano(valor: unknown): string {
+  if (valor === null || valor === undefined) return '';
+  if (typeof valor === 'string') return valor.trim();
+  if (typeof valor === 'number' || typeof valor === 'boolean') return String(valor);
+  return '';
+}
+
+function semanaPlana(valor: unknown): number | null {
+  if (typeof valor === 'number' && Number.isInteger(valor)) return valor;
+  if (typeof valor === 'string' && valor.trim() !== '') {
+    const n = Number(valor.trim());
+    if (Number.isInteger(n)) return n;
+  }
+  return null;
+}
+
+function subceldaPlana(valor: unknown): SubceldaCorreccionPesaje | null {
+  return valor === 'am' || valor === 'pm' || valor === 'ambos' ? valor : null;
+}
+
+/**
+ * Convierte el JSON crudo que devolvió el modelo (ya des-serializado) en una
+ * lista de `ItemCorreccionModeloPesaje`. Tolerante por diseño, mismo
+ * criterio que `parsearRespuestaModeloOcrPesaje`: un ítem mal formado NUNCA
+ * aborta el resto -- se conserva con lo que se pueda leer (y lo demás en
+ * `null`, que `interpretarCorreccionPesaje` reportará como no entendido en
+ * vez de fallar en silencio). Solo `items` ausente/no-arreglo es fatal: ahí
+ * no hay nada que rescatar.
+ */
+export function parsearRespuestaModeloCorreccionPesaje(bruto: unknown): {
+  items: ItemCorreccionModeloPesaje[];
+  avisos: string[];
+} {
+  const avisos: string[] = [];
+  if (bruto === null || typeof bruto !== 'object') {
+    throw new Error('La respuesta del modelo de corrección no es un objeto JSON.');
+  }
+  const raiz = bruto as Record<string, unknown>;
+  const itemsBrutos = raiz.items;
+  if (!Array.isArray(itemsBrutos)) {
+    throw new Error("La respuesta del modelo de corrección no trae el arreglo 'items'.");
+  }
+
+  const items: ItemCorreccionModeloPesaje[] = itemsBrutos.map((itemBruto, i) => {
+    if (itemBruto === null || typeof itemBruto !== 'object') {
+      avisos.push(`ítem ${i + 1}: no es un objeto -- se descarta su contenido, queda como no entendido`);
+      return { nombreMencionado: '', semana: null, subcelda: null, sinDato: false, valorTexto: null };
+    }
+    const item = itemBruto as Record<string, unknown>;
+    return {
+      nombreMencionado: textoPlano(item.nombre_mencionado),
+      semana: semanaPlana(item.semana),
+      subcelda: subceldaPlana(item.subcelda),
+      sinDato: item.sin_dato === true,
+      valorTexto: item.sin_dato === true ? null : textoPlano(item.valor_texto) || null,
+    };
+  });
+
+  return { items, avisos };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Validación: entidades del modelo -> celdas concretas, o "no entendida".
+// ---------------------------------------------------------------------------
+
+export interface CorreccionPesajeAplicable {
+  animalId: string;
+  nombre: string;
+  semana: SemanaPesaje;
+  fecha: string;
+  subcelda: 'am' | 'pm';
+  /** `null` = limpia la celda ("no se pesó"), nunca 0. */
+  valor: number | null;
+}
+
+export interface CorreccionPesajeNoEntendida {
+  nombreMencionado: string;
+  semana: number | null;
+  detalle: string;
+}
+
+export interface ResultadoInterpretacionCorreccionPesaje {
+  aplicables: CorreccionPesajeAplicable[];
+  noEntendidas: CorreccionPesajeNoEntendida[];
+}
+
+/**
+ * Valida cada ítem que el modelo extrajo del texto libre contra el roster
+ * (nombre) y la grilla de semanas del mes (`fechasPorSemana`, la MISMA que
+ * ya resolvió `fechasPesajeMensuales` para la lectura por foto -- nunca se
+ * vuelve a derivar). Un ítem que falle CUALQUIERA de las tres anclas (vaca,
+ * semana, valor) va a `noEntendidas` -- nunca se aplica a medias ni se
+ * adivina la parte que falta.
+ */
+export function interpretarCorreccionPesaje(
+  items: readonly ItemCorreccionModeloPesaje[],
+  roster: RosterPesaje,
+  fechasPorSemana: Readonly<Record<SemanaPesaje, string | null>>,
+): ResultadoInterpretacionCorreccionPesaje {
+  const aplicables: CorreccionPesajeAplicable[] = [];
+  const noEntendidas: CorreccionPesajeNoEntendida[] = [];
+
+  for (const item of items) {
+    const ancla = resolverNombreEnRosterPesaje(item.nombreMencionado, roster);
+    if (!ancla.ok) {
+      noEntendidas.push({ nombreMencionado: item.nombreMencionado, semana: item.semana, detalle: ancla.detalle });
+      continue;
+    }
+    const nombre = ancla.entrada.nombre;
+
+    if (item.semana === null || !(SEMANAS_PESAJE as readonly number[]).includes(item.semana)) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana: item.semana,
+        detalle: `no especifica una semana válida (1 a 5) para ${nombre} -- dila explícita, p. ej. "semana 2"`,
+      });
+      continue;
+    }
+    const semana = item.semana as SemanaPesaje;
+
+    const fecha = fechasPorSemana[semana];
+    if (fecha === null) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `la semana ${semana} no existe en la planilla de este mes`,
+      });
+      continue;
+    }
+
+    // "no se pesó" sin AM/PM explícito limpia AMBAS -- ninguno de los dos
+    // ordeños pasó esa semana. Con valor (no sinDato) sí hace falta que el
+    // texto diga cuál de los dos: escribir el mismo número en AM y PM sin que
+    // el usuario lo haya dicho sería adivinar.
+    const subceldas: Array<'am' | 'pm'> =
+      item.subcelda === 'ambos' || (item.sinDato && item.subcelda === null)
+        ? ['am', 'pm']
+        : item.subcelda === 'am' || item.subcelda === 'pm'
+          ? [item.subcelda]
+          : [];
+
+    if (subceldas.length === 0) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `no especifica si es AM, PM o ambos para ${nombre} semana ${semana}`,
+      });
+      continue;
+    }
+
+    if (item.sinDato) {
+      for (const sub of subceldas) {
+        aplicables.push({ animalId: ancla.entrada.id, nombre, semana, fecha, subcelda: sub, valor: null });
+      }
+      continue;
+    }
+
+    const parseado = item.valorTexto ? parseValorNumerico(item.valorTexto, { fracciones: true }) : null;
+    if (!item.valorTexto || !parseado || parseado.valor === null) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `no pude interpretar '${item.valorTexto ?? ''}' como litros para ${nombre} semana ${semana}`,
+      });
+      continue;
+    }
+    for (const sub of subceldas) {
+      aplicables.push({ animalId: ancla.entrada.id, nombre, semana, fecha, subcelda: sub, valor: parseado.valor });
+    }
+  }
+
+  return { aplicables, noEntendidas };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Aplicar correcciones YA validadas sobre el diff en memoria.
+// ---------------------------------------------------------------------------
+
+/**
+ * Aplica correcciones validadas sobre el diff que ya se le mostró al
+ * usuario -- SIEMPRE en memoria, nunca contra la base de datos: el
+ * commit (N13) es un paso posterior y separado, gateado por el "ok"
+ * explícito. Una corrección que no toca una celda del diff (animal/semana
+ * que no vino en la lectura original) la agrega -- puede ser una vaca que
+ * el OCR no leyó y que Fernando corrige a mano en el mismo mensaje.
+ *
+ * `clasificacion` se recalcula con la MISMA regla que `construirDiffPesaje`
+ * (litrosTotal null -> 'sin_dato'; sin fila existente -> 'nuevo'; con fila
+ * existente -> 'cambio' -- nunca hace falta distinguir 'cambio' de
+ * 'sin_cambio' después de una corrección humana, ambas son escribibles por
+ * igual). `noConfiable` pasa a `false`: un humano confirmó la celda, ya no
+ * es "el modelo dudó".
+ */
+export function aplicarCorreccionesADiff(
+  diff: readonly CeldaDiffPesaje[],
+  aplicables: readonly CorreccionPesajeAplicable[],
+): CeldaDiffPesaje[] {
+  if (aplicables.length === 0) return [...diff];
+
+  type Cambio = { am?: number | null; pm?: number | null };
+  const porCelda = new Map<string, Cambio>();
+  for (const correccion of aplicables) {
+    const clave = `${correccion.animalId}|${correccion.semana}`;
+    const actual = porCelda.get(clave) ?? {};
+    if (correccion.subcelda === 'am') actual.am = correccion.valor;
+    else actual.pm = correccion.valor;
+    porCelda.set(clave, actual);
+  }
+
+  const resultado = diff.map((celda): CeldaDiffPesaje => {
+    const clave = `${celda.animalId}|${celda.semana}`;
+    const cambio = porCelda.get(clave);
+    if (!cambio) return celda;
+    porCelda.delete(clave); // lo que sobrevive al final son celdas NUEVAS (ver abajo)
+
+    const litrosAm = 'am' in cambio ? (cambio.am as number | null) : celda.litrosAm;
+    const litrosPm = 'pm' in cambio ? (cambio.pm as number | null) : celda.litrosPm;
+    return recalcularCelda({ ...celda, litrosAm, litrosPm });
+  });
+
+  // Correcciones que no calzaron con ninguna celda ya presente en el diff
+  // (p. ej. una vaca que la foto no leyó y que Fernando agrega a mano en la
+  // misma corrección) -- se agregan como celdas nuevas, nunca se descartan.
+  for (const [clave, cambio] of porCelda) {
+    const [animalId, semanaTexto] = clave.split('|');
+    const semana = Number(semanaTexto) as SemanaPesaje;
+    const nombre = aplicables.find((a) => a.animalId === animalId && a.semana === semana)?.nombre ?? '';
+    const fecha = aplicables.find((a) => a.animalId === animalId && a.semana === semana)?.fecha ?? '';
+    resultado.push(
+      recalcularCelda({
+        animalId,
+        nombre,
+        semana,
+        fecha,
+        litrosAm: 'am' in cambio ? (cambio.am as number | null) : null,
+        litrosPm: 'pm' in cambio ? (cambio.pm as number | null) : null,
+        litrosTotal: null,
+        soloUnOrdeno: false,
+        existenteId: null,
+        clasificacion: 'sin_dato',
+        noConfiable: false,
+      }),
+    );
+  }
+
+  return resultado;
+}
+
+function recalcularCelda(celda: CeldaDiffPesaje): CeldaDiffPesaje {
+  const litrosTotal = celda.litrosAm === null && celda.litrosPm === null ? null : (celda.litrosAm ?? 0) + (celda.litrosPm ?? 0);
+  const clasificacion: ClasificacionCeldaPesaje =
+    litrosTotal === null ? 'sin_dato' : celda.existenteId ? 'cambio' : 'nuevo';
+  return {
+    ...celda,
+    litrosTotal,
+    soloUnOrdeno: (celda.litrosAm === null) !== (celda.litrosPm === null),
+    clasificacion,
+    noConfiable: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Prompt y esquema de salida del modelo de interpretación.
+// ---------------------------------------------------------------------------
+
+/** Esquema JSON estricto -- mismo criterio que `esquemaJsonOcrPesaje`: sin
+ * uniones de tipo abiertas donde se pueda evitar, ausencia = `null`. */
+export function esquemaJsonCorreccionPesaje(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      items: {
+        type: 'array',
+        description: 'Una entrada por cada corrección/aclaración que el texto menciona.',
+        items: {
+          type: 'object',
+          properties: {
+            nombre_mencionado: {
+              type: 'string',
+              description: 'El nombre de la vaca tal como aparece en el texto, verbatim.',
+            },
+            semana: {
+              type: ['integer', 'null'],
+              description: 'Número de semana (1 a 5) que el texto menciona explícitamente. null si no lo dice.',
+            },
+            subcelda: {
+              type: ['string', 'null'],
+              enum: ['am', 'pm', 'ambos', null],
+              description:
+                "'am' u 'pm' si el texto distingue el ordeño; 'ambos' cuando habla de la vaca sin distinguir (p. ej. 'no se pesó'); null si no se puede determinar.",
+            },
+            sin_dato: {
+              type: 'boolean',
+              description: "true cuando el texto dice que la vaca NO se pesó / no hay dato para esa celda.",
+            },
+            valor_texto: {
+              type: ['string', 'null'],
+              description:
+                'El valor de litros tal como lo escribió el usuario (puede traer coma o fracción). null cuando sin_dato es true.',
+            },
+          },
+          required: ['nombre_mencionado', 'semana', 'subcelda', 'sin_dato', 'valor_texto'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['items'],
+    additionalProperties: false,
+  };
+}
+
+/**
+ * Prompt de interpretación. Deliberadamente NO incluye el roster de vacas
+ * activas (mismo criterio que `construirPromptOcrPesaje`): el modelo solo
+ * EXTRAE entidades del texto -- el nombre exacto que Fernando escribió, tal
+ * cual -- y es `interpretarCorreccionPesaje` quien lo valida contra el
+ * roster real. Pasarle el roster al modelo volvería la extracción un espejo
+ * de sí misma en vez de una lectura honesta del texto.
+ */
+export function construirPromptCorreccionPesaje(): string {
+  return [
+    'Eres un asistente que interpreta correcciones en español, dichas en lenguaje natural, sobre una planilla de pesaje de leche de un hato lechero en Colombia.',
+    '',
+    'El usuario acaba de ver un resumen de lo que se leyó de una foto de la planilla (vaca, semana, litros AM/PM) y ahora escribe correcciones o aclaraciones en texto libre. Tu único trabajo es EXTRAER, para cada corrección que menciona, estos datos: el nombre de la vaca (tal como lo escribió, sin corregirlo ni normalizarlo), la semana (1 a 5) si la menciona, si habla de AM, PM o de la vaca en general, si dice que la vaca NO se pesó, y el valor de litros si da uno.',
+    '',
+    'EJEMPLOS (los nombres son solo ilustrativos, no una lista real):',
+    '- "LUNA sem 2 AM son 6.5" -> {nombre_mencionado: "LUNA", semana: 2, subcelda: "am", sin_dato: false, valor_texto: "6.5"}',
+    '- "PRINCESA no se pesó" -> {nombre_mencionado: "PRINCESA", semana: null, subcelda: null, sin_dato: true, valor_texto: null} (semana null porque el texto no la menciona -- NO la adivines)',
+    '- "la vaca REINA semana 3 no se pesó" -> {nombre_mencionado: "REINA", semana: 3, subcelda: "ambos", sin_dato: true, valor_texto: null}',
+    '',
+    'REGLAS DURAS:',
+    '1. NUNCA inventes una semana, un AM/PM o un valor que el texto no diga explícita o inequívocamente. Si no está claro, deja ese campo en null (o sin_dato en false con valor_texto null) -- es preferible reportar que no se entendió a adivinar.',
+    '2. Copia el nombre EXACTAMENTE como aparece en el texto, sin corregir ortografía ni completar el nombre real de una vaca -- eso lo hace otro paso, no tú.',
+    '3. El valor de litros se copia tal cual está escrito (puede traer coma, punto o fracción como "6 1/2"); no lo conviertas ni lo redondees.',
+    '4. Una sola frase puede traer varias correcciones (una por vaca) -- devuelve un ítem por cada una.',
+    '',
+    'Responde ÚNICAMENTE con el JSON del esquema pedido. Sin explicaciones, sin markdown.',
+  ].join('\n');
+}

--- a/src/utils/importHato/tipos.ts
+++ b/src/utils/importHato/tipos.ts
@@ -39,6 +39,14 @@ export interface CrudoFilaChequeo {
   sx: string | null;
   fechaServicio: string | null;
   toro: string | null;
+  /** "Estado registrado" (D-E, B5.4): el texto VERBATIM impreso en la
+   * columna de referencia -- la etiqueta de `EstadoReproductivo`
+   * (`etiquetaEstadoReproductivo`, calculosHato.ts) que el sistema creía
+   * cierta al momento de exportar/imprimir la planilla. Nunca se interpreta
+   * acá (ni se convierte a un `EstadoReproductivo`): es evidencia cruda que
+   * el diff compara contra lo que el sistema cree AHORA (N23). `null` en
+   * cualquier generación histórica -- esa columna no existía. */
+  estadoRegistrado: string | null;
   /** Se conserva por trazabilidad pero NUNCA se interpreta: es una fórmula
    * `TODAY()` congelada, no un dato del chequeo (doc S2 QA §2.4). */
   tp: string | null;
@@ -83,6 +91,13 @@ export interface FilaChequeoNormalizada {
   fechaProbableParto: string | null;
   toroNombre: string | null;
   tipoServicio: 'monta' | 'inseminacion' | null;
+  /** Copia trimeada de `raw.estadoRegistrado` -- lo que estaba impreso en
+   * "Estado registrado" cuando se exportó esta planilla (D-E, B5.4). `null`
+   * cuando la hoja no trae esa columna (toda generación histórica) o la
+   * celda vino vacía. El diff (`diffChequeo.ts`) la compara contra el
+   * `EstadoReproductivo` que el sistema deriva HOY -- nunca contra otro
+   * campo, y nunca se reinterpreta a un tipo cerrado acá. */
+  estadoRegistrado: string | null;
 
   issues: ParseIssue[];
 }

--- a/src/utils/ordenarAnimalesHato.ts
+++ b/src/utils/ordenarAnimalesHato.ts
@@ -19,8 +19,9 @@
 
 import { chipEstadoReproductivo } from './hatoUi';
 import type { AnimalHatoDerivado } from '@/components/hato/hooks/useHatoAnimales';
+import { proximoEventoHato } from '@/utils/hato/listaHato';
 
-export type ColumnaOrdenableAnimales = 'numero' | 'nombre' | 'estado' | 'pl' | 'proximo';
+export type ColumnaOrdenableAnimales = 'numero' | 'nombre' | 'edad' | 'partos' | 'ultimaCria' | 'estado' | 'pl' | 'proximo';
 export type DireccionOrdenAnimales = 'asc' | 'desc';
 
 /** Comparador base compartido: numéricas por valor, texto por
@@ -48,23 +49,42 @@ export function ordenarPorValor<T>(
 /** Fecha objetivo cruda (ISO) del "próximo evento" -- SOLO para ordenar por
  * fecha real, nunca por el texto ya formateado ("Parto: ..."/"Secar:
  * ..."), que mezclaría los dos tipos de evento alfabéticamente en vez de
- * cronológicamente. */
-function proximoEventoFecha(animal: AnimalHatoDerivado): string | null {
-  return animal.derivado.fecha_probable_parto ?? animal.derivado.fecha_secar ?? null;
+ * cronológicamente.
+ *
+ * Sale del MISMO `proximoEventoHato` que pinta la celda (N19): si el orden
+ * usara su propio criterio, la tabla mostraría un hito y ordenaría por otro.
+ * Un hito sin fecha (rechequeo, servir) ordena como ausente -- al final en
+ * ambas direcciones, igual que cualquier otro `null`. */
+function proximoEventoFecha(animal: AnimalHatoDerivado, hoyISO: string): string | null {
+  return proximoEventoHato({ derivado: animal.derivado }, hoyISO)?.fecha ?? null;
 }
 
-const EXTRACTORES: Record<ColumnaOrdenableAnimales, (a: AnimalHatoDerivado) => string | number | null> = {
+const EXTRACTORES: Record<
+  ColumnaOrdenableAnimales,
+  (a: AnimalHatoDerivado, hoyISO: string) => string | number | null
+> = {
   numero: (a) => a.numero,
   nombre: (a) => a.nombre,
+  // Se ordena por FECHA DE NACIMIENTO, no por la edad calculada: son
+  // monótonas inversas la una de la otra, y la fecha no arrastra el
+  // redondeo a un decimal (dos animales nacidos con días de diferencia
+  // empatarían en 3,4 años y se ordenarían por azar). El signo se invierte
+  // para que "asc" signifique lo que el usuario espera al pulsar "Edad":
+  // de la más joven a la más vieja.
+  edad: (a) => (a.fechaNacimiento ? -Date.parse(`${a.fechaNacimiento}T00:00:00Z`) : null),
+  partos: (a) => a.numPartos,
+  ultimaCria: (a) => a.ultimoPartoFecha,
   estado: (a) => chipEstadoReproductivo(a.derivado.estado).label,
   pl: (a) => a.pl,
-  proximo: (a) => proximoEventoFecha(a),
+  proximo: (a, hoyISO) => proximoEventoFecha(a, hoyISO),
 };
 
 export function ordenarAnimalesHato(
   animales: AnimalHatoDerivado[],
   columna: ColumnaOrdenableAnimales,
   direccion: DireccionOrdenAnimales,
+  hoyISO: string,
 ): AnimalHatoDerivado[] {
-  return ordenarPorValor(animales, EXTRACTORES[columna], direccion);
+  const extractor = EXTRACTORES[columna];
+  return ordenarPorValor(animales, (a) => extractor(a, hoyISO), direccion);
 }

--- a/src/utils/telegramAlertas.ts
+++ b/src/utils/telegramAlertas.ts
@@ -1,0 +1,167 @@
+// Lógica pura de suscripción a alertas por usuario de Telegram.
+// Extraído para testabilidad — mismo patrón que telegramUsuarios.ts.
+//
+// El catálogo de alertas (`alertas_catalogo`) vive en base de datos y hoy
+// solo tiene filas del módulo `hato`; mañana tendrá `aguacate` y `ganado`
+// sin que este archivo cambie. Nada aquí asume una lista fija de módulos o
+// de claves de alerta — todo se deriva de las filas que llegan del catálogo.
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export interface AlertaCatalogoRow {
+  clave: string;
+  modulo: string;
+  nombre: string;
+  descripcion: string | null;
+  orden: number;
+  activo: boolean;
+}
+
+export interface AlertaSuscripcionRow {
+  telegram_usuario_id: string;
+  alerta_clave: string;
+  recibe: boolean;
+  escalamiento: boolean;
+}
+
+export interface AlertaModuloGrupo {
+  modulo: string;
+  label: string;
+  alertas: AlertaCatalogoRow[];
+}
+
+/** Estado de edición en el modal: clave de alerta -> casillas marcadas. */
+export type SuscripcionEstado = Record<string, { recibe: boolean; escalamiento: boolean }>;
+
+export interface ResumenSuscripciones {
+  recibe: number;
+  escalamiento: number;
+}
+
+// ---------------------------------------------------------------------------
+// Etiquetas de módulo
+// ---------------------------------------------------------------------------
+
+// Solo para presentación — no restringe qué módulos puede traer el catálogo.
+// Un módulo que no está aquí (p. ej. uno nuevo agregado en base de datos) cae
+// al fallback de capitalizar la clave, nunca revienta ni se oculta.
+const MODULO_LABELS: Record<string, string> = {
+  hato: 'Hato Lechero',
+  aguacate: 'Aguacate',
+  ganado: 'Ganado',
+};
+
+export function labelModulo(modulo: string): string {
+  const conocida = MODULO_LABELS[modulo];
+  if (conocida) return conocida;
+  if (!modulo) return modulo;
+  return modulo.charAt(0).toUpperCase() + modulo.slice(1);
+}
+
+// ---------------------------------------------------------------------------
+// Agrupación del catálogo
+// ---------------------------------------------------------------------------
+
+export function agruparAlertasPorModulo(catalogo: AlertaCatalogoRow[]): AlertaModuloGrupo[] {
+  const porModulo = new Map<string, AlertaCatalogoRow[]>();
+
+  for (const fila of catalogo) {
+    if (fila.activo === false) continue;
+    const lista = porModulo.get(fila.modulo);
+    if (lista) {
+      lista.push(fila);
+    } else {
+      porModulo.set(fila.modulo, [fila]);
+    }
+  }
+
+  const grupos: AlertaModuloGrupo[] = Array.from(porModulo.entries()).map(([modulo, alertas]) => ({
+    modulo,
+    label: labelModulo(modulo),
+    alertas: [...alertas].sort((a, b) => a.orden - b.orden),
+  }));
+
+  grupos.sort((a, b) => {
+    const ordenA = a.alertas[0]?.orden ?? 0;
+    const ordenB = b.alertas[0]?.orden ?? 0;
+    if (ordenA !== ordenB) return ordenA - ordenB;
+    return a.modulo.localeCompare(b.modulo);
+  });
+
+  return grupos;
+}
+
+// ---------------------------------------------------------------------------
+// Estado de edición
+// ---------------------------------------------------------------------------
+
+export function construirEstadoDesdeSuscripciones(subs: AlertaSuscripcionRow[]): SuscripcionEstado {
+  const estado: SuscripcionEstado = {};
+  for (const s of subs) {
+    estado[s.alerta_clave] = { recibe: !!s.recibe, escalamiento: !!s.escalamiento };
+  }
+  return estado;
+}
+
+export function alternarRecibe(estado: SuscripcionEstado, clave: string): SuscripcionEstado {
+  const actual = estado[clave] ?? { recibe: false, escalamiento: false };
+  return { ...estado, [clave]: { ...actual, recibe: !actual.recibe } };
+}
+
+export function alternarEscalamiento(estado: SuscripcionEstado, clave: string): SuscripcionEstado {
+  const actual = estado[clave] ?? { recibe: false, escalamiento: false };
+  return { ...estado, [clave]: { ...actual, escalamiento: !actual.escalamiento } };
+}
+
+// ---------------------------------------------------------------------------
+// Persistencia (construcción de filas — el upsert real vive en el componente)
+// ---------------------------------------------------------------------------
+
+/**
+ * Una fila por cada alerta del catálogo (nunca se omite una clave solo
+ * porque nunca se tocó su casilla): así "desmarcar" también se persiste, en
+ * vez de dejar en la tabla el último valor que sí se guardó.
+ */
+export function construirFilasParaGuardar(
+  usuarioId: string,
+  estado: SuscripcionEstado,
+  catalogo: AlertaCatalogoRow[],
+): AlertaSuscripcionRow[] {
+  return catalogo.map((alerta) => {
+    const actual = estado[alerta.clave] ?? { recibe: false, escalamiento: false };
+    return {
+      telegram_usuario_id: usuarioId,
+      alerta_clave: alerta.clave,
+      recibe: actual.recibe,
+      escalamiento: actual.escalamiento,
+    };
+  });
+}
+
+// ---------------------------------------------------------------------------
+// Resumen para la tabla de usuarios
+// ---------------------------------------------------------------------------
+
+export function contarSuscripcionesUsuario(
+  todas: AlertaSuscripcionRow[],
+  usuarioId: string,
+): ResumenSuscripciones {
+  let recibe = 0;
+  let escalamiento = 0;
+  for (const s of todas) {
+    if (s.telegram_usuario_id !== usuarioId) continue;
+    if (s.recibe) recibe++;
+    if (s.escalamiento) escalamiento++;
+  }
+  return { recibe, escalamiento };
+}
+
+export function formatearResumenAlertas(resumen: ResumenSuscripciones): string {
+  if (resumen.recibe === 0) {
+    return resumen.escalamiento === 0 ? 'Sin alertas' : `Sin alertas (${resumen.escalamiento} esc.)`;
+  }
+  const base = `${resumen.recibe} alerta${resumen.recibe === 1 ? '' : 's'}`;
+  return resumen.escalamiento === 0 ? base : `${base} (${resumen.escalamiento} esc.)`;
+}

--- a/supabase/functions/make-server-1ccce916/calculos-hato.ts
+++ b/supabase/functions/make-server-1ccce916/calculos-hato.ts
@@ -2143,6 +2143,55 @@ export function derivarEstadoReproductivo(
   };
 }
 
+/**
+ * Etiqueta legible de un `EstadoReproductivo`, en el vocabulario de CINCO
+ * estados de D-D (Vacía · Servida · Confirmada · Por secar · Seca) más los
+ * estados no-aplicables/terminales. Extraída de `hatoUi.ts::chipEstadoReproductivo`
+ * (S8) para que exista UNA sola fuente del TEXTO -- el color/className sigue
+ * viviendo en `hatoUi.ts` (browser-only), que ahora reusa esta función.
+ *
+ * Por qué vive acá y no solo en `hatoUi.ts`: la columna "Estado registrado"
+ * de la planilla de chequeo (D-E, docs/plan_hato_telegram_estados_agosto_2026.md
+ * N21-N23) imprime este mismo texto en el `.xlsx`/PDF (`exportarPlanillaChequeo*.ts`,
+ * browser) y el endpoint de diff (Deno, `hato-chequeo-preview.ts`) necesita
+ * calcular el MISMO texto para detectar cuándo lo impreso ya no coincide con
+ * lo que el sistema cree HOY -- y el lado Deno no puede importar `hatoUi.ts`
+ * (no es parte del trío espejado). Este archivo sí lo es, así que la etiqueta
+ * viaja gratis a los tres lados sin duplicar el vocabulario.
+ */
+export function etiquetaEstadoReproductivo(estado: EstadoReproductivo): string {
+  switch (estado) {
+    case 'preñada':
+      return 'Confirmada';
+    case 'parida_reciente':
+      return 'Vacía';
+    case 'servida':
+      return 'Servida';
+    case 'proxima_a_secar':
+      return 'Por secar';
+    case 'seca':
+      return 'Seca';
+    case 'vacia_por_servir':
+      return 'Vacía';
+    case 'novilla':
+      return 'Vacía';
+    case 'cria':
+      return 'Cría';
+    case 'indeterminado':
+      return '—';
+    case 'vendida':
+      return 'Vendida';
+    case 'muerta':
+      return 'Muerta';
+    case 'descartada':
+      return 'Descartada';
+    default: {
+      const _exhaustivo: never = estado;
+      return String(_exhaustivo);
+    }
+  }
+}
+
 // ============================================================================
 // BLOQUE 5 — PL / productividad
 // ============================================================================

--- a/supabase/functions/make-server-1ccce916/calculos-hato.ts
+++ b/supabase/functions/make-server-1ccce916/calculos-hato.ts
@@ -1639,9 +1639,31 @@ export function derivarSexoCria(input: InputSexoCria): SexoCria | null {
 // BLOQUE 4 — Derivación de estado reproductivo (v_hato_estado_actual + config)
 // ============================================================================
 
-/** Subconjunto de columnas de `v_hato_estado_actual` (migración 056) que
- * este motor consume. La vista expone solo hechos -- todo el cálculo de
- * fechas/umbrales vive aquí, nunca en la vista (plan §7.1, brief S1 Decisión 3). */
+/** Evidencia detrás de una confirmación de preñez (`hato_eventos.datos.metodo`,
+ * escrito por `hatoCicloManual.ts` desde S3). Es la ÚNICA diferencia entre
+ * los estados "servida" y "confirmada" de D-D. */
+export type MetodoConfirmacionPrenez = 'presuncion' | 'palpacion';
+
+/** Motivo por el que una vaca necesita revisión humana, para la columna de
+ * señales de la lista del hato (D-D, 2026-08-13: "el estado ya no absorbe
+ * aborto/indeterminado — eso vive en una columna de alertas aparte que dice
+ * qué pasó"). Nunca se mezcla con `estado`: el estado dice en qué punto del
+ * ciclo está la vaca, la señal dice por qué ese dato puede no ser confiable.
+ *
+ * - `aborto`: el evento más reciente del animal es un aborto. El estado SÍ
+ *   se conoce (queda vacía) -- la señal solo explica el porqué.
+ * - `evento_posterior`: hay un evento más nuevo que los 4 que este motor
+ *   sabe clasificar y NO es un aborto (celo, rechequeo, compra,
+ *   cambio_etapa...). Ahí el estado es genuinamente desconocido. */
+export interface SenalRevisionHato {
+  tipo: 'aborto' | 'evento_posterior';
+  fecha: string;
+}
+
+/** Subconjunto de columnas de `v_hato_estado_actual` (migración 056, ampliada
+ * por 062/089/092/094) que este motor consume. La vista expone solo hechos --
+ * todo el cálculo de fechas/umbrales vive aquí, nunca en la vista
+ * (plan §7.1, brief S1 Decisión 3). */
 export interface EstadoActualHatoRow {
   etapa: 'ternera' | 'novilla' | 'vaca' | 'toro';
   raza: string | null;
@@ -1659,6 +1681,21 @@ export interface EstadoActualHatoRow {
    * o muerte, no se proyecta un ciclo de preñez activo con datos que ese
    * evento puede haber invalidado -- ver `derivarEstadoReproductivo`. */
   ultimo_evento_fecha: string | null;
+  /** `datos->>'metodo'` del ÚLTIMO `confirmacion_prenez` (columna de la
+   * vista desde la migración 094). Decisión del dueño D-D (2026-08-13):
+   * "servida = preñada por presunción, confirmada = palpada", así que este
+   * campo es lo único que separa dos estados distintos a partir del MISMO
+   * tipo de evento. `null` = confirmación sin método registrado
+   * (importación histórica o marca anterior a S3) y se trata como
+   * PRESUNCIÓN: afirmar que un veterinario palpó sin evidencia es la única
+   * lectura de las dos que no se puede deshacer. */
+  ultima_confirmacion_prenez_metodo: MetodoConfirmacionPrenez | null;
+  /** MAX(fecha) de los eventos `aborto` del animal (columna de la vista
+   * desde la migración 094). Permite tipificar el caso que antes caía en
+   * `indeterminado` sin explicación: tras un aborto la vaca está VACÍA (eso
+   * es un hecho biológico, no una suposición) y el motivo viaja en
+   * `senal_revision`, no disfrazado dentro del `estado`. */
+  ultimo_aborto_fecha: string | null;
   /** `tipo` de `parseEstado` sobre el `ESTADO`/`OBS` del último chequeo
    * cerrado (`'vacia_apta' | 'vacia_problema' | 'fecha_heredada' |
    * 'desconocido' | 'vacio'`), o `null` si no hay ninguna señal disponible
@@ -1726,6 +1763,14 @@ export interface EstadoReproductivoDerivado {
    * no hay ninguna señal disponible -- nunca se adivina.
    */
   vacia_es_problema: boolean | null;
+  /**
+   * Motivo por el que este animal necesita una mirada humana (D-D). `null`
+   * = nada que revisar. Es información SEPARADA de `estado` a propósito: el
+   * vocabulario de 5 estados del dueño (vacía · servida · confirmada · por
+   * secar · seca) describe el punto del ciclo, y meter "abortó" o "hay algo
+   * raro" dentro de esa lista obligaría a mentir en uno de los dos ejes.
+   */
+  senal_revision: SenalRevisionHato | null;
   alertas: AlertasReproductivas;
 }
 
@@ -1792,6 +1837,22 @@ function clasificarVaciaProblema(
 }
 
 /**
+ * D-D (dueño, 2026-08-13): una confirmación de preñez vale como `preñada`
+ * (etiqueta "Confirmada") SOLO si viene de una palpación. Una confirmación
+ * por presunción deja a la vaca en `servida` -- que es exactamente lo que
+ * el dueño quiso decir con "servida = preñada por presunción".
+ *
+ * `null` (confirmación sin método: importación histórica o marca anterior a
+ * S3) se lee como presunción. Es la asimetría deliberada: dar por palpada
+ * una vaca que nadie palpó lleva a secarla y dejar de ordeñarla con datos
+ * que nadie verificó; el error contrario solo hace que se la vuelva a
+ * revisar.
+ */
+function estadoDeConfirmacion(fila: EstadoActualHatoRow): EstadoReproductivo {
+  return fila.ultima_confirmacion_prenez_metodo === 'palpacion' ? 'preñada' : 'servida';
+}
+
+/**
  * Deriva el estado reproductivo actual de un animal y las 4 alertas de
  * §7.3 (secado_due, rechequeo_due, servicio_sin_confirmacion, parto_proximo)
  * a partir de los hechos de `v_hato_estado_actual` + `HatoConfig`. Todos los
@@ -1830,6 +1891,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: false,
       vacia_es_problema: null,
+      senal_revision: null,
       alertas: SIN_ALERTAS,
     };
   }
@@ -1846,6 +1908,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
       vacia_es_problema: null,
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1888,6 +1951,7 @@ export function derivarEstadoReproductivo(
       // Una novilla nunca ha entrado al ciclo reproductivo: la pregunta
       // "¿normal o problema?" no aplica todavía.
       vacia_es_problema: esNovilla ? null : clasificarVaciaProblema(fila.ultimo_estado_chequeo, null, config),
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1898,26 +1962,44 @@ export function derivarEstadoReproductivo(
   });
   const masReciente = candidatos[0].tipo;
 
-  // Salvaguarda: `v_hato_estado_actual` no expone una columna dedicada de
-  // "último aborto" (a diferencia de parto/secado_real/confirmación), pero sí
-  // `ultimo_evento_fecha` (MAX sobre TODO `hato_eventos`, cualquier tipo). Si
-  // hay un evento más reciente que el más nuevo de los 4 que sí sabemos
-  // clasificar, algo pasó que este motor no puede tipificar aquí -- casi
-  // siempre un aborto, venta o muerte -- y proyectar SECAR/PP desde el
-  // servicio viejo sería exactamente el error real encontrado (QA, MONA:
-  // SX='aborto' con SECAR/PP de la fila cruda todavía "vigentes" en la
-  // planilla). Nunca se asume que el ciclo sigue activo cuando hay una señal
-  // de que no es así, aunque no se sepa de qué tipo es.
+  // Salvaguarda: `ultimo_evento_fecha` es MAX sobre TODO `hato_eventos`
+  // (cualquier tipo). Si hay un evento más reciente que el más nuevo de los 4
+  // que este motor sabe clasificar, algo pasó que invalida el ciclo -- y
+  // proyectar SECAR/PP desde el servicio viejo sería exactamente el error
+  // real encontrado (QA, MONA: SX='aborto' con SECAR/PP de la fila cruda
+  // todavía "vigentes" en la planilla). Nunca se asume que el ciclo sigue
+  // activo cuando hay una señal de que no es así.
+  //
+  // Desde la migración 094 esa señal se puede TIPIFICAR en el caso más
+  // frecuente. Si el evento más nuevo es un aborto, el estado no es
+  // desconocido: la vaca quedó VACÍA -- eso es un hecho biológico, no una
+  // suposición -- y el motivo viaja en `senal_revision`, que es justamente
+  // lo que pide D-D ("el estado ya no absorbe aborto/indeterminado"). Solo
+  // cuando el evento posterior NO es un aborto (celo, rechequeo, compra,
+  // cambio_etapa...) el estado sigue siendo genuinamente `indeterminado`.
   if (fila.ultimo_evento_fecha && fila.ultimo_evento_fecha > candidatos[0].fecha) {
+    const esAborto = fila.ultimo_aborto_fecha === fila.ultimo_evento_fecha;
     return {
-      estado: 'indeterminado',
+      estado: esAborto ? 'vacia_por_servir' : 'indeterminado',
       fecha_secar: null,
       fecha_probable_parto: null,
+      // `dias_abiertos` cuenta desde el ÚLTIMO PARTO, no desde cualquier fin
+      // de gestación: un aborto no es un parto y no ancla ese contador.
+      // Queda `null` -- nunca un número inventado desde otra fecha.
       dias_abiertos: null,
       tiempo_prenez_dias: null,
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
-      vacia_es_problema: null,
+      // Tras un aborto la vaca está vacía y la pregunta "¿normal o
+      // problema?" sí aplica -- pero sin ancla de tiempo utilizable (ver
+      // arriba) solo puede responderla la señal explícita del chequeo.
+      vacia_es_problema: esAborto
+        ? clasificarVaciaProblema(fila.ultimo_estado_chequeo, null, config)
+        : null,
+      senal_revision: {
+        tipo: esAborto ? 'aborto' : 'evento_posterior',
+        fecha: fila.ultimo_evento_fecha,
+      },
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1937,6 +2019,7 @@ export function derivarEstadoReproductivo(
       tiempo_secada_dias: null,
       proxima_a_reemplazo: proximaAReemplazo,
       vacia_es_problema: clasificarVaciaProblema(fila.ultimo_estado_chequeo, diasAbiertos, config),
+      senal_revision: null,
       alertas: { ...SIN_ALERTAS, rechequeo_due: rechequeoDue },
     };
   }
@@ -1953,7 +2036,8 @@ export function derivarEstadoReproductivo(
     // inventada -- pero el ESTADO real (`seca`/`preñada`) sí se conoce y se
     // devuelve. `tiempo_secada_dias` sí se puede calcular en `seca` porque
     // `ultimo_secado_real_fecha` es un dato real, no una proyección.
-    const estadoSinAncla: EstadoReproductivo = masReciente === 'secado_real' ? 'seca' : 'preñada';
+    const estadoSinAncla: EstadoReproductivo =
+      masReciente === 'secado_real' ? 'seca' : estadoDeConfirmacion(fila);
     const tiempoSecadaDiasSinAncla =
       estadoSinAncla === 'seca' && fila.ultimo_secado_real_fecha
         ? diferenciaDias(fila.ultimo_secado_real_fecha, fechaReferencia)
@@ -1970,6 +2054,7 @@ export function derivarEstadoReproductivo(
       // pregunta "¿normal o problema?" no aplica aquí, igual que en la rama
       // con ancla más abajo.
       vacia_es_problema: null,
+      senal_revision: null,
       // Sin ancla no hay `fecha_secar` que comparar, así que `secado_due` y
       // `parto_proximo` quedan en `false` (SIN_ALERTAS) -- no hay fecha
       // basura contra la que compararlas. `hatoAlertas.ts` además exige
@@ -2004,7 +2089,7 @@ export function derivarEstadoReproductivo(
   } else if (dentroVentanaSecar || secadoDue) {
     estado = 'proxima_a_secar';
   } else if (masReciente === 'confirmacion') {
-    estado = 'preñada';
+    estado = estadoDeConfirmacion(fila);
   } else {
     estado = 'servida';
   }
@@ -2048,6 +2133,7 @@ export function derivarEstadoReproductivo(
     // "servicios repetidos sin concepción" ya lo cubre la alerta
     // `servicio_sin_confirmacion` de arriba, sin necesidad de duplicarlo.
     vacia_es_problema: null,
+    senal_revision: null,
     alertas: {
       secado_due: secadoDue,
       rechequeo_due: rechequeoDue,

--- a/supabase/functions/make-server-1ccce916/hato-alertas-tick.ts
+++ b/supabase/functions/make-server-1ccce916/hato-alertas-tick.ts
@@ -29,21 +29,39 @@
 //                    `.upsert(..., { onConflict: 'regla_clave', ignoreDuplicates: true })`
 //                    -- el `ON CONFLICT ... DO NOTHING` real, PostgREST no
 //                    tiene otra forma de expresarlo.
-//   (b) Despachar -- para cada alerta activa (`pendiente`/`enviada`) cuyo
-//                    `tipo` está `activo` en `hato_alertas_config` Y tiene
-//                    `destinatario_telegram_id` configurado: primer envío
-//                    incondicional si `pendiente`; reenvío solo si
-//                    `debeReenviar(...)` (≥48h desde el último intento,
-//                    <3 intentos) si ya estaba `enviada`. Sin destinatario
-//                    configurado -> se deja `pendiente`, CERO mensajes
-//                    salientes -- este es el default "modo sombra" (el seed
-//                    de 056 no trae ningún destinatario): desplegar este
-//                    endpoint no dispara nada hasta que alguien configure
-//                    `hato_alertas_config` a mano.
+//   (b) Despachar -- BROADCAST (migración 096, 2026-08-14): para cada alerta
+//                    activa (`pendiente`/`enviada`) cuyo `tipo` está `activo`
+//                    en `hato_alertas_config`, se resuelve la lista de
+//                    suscritos con `recibe=true` para esa clave
+//                    (`telegram_alertas_suscripciones`, join
+//                    `telegram_usuarios` activos) y se manda UN mensaje POR
+//                    SUSCRITO -- no una alerta por persona, una sola alerta
+//                    que le llega a todos. Primer envío incondicional si
+//                    `pendiente`; reenvío (a la MISMA lista de suscritos)
+//                    solo si `debeReenviar(...)` (≥48h desde el último
+//                    intento, <3 intentos) si ya estaba `enviada` -- el
+//                    umbral de reenvío sigue siendo por ALERTA, no por
+//                    persona, mismo mecanismo de antes. Sin ningún suscrito
+//                    con `recibe=true` para esa clave -> se deja `pendiente`,
+//                    CERO mensajes salientes (mismo "modo sombra" de antes,
+//                    ahora gobernado por la tabla de suscripciones en vez de
+//                    `hato_alertas_config.destinatario_telegram_id`, que esta
+//                    fase YA NO LEE -- ver migración 096). Cada envío exitoso
+//                    se registra en `hato_alertas_envios` (alerta_id,
+//                    telegram_id, message_id) -- es lo que permite cerrar la
+//                    alerta para TODOS cuando el primero responde (ver
+//                    `telegram/bot.ts`).
 //   (c) Escalar/expirar -- `decidirAccionEscalamiento` sobre las alertas que
 //                    siguen activas tras (b). Telegram no permite
 //                    `editMessageText` pasadas 48h -- el escalamiento SIEMPRE
-//                    manda un mensaje NUEVO (nunca edita el original).
+//                    manda un mensaje NUEVO (nunca edita el original). El
+//                    escalamiento (096) también es broadcast: va a TODOS los
+//                    suscritos con `escalamiento=true` para esa clave, no a
+//                    la variable de entorno `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID`
+//                    (esa variable queda SIN USO por este handler desde
+//                    096 -- no se borra del entorno, ver CLAUDE.md). Sin
+//                    ningún suscrito con `escalamiento=true` -> se marca
+//                    `escalada` sin mandar nada, mismo contrato de antes.
 //
 // Nota de diseño (I/O, no cambia el motor puro): `hato_alertas` (migración
 // 056) no tiene una columna dedicada para "cuándo se envió por primera vez"
@@ -53,25 +71,25 @@
 // umbral de escalamiento sería incorrecto: cada reenvío correría el reloj de
 // escalamiento hacia adelante, retrasándolo exactamente cuando más urge (una
 // alerta que ya se reenvió varias veces sin respuesta). En vez de agregar
-// una columna nueva (fuera del alcance de esta sesión -- "no new migrations
-// needed"), el instante del primer envío se guarda dentro de la columna
-// `datos JSONB` ya existente (`datos.enviada_en`), que SÍ sobrevive
+// una columna nueva, el instante del primer envío se guarda dentro de la
+// columna `datos JSONB` ya existente (`datos.enviada_en`), que SÍ sobrevive
 // intacta a los reenvíos porque este handler nunca la sobreescribe una vez
 // puesta. `updated_at` sigue siendo la fuente correcta para "último intento"
 // (resend policy), porque ese valor SÍ debe correrse con cada intento -- es
 // exactamente lo que esa política mide.
 //
-// Recipiente de escalamiento: `hato_alertas_config` (migración 056) solo
-// declara UN destinatario por tipo -- no hay una columna separada para "a
-// quién escalar" (Martha) vs. "a quién se le manda primero" (Fernando,
-// habilitado por tipo tras el segundo checkpoint de confianza del plan §8).
-// Agregar esa columna sería un cambio de esquema fuera del alcance de esta
-// sesión. Solución sin migración: variable de entorno opcional
-// `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` (secreto de edge function, mismo
-// mecanismo que `HATO_ALERTAS_TICK_SECRET`). Si no está configurada, el
-// contrato explícito del plan aplica ("si no hay destinatario configurado,
-// solo se marca escalada"): se marca `escalada` sin enviar nada. Contar como
-// hallazgo a validar con el dueño -- ver el reporte de la sesión.
+// `hato_alertas.destinatario_telegram_id` (columna singular, existe desde
+// 056) sobrevive con un significado DISTINTO desde 096: ya no es "el único
+// destinatario" (el broadcast no tiene uno), es "a quién se le envió
+// primero" -- este handler la fija UNA sola vez, en el primer envío exitoso,
+// y nunca la vuelve a tocar (ni en reenvíos ni en despachos posteriores a
+// nuevos suscritos). Se conserva en vez de borrarse porque hay historia
+// real detrás (todas las filas hasta hoy la tienen puesta) -- decisión de
+// esta sesión, documentada en el reporte que acompaña la migración 096.
+// `hato_alertas_config.destinatario_telegram_id` (la columna singular de la
+// tabla de CONFIGURACIÓN, no de esta) queda VESTIGIAL desde el mismo cambio
+// -- este handler ya no la lee en absoluto (fase b/c de abajo), aunque la
+// columna sigue en la tabla (096 no la borra).
 //
 // I/O puro en este archivo: parseo/auth, consultas a Supabase, llamadas a
 // Telegram. Toda la lógica de negocio vive en el módulo puro `hatoAlertas.ts`
@@ -84,14 +102,21 @@ import {
   debeReenviar,
   decidirAccionEscalamiento,
   decidirExpiracionTerminal,
+  claveAlertaCatalogo,
+  agruparSuscriptoresPorClave,
   type AnimalHatoParaAlertas,
   type PasoTratamientoPendienteInput,
   type AlertaGenerada,
   type TipoAlertaHato,
   type EstadoAlertaHato,
+  type FilaSuscripcionAlerta,
 } from './hato-alertas.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
 import { enviarMensajeTelegram } from './telegram/enviar.ts';
+
+/** Módulo de este handler dentro de `alertas_catalogo` -- única fuente de
+ * la constante `'hato'` en todo el archivo (migración 096, `clave = modulo.tipo`). */
+const MODULO_ALERTAS = 'hato';
 
 function respuestaError(c: Context, status: 400 | 500 | 503, error: string) {
   return c.json({ success: false, error }, status);
@@ -124,9 +149,35 @@ function verificarSecretoTick(c: Context): Response | null {
 
 interface FilaAlertaConfig {
   tipo: TipoAlertaHato;
-  destinatario_telegram_id: string | null;
   horas_escalamiento: number;
   activo: boolean;
+}
+
+/** Fila cruda de `telegram_alertas_suscripciones` JOIN `telegram_usuarios`
+ * (migración 096) -- el embed de PostgREST puede venir como objeto o como
+ * array de un elemento según la versión del cliente, de ahí el `Array.isArray`
+ * en `resolverFilasSuscripcion`. Solo se listan suscritos ACTIVOS: la
+ * consulta filtra `telegram_usuarios.activo = true`. */
+interface FilaSuscripcionCruda {
+  alerta_clave: string;
+  recibe: boolean;
+  escalamiento: boolean;
+  telegram_usuarios: { telegram_id: number } | { telegram_id: number }[] | null;
+}
+
+function resolverFilasSuscripcion(filas: FilaSuscripcionCruda[]): FilaSuscripcionAlerta[] {
+  return filas
+    .map((f) => {
+      const usuario = Array.isArray(f.telegram_usuarios) ? f.telegram_usuarios[0] : f.telegram_usuarios;
+      if (usuario == null) return null;
+      return {
+        alerta_clave: f.alerta_clave,
+        recibe: f.recibe,
+        escalamiento: f.escalamiento,
+        telegram_id: String(usuario.telegram_id),
+      };
+    })
+    .filter((f): f is FilaSuscripcionAlerta => f !== null);
 }
 
 interface FilaAlertaActiva {
@@ -181,15 +232,33 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
   }
 
-  // --- hato_alertas_config -- destinatario/activo/horas por tipo ------
+  // --- hato_alertas_config -- activo/horas por tipo. Ya NO se lee
+  //     `destinatario_telegram_id` de aquí (096) -- los destinatarios salen
+  //     de `telegram_alertas_suscripciones`, abajo. La columna sigue en la
+  //     tabla (vestigial, ver cabecera del archivo). --------------------
   const { data: filasAlertasConfig, error: errorAlertasConfig } = await supabase
     .from('hato_alertas_config')
-    .select('tipo, destinatario_telegram_id, horas_escalamiento, activo');
+    .select('tipo, horas_escalamiento, activo');
   if (errorAlertasConfig) {
     return respuestaError(c, 500, `No se pudo leer hato_alertas_config: ${errorAlertasConfig.message}`);
   }
   const configPorTipo = new Map<TipoAlertaHato, FilaAlertaConfig>(
     ((filasAlertasConfig ?? []) as FilaAlertaConfig[]).map((f) => [f.tipo, f]),
+  );
+
+  // --- telegram_alertas_suscripciones -- quién recibe / quién escala, por
+  //     clave (`modulo.tipo`, migración 096). Solo suscritos ACTIVOS en
+  //     telegram_usuarios -- uno desactivado no debe recibir ni escalar
+  //     aunque su fila de suscripción siga con recibe/escalamiento=true. ---
+  const { data: filasSuscripcionesCrudas, error: errorSuscripciones } = await supabase
+    .from('telegram_alertas_suscripciones')
+    .select('alerta_clave, recibe, escalamiento, telegram_usuarios!inner(telegram_id, activo)')
+    .eq('telegram_usuarios.activo', true);
+  if (errorSuscripciones) {
+    return respuestaError(c, 500, `No se pudieron leer las suscripciones de alertas: ${errorSuscripciones.message}`);
+  }
+  const suscriptoresPorClave = agruparSuscriptoresPorClave(
+    resolverFilasSuscripcion((filasSuscripcionesCrudas ?? []) as FilaSuscripcionCruda[]),
   );
 
   // =========================================================================
@@ -284,12 +353,23 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
   }
   const activas = (filasActivas ?? []) as FilaAlertaActiva[];
 
-  let enviadas = 0;
+  let enviadas = 0; // # de ALERTAS con al menos un envío exitoso en este tick
+  let mensajesEnviados = 0; // # de mensajes de Telegram individuales enviados (broadcast)
   let saltadasSinDestinatario = 0;
 
   for (const alerta of activas) {
     const config = configPorTipo.get(alerta.tipo);
-    if (!config || !config.activo || !config.destinatario_telegram_id) {
+    if (!config || !config.activo) {
+      saltadasSinDestinatario += 1;
+      continue;
+    }
+
+    // Broadcast (096): TODOS los suscritos con recibe=true para esta clave,
+    // no un único destinatario. `hato_alertas_config.destinatario_telegram_id`
+    // ya no se lee -- ver cabecera del archivo.
+    const clave = claveAlertaCatalogo(MODULO_ALERTAS, alerta.tipo);
+    const destinatarios = suscriptoresPorClave.get(clave)?.recibe ?? [];
+    if (destinatarios.length === 0) {
       saltadasSinDestinatario += 1;
       continue;
     }
@@ -303,28 +383,65 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     if (!debeEnviar) continue;
 
     const mensaje = (alerta.datos?.mensaje as string | undefined) ?? 'Alerta del hato lechero (sin mensaje generado).';
-    const resultado = await enviarMensajeTelegram(supabase, {
-      telegramId: config.destinatario_telegram_id,
-      texto: mensaje,
-      tipoMensaje: 'alerta_hato',
-      flujo: alerta.tipo,
-      botones: [
-        { texto: 'Sí', callbackData: `hato_alerta:${alerta.id}:si` },
-        { texto: 'Todavía no', callbackData: `hato_alerta:${alerta.id}:no` },
-        { texto: 'Otra cosa', callbackData: `hato_alerta:${alerta.id}:otro` },
-      ],
-    });
+    const botones = [
+      { texto: 'Sí', callbackData: `hato_alerta:${alerta.id}:si` },
+      { texto: 'Todavía no', callbackData: `hato_alerta:${alerta.id}:no` },
+      { texto: 'Otra cosa', callbackData: `hato_alerta:${alerta.id}:otro` },
+    ];
 
-    const datosActualizados = resultado.ok && !alerta.datos?.enviada_en
+    // Un envío por suscrito -- un fallo puntual (chat bloqueado, etc.) NO
+    // debe tumbar el envío a los demás suscritos de la misma alerta.
+    let algunEnvioOk = false;
+    let primerDestinatarioOk: string | null = null;
+    const filasEnvios: Array<{ alerta_id: string; telegram_id: string; message_id: number | null; enviado_at: string }> = [];
+
+    for (const telegramId of destinatarios) {
+      const resultado = await enviarMensajeTelegram(supabase, {
+        telegramId,
+        texto: mensaje,
+        tipoMensaje: 'alerta_hato',
+        flujo: alerta.tipo,
+        botones,
+      });
+      if (resultado.ok) {
+        algunEnvioOk = true;
+        mensajesEnviados += 1;
+        if (!primerDestinatarioOk) primerDestinatarioOk = telegramId;
+        // `message_id` es lo que permite editar este mensaje puntual cuando
+        // otro suscrito cierre la alerta (telegram/bot.ts). Un reenvío
+        // pisa la fila anterior de este mismo (alerta, telegram_id) a
+        // propósito -- el mensaje viejo ya pasó los límites de edición de
+        // Telegram (48h), el nuevo es el único editable de aquí en más.
+        filasEnvios.push({
+          alerta_id: alerta.id,
+          telegram_id: telegramId,
+          message_id: resultado.telegramMessageId ?? null,
+          enviado_at: fechaHoraReferencia,
+        });
+      }
+    }
+
+    if (filasEnvios.length > 0) {
+      const { error: errorEnvios } = await supabase
+        .from('hato_alertas_envios')
+        .upsert(filasEnvios, { onConflict: 'alerta_id,telegram_id' });
+      if (errorEnvios) {
+        console.error(`[hato-alertas-tick] no se pudieron registrar los envíos de la alerta ${alerta.id}:`, errorEnvios.message);
+      }
+    }
+
+    const datosActualizados = algunEnvioOk && !alerta.datos?.enviada_en
       ? { ...alerta.datos, enviada_en: fechaHoraReferencia }
       : alerta.datos;
 
     const { error: errorUpdate } = await supabase
       .from('hato_alertas')
       .update({
-        estado: resultado.ok ? 'enviada' : alerta.estado,
+        estado: algunEnvioOk ? 'enviada' : alerta.estado,
         intentos: alerta.intentos + 1,
-        destinatario_telegram_id: config.destinatario_telegram_id,
+        // "A quién se le envió primero" (096) -- se fija UNA sola vez, nunca
+        // se pisa en reenvíos ni en despachos a suscritos nuevos.
+        destinatario_telegram_id: alerta.destinatario_telegram_id ?? primerDestinatarioOk,
         datos: datosActualizados,
       })
       .eq('id', alerta.id);
@@ -335,22 +452,27 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
 
     // Reflejar el cambio en memoria para que la fase (c) vea el estado
     // post-despacho sin una segunda consulta a la base.
-    alerta.estado = resultado.ok ? 'enviada' : alerta.estado;
+    alerta.estado = algunEnvioOk ? 'enviada' : alerta.estado;
     alerta.intentos += 1;
     alerta.datos = datosActualizados;
     alerta.updated_at = fechaHoraReferencia;
+    alerta.destinatario_telegram_id = alerta.destinatario_telegram_id ?? primerDestinatarioOk;
 
-    if (resultado.ok) enviadas += 1;
+    if (algunEnvioOk) enviadas += 1;
   }
 
   // =========================================================================
   // (c) ESCALAR / EXPIRAR
   // =========================================================================
 
-  const telegramIdEscalamiento = Deno.env.get('HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID') || null;
+  // `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` YA NO SE LEE -- desde 096 el
+  // escalamiento es broadcast a los suscritos con escalamiento=true de cada
+  // clave (ver cabecera del archivo). La variable de entorno queda sin uso
+  // en este handler; no se borra del entorno por si algo más la necesitara.
 
   let escaladas = 0;
   let expiradas = 0;
+  let mensajesEscalamiento = 0;
 
   for (const alerta of activas) {
     const config = configPorTipo.get(alerta.tipo);
@@ -380,16 +502,26 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     }
 
     // accion === 'escalar' -- Telegram no permite editar un mensaje pasadas
-    // 48h: se manda uno NUEVO, nunca se edita el original.
-    if (telegramIdEscalamiento) {
+    // 48h: se manda uno NUEVO, nunca se edita el original. Broadcast (096):
+    // a TODOS los suscritos con escalamiento=true para esta clave, no a un
+    // único destinatario de la variable de entorno.
+    const claveEscalamiento = claveAlertaCatalogo(MODULO_ALERTAS, alerta.tipo);
+    const destinatariosEscalamiento = suscriptoresPorClave.get(claveEscalamiento)?.escalamiento ?? [];
+    if (destinatariosEscalamiento.length > 0) {
       const mensajeBase = (alerta.datos?.mensaje as string | undefined) ?? 'Alerta del hato lechero (sin mensaje generado).';
-      await enviarMensajeTelegram(supabase, {
-        telegramId: telegramIdEscalamiento,
-        texto: `⏰ Sin respuesta hace más de ${horasEscalamiento}h -- ${mensajeBase}`,
-        tipoMensaje: 'alerta_hato_escalamiento',
-        flujo: alerta.tipo,
-      });
+      for (const telegramId of destinatariosEscalamiento) {
+        const resultado = await enviarMensajeTelegram(supabase, {
+          telegramId,
+          texto: `⏰ Sin respuesta hace más de ${horasEscalamiento}h -- ${mensajeBase}`,
+          tipoMensaje: 'alerta_hato_escalamiento',
+          flujo: alerta.tipo,
+        });
+        if (resultado.ok) mensajesEscalamiento += 1;
+      }
     }
+    // Sin ningún suscrito con escalamiento=true -- se marca `escalada` sin
+    // mandar nada, mismo contrato de antes (antes: sin la variable de
+    // entorno configurada).
     const { error } = await supabase
       .from('hato_alertas')
       .update({ estado: 'escalada', escalada_at: fechaHoraReferencia })
@@ -438,9 +570,11 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
     success: true,
     fechaReferencia,
     generadas: alertasNuevas.length,
-    enviadas,
+    enviadas, // # de alertas con al menos un envío exitoso
+    mensajes_enviados: mensajesEnviados, // # de mensajes de Telegram individuales (broadcast, 096)
     saltadas_sin_destinatario: saltadasSinDestinatario,
     escaladas,
+    mensajes_escalamiento: mensajesEscalamiento,
     expiradas: expiradas + expiradasAtascadas,
     expiradas_atascadas: expiradasAtascadas,
   });

--- a/supabase/functions/make-server-1ccce916/hato-alertas-tick.ts
+++ b/supabase/functions/make-server-1ccce916/hato-alertas-tick.ts
@@ -199,7 +199,7 @@ export async function handleHatoAlertasTick(c: Context): Promise<Response> {
   const { data: filasEstado, error: errorEstado } = await supabase
     .from('v_hato_estado_actual')
     .select(
-      'animal_id, numero, nombre, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultimo_estado_chequeo',
+      'animal_id, numero, nombre, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultimo_estado_chequeo, ultima_confirmacion_prenez_metodo, ultimo_aborto_fecha',
     );
   if (errorEstado) {
     return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${errorEstado.message}`);

--- a/supabase/functions/make-server-1ccce916/hato-alertas.ts
+++ b/supabase/functions/make-server-1ccce916/hato-alertas.ts
@@ -533,3 +533,136 @@ export function decidirExpiracionTerminal(
   const ancla = alerta.escalada_at ?? alerta.updated_at;
   return diferenciaDiasIso(ancla, fechaHoraReferencia) > diasUmbral;
 }
+
+// ============================================================================
+// BLOQUE 8 — Suscripciones por usuario de Telegram (migración 096, plan
+// "Suscripciones a alertas por usuario de Telegram", 2026-08-14)
+//
+// Decisión del dueño (contrato, ver migración 096): BROADCAST con cierre por
+// el primero -- una alerta se manda a TODOS los suscritos de su tipo, y la
+// primera respuesta la cierra para todos. El escalamiento es una segunda
+// casilla POR TIPO y por persona (`telegram_alertas_suscripciones.escalamiento`)
+// -- la variable de entorno `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` deja de
+// ser la fuente de verdad (`hato-alertas-tick.ts` ya no la lee).
+//
+// Este bloque es deliberadamente GENÉRICO por módulo (`alertas_catalogo`
+// sirve a cualquiera, no solo al hato) -- `claveAlertaCatalogo`/
+// `agruparSuscriptoresPorClave` no importan nada de `calculosHato` ni saben
+// qué es una vaca. Los constructores de mensaje de "ya resuelta"/"cerrada
+// para todos" SÍ son específicos del hato porque forman parte del texto que
+// ve Fernando/Martha en el chat -- si mañana `aguacate`/`ganado` tienen su
+// propio motor de alertas, ese motor tendrá sus propios constructores de
+// mensaje (mismo criterio que ya separa `hato_alertas` de un futuro
+// `aguacate_alertas`).
+// ============================================================================
+
+/**
+ * Clave de `alertas_catalogo` para un tipo de alerta de un módulo dado
+ * (`modulo.tipo`, migración 096). Único punto que arma esa concatenación --
+ * tanto el tick (resolver destinatarios/escalamiento) como cualquier código
+ * futuro que necesite la misma clave la calculan aquí, nunca con un
+ * template string suelto en otro archivo.
+ */
+export function claveAlertaCatalogo(modulo: string, tipo: string): string {
+  return `${modulo}.${tipo}`;
+}
+
+/** Fila mínima de `telegram_alertas_suscripciones` JOIN `telegram_usuarios`
+ * que este motor necesita -- el caller (tick) ya resolvió `telegram_id`
+ * desde el embed y ya filtró `telegram_usuarios.activo = true` en la
+ * consulta (un suscrito desactivado no debe recibir ni escalar). */
+export interface FilaSuscripcionAlerta {
+  alerta_clave: string;
+  recibe: boolean;
+  escalamiento: boolean;
+  /** `telegram_usuarios.telegram_id`, como string -- mismo motivo que
+   * `OpcionesEnvioTelegram.telegramId` en `telegram/enviar.ts` (no arriesgar
+   * precisión de un `bigint` al pasar por un `number` de JS). */
+  telegram_id: string;
+}
+
+/** Destinatarios de un tipo de alerta, ya separados por las dos casillas. Un
+ * mismo `telegram_id` puede aparecer en ambas listas (recibe Y escala) o
+ * solo en una. */
+export interface SuscriptoresPorClave {
+  recibe: string[];
+  escalamiento: string[];
+}
+
+/**
+ * Agrupa las filas de suscripción (ya resueltas a `telegram_id`, JOIN hecho
+ * por el caller) por `alerta_clave`, separando quién recibe el envío normal
+ * de quién recibe el escalamiento. Pura -- ninguna llamada a Supabase ni a
+ * Telegram aquí, eso vive en `hato-alertas-tick.ts` (I/O).
+ */
+export function agruparSuscriptoresPorClave(filas: FilaSuscripcionAlerta[]): Map<string, SuscriptoresPorClave> {
+  const mapa = new Map<string, SuscriptoresPorClave>();
+  for (const fila of filas) {
+    let entrada = mapa.get(fila.alerta_clave);
+    if (!entrada) {
+      entrada = { recibe: [], escalamiento: [] };
+      mapa.set(fila.alerta_clave, entrada);
+    }
+    if (fila.recibe) entrada.recibe.push(fila.telegram_id);
+    if (fila.escalamiento) entrada.escalamiento.push(fila.telegram_id);
+  }
+  return mapa;
+}
+
+// ----------------------------------------------------------------------------
+// Mensajes de cierre (callback `hato_alerta:{id}:{si|no|otro}` en
+// `telegram/bot.ts`) -- broadcast con cierre por el primero.
+// ----------------------------------------------------------------------------
+
+/** Texto corto de cada respuesta posible, para componer los mensajes de
+ * cierre -- una sola definición, reutilizada por los dos constructores de
+ * abajo (antes había un riesgo real de que "Todavía no" se escribiera
+ * distinto en dos lugares). */
+export function etiquetaRespuestaAlerta(respuesta: 'si' | 'no' | 'otro'): string {
+  switch (respuesta) {
+    case 'si':
+      return 'Sí';
+    case 'no':
+      return 'Todavía no';
+    case 'otro':
+      return 'Otra cosa';
+    default: {
+      const _exhaustivo: never = respuesta;
+      return _exhaustivo;
+    }
+  }
+}
+
+/**
+ * Mensaje que reemplaza el de un suscrito que llega TARDE a responder una
+ * alerta que otro suscrito ya cerró (broadcast, cierre por el primero) --
+ * tanto para el popup de `answerCallbackQuery` de quien toca el botón dos
+ * veces como para editar el mensaje de los demás suscritos cuando alguno de
+ * ellos SÍ fue el primero. "Amablemente", no un error -- es el
+ * comportamiento esperado del diseño, no una falla.
+ */
+export function construirMensajeAlertaYaResuelta(
+  estado: EstadoAlertaHato,
+  respondidaPor: string | null,
+  respuesta: 'si' | 'no' | 'otro' | null,
+): string {
+  if (respondidaPor && respuesta) {
+    return `Esta alerta ya fue resuelta por ${respondidaPor} (respuesta: "${etiquetaRespuestaAlerta(respuesta)}"). No quedó nada más por hacer.`;
+  }
+  return `Esta alerta ya no está activa (estado: ${estado}).`;
+}
+
+/**
+ * Texto con el que se edita el mensaje de CADA suscrito al que se le envió
+ * la alerta (vía `hato_alertas_envios.message_id`), una vez que uno de ellos
+ * la cierra -- así todos ven que ya se resolvió y por quién, sin tener que
+ * abrir la app. `mensajeOriginal` es el mismo texto que ya recibieron (se
+ * conserva, no se reemplaza, para no perder el contexto de la alerta).
+ */
+export function construirMensajeCierreAlertaBroadcast(
+  mensajeOriginal: string,
+  respondidaPor: string,
+  respuesta: 'si' | 'no' | 'otro',
+): string {
+  return `✅ Resuelto por ${respondidaPor}: "${etiquetaRespuestaAlerta(respuesta)}"\n\n${mensajeOriginal}`;
+}

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-commit.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-commit.ts
@@ -50,6 +50,8 @@ import {
   construirPayloadCommit,
   seleccionarUltimaCriaAnteriorPorAnimal,
   seleccionarFechasServicioConocidasPorAnimal,
+  fusionarEventosManualesEnDedupe,
+  type EventoManualHistorico,
   type FilaUltimaCriaHistorico,
 } from './importHato/commitChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
@@ -283,7 +285,39 @@ export async function handleHatoChequeoCommit(c: Context): Promise<Response> {
   // trae `fechaServicio` por fila (ver `FilaChequeoVacaHistorico`), sin una
   // consulta adicional. Ver `derivarEventosDeChequeo`/`descomponerSX` para el
   // bug real que corrige (CAMILA #154).
-  const fechasServicioConocidasPorAnimal = seleccionarFechasServicioConocidasPorAnimal(historico, chequeo.fecha);
+  const fechasServicioBase = seleccionarFechasServicioConocidasPorAnimal(historico, chequeo.fecha);
+
+  // N10 -- Eventos registrados A MANO (`chequeo_vaca_id IS NULL`): la monta
+  // que Fernando marcó por Telegram el 10, el parto que Martha marcó en la
+  // Hoja de Vida. NO están en `hato_chequeo_vacas`, así que sin esta consulta
+  // los dos mapas de deduplicación de arriba no los ven y el chequeo emite un
+  // SEGUNDO evento para el mismo hecho -- la forma exacta del bug que costó
+  // tres rondas de limpieza en julio de 2026.
+  let eventosManuales: EventoManualHistorico[] = [];
+  if (animalIds.length > 0) {
+    const { data, error } = await supabase
+      .from('hato_eventos')
+      .select('animal_id, tipo, fecha')
+      .in('animal_id', animalIds)
+      .in('tipo', ['servicio', 'parto'])
+      .is('chequeo_vaca_id', null)
+      .lt('fecha', chequeo.fecha);
+    if (error) return respuestaError(c, 500, { error: `No se pudo leer hato_eventos: ${error.message}` });
+    eventosManuales = (data ?? []).map((fila: Record<string, unknown>) => ({
+      animalId: fila.animal_id as string,
+      tipo: fila.tipo as string,
+      fecha: fila.fecha as string,
+    }));
+  }
+
+  const fusionado = fusionarEventosManualesEnDedupe(
+    fechasServicioBase,
+    ultimaCriaAnteriorPorAnimal,
+    eventosManuales,
+    chequeo.fecha,
+  );
+  const fechasServicioConocidasPorAnimal = fusionado.fechasServicioPorAnimal;
+  const ultimaCriaAnteriorFusionada = fusionado.ultimaCriaAnteriorPorAnimal;
 
   // --- 4. Revalidar el ALCANCE contra el diff fresco --------------------
   const { aceptadas, rechazadas } = validarFilasCommit(filas, diffFresco);
@@ -296,7 +330,7 @@ export async function handleHatoChequeoCommit(c: Context): Promise<Response> {
 
   // --- 5. Derivar eventos + resolver toro_id (I/O: SELECT-o-INSERT) ----
   const vacas = construirFilasVacas(aceptadas);
-  const { eventos } = derivarEventosDeChequeo(aceptadas, ultimaCriaAnteriorPorAnimal, fechasServicioConocidasPorAnimal);
+  const { eventos } = derivarEventosDeChequeo(aceptadas, ultimaCriaAnteriorFusionada, fechasServicioConocidasPorAnimal);
 
   const nombresToro = [...new Set(eventos.map((e) => e.toro_nombre).filter((n): n is string => !!n && n.trim() !== ''))];
   const toroCache = new Map<string, string>();

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-preview.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-preview.ts
@@ -28,10 +28,12 @@ import { normalizarHojas } from './importHato/normalizar.ts';
 import { construirDiffChequeo, seleccionarUltimoChequeoPorAnimal } from './importHato/diffChequeo.ts';
 import type {
   AnimalHatoActual,
+  AnimalEstadoRegistradoActual,
   FilaChequeoVacaHistorico,
 } from './importHato/diffChequeo.ts';
 import type { HojaCruda } from './importHato/tipos.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { derivarEstadoReproductivo, etiquetaEstadoReproductivo, type EstadoActualHatoRow } from './calculos-hato.ts';
 
 const TAMANO_MAXIMO_BYTES = 20 * 1024 * 1024; // 20 MB -- una planilla real pesa unos pocos cientos de KB.
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053).
@@ -235,8 +237,40 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
     });
   }
 
+  // --- 4b. "Estado registrado" (D-E, N21/N23): lo que el motor de 5 estados
+  // cree AHORA para cada animal de la hoja -- recalculado en este mismo
+  // momento contra `v_hato_estado_actual` (que fusiona TODO `hato_eventos`
+  // sin importar `chequeo_vaca_id`, incluidos los eventos manuales de
+  // Telegram), nunca cacheado desde cuando se imprimió la planilla. Es la
+  // pieza que permite al diff marcar el conflicto explícito "registrado vs.
+  // papel" (docs/plan_hato_telegram_estados_agosto_2026.md §3 Capa 5).
+  let estadosRegistrados: AnimalEstadoRegistradoActual[] = [];
+  if (animalIds.length > 0) {
+    const { data, error } = await supabase
+      .from('v_hato_estado_actual')
+      .select(
+        'animal_id, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultima_confirmacion_prenez_metodo, ultimo_aborto_fecha, ultimo_estado_chequeo',
+      )
+      .in('animal_id', animalIds);
+    if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
+    // Mismo criterio de "hoy" que `hato-alertas-tick.ts` (UTC) -- las edge
+    // functions quedan deliberadamente fuera del arreglo de "hoy en hora
+    // local" (CLAUDE.md, "Hoy siempre se toma en hora LOCAL"): un desfase de
+    // un día en esta comparación de referencia no cambia la CLASIFICACIÓN
+    // reproductiva de una vaca de un día para otro salvo en el borde exacto
+    // de un umbral, y el conflicto que esto detecta ya es de días/semanas.
+    const hoy = new Date().toISOString().slice(0, 10);
+    estadosRegistrados = (data ?? []).map((fila: Record<string, unknown>) => {
+      const derivado = derivarEstadoReproductivo(fila as unknown as EstadoActualHatoRow, config, hoy);
+      return {
+        animalId: fila.animal_id as string,
+        estado: etiquetaEstadoReproductivo(derivado.estado),
+      };
+    });
+  }
+
   const ultimosChequeos = seleccionarUltimoChequeoPorAnimal(historico);
-  const diffChequeos = construirDiffChequeo(salida.chequeos, animales, ultimosChequeos);
+  const diffChequeos = construirDiffChequeo(salida.chequeos, animales, ultimosChequeos, estadosRegistrados);
 
   // Fecha del chequeo, para precargar el campo `chequeo.fecha` del commit
   // (`POST .../hato/chequeo/commit`, `hato-chequeo-commit.ts`) sin que el

--- a/supabase/functions/make-server-1ccce916/hato-pesaje-commit.ts
+++ b/supabase/functions/make-server-1ccce916/hato-pesaje-commit.ts
@@ -2,57 +2,41 @@
 // /make-server-1ccce916/hato/pesaje/commit`.
 //
 // El paso "Aprobar" que sigue al diff de `hato-pesaje-foto.ts` (ese endpoint
-// NUNCA comete un INSERT/UPDATE). Este SÍ escribe -- es el único camino de
-// escritura del commit de un pesaje por foto.
+// NUNCA comete un INSERT/UPDATE). Este SÍ escribe -- es uno de los dos
+// caminos de escritura del commit de un pesaje por foto (el otro es el bot
+// de Telegram, `telegram/conversations/pesajeLeche.ts`, N13 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md`, que llama a la MISMA
+// función de orquestación).
 //
 // Contrato: el cliente manda las CELDAS que quiere guardar (`celdas`, la
 // forma `CeldaDiffPesaje` que devolvió el preview -- posiblemente con
 // `litrosAm`/`litrosPm` CORREGIDOS a mano, D-6). Nunca reenvía la foto ni
 // pide que se vuelva a leer.
 //
-// REVALIDACIÓN CONTRA EL ESTADO FRESCO (mismo espíritu que
-// `hato-chequeo-commit.ts`, adaptado a que acá cada celda es un HECHO
-// INDEPENDIENTE, no partes de un mismo evento):
-//   - `animal_id` debe seguir siendo una vaca en ordeño ACTIVA en este
-//     instante -- si se vendió/murió entre la vista previa y la aprobación,
-//     esa celda se rechaza, nunca se escribe contra una identidad caducada.
-//   - `fecha` debe seguir siendo una ocurrencia real de
-//     `hato_config.dia_pesaje_semanal` para (anio, mes) -- si el ajuste
-//     cambió entre tanto, esa celda se rechaza en vez de escribir una fecha
-//     que ya no es la que la planilla impresa mostraba.
-//   - El `existenteId` (UPDATE vs INSERT) se RE-DERIVA de una consulta
-//     fresca a `hato_pesajes_leche` -- nunca se confía en el id que trae el
-//     cliente, que pudo quedar viejo si alguien más guardó ese mismo
-//     (vaca, fecha) mientras tanto.
+// REVALIDACIÓN CONTRA EL ESTADO FRESCO + escritura UPDATE-por-id/INSERT:
+// toda esa orquestación vive en `./hato-pesaje-pipeline.ts`
+// (`ejecutarCommitPesaje`), extraída para que el bot de Telegram reuse
+// EXACTAMENTE la misma revalidación (N13 del plan: "Reusa la revalidación
+// que ya existe en `hato-pesaje-commit.ts`") sin cambiar el comportamiento
+// observable de este endpoint. Este archivo queda como I/O puro: auth,
+// parseo/forma del body, y traducción del resultado a una respuesta HTTP.
 //
 // A DIFERENCIA del commit de chequeo (una sola RPC, todo o nada: un chequeo
 // es UN evento con varias filas relacionadas), acá cada celda es un hecho
 // independiente (`UNIQUE(animal_id, fecha)`, sin relación entre vacas ni
-// entre semanas) -- así que una celda inválida NO aborta las demás: se
-// escriben las que validan y se reportan las que no, para que una vaca
-// vendida entre medias no le cueste a Martha los otros 67 pesajes.
+// entre semanas) -- así que una celda inválida NO aborta las demás.
 //
-// Escritura vía UPDATE-por-id + INSERT (nunca upsert de PostgREST -- mismo
-// patrón que `useProduccionHato.guardarPesajes`, el camino de escritura
-// manual del grid semanal). `fuente: 'foto'` distingue esta vía de `'web'`
-// (grid manual) y `'telegram'`. `created_by` se setea EXPLÍCITO desde la
-// sesión verificada -- `hato_pesajes_leche` no tiene trigger de
-// `created_by` (a diferencia de `tareas`/`fin_gastos`/…, migraciones
-// 040/050/063/074) y este handler escribe con la service role
-// (`auth.uid()` sería NULL), así que sin esto la autoría se perdería.
-//
-// I/O puro en este archivo. Toda la lógica de clasificación/armado vive en
-// `./importHato/ocrPesaje.ts` (copia GENERADA, ver
-// docs/hato/regenerar-copias-importhato.py).
+// `fuente: 'foto'` distingue esta vía de `'web'` (grid manual) y
+// `'telegram'` (bot). `created_by` se setea EXPLÍCITO desde la sesión
+// verificada -- `hato_pesajes_leche` no tiene trigger de `created_by` (a
+// diferencia de `tareas`/`fin_gastos`/…, migraciones 040/050/063/074) y
+// este handler escribe con la service role (`auth.uid()` sería NULL), así
+// que sin esto la autoría se perdería.
 
 import { Context } from 'npm:hono';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
-import { fechasPesajeMensuales } from './calculos-hato.ts';
-import {
-  esCandidataRosterPesaje,
-  ETAPAS_ROSTER_PESAJE,
-  type CeldaDiffPesaje,
-} from './importHato/ocrPesaje.ts';
+import { ejecutarCommitPesaje, type CeldaCommitPesajeEntrada } from './hato-pesaje-pipeline.ts';
+import type { CeldaDiffPesaje } from './importHato/ocrPesaje.ts';
 
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053).
 
@@ -96,20 +80,13 @@ async function verificarAcceso(
 // Body esperado -- solo lo que el handler necesita para escribir; el resto
 // de `CeldaDiffPesaje` (nombre, clasificación) se ignora, nunca se confía.
 // ---------------------------------------------------------------------------
-interface CeldaCommitPesaje {
-  animalId: string;
-  fecha: string;
-  litrosAm: number | null;
-  litrosPm: number | null;
-}
-
 interface BodyCommitPesaje {
   anio?: number;
   mes?: number;
   celdas?: Array<Partial<CeldaDiffPesaje>>;
 }
 
-function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaCommitPesaje[] } | { error: string } {
+function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaCommitPesajeEntrada[] } | { error: string } {
   if (typeof body !== 'object' || body === null) {
     return { error: 'El cuerpo de la solicitud debe ser un objeto JSON.' };
   }
@@ -125,7 +102,7 @@ function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaC
     return { error: "'celdas' debe ser un arreglo no vacío -- no hay nada que aprobar." };
   }
 
-  const celdas: CeldaCommitPesaje[] = [];
+  const celdas: CeldaCommitPesajeEntrada[] = [];
   for (const c of b.celdas) {
     if (typeof c !== 'object' || c === null || typeof c.animalId !== 'string' || typeof c.fecha !== 'string') {
       return { error: 'Cada celda debe traer animalId (string) y fecha (AAAA-MM-DD).' };
@@ -144,12 +121,6 @@ function validarBody(body: unknown): { anio: number; mes: number; celdas: CeldaC
   }
 
   return { anio: b.anio as number, mes: b.mes as number, celdas };
-}
-
-interface CeldaRechazada {
-  animalId: string;
-  fecha: string;
-  motivo: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -175,121 +146,28 @@ export async function handleHatoPesajeCommit(c: Context): Promise<Response> {
   if ('error' in validado) return respuestaError(c, 400, { error: validado.error });
   const { anio, mes, celdas } = validado;
 
-  // --- 2. hato_config.dia_pesaje_semanal FRESCO -- recomputa las fechas
-  //    válidas para (anio, mes) EN ESTE INSTANTE, nunca las que vio el
-  //    cliente en la vista previa. --------------------------------------
-  const { data: configData, error: configError } = await supabase
-    .from('hato_config')
-    .select('valor')
-    .eq('clave', 'dia_pesaje_semanal')
-    .maybeSingle();
-  if (configError) return respuestaError(c, 500, { error: `No se pudo leer hato_config: ${configError.message}` });
-  const configValor = configData?.valor as { iso?: unknown } | undefined;
-  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
-    return respuestaError(c, 500, {
-      error: 'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064).',
-    });
-  }
-  const fechasValidasHoy = new Set(fechasPesajeMensuales(anio, mes, configValor.iso as number));
+  // --- 2. Revalidación + escritura, compartida con el bot (N13) -------------
+  const resultado = await ejecutarCommitPesaje({
+    supabase,
+    anio,
+    mes,
+    celdas,
+    createdBy: acceso.userId,
+    fuente: 'foto',
+  });
 
-  // --- 3. Roster FRESCO -- mismo criterio que imprimió la planilla y que usó
-  //    el OCR (`esCandidataRosterPesaje`), nunca uno propio: si acá fuera más
-  //    estrecho, los litros de una fila que Martha vio y aprobó se perderían
-  //    en silencio. Es también lo que acota el "agregar vaca" manual de la
-  //    grilla de revisión: se puede añadir cualquiera del roster, y nada más.
-  const animalIds = [...new Set(celdas.map((c) => c.animalId))];
-  const { data: animalesData, error: animalesError } = await supabase
-    .from('hato_animales')
-    .select('id, etapa, estado')
-    .in('id', animalIds)
-    .in('etapa', ETAPAS_ROSTER_PESAJE);
-  if (animalesError) {
-    return respuestaError(c, 500, { error: `No se pudo leer hato_animales: ${animalesError.message}` });
-  }
-  const activasAhora = new Set(
-    ((animalesData ?? []) as Array<{ id: string; etapa: string | null; estado: string | null }>)
-      .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
-      .map((a) => a.id),
-  );
-
-  // --- 4. Filtrar: solo celdas cuya vaca sigue activa y cuya fecha sigue
-  //    siendo una ocurrencia real del día de pesaje configurado. Cada celda
-  //    es un hecho independiente -- una inválida no bota a las demás. -----
-  const aceptadas: CeldaCommitPesaje[] = [];
-  const rechazadas: CeldaRechazada[] = [];
-  for (const celda of celdas) {
-    if (!activasAhora.has(celda.animalId)) {
-      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'El animal ya no está en el roster de la planilla -- puede haberse vendido o cambiado de etapa desde la vista previa.' });
-      continue;
+  if (!resultado.ok) {
+    if (resultado.status === 400) {
+      return respuestaError(c, 400, { error: resultado.error, celdasRechazadas: resultado.celdasRechazadas });
     }
-    if (!fechasValidasHoy.has(celda.fecha)) {
-      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'Esa fecha ya no corresponde a una semana de pesaje configurada para este mes.' });
-      continue;
-    }
-    aceptadas.push(celda);
-  }
-
-  if (aceptadas.length === 0) {
-    return respuestaError(c, 400, {
-      error: 'Ninguna celda pasó la revalidación -- el hato cambió desde la vista previa. No se escribió nada.',
-      celdasRechazadas: rechazadas,
-    });
-  }
-
-  // --- 5. Existentes FRESCOS -- decide UPDATE-por-id vs INSERT; nunca se
-  //    confía en el `existenteId` que trajo el cliente. -------------------
-  const fechasEnLote = [...new Set(aceptadas.map((c) => c.fecha))];
-  const { data: existentesData, error: existentesError } = await supabase
-    .from('hato_pesajes_leche')
-    .select('id, animal_id, fecha')
-    .in('animal_id', [...new Set(aceptadas.map((c) => c.animalId))])
-    .in('fecha', fechasEnLote);
-  if (existentesError) return respuestaError(c, 500, { error: `No se pudo leer hato_pesajes_leche: ${existentesError.message}` });
-  const idExistentePorClave = new Map<string, string>();
-  for (const fila of (existentesData ?? []) as Array<{ id: string; animal_id: string; fecha: string }>) {
-    idExistentePorClave.set(`${fila.animal_id}|${fila.fecha}`, fila.id);
-  }
-
-  // --- 6. Escritura: UPDATE-por-id + INSERT, nunca upsert de PostgREST
-  //    (mismo patrón que `useProduccionHato.guardarPesajes`). -------------
-  let actualizados = 0;
-  let creados = 0;
-  const nuevasFilas: Array<{ animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number; fuente: string; created_by: string }> = [];
-
-  for (const celda of aceptadas) {
-    const total = (celda.litrosAm ?? 0) + (celda.litrosPm ?? 0);
-    const existenteId = idExistentePorClave.get(`${celda.animalId}|${celda.fecha}`);
-    if (existenteId) {
-      const { error } = await supabase
-        .from('hato_pesajes_leche')
-        .update({ litros_am: celda.litrosAm, litros_pm: celda.litrosPm, litros_total: total, fuente: 'foto' })
-        .eq('id', existenteId);
-      if (error) return respuestaError(c, 500, { error: `No se pudo actualizar el pesaje de '${celda.animalId}' en ${celda.fecha}: ${error.message}` });
-      actualizados += 1;
-    } else {
-      nuevasFilas.push({
-        animal_id: celda.animalId,
-        fecha: celda.fecha,
-        litros_am: celda.litrosAm,
-        litros_pm: celda.litrosPm,
-        litros_total: total,
-        fuente: 'foto',
-        created_by: acceso.userId,
-      });
-    }
-  }
-
-  if (nuevasFilas.length > 0) {
-    const { error } = await supabase.from('hato_pesajes_leche').insert(nuevasFilas);
-    if (error) return respuestaError(c, 500, { error: `No se pudieron insertar los pesajes nuevos: ${error.message}` });
-    creados = nuevasFilas.length;
+    return respuestaError(c, 500, { error: resultado.error });
   }
 
   return c.json({
     success: true,
-    guardados: actualizados + creados,
-    actualizados,
-    creados,
-    celdasRechazadas: rechazadas,
+    guardados: resultado.guardados,
+    actualizados: resultado.actualizados,
+    creados: resultado.creados,
+    celdasRechazadas: resultado.celdasRechazadas,
   });
 }

--- a/supabase/functions/make-server-1ccce916/hato-pesaje-foto.ts
+++ b/supabase/functions/make-server-1ccce916/hato-pesaje-foto.ts
@@ -26,62 +26,32 @@
 // negocio. Los litros se interpretan con `parseValorNumerico`
 // (`calculos-hato.ts`), nunca un segundo parser numérico.
 //
-// I/O puro en este archivo: multipart, Storage, la llamada HTTP a
-// OpenRouter y las consultas a Supabase. Toda la lógica (roster, cotejo del
-// ancla, diff contra lo ya guardado, prompt y esquema) vive en el módulo
-// puro `./importHato/ocrPesaje.ts` (copia GENERADA de
-// `src/utils/importHato/ocrPesaje.ts`, ver
-// docs/hato/regenerar-copias-importhato.py) y está cubierta por Vitest.
+// I/O puro en este archivo: multipart y la traducción del resultado del
+// pipeline a una respuesta HTTP. TODA la orquestación (Storage, modelo de
+// visión, roster, diff) vive en `./hato-pesaje-pipeline.ts`
+// (`ejecutarPipelinePesajeFoto`, N11 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md`) -- extraída para que el
+// bot de Telegram (`telegram/conversations/pesajeLeche.ts`) use EXACTAMENTE
+// el mismo pipeline, sin cambiar el comportamiento observable de este
+// endpoint. La lógica pura (roster, cotejo del ancla, diff, prompt y
+// esquema) vive en `./importHato/ocrPesaje.ts` (copia GENERADA de
+// `src/utils/importHato/ocrPesaje.ts`) y está cubierta por Vitest.
 //
-// NUNCA escribe en tablas de dominio. Sí guarda las fotos en Storage: la
-// foto ES la capa cruda de esta ruta -- el equivalente del `*_raw` del
-// chequeo.
+// NUNCA escribe en tablas de dominio. Sí guarda las fotos en Storage (dentro
+// del pipeline): la foto ES la capa cruda de esta ruta -- el equivalente del
+// `*_raw` del chequeo.
 
 import { Context } from 'npm:hono';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
-import { fechasPesajeMensuales } from './calculos-hato.ts';
 import {
-  construirDiffPesaje,
-  construirPromptOcrPesaje,
-  construirRosterPesaje,
-  esCandidataRosterPesaje,
-  esquemaJsonOcrPesaje,
-  ETAPAS_ROSTER_PESAJE,
-  parsearRespuestaModeloOcrPesaje,
-  procesarLecturaOcrPesaje,
-  SEMANAS_PESAJE,
-  type AnimalRosterPesaje,
-  type LecturaOcrPesajePagina,
-  type PesajeExistente,
-  type SemanaPesaje,
-} from './importHato/ocrPesaje.ts';
+  ejecutarPipelinePesajeFoto,
+  MAXIMO_FOTOS_PESAJE,
+  TAMANO_MAXIMO_FOTO_PESAJE_BYTES,
+  TIPOS_ACEPTADOS_FOTO_PESAJE,
+  type FotoPesajeEntrada,
+} from './hato-pesaje-pipeline.ts';
 
-// --- Límites de entrada -----------------------------------------------------
-// El hato tiene 68 vacas activas (2026-08-06); a 16 columnas por fila, la
-// planilla real ocupa varias páginas (ver `exportarPlanillaPesajePDF.ts`,
-// 4 páginas medidas). Mismos límites que `hato-chequeo-foto.ts`.
-const MAXIMO_FOTOS = 6;
-const TAMANO_MAXIMO_FOTO_BYTES = 15 * 1024 * 1024;
-const TIPOS_ACEPTADOS = new Set([
-  'image/jpeg',
-  'image/jpg',
-  'image/png',
-  'image/webp',
-  'image/heic',
-  'image/heif',
-]);
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo set de escritura del módulo (053), igual que chequeo/foto.
-
-// --- Modelo de visión -------------------------------------------------------
-const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
-const MODELO_VISION = 'google/gemini-3-flash-preview';
-const TIMEOUT_MODELO_MS = 120_000;
-
-// --- Storage ----------------------------------------------------------------
-// Bucket privado propio (migración 086 -- patrón 072/085: RLS on, políticas
-// explícitas Administrador+Gerencia, DELETE Gerencia-only). Nunca se mezcla
-// con `chequeos-fotos` (otro dominio) ni con `hato-liquidaciones-fotos`.
-const BUCKET_FOTOS = 'hato-pesajes-fotos';
 
 function respuestaError(c: Context, status: 400 | 401 | 403 | 500 | 502 | 503, error: string) {
   return c.json({ success: false, error }, status);
@@ -122,125 +92,6 @@ async function verificarAcceso(
   }
 
   return { userId: userData.user.id };
-}
-
-// ---------------------------------------------------------------------------
-// Utilidades de I/O -- idénticas a `hato-chequeo-foto.ts` (cada handler es
-// autocontenido en su propio I/O, mismo patrón que el resto de `hato-*.ts`).
-// ---------------------------------------------------------------------------
-
-function bytesABase64(bytes: Uint8Array): string {
-  const TAMANO_BLOQUE = 0x8000;
-  let binario = '';
-  for (let i = 0; i < bytes.length; i += TAMANO_BLOQUE) {
-    binario += String.fromCharCode(...bytes.subarray(i, i + TAMANO_BLOQUE));
-  }
-  return btoa(binario);
-}
-
-function extensionDeTipo(tipo: string, nombre: string): string {
-  const porNombre = nombre.match(/\.([a-z0-9]{2,5})$/i)?.[1];
-  if (porNombre) return porNombre.toLowerCase();
-  const sufijo = tipo.split('/')[1];
-  return sufijo ? sufijo.toLowerCase() : 'jpg';
-}
-
-function extraerJson(contenido: string): unknown {
-  const limpio = contenido.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
-  return JSON.parse(limpio);
-}
-
-interface FotoRecibida {
-  pagina: number;
-  nombre: string;
-  tipo: string;
-  bytes: Uint8Array;
-}
-
-interface LlamadaModeloOk {
-  ok: true;
-  lectura: LecturaOcrPesajePagina;
-}
-interface LlamadaModeloError {
-  ok: false;
-  pagina: number;
-  error: string;
-}
-
-async function leerFotoConModelo(
-  foto: FotoRecibida,
-  totalFotos: number,
-  prompt: string,
-  esquema: Record<string, unknown>,
-  apiKey: string,
-): Promise<LlamadaModeloOk | LlamadaModeloError> {
-  const dataUrl = `data:${foto.tipo};base64,${bytesABase64(foto.bytes)}`;
-  const controller = new AbortController();
-  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MODELO_MS);
-
-  try {
-    const respuesta = await fetch(OPENROUTER_URL, {
-      method: 'POST',
-      headers: {
-        'Content-Type': 'application/json',
-        Authorization: `Bearer ${apiKey}`,
-      },
-      body: JSON.stringify({
-        model: MODELO_VISION,
-        messages: [
-          { role: 'system', content: prompt },
-          {
-            role: 'user',
-            content: [
-              {
-                type: 'text',
-                // "foto N de M", no "página N": desde 2026-08-11 la planilla
-                // cabe en UNA hoja y se fotografía por franjas, así que
-                // llamarla página inducía al modelo a esperar una planilla
-                // completa (con encabezados) en cada imagen.
-                text: `Transcribe la foto ${foto.pagina} de ${totalFotos} de la planilla de pesaje. Puede ser una franja de la hoja, no la hoja entera. Devuelve una entrada por cada fila de vaca visible, en el orden en que aparecen.`,
-              },
-              { type: 'image_url', image_url: { url: dataUrl } },
-            ],
-          },
-        ],
-        temperature: 0,
-        max_tokens: 12000,
-        response_format: {
-          type: 'json_schema',
-          json_schema: { name: 'planilla_pesaje', strict: true, schema: esquema },
-        },
-      }),
-      signal: controller.signal,
-    });
-    clearTimeout(timeoutId);
-
-    if (!respuesta.ok) {
-      const detalle = await respuesta.text().catch(() => '');
-      return {
-        ok: false,
-        pagina: foto.pagina,
-        error: `el modelo de visión respondió ${respuesta.status}: ${detalle.slice(0, 300)}`,
-      };
-    }
-
-    const resultado = await respuesta.json();
-    const contenido = resultado?.choices?.[0]?.message?.content;
-    if (typeof contenido !== 'string' || contenido.trim() === '') {
-      return { ok: false, pagina: foto.pagina, error: 'el modelo de visión devolvió una respuesta vacía' };
-    }
-
-    return { ok: true, lectura: parsearRespuestaModeloOcrPesaje(extraerJson(contenido), foto.pagina) };
-  } catch (err) {
-    clearTimeout(timeoutId);
-    const mensaje =
-      err instanceof Error && err.name === 'AbortError'
-        ? `la lectura superó el tiempo máximo (${TIMEOUT_MODELO_MS / 1000}s)`
-        : err instanceof Error
-          ? err.message
-          : String(err);
-    return { ok: false, pagina: foto.pagina, error: mensaje };
-  }
 }
 
 // ---------------------------------------------------------------------------
@@ -297,25 +148,25 @@ export async function handleHatoPesajeFoto(c: Context): Promise<Response> {
   if (archivos.length === 0) {
     return respuestaError(c, 400, 'Faltan las fotos de la planilla (multipart/form-data, campo "fotos").');
   }
-  if (archivos.length > MAXIMO_FOTOS) {
-    return respuestaError(c, 400, `Se aceptan máximo ${MAXIMO_FOTOS} fotos por carga (llegaron ${archivos.length}).`);
+  if (archivos.length > MAXIMO_FOTOS_PESAJE) {
+    return respuestaError(c, 400, `Se aceptan máximo ${MAXIMO_FOTOS_PESAJE} fotos por carga (llegaron ${archivos.length}).`);
   }
 
-  const fotos: FotoRecibida[] = [];
+  const fotos: FotoPesajeEntrada[] = [];
   for (let i = 0; i < archivos.length; i++) {
     const archivo = archivos[i];
     if (archivo.size === 0) {
       return respuestaError(c, 400, `La foto ${i + 1} ('${archivo.name}') está vacía.`);
     }
-    if (archivo.size > TAMANO_MAXIMO_FOTO_BYTES) {
+    if (archivo.size > TAMANO_MAXIMO_FOTO_PESAJE_BYTES) {
       return respuestaError(
         c,
         400,
-        `La foto ${i + 1} ('${archivo.name}') supera el tamaño máximo de ${TAMANO_MAXIMO_FOTO_BYTES / 1024 / 1024} MB.`,
+        `La foto ${i + 1} ('${archivo.name}') supera el tamaño máximo de ${TAMANO_MAXIMO_FOTO_PESAJE_BYTES / 1024 / 1024} MB.`,
       );
     }
     const tipo = (archivo.type || '').toLowerCase();
-    if (!TIPOS_ACEPTADOS.has(tipo)) {
+    if (!TIPOS_ACEPTADOS_FOTO_PESAJE.has(tipo)) {
       return respuestaError(
         c,
         400,
@@ -330,153 +181,20 @@ export async function handleHatoPesajeFoto(c: Context): Promise<Response> {
     });
   }
 
-  const generadoEn = new Date().toISOString();
-
-  // --- 2. Guardar la capa cruda ANTES de leerla -----------------------------
-  const prefijoStorage = `pesaje-foto/${generadoEn.replace(/[:.]/g, '-')}-${crypto.randomUUID().slice(0, 8)}`;
-  const rutasStorage: Array<string | null> = [];
-  const erroresStorage: string[] = [];
-  for (const foto of fotos) {
-    const ruta = `${prefijoStorage}/pagina-${foto.pagina}.${extensionDeTipo(foto.tipo, foto.nombre)}`;
-    const { error } = await supabase.storage
-      .from(BUCKET_FOTOS)
-      .upload(ruta, foto.bytes, { contentType: foto.tipo, upsert: false });
-    if (error) {
-      rutasStorage.push(null);
-      erroresStorage.push(`página ${foto.pagina}: ${error.message}`);
-    } else {
-      rutasStorage.push(ruta);
-    }
+  // --- 2. Pipeline compartido con el bot de Telegram (N11) ------------------
+  const resultado = await ejecutarPipelinePesajeFoto({ supabase, apiKey, fotos, anio, mes });
+  if (!resultado.ok) {
+    return respuestaError(c, resultado.status, resultado.error);
   }
 
-  // --- 3. hato_config.dia_pesaje_semanal + roster VIGENTE de la planilla ----
-  const [configRes, rosterRes] = await Promise.all([
-    supabase.from('hato_config').select('valor').eq('clave', 'dia_pesaje_semanal').maybeSingle(),
-    // MISMO universo que exporta la planilla (`esCandidataRosterPesaje`,
-    // `importHato/ocrPesaje.ts` -- una sola definición espejada acá y usada
-    // igual por `useProduccionHato.fetchRosterPesaje` y por el commit).
-    supabase.from('hato_animales').select('id, nombre, etapa, estado').eq('estado', 'activa').in('etapa', ETAPAS_ROSTER_PESAJE),
-  ]);
-
-  if (configRes.error) return respuestaError(c, 500, `No se pudo leer hato_config: ${configRes.error.message}`);
-  const configValor = configRes.data?.valor as { iso?: unknown } | undefined;
-  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
-    return respuestaError(
-      c,
-      500,
-      'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064) -- no se puede resolver a qué fecha corresponde cada semana.',
-    );
-  }
-  const diaPesajeIso = configValor.iso;
-
-  if (rosterRes.error) return respuestaError(c, 500, `No se pudo leer hato_animales: ${rosterRes.error.message}`);
-  const animalesRoster: AnimalRosterPesaje[] = (
-    (rosterRes.data ?? []) as Array<{ id: string; nombre: string | null; etapa: string | null; estado: string | null }>
-  )
-    .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
-    .map((a) => ({ id: a.id, nombre: a.nombre ?? '' }));
-  const roster = construirRosterPesaje(animalesRoster);
-
-  if (roster.entradas.length === 0) {
-    return respuestaError(
-      c,
-      500,
-      'No hay vacas en ordeño activas con nombre en el hato: sin roster no se puede validar el ancla de ninguna fila.',
-    );
-  }
-
-  const fechasArr = fechasPesajeMensuales(anio, mes, diaPesajeIso);
-  const fechasPorSemana = {} as Record<SemanaPesaje, string | null>;
-  for (const semana of SEMANAS_PESAJE) fechasPorSemana[semana] = fechasArr[semana - 1] ?? null;
-
-  // --- 4. Lectura con el modelo de visión (una llamada por foto) -----------
-  const prompt = construirPromptOcrPesaje();
-  const esquema = esquemaJsonOcrPesaje();
-  const resultados = await Promise.all(
-    fotos.map((foto) => leerFotoConModelo(foto, fotos.length, prompt, esquema, apiKey)),
-  );
-
-  const lecturas: LecturaOcrPesajePagina[] = [];
-  const erroresLectura: string[] = [];
-  for (const resultado of resultados) {
-    if (resultado.ok) lecturas.push(resultado.lectura);
-    else erroresLectura.push(`página ${resultado.pagina}: ${resultado.error}`);
-  }
-
-  if (lecturas.length === 0) {
-    return respuestaError(
-      c,
-      502,
-      `No se pudo leer ninguna de las fotos. ${erroresLectura.join(' | ')}${
-        rutasStorage.some((r) => r !== null) ? ' Las fotos sí quedaron guardadas.' : ''
-      }`,
-    );
-  }
-
-  // --- 5. Anti-row-drift por nombre (lógica pura) ---------------------------
-  const ocr = procesarLecturaOcrPesaje(lecturas, roster);
-
-  // --- 6. Existentes en hato_pesajes_leche, para clasificar el diff --------
-  const animalIdsLeidos = ocr.filasConfirmadas.map((f) => f.animalId);
-  const fechasValidas = SEMANAS_PESAJE.map((s) => fechasPorSemana[s]).filter((f): f is string => f !== null);
-  const existentes = new Map<string, Map<string, PesajeExistente>>();
-  if (animalIdsLeidos.length > 0 && fechasValidas.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_pesajes_leche')
-      .select('id, animal_id, fecha, litros_am, litros_pm, litros_total')
-      .in('animal_id', animalIdsLeidos)
-      .in('fecha', fechasValidas);
-    if (error) return respuestaError(c, 500, `No se pudo leer hato_pesajes_leche: ${error.message}`);
-    for (const fila of (data ?? []) as Array<{ id: string; animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number }>) {
-      if (!existentes.has(fila.animal_id)) existentes.set(fila.animal_id, new Map());
-      existentes.get(fila.animal_id)!.set(fila.fecha, {
-        id: fila.id,
-        litrosAm: fila.litros_am,
-        litrosPm: fila.litros_pm,
-        litrosTotal: fila.litros_total,
-      });
-    }
-  }
-
-  const diff = construirDiffPesaje(ocr.filasConfirmadas, fechasPorSemana, existentes);
-  const celdasNoConfiables = ocr.filasConfirmadas.reduce((n, f) => n + f.celdasNoConfiables.length, 0);
-
-  // --- 7. Respuesta: NUNCA escribe -------------------------------------------
+  // --- 3. Respuesta: NUNCA escribe -------------------------------------------
   return c.json({
     success: true,
-    generadoEn,
-    anio,
-    mes,
-    fechasPorSemana,
-    diff,
-    ocr: {
-      modelo: MODELO_VISION,
-      fotos: fotos.map((f, i) => ({
-        pagina: f.pagina,
-        nombre: f.nombre,
-        tipo: f.tipo,
-        bytes: f.bytes.length,
-        rutaStorage: rutasStorage[i],
-      })),
-      almacenamiento: {
-        bucket: BUCKET_FOTOS,
-        prefijo: prefijoStorage,
-        ok: erroresStorage.length === 0,
-        errores: erroresStorage,
-      },
-      paginasNoLeidas: erroresLectura,
-      filasNoLeidas: ocr.filasNoLeidas,
-      vacasSinLeer: ocr.vacasSinLeer,
-      advertencias: ocr.advertencias,
-      resumen: {
-        vacasEnRoster: roster.entradas.length,
-        fotosRecibidas: fotos.length,
-        fotosLeidas: lecturas.length,
-        filasConfirmadas: ocr.filasConfirmadas.length,
-        filasNoLeidas: ocr.filasNoLeidas.length,
-        vacasSinLeer: ocr.vacasSinLeer.length,
-        celdasNoConfiables,
-      },
-    },
+    generadoEn: resultado.resultado.generadoEn,
+    anio: resultado.resultado.anio,
+    mes: resultado.resultado.mes,
+    fechasPorSemana: resultado.resultado.fechasPorSemana,
+    diff: resultado.resultado.diff,
+    ocr: resultado.resultado.ocr,
   });
 }

--- a/supabase/functions/make-server-1ccce916/hato-pesaje-pipeline.ts
+++ b/supabase/functions/make-server-1ccce916/hato-pesaje-pipeline.ts
@@ -1,0 +1,654 @@
+// hato-pesaje-pipeline.ts — N11-N13 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md` §3 Capa 2 / §8.2.
+//
+// POR QUÉ EXISTE ESTE ARCHIVO: hasta esta sesión, la lectura por foto
+// (`leerFotoConModelo` + el armado de roster/config/diff) vivía DENTRO del
+// handler de Hono de `hato-pesaje-foto.ts`, y la escritura (revalidación +
+// UPDATE-o-INSERT) vivía dentro del handler de `hato-pesaje-commit.ts` — ni
+// una ni otra eran reutilizables. El bot de Telegram (`/pesaje`,
+// `telegram/conversations/pesajeLeche.ts`) necesita EXACTAMENTE el mismo
+// pipeline (no un segundo lector de celdas, no una segunda revalidación),
+// así que este archivo extrae la orquestación a funciones puras-de-I/O
+// (reciben sus dependencias por parámetro, no leen `Context` de Hono) que
+// ambos consumidores llaman. `hato-pesaje-foto.ts` y `hato-pesaje-commit.ts`
+// quedan como I/O puro: parsean la petición HTTP, llaman a este módulo, y
+// traducen el resultado a una respuesta -- el comportamiento observable de
+// esos dos endpoints NO cambia.
+//
+// Tres funciones, una por nodo del plan:
+//   - `ejecutarPipelinePesajeFoto` (N11) -- guarda la capa cruda en Storage,
+//     lee cada foto con el modelo de visión, coteja el ancla por nombre
+//     (`ocrPesaje.ts`) y arma el diff contra `hato_pesajes_leche`. NUNCA
+//     escribe en tablas de dominio (mismo contrato que el endpoint).
+//   - `llamarModeloCorreccionPesaje` (N12) -- la ÚNICA llamada HTTP al
+//     modelo para interpretar una corrección en texto libre (D-C). El
+//     prompt/esquema y la VALIDACIÓN de lo que el modelo devuelve viven en
+//     `./importHato/ocrPesajeCorreccion.ts` (puro, espejado, testeado desde
+//     Vitest) -- acá solo se hace la llamada HTTP y se le pasa la respuesta
+//     cruda a `parsearRespuestaModeloCorreccionPesaje`.
+//   - `ejecutarCommitPesaje` (N13) -- la MISMA revalidación fresca que ya
+//     tenía `hato-pesaje-commit.ts` (vaca sigue activa, fecha sigue siendo
+//     una ocurrencia real del mes) + escritura UPDATE-por-id/INSERT, commit
+//     por CELDA (una inválida no bota a las demás).
+//
+// Los litros se interpretan con `parseValorNumerico` (`calculos-hato.ts`),
+// nunca un segundo parser. El cotejo de nombre reusa
+// `resolverNombreEnRosterPesaje`/`validarAnclaFilaPesaje` de `ocrPesaje.ts`.
+
+import { createClient } from 'jsr:@supabase/supabase-js@2';
+import { fechasPesajeMensuales } from './calculos-hato.ts';
+import {
+  construirDiffPesaje,
+  construirRosterPesaje,
+  esCandidataRosterPesaje,
+  esquemaJsonOcrPesaje,
+  construirPromptOcrPesaje,
+  ETAPAS_ROSTER_PESAJE,
+  parsearRespuestaModeloOcrPesaje,
+  procesarLecturaOcrPesaje,
+  SEMANAS_PESAJE,
+  type AnimalRosterPesaje,
+  type CeldaDiffPesaje,
+  type FilaPesajeNoLeida,
+  type LecturaOcrPesajePagina,
+  type PesajeExistente,
+  type SemanaPesaje,
+  type VacaPesajeSinLeer,
+} from './importHato/ocrPesaje.ts';
+import {
+  construirPromptCorreccionPesaje,
+  esquemaJsonCorreccionPesaje,
+  parsearRespuestaModeloCorreccionPesaje,
+  type ItemCorreccionModeloPesaje,
+} from './importHato/ocrPesajeCorreccion.ts';
+
+type SupabaseAdmin = ReturnType<typeof createClient>;
+
+// ---------------------------------------------------------------------------
+// Límites/constantes compartidos -- ÚNICA definición para que el endpoint
+// HTTP y la conversación de Telegram acepten exactamente lo mismo (brief
+// N11: "mismo límite y mismos tipos MIME que el endpoint").
+// ---------------------------------------------------------------------------
+export const MAXIMO_FOTOS_PESAJE = 6;
+export const TAMANO_MAXIMO_FOTO_PESAJE_BYTES = 15 * 1024 * 1024;
+export const TIPOS_ACEPTADOS_FOTO_PESAJE = new Set([
+  'image/jpeg',
+  'image/jpg',
+  'image/png',
+  'image/webp',
+  'image/heic',
+  'image/heif',
+]);
+
+// Bucket privado propio (migración 086 -- patrón 072/085). Nunca se mezcla
+// con `chequeos-fotos` (otro dominio) ni con `hato-liquidaciones-fotos`.
+const BUCKET_FOTOS_PESAJE = 'hato-pesajes-fotos';
+
+const OPENROUTER_URL = 'https://openrouter.ai/api/v1/chat/completions';
+const MODELO_VISION_PESAJE = 'google/gemini-3-flash-preview';
+const TIMEOUT_MODELO_MS = 120_000;
+
+// ---------------------------------------------------------------------------
+// Helpers de codificación -- idénticos a los que vivían en
+// `hato-pesaje-foto.ts` antes de esta extracción.
+// ---------------------------------------------------------------------------
+
+function bytesABase64(bytes: Uint8Array): string {
+  const TAMANO_BLOQUE = 0x8000;
+  let binario = '';
+  for (let i = 0; i < bytes.length; i += TAMANO_BLOQUE) {
+    binario += String.fromCharCode(...bytes.subarray(i, i + TAMANO_BLOQUE));
+  }
+  return btoa(binario);
+}
+
+function extensionDeTipo(tipo: string, nombre: string): string {
+  const porNombre = nombre.match(/\.([a-z0-9]{2,5})$/i)?.[1];
+  if (porNombre) return porNombre.toLowerCase();
+  const sufijo = tipo.split('/')[1];
+  return sufijo ? sufijo.toLowerCase() : 'jpg';
+}
+
+function extraerJson(contenido: string): unknown {
+  const limpio = contenido.trim().replace(/^```(?:json)?\s*/i, '').replace(/\s*```$/, '');
+  return JSON.parse(limpio);
+}
+
+// ---------------------------------------------------------------------------
+// N11 — Pipeline de lectura por foto (preview, nunca escribe en dominio).
+// ---------------------------------------------------------------------------
+
+export interface FotoPesajeEntrada {
+  /** 1-based, en el orden en que el caller recibió las fotos. */
+  pagina: number;
+  nombre: string;
+  tipo: string;
+  bytes: Uint8Array;
+}
+
+export interface PipelinePesajeFotoResultado {
+  generadoEn: string;
+  anio: number;
+  mes: number;
+  fechasPorSemana: Record<SemanaPesaje, string | null>;
+  diff: CeldaDiffPesaje[];
+  /** El roster que validó el ancla de esta lectura, como ARREGLO plano
+   * (nunca el `RosterPesaje` con su `Map` interno): N12 lo necesita para
+   * resolver el nombre de una corrección con el MISMO cotejo, pero el bot
+   * de Telegram persiste el resultado de este pipeline a través de
+   * `conversation.external()` -- eso pasa por el storage jsonb de
+   * `telegram_conversations`, y un `Map` no sobrevive un `JSON.stringify`.
+   * El caller reconstruye el `RosterPesaje` con `construirRosterPesaje`
+   * (puro, determinista) cada vez que lo necesita. */
+  rosterAnimales: AnimalRosterPesaje[];
+  ocr: {
+    modelo: string;
+    fotos: Array<{ pagina: number; nombre: string; tipo: string; bytes: number; rutaStorage: string | null }>;
+    almacenamiento: { bucket: string; prefijo: string; ok: boolean; errores: string[] };
+    paginasNoLeidas: string[];
+    filasNoLeidas: FilaPesajeNoLeida[];
+    vacasSinLeer: VacaPesajeSinLeer[];
+    advertencias: string[];
+    resumen: {
+      vacasEnRoster: number;
+      fotosRecibidas: number;
+      fotosLeidas: number;
+      filasConfirmadas: number;
+      filasNoLeidas: number;
+      vacasSinLeer: number;
+      celdasNoConfiables: number;
+    };
+  };
+}
+
+export type ResultadoPipelinePesajeFoto =
+  | { ok: true; resultado: PipelinePesajeFotoResultado }
+  | { ok: false; status: 500 | 502; error: string };
+
+interface LlamadaModeloOk {
+  ok: true;
+  lectura: LecturaOcrPesajePagina;
+}
+interface LlamadaModeloError {
+  ok: false;
+  pagina: number;
+  error: string;
+}
+
+async function leerFotoConModelo(
+  foto: FotoPesajeEntrada,
+  totalFotos: number,
+  prompt: string,
+  esquema: Record<string, unknown>,
+  apiKey: string,
+): Promise<LlamadaModeloOk | LlamadaModeloError> {
+  const dataUrl = `data:${foto.tipo};base64,${bytesABase64(foto.bytes)}`;
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MODELO_MS);
+
+  try {
+    const respuesta = await fetch(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODELO_VISION_PESAJE,
+        messages: [
+          { role: 'system', content: prompt },
+          {
+            role: 'user',
+            content: [
+              {
+                type: 'text',
+                // "foto N de M", no "página N": desde 2026-08-11 la planilla
+                // cabe en UNA hoja y se fotografía por franjas, así que
+                // llamarla página inducía al modelo a esperar una planilla
+                // completa (con encabezados) en cada imagen.
+                text: `Transcribe la foto ${foto.pagina} de ${totalFotos} de la planilla de pesaje. Puede ser una franja de la hoja, no la hoja entera. Devuelve una entrada por cada fila de vaca visible, en el orden en que aparecen.`,
+              },
+              { type: 'image_url', image_url: { url: dataUrl } },
+            ],
+          },
+        ],
+        temperature: 0,
+        max_tokens: 12000,
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'planilla_pesaje', strict: true, schema: esquema },
+        },
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!respuesta.ok) {
+      const detalle = await respuesta.text().catch(() => '');
+      return {
+        ok: false,
+        pagina: foto.pagina,
+        error: `el modelo de visión respondió ${respuesta.status}: ${detalle.slice(0, 300)}`,
+      };
+    }
+
+    const resultado = await respuesta.json();
+    const contenido = resultado?.choices?.[0]?.message?.content;
+    if (typeof contenido !== 'string' || contenido.trim() === '') {
+      return { ok: false, pagina: foto.pagina, error: 'el modelo de visión devolvió una respuesta vacía' };
+    }
+
+    return { ok: true, lectura: parsearRespuestaModeloOcrPesaje(extraerJson(contenido), foto.pagina) };
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const mensaje =
+      err instanceof Error && err.name === 'AbortError'
+        ? `la lectura superó el tiempo máximo (${TIMEOUT_MODELO_MS / 1000}s)`
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, pagina: foto.pagina, error: mensaje };
+  }
+}
+
+/**
+ * N11: orquesta toda la ruta de lectura por foto -- guarda la capa cruda en
+ * Storage ANTES de leerla, resuelve `hato_config.dia_pesaje_semanal` y el
+ * roster vigente, llama al modelo (una vez por foto, en paralelo), coteja
+ * el ancla por nombre y arma el diff contra `hato_pesajes_leche`. NUNCA
+ * escribe en tablas de dominio -- ver `ejecutarCommitPesaje` para eso.
+ *
+ * Comparte esta orquestación el endpoint HTTP (`hato-pesaje-foto.ts`) y la
+ * conversación de Telegram (`pesajeLeche.ts`) -- es el pipeline que pedía
+ * N11 del plan, no un segundo lector de celdas ni un segundo armado de
+ * roster.
+ */
+export async function ejecutarPipelinePesajeFoto(params: {
+  supabase: SupabaseAdmin;
+  apiKey: string;
+  fotos: readonly FotoPesajeEntrada[];
+  anio: number;
+  mes: number;
+}): Promise<ResultadoPipelinePesajeFoto> {
+  const { supabase, apiKey, fotos, anio, mes } = params;
+  const generadoEn = new Date().toISOString();
+
+  // --- 1. Guardar la capa cruda ANTES de leerla -----------------------------
+  const prefijoStorage = `pesaje-foto/${generadoEn.replace(/[:.]/g, '-')}-${crypto.randomUUID().slice(0, 8)}`;
+  const rutasStorage: Array<string | null> = [];
+  const erroresStorage: string[] = [];
+  for (const foto of fotos) {
+    const ruta = `${prefijoStorage}/pagina-${foto.pagina}.${extensionDeTipo(foto.tipo, foto.nombre)}`;
+    const { error } = await supabase.storage
+      .from(BUCKET_FOTOS_PESAJE)
+      .upload(ruta, foto.bytes, { contentType: foto.tipo, upsert: false });
+    if (error) {
+      rutasStorage.push(null);
+      erroresStorage.push(`página ${foto.pagina}: ${error.message}`);
+    } else {
+      rutasStorage.push(ruta);
+    }
+  }
+
+  // --- 2. hato_config.dia_pesaje_semanal + roster VIGENTE de la planilla ----
+  const [configRes, rosterRes] = await Promise.all([
+    supabase.from('hato_config').select('valor').eq('clave', 'dia_pesaje_semanal').maybeSingle(),
+    supabase.from('hato_animales').select('id, nombre, etapa, estado').eq('estado', 'activa').in('etapa', ETAPAS_ROSTER_PESAJE),
+  ]);
+
+  if (configRes.error) return { ok: false, status: 500, error: `No se pudo leer hato_config: ${configRes.error.message}` };
+  const configValor = configRes.data?.valor as { iso?: unknown } | undefined;
+  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
+    return {
+      ok: false,
+      status: 500,
+      error: 'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064) -- no se puede resolver a qué fecha corresponde cada semana.',
+    };
+  }
+  const diaPesajeIso = configValor.iso;
+
+  if (rosterRes.error) return { ok: false, status: 500, error: `No se pudo leer hato_animales: ${rosterRes.error.message}` };
+  const animalesRoster: AnimalRosterPesaje[] = (
+    (rosterRes.data ?? []) as Array<{ id: string; nombre: string | null; etapa: string | null; estado: string | null }>
+  )
+    .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
+    .map((a) => ({ id: a.id, nombre: a.nombre ?? '' }));
+  const roster = construirRosterPesaje(animalesRoster);
+
+  if (roster.entradas.length === 0) {
+    return {
+      ok: false,
+      status: 500,
+      error: 'No hay vacas en ordeño activas con nombre en el hato: sin roster no se puede validar el ancla de ninguna fila.',
+    };
+  }
+
+  const fechasArr = fechasPesajeMensuales(anio, mes, diaPesajeIso);
+  const fechasPorSemana = {} as Record<SemanaPesaje, string | null>;
+  for (const semana of SEMANAS_PESAJE) fechasPorSemana[semana] = fechasArr[semana - 1] ?? null;
+
+  // --- 3. Lectura con el modelo de visión (una llamada por foto) -----------
+  const prompt = construirPromptOcrPesaje();
+  const esquema = esquemaJsonOcrPesaje();
+  const resultados = await Promise.all(
+    fotos.map((foto) => leerFotoConModelo(foto, fotos.length, prompt, esquema, apiKey)),
+  );
+
+  const lecturas: LecturaOcrPesajePagina[] = [];
+  const erroresLectura: string[] = [];
+  for (const resultado of resultados) {
+    if (resultado.ok) lecturas.push(resultado.lectura);
+    else erroresLectura.push(`página ${resultado.pagina}: ${resultado.error}`);
+  }
+
+  if (lecturas.length === 0) {
+    return {
+      ok: false,
+      status: 502,
+      error: `No se pudo leer ninguna de las fotos. ${erroresLectura.join(' | ')}${
+        rutasStorage.some((r) => r !== null) ? ' Las fotos sí quedaron guardadas.' : ''
+      }`,
+    };
+  }
+
+  // --- 4. Anti-row-drift por nombre (lógica pura) ---------------------------
+  const ocr = procesarLecturaOcrPesaje(lecturas, roster);
+
+  // --- 5. Existentes en hato_pesajes_leche, para clasificar el diff --------
+  const animalIdsLeidos = ocr.filasConfirmadas.map((f) => f.animalId);
+  const fechasValidas = SEMANAS_PESAJE.map((s) => fechasPorSemana[s]).filter((f): f is string => f !== null);
+  const existentes = new Map<string, Map<string, PesajeExistente>>();
+  if (animalIdsLeidos.length > 0 && fechasValidas.length > 0) {
+    const { data, error } = await supabase
+      .from('hato_pesajes_leche')
+      .select('id, animal_id, fecha, litros_am, litros_pm, litros_total')
+      .in('animal_id', animalIdsLeidos)
+      .in('fecha', fechasValidas);
+    if (error) return { ok: false, status: 500, error: `No se pudo leer hato_pesajes_leche: ${error.message}` };
+    for (const fila of (data ?? []) as Array<{ id: string; animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number }>) {
+      if (!existentes.has(fila.animal_id)) existentes.set(fila.animal_id, new Map());
+      existentes.get(fila.animal_id)!.set(fila.fecha, {
+        id: fila.id,
+        litrosAm: fila.litros_am,
+        litrosPm: fila.litros_pm,
+        litrosTotal: fila.litros_total,
+      });
+    }
+  }
+
+  const diff = construirDiffPesaje(ocr.filasConfirmadas, fechasPorSemana, existentes);
+  const celdasNoConfiables = ocr.filasConfirmadas.reduce((n, f) => n + f.celdasNoConfiables.length, 0);
+
+  return {
+    ok: true,
+    resultado: {
+      generadoEn,
+      anio,
+      mes,
+      fechasPorSemana,
+      diff,
+      rosterAnimales: animalesRoster,
+      ocr: {
+        modelo: MODELO_VISION_PESAJE,
+        fotos: fotos.map((f, i) => ({
+          pagina: f.pagina,
+          nombre: f.nombre,
+          tipo: f.tipo,
+          bytes: f.bytes.length,
+          rutaStorage: rutasStorage[i],
+        })),
+        almacenamiento: {
+          bucket: BUCKET_FOTOS_PESAJE,
+          prefijo: prefijoStorage,
+          ok: erroresStorage.length === 0,
+          errores: erroresStorage,
+        },
+        paginasNoLeidas: erroresLectura,
+        filasNoLeidas: ocr.filasNoLeidas,
+        vacasSinLeer: ocr.vacasSinLeer,
+        advertencias: ocr.advertencias,
+        resumen: {
+          vacasEnRoster: roster.entradas.length,
+          fotosRecibidas: fotos.length,
+          fotosLeidas: lecturas.length,
+          filasConfirmadas: ocr.filasConfirmadas.length,
+          filasNoLeidas: ocr.filasNoLeidas.length,
+          vacasSinLeer: ocr.vacasSinLeer.length,
+          celdasNoConfiables,
+        },
+      },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// N12 — Interpretación de una corrección en texto libre (decisión D-C).
+// ---------------------------------------------------------------------------
+
+export type ResultadoLlamadaCorreccionPesaje =
+  | { ok: true; items: ItemCorreccionModeloPesaje[]; avisos: string[] }
+  | { ok: false; error: string };
+
+/**
+ * N12: la ÚNICA llamada HTTP al modelo para interpretar el texto libre de
+ * una corrección. El prompt y el esquema vienen de
+ * `ocrPesajeCorreccion.ts` (puro, espejado) -- acá solo se hace la
+ * petición y se le pasa la respuesta cruda a
+ * `parsearRespuestaModeloCorreccionPesaje`, que es quien decide la forma.
+ * Esta función NUNCA valida el contenido (nombre contra roster, semana
+ * contra la grilla del mes): eso es `interpretarCorreccionPesaje`, pura,
+ * llamada por el caller DESPUÉS de esto.
+ */
+export async function llamarModeloCorreccionPesaje(
+  texto: string,
+  apiKey: string,
+): Promise<ResultadoLlamadaCorreccionPesaje> {
+  const prompt = construirPromptCorreccionPesaje();
+  const esquema = esquemaJsonCorreccionPesaje();
+  const controller = new AbortController();
+  const timeoutId = setTimeout(() => controller.abort(), TIMEOUT_MODELO_MS);
+
+  try {
+    const respuesta = await fetch(OPENROUTER_URL, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        Authorization: `Bearer ${apiKey}`,
+      },
+      body: JSON.stringify({
+        model: MODELO_VISION_PESAJE,
+        messages: [
+          { role: 'system', content: prompt },
+          { role: 'user', content: texto },
+        ],
+        temperature: 0,
+        max_tokens: 4000,
+        response_format: {
+          type: 'json_schema',
+          json_schema: { name: 'correccion_pesaje', strict: true, schema: esquema },
+        },
+      }),
+      signal: controller.signal,
+    });
+    clearTimeout(timeoutId);
+
+    if (!respuesta.ok) {
+      const detalle = await respuesta.text().catch(() => '');
+      return { ok: false, error: `el modelo respondió ${respuesta.status}: ${detalle.slice(0, 300)}` };
+    }
+
+    const resultado = await respuesta.json();
+    const contenido = resultado?.choices?.[0]?.message?.content;
+    if (typeof contenido !== 'string' || contenido.trim() === '') {
+      return { ok: false, error: 'el modelo devolvió una respuesta vacía' };
+    }
+
+    const { items, avisos } = parsearRespuestaModeloCorreccionPesaje(extraerJson(contenido));
+    return { ok: true, items, avisos };
+  } catch (err) {
+    clearTimeout(timeoutId);
+    const mensaje =
+      err instanceof Error && err.name === 'AbortError'
+        ? `la interpretación superó el tiempo máximo (${TIMEOUT_MODELO_MS / 1000}s)`
+        : err instanceof Error
+          ? err.message
+          : String(err);
+    return { ok: false, error: mensaje };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// N13 — Commit por celda (revalidación fresca + escritura).
+// ---------------------------------------------------------------------------
+
+export interface CeldaCommitPesajeEntrada {
+  animalId: string;
+  fecha: string; // AAAA-MM-DD
+  litrosAm: number | null;
+  litrosPm: number | null;
+}
+
+export interface CeldaPesajeRechazada {
+  animalId: string;
+  fecha: string;
+  motivo: string;
+}
+
+export type ResultadoCommitPesaje =
+  | { ok: true; guardados: number; actualizados: number; creados: number; celdasRechazadas: CeldaPesajeRechazada[] }
+  | { ok: false; status: 400; error: string; celdasRechazadas: CeldaPesajeRechazada[] }
+  | { ok: false; status: 500; error: string };
+
+/**
+ * N13: la MISMA revalidación fresca que ya tenía `hato-pesaje-commit.ts`
+ * (la vaca sigue en el roster de la planilla EN ESTE INSTANTE; la fecha
+ * sigue siendo una ocurrencia real de `hato_config.dia_pesaje_semanal` para
+ * `(anio, mes)` EN ESTE INSTANTE) + escritura UPDATE-por-id/INSERT (nunca
+ * upsert de PostgREST). Commit por CELDA: una celda inválida se rechaza
+ * sola, el resto entra -- así una vaca vendida entre la vista previa y la
+ * aprobación no le cuesta a Martha/Fernando los demás pesajes.
+ *
+ * `createdBy` viaja EXPLÍCITO (riesgo R-6 del plan): el caller (endpoint
+ * HTTP o bot de Telegram) escribe con `service_role`, donde `auth.uid()` es
+ * NULL, así que sin este parámetro la autoría se perdería. `fuente` la
+ * decide el caller (`'foto'` para el endpoint web, `'telegram'` para el
+ * bot) -- no hay un valor por defecto acá a propósito, para que no se
+ * pueda commitear sin declarar de dónde vino.
+ */
+export async function ejecutarCommitPesaje(params: {
+  supabase: SupabaseAdmin;
+  anio: number;
+  mes: number;
+  celdas: readonly CeldaCommitPesajeEntrada[];
+  createdBy: string;
+  fuente: string;
+}): Promise<ResultadoCommitPesaje> {
+  const { supabase, anio, mes, celdas, createdBy, fuente } = params;
+
+  // --- 1. hato_config.dia_pesaje_semanal FRESCO -----------------------------
+  const { data: configData, error: configError } = await supabase
+    .from('hato_config')
+    .select('valor')
+    .eq('clave', 'dia_pesaje_semanal')
+    .maybeSingle();
+  if (configError) return { ok: false, status: 500, error: `No se pudo leer hato_config: ${configError.message}` };
+  const configValor = configData?.valor as { iso?: unknown } | undefined;
+  if (!configValor || typeof configValor.iso !== 'number' || configValor.iso < 1 || configValor.iso > 7) {
+    return {
+      ok: false,
+      status: 500,
+      error: 'hato_config.dia_pesaje_semanal no está configurado o tiene un valor inválido (migración 064).',
+    };
+  }
+  const fechasValidasHoy = new Set(fechasPesajeMensuales(anio, mes, configValor.iso as number));
+
+  // --- 2. Roster FRESCO -----------------------------------------------------
+  const animalIds = [...new Set(celdas.map((c) => c.animalId))];
+  const { data: animalesData, error: animalesError } = await supabase
+    .from('hato_animales')
+    .select('id, etapa, estado')
+    .in('id', animalIds)
+    .in('etapa', ETAPAS_ROSTER_PESAJE);
+  if (animalesError) {
+    return { ok: false, status: 500, error: `No se pudo leer hato_animales: ${animalesError.message}` };
+  }
+  const activasAhora = new Set(
+    ((animalesData ?? []) as Array<{ id: string; etapa: string | null; estado: string | null }>)
+      .filter((a) => esCandidataRosterPesaje({ etapa: a.etapa, estado: a.estado }))
+      .map((a) => a.id),
+  );
+
+  // --- 3. Filtrar: solo celdas cuya vaca sigue activa y cuya fecha sigue
+  //    siendo una ocurrencia real del día de pesaje configurado. ------------
+  const aceptadas: CeldaCommitPesajeEntrada[] = [];
+  const rechazadas: CeldaPesajeRechazada[] = [];
+  for (const celda of celdas) {
+    if (!activasAhora.has(celda.animalId)) {
+      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'El animal ya no está en el roster de la planilla -- puede haberse vendido o cambiado de etapa desde la vista previa.' });
+      continue;
+    }
+    if (!fechasValidasHoy.has(celda.fecha)) {
+      rechazadas.push({ animalId: celda.animalId, fecha: celda.fecha, motivo: 'Esa fecha ya no corresponde a una semana de pesaje configurada para este mes.' });
+      continue;
+    }
+    aceptadas.push(celda);
+  }
+
+  if (aceptadas.length === 0) {
+    return {
+      ok: false,
+      status: 400,
+      error: 'Ninguna celda pasó la revalidación -- el hato cambió desde la vista previa. No se escribió nada.',
+      celdasRechazadas: rechazadas,
+    };
+  }
+
+  // --- 4. Existentes FRESCOS -------------------------------------------------
+  const fechasEnLote = [...new Set(aceptadas.map((c) => c.fecha))];
+  const { data: existentesData, error: existentesError } = await supabase
+    .from('hato_pesajes_leche')
+    .select('id, animal_id, fecha')
+    .in('animal_id', [...new Set(aceptadas.map((c) => c.animalId))])
+    .in('fecha', fechasEnLote);
+  if (existentesError) return { ok: false, status: 500, error: `No se pudo leer hato_pesajes_leche: ${existentesError.message}` };
+  const idExistentePorClave = new Map<string, string>();
+  for (const fila of (existentesData ?? []) as Array<{ id: string; animal_id: string; fecha: string }>) {
+    idExistentePorClave.set(`${fila.animal_id}|${fila.fecha}`, fila.id);
+  }
+
+  // --- 5. Escritura: UPDATE-por-id + INSERT (nunca upsert de PostgREST) ----
+  let actualizados = 0;
+  let creados = 0;
+  const nuevasFilas: Array<{ animal_id: string; fecha: string; litros_am: number | null; litros_pm: number | null; litros_total: number; fuente: string; created_by: string }> = [];
+
+  for (const celda of aceptadas) {
+    const total = (celda.litrosAm ?? 0) + (celda.litrosPm ?? 0);
+    const existenteId = idExistentePorClave.get(`${celda.animalId}|${celda.fecha}`);
+    if (existenteId) {
+      const { error } = await supabase
+        .from('hato_pesajes_leche')
+        .update({ litros_am: celda.litrosAm, litros_pm: celda.litrosPm, litros_total: total, fuente })
+        .eq('id', existenteId);
+      if (error) return { ok: false, status: 500, error: `No se pudo actualizar el pesaje de '${celda.animalId}' en ${celda.fecha}: ${error.message}` };
+      actualizados += 1;
+    } else {
+      nuevasFilas.push({
+        animal_id: celda.animalId,
+        fecha: celda.fecha,
+        litros_am: celda.litrosAm,
+        litros_pm: celda.litrosPm,
+        litros_total: total,
+        fuente,
+        created_by: createdBy,
+      });
+    }
+  }
+
+  if (nuevasFilas.length > 0) {
+    const { error } = await supabase.from('hato_pesajes_leche').insert(nuevasFilas);
+    if (error) return { ok: false, status: 500, error: `No se pudieron insertar los pesajes nuevos: ${error.message}` };
+    creados = nuevasFilas.length;
+  }
+
+  return { ok: true, guardados: actualizados + creados, actualizados, creados, celdasRechazadas: rechazadas };
+}

--- a/supabase/functions/make-server-1ccce916/importHato/chequeos.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/chequeos.ts
@@ -82,6 +82,7 @@ const CRUDO_VACIO: CrudoFilaChequeo = {
   sx: null,
   fechaServicio: null,
   toro: null,
+  estadoRegistrado: null,
   tp: null,
   estado: null,
   secar: null,
@@ -207,6 +208,13 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
     const toroRes = parseToro(toroCruda, config);
     issues.push(...conCampo('Toro', toroRes.issues));
 
+    // "Estado registrado" (D-E, B5.4): texto de referencia, NUNCA
+    // interpretado -- se conserva verbatim para que el diff lo compare
+    // contra lo que el motor deriva hoy (N23). `null` cuando la hoja no trae
+    // esta columna (toda generación histórica, `colmap.estadoRegistrado ===
+    // null`) o la celda vino vacía.
+    const estadoRegistradoTexto = valorCeldaATexto(celda(filaFisica, colmap.estadoRegistrado));
+
     // D6 (decisión del dueño, 2026-07-22, resolution-report.md §6): un
     // código de ESTADO filtrado a la columna Toro NUNCA es un toro, "sin
     // excepción" -- incluso si la fila SÍ trae una fecha de servicio real.
@@ -272,6 +280,7 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
       sx: valorCeldaATexto(sxCruda),
       fechaServicio: fechaServicioTexto,
       toro: valorCeldaATexto(toroCruda),
+      estadoRegistrado: estadoRegistradoTexto,
       tp: tpTexto,
       estado: estadoTexto,
       secar: secarTexto,
@@ -298,6 +307,7 @@ export function procesarHojaChequeo(hoja: HojaCruda, config: HatoConfig): Result
       fechaProbableParto,
       toroNombre: toroRes.toroNombre,
       tipoServicio: toroRes.tipoServicio,
+      estadoRegistrado: estadoRegistradoTexto,
       issues,
     });
   }

--- a/supabase/functions/make-server-1ccce916/importHato/commitChequeo.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/commitChequeo.ts
@@ -309,6 +309,79 @@ export function seleccionarFechasServicioConocidasPorAnimal(
   return resultado;
 }
 
+/** Un evento del hato registrado A MANO (`chequeo_vaca_id IS NULL`): por
+ * Telegram (`/evento`, fuente `telegram`), por el diálogo de marcar ciclo
+ * (fuente `web`) o por venta/muerte. El caller lo trae ya filtrado. */
+export interface EventoManualHistorico {
+  animalId: string;
+  tipo: string;
+  fecha: string;
+}
+
+/**
+ * **N10 — el nodo que impide que el chequeo duplique lo que ya se registró a
+ * mano.** Fusiona los eventos manuales en los dos mapas de deduplicación que
+ * consume `derivarEventosDeChequeo`.
+ *
+ * Por qué existe: los dos mecanismos anti-duplicado del módulo
+ * (`fechasServicioConocidas` para servicios, `ultimaCriaAnterior` para
+ * partos) se alimentaban EXCLUSIVAMENTE de `hato_chequeo_vacas`, porque
+ * hasta ahora todos los eventos derivados venían de una planilla. Desde que
+ * Fernando registra la monta el mismo día en el corral, ese supuesto es
+ * falso: su monta del 10 de agosto no está en ninguna fila de chequeo, así
+ * que al aprobar el chequeo del 20 —que trae esa misma F Servicio, porque
+ * la veterinaria la copia de lo que ya sabe— el motor emitiría un SEGUNDO
+ * evento de servicio para la misma monta.
+ *
+ * Es exactamente la forma del bug que costó tres rondas de limpieza en julio
+ * de 2026 (385 servicios y 806 partos duplicados en producción). La
+ * diferencia es que aquel se descubrió con los datos ya corrompidos.
+ *
+ * Puro: devuelve mapas NUEVOS, no muta los que recibe.
+ */
+export function fusionarEventosManualesEnDedupe(
+  fechasServicioPorAnimal: Map<string, Set<string>>,
+  ultimaCriaAnteriorPorAnimal: Map<string, string | null>,
+  eventosManuales: EventoManualHistorico[],
+  chequeoNuevoFecha: string,
+): {
+  fechasServicioPorAnimal: Map<string, Set<string>>;
+  ultimaCriaAnteriorPorAnimal: Map<string, string | null>;
+} {
+  const servicios = new Map<string, Set<string>>();
+  for (const [animalId, fechas] of fechasServicioPorAnimal) {
+    servicios.set(animalId, new Set(fechas));
+  }
+  const crias = new Map<string, string | null>(ultimaCriaAnteriorPorAnimal);
+
+  for (const evento of eventosManuales) {
+    // Solo lo ESTRICTAMENTE anterior al chequeo que se aprueba -- mismo
+    // criterio que los dos selectores de arriba. Un evento manual del mismo
+    // día o posterior no es "lo ya conocido", es otro hecho.
+    if (evento.fecha >= chequeoNuevoFecha) continue;
+
+    if (evento.tipo === 'servicio') {
+      if (!servicios.has(evento.animalId)) servicios.set(evento.animalId, new Set());
+      servicios.get(evento.animalId)!.add(evento.fecha);
+      continue;
+    }
+
+    if (evento.tipo === 'parto') {
+      // `ultimaCriaAnterior` es UNA fecha (la última cría conocida), no un
+      // conjunto: `decidirEventoParto` agrupa por proximidad contra ella.
+      // Un parto manual solo la reemplaza si es MÁS RECIENTE que lo que ya
+      // había -- si el chequeo anterior reportó una cría posterior, esa
+      // sigue siendo la última.
+      const actual = crias.get(evento.animalId) ?? null;
+      if (actual === null || evento.fecha > actual) {
+        crias.set(evento.animalId, evento.fecha);
+      }
+    }
+  }
+
+  return { fechasServicioPorAnimal: servicios, ultimaCriaAnteriorPorAnimal: crias };
+}
+
 /**
  * Deriva los eventos de `hato_eventos` de cada fila aprobada, reusando
  * `descomponerSX` (mismo motor que `Load` y la captura en vivo). Una fila

--- a/supabase/functions/make-server-1ccce916/importHato/diffChequeo.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/diffChequeo.ts
@@ -139,6 +139,27 @@ export interface CampoDiffChequeo {
   nuevo: unknown;
 }
 
+/**
+ * Conflicto explícito entre "lo registrado" y "lo impreso" (D-E, N23,
+ * docs/plan_hato_telegram_estados_agosto_2026.md §3 Capa 5). La planilla sale
+ * pre-impresa con la etiqueta del `EstadoReproductivo` que el motor creía
+ * cierta al momento de exportar ("Estado registrado", columna gris de solo
+ * referencia -- Martha nunca escribe ahí). Entre que se imprime y que se
+ * sube de vuelta puede haber pasado CUALQUIER COSA que cambie esa lectura: un
+ * evento de Telegram nuevo, una corrección manual, un chequeo distinto ya
+ * aprobado -- y eso tiene que verse ANTES de aprobar, no descubrirse después
+ * (la contradicción es justo lo que N23 pide mostrar). `actual` se recalcula
+ * SIEMPRE con el estado fresco de la base al momento del diff (mismo
+ * principio que el resto de este archivo: nunca el diff viejo que vio la
+ * pantalla).
+ */
+export interface ConflictoEstadoRegistrado {
+  /** Lo que decía la planilla cuando se exportó/imprimió. */
+  impreso: string;
+  /** Lo que el sistema cree AHORA, recién recalculado. */
+  actual: string;
+}
+
 export interface FilaDiffChequeo {
   fila: number;
   numero: number | null;
@@ -157,6 +178,25 @@ export interface FilaDiffChequeo {
   diferencias: CampoDiffChequeo[];
   motivoNoReconocido: string | null;
   issues: ParseIssue[];
+  /** `null` cuando no hay nada que contrastar: fila `nuevo`/`no_reconocido`
+   * (sin `animalId`), la hoja no trae la columna "Estado registrado" (toda
+   * generación anterior a B5.4), la celda vino vacía, o lo impreso SIGUE
+   * coincidiendo con lo que el sistema cree hoy. Ver `ConflictoEstadoRegistrado`. */
+  conflictoEstadoRegistrado: ConflictoEstadoRegistrado | null;
+}
+
+/** "Lo que el sistema cree HOY" para un animal -- la etiqueta de
+ * `EstadoReproductivo` (`etiquetaEstadoReproductivo`, calculosHato.ts),
+ * recalculada por el handler contra el estado FRESCO de `v_hato_estado_actual`
+ * en el momento del diff, nunca cacheada. El handler arma este arreglo; este
+ * módulo solo lo usa para comparar texto contra texto -- no conoce el motor
+ * de estados ni el vocabulario de 5 estados, mismo principio de capas que el
+ * resto de `importHato/`. */
+export interface AnimalEstadoRegistradoActual {
+  animalId: string;
+  /** Etiqueta YA calculada (`etiquetaEstadoReproductivo`), lista para
+   * comparar texto a texto contra `fila.estadoRegistrado`. */
+  estado: string;
 }
 
 export interface ResumenDiffChequeo {
@@ -169,6 +209,12 @@ export interface ResumenDiffChequeo {
    * clasificación -- independiente de `noReconocidos` (una fila puede tener
    * issues y aun así resolverse a un animal). */
   conIssues: number;
+  /** Filas cuyo "Estado registrado" impreso ya NO coincide con lo que el
+   * sistema cree hoy (N23, D-E) -- la señal que tiene que verse ANTES de
+   * aprobar. Independiente de `cambios`: una fila puede no traer ningún
+   * cambio de campo (Martha no tocó nada) y aun así tener este conflicto,
+   * porque lo que cambió fue el sistema, no el papel. */
+  conConflictoEstadoRegistrado: number;
 }
 
 export interface ResultadoDiffChequeo {
@@ -237,7 +283,33 @@ function filaNoReconocida(fila: FilaChequeoNormalizada, numeroEsProvisional: boo
     diferencias: [],
     motivoNoReconocido: motivo,
     issues: fila.issues,
+    // Sin animal resuelto no hay contra qué contrastar "lo que el sistema
+    // cree hoy" -- nunca se inventa un conflicto para una fila que ni
+    // siquiera se sabe de quién es.
+    conflictoEstadoRegistrado: null,
   };
+}
+
+/**
+ * N23: compara `estadoRegistrado` IMPRESO (crudo, tal como salió en la
+ * planilla) contra lo que el sistema cree AHORA (`estadosRegistrados`,
+ * recién recalculado por el handler). `null` cuando no hay nada que
+ * contrastar -- la hoja no trae la columna (generación anterior a B5.4), la
+ * celda vino vacía, o el animal no aparece en `estadosRegistrados` (no
+ * debería pasar para una fila con `animalId` resuelto, pero un mapa
+ * incompleto no debe fabricar un conflicto falso).
+ */
+function calcularConflictoEstadoRegistrado(
+  estadoRegistradoImpreso: string | null,
+  animalId: string,
+  estadosRegistradosPorAnimalId: Map<string, string>,
+): ConflictoEstadoRegistrado | null {
+  const impreso = estadoRegistradoImpreso?.trim();
+  if (!impreso) return null;
+  const actual = estadosRegistradosPorAnimalId.get(animalId);
+  if (actual === undefined) return null;
+  if (impreso === actual) return null;
+  return { impreso, actual };
 }
 
 /**
@@ -245,17 +317,28 @@ function filaNoReconocida(fila: FilaChequeoNormalizada, numeroEsProvisional: boo
  * actual del hato. `animales`/`ultimosChequeos` son la forma plana que el
  * handler del endpoint arma con dos consultas a Supabase (`hato_animales` +
  * `hato_chequeo_vacas` reducida vía `seleccionarUltimoChequeoPorAnimal`).
+ *
+ * `estadosRegistrados` (N23, D-E) es OPCIONAL y por defecto vacío -- sin él
+ * (llamadas existentes, o un handler que no lo calculó todavía) el diff se
+ * comporta exactamente igual que antes, solo que `conflictoEstadoRegistrado`
+ * sale siempre `null`. El handler lo arma recalculando `derivarEstadoReproductivo`
+ * contra `v_hato_estado_actual` FRESCA para los animales de esta hoja -- nunca
+ * un valor cacheado del momento en que se imprimió la planilla.
  */
 export function construirDiffChequeo(
   filas: FilaChequeoNormalizada[],
   animales: AnimalHatoActual[],
   ultimosChequeos: UltimoChequeoVacaActual[],
+  estadosRegistrados: AnimalEstadoRegistradoActual[] = [],
 ): ResultadoDiffChequeo {
   const animalesPorNumero = new Map<number, AnimalHatoActual>();
   for (const a of animales) animalesPorNumero.set(a.numero, a);
 
   const ultimoPorAnimalId = new Map<string, UltimoChequeoVacaActual>();
   for (const u of ultimosChequeos) ultimoPorAnimalId.set(u.animalId, u);
+
+  const estadosRegistradosPorAnimalId = new Map<string, string>();
+  for (const e of estadosRegistrados) estadosRegistradosPorAnimalId.set(e.animalId, e.estado);
 
   // Colisión DENTRO de la hoja subida (mismo número, nombres distintos) --
   // mismo motor que ya protege el pipeline histórico. `nombre` nunca es
@@ -305,6 +388,9 @@ export function construirDiffChequeo(
         diferencias: [],
         motivoNoReconocido: null,
         issues: fila.issues,
+        // Ficha nueva: no hay animal contra el cual recalcular "lo que el
+        // sistema cree hoy".
+        conflictoEstadoRegistrado: null,
       };
     }
 
@@ -322,6 +408,11 @@ export function construirDiffChequeo(
       diferencias,
       motivoNoReconocido: null,
       issues: fila.issues,
+      conflictoEstadoRegistrado: calcularConflictoEstadoRegistrado(
+        fila.estadoRegistrado,
+        animal.id,
+        estadosRegistradosPorAnimalId,
+      ),
     };
   });
 
@@ -332,6 +423,7 @@ export function construirDiffChequeo(
     cambios: filasDiff.filter((f) => f.clasificacion === 'cambio').length,
     noReconocidos: filasDiff.filter((f) => f.clasificacion === 'no_reconocido').length,
     conIssues: filasDiff.filter((f) => f.issues.length > 0).length,
+    conConflictoEstadoRegistrado: filasDiff.filter((f) => f.conflictoEstadoRegistrado !== null).length,
   };
 
   return { filas: filasDiff, resumen, colisionesEnHoja };

--- a/supabase/functions/make-server-1ccce916/importHato/grilla.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/grilla.ts
@@ -41,6 +41,12 @@ export type ColumnaLogicaChequeo =
   | 'sx'
   | 'fechaServicio'
   | 'toro'
+  /** "Estado registrado" (D-E, plan agosto 2026 N21-N22): columna PRE-LLENADA
+   * y de solo referencia -- lo que el motor de 5 estados cree HOY, impreso
+   * para que la vet lo verifique contra la vaca real. Nunca se le pide nada
+   * a Martha en esta columna (esa es `estado`, la de al lado). Solo existe en
+   * el formato B5.3/B5.4 propio -- ninguna generación histórica la trae. */
+  | 'estadoRegistrado'
   | 'tp'
   | 'estado'
   | 'secar'
@@ -58,6 +64,7 @@ export const COLMAP_VACIO: ColmapChequeo = {
   sx: null,
   fechaServicio: null,
   toro: null,
+  estadoRegistrado: null,
   tp: null,
   estado: null,
   secar: null,
@@ -104,6 +111,10 @@ const ALIAS_ANCLA: Record<
   sx: ['SX', 'SEXO CRÍA'], // 'Sexo cría' es B5.3
   fechaServicio: ['F SERVICIO', 'FECHA SERVICIO'], // 'Fecha Servicio' es B5.3
   toro: ['T', 'TORO'],
+  // 'Estado registrado' es B5.4 (D-E, plan agosto 2026) -- exclusiva de
+  // nuestro propio formato, nunca ambigua con el alias 'ESTADO' del grupo
+  // final (comparación EXACTA de texto normalizado, ver `buscarColumnas`).
+  estadoRegistrado: ['ESTADO REGISTRADO'],
   ttto: ['TTTO', 'TRATAMIENTO'], // 'Tratamiento' es B5.3
 };
 
@@ -316,6 +327,11 @@ function colmapPosicional(offset: number): ColmapChequeo {
     sx: offset + 5,
     fechaServicio: offset + 6,
     toro: offset + 7,
+    // Ninguna de las 4 hojas headerless del corpus histórico trae 'Estado
+    // registrado' (B5.4, solo existe en nuestro propio formato exportado, que
+    // SIEMPRE lleva encabezado real) -- se deja sin columna, nunca se inventa
+    // una posición.
+    estadoRegistrado: null,
     tp: offset + 8,
     estado: offset + 9,
     secar: offset + 10,
@@ -380,6 +396,7 @@ const COLUMNAS_PARA_FILTRO_VACIO: ColumnaLogicaChequeo[] = [
   'sx',
   'fechaServicio',
   'toro',
+  'estadoRegistrado',
   'estado',
   'secar',
   'pp',

--- a/supabase/functions/make-server-1ccce916/importHato/ocrChequeo.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/ocrChequeo.ts
@@ -78,6 +78,7 @@ export const COLUMNAS_OCR = [
   'sexo_cria',
   'fecha_servicio',
   'toro',
+  'estado_registrado',
   'estado',
   'secar',
   'parto_probable',
@@ -108,6 +109,7 @@ export const ENCABEZADO_POR_COLUMNA_OCR: Record<ColumnaOcr, string> = {
   sexo_cria: 'Sexo cría',
   fecha_servicio: 'Fecha Servicio',
   toro: 'Toro',
+  estado_registrado: 'Estado registrado',
   estado: 'Estado',
   secar: 'Secar',
   parto_probable: 'Parto Probable',
@@ -781,6 +783,21 @@ export const VOCABULARIO_SX: readonly string[] = [
 /** Códigos de la columna Estado que `parseEstado` reconoce. */
 export const VOCABULARIO_ESTADO: readonly string[] = ['ok', 'rech'];
 
+/** Etiquetas que puede traer la columna "Estado registrado" (D-E, B5.4) --
+ * las CINCO del vocabulario del dueño más el guion de "sin clasificar". Es
+ * una columna de REFERENCIA que el sistema pre-imprime; Martha nunca escribe
+ * ahí, así que el modelo solo necesita reconocer una de estas palabras (o
+ * transcribir lo que vea si algo salió distinto -- regla 3 del prompt sigue
+ * mandando). */
+export const VOCABULARIO_ESTADO_REGISTRADO: readonly string[] = [
+  'Vacía',
+  'Servida',
+  'Confirmada',
+  'Por secar',
+  'Seca',
+  '—',
+];
+
 export interface VocabularioOcr {
   /** Nombres de toro reales, de `hato_toros`. */
   toros: readonly string[];
@@ -882,6 +899,7 @@ export function construirPromptOcr(vocabulario: VocabularioOcr): string {
     'VOCABULARIO ESPERADO (úsalo para leer mejor la letra, NO para reemplazar lo que ves):',
     `- Fechas: formato día/mes/año, por ejemplo 5/11/2026. Transcríbelas tal cual estén escritas.`,
     `- Columna 'Sexo cría' (código SX): ${VOCABULARIO_SX.join(', ')}. La letra A es hembra, la O es macho, el signo + significa que la cría murió, y un número después de la letra es la chapeta de la cría.`,
+    `- Columna 'Estado registrado' (letra impresa, GRIS, de referencia -- nunca escrita a mano): una de estas palabras: ${VOCABULARIO_ESTADO_REGISTRADO.join(', ')}.`,
     `- Columna 'Estado': ${VOCABULARIO_ESTADO.join(', ')}.`,
     `- Columna 'Toro': nombres del catálogo real: ${toros}. A veces va precedido de 'Toro ' o 'Ins '. Si el nombre escrito no está en el catálogo, transcríbelo igual tal cual.`,
     `- Columnas 'PL' y '# Partos': números.`,

--- a/supabase/functions/make-server-1ccce916/importHato/ocrPesaje.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/ocrPesaje.ts
@@ -320,13 +320,25 @@ export type ResultadoAnclaPesaje =
  * ambigüedad real. */
 const TOLERANCIA_EDICION_NOMBRE = 1;
 
-export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje): ResultadoAnclaPesaje {
-  const leido = normalizarNombrePesaje(fila.nombreImpreso);
+/**
+ * Cotejo de un nombre contra el roster de la planilla -- el corazón del
+ * anti-row-drift. Nace del ancla de la ruta FOTO (`validarAnclaFilaPesaje`,
+ * abajo, que solo le pasa `fila.nombreImpreso`), pero es la MISMA regla que
+ * necesita `ocrPesajeCorreccion.ts` para resolver el nombre que Fernando
+ * escribe en una corrección de texto libre (D-C): exacto único -> resuelto;
+ * exacto ambiguo -> nunca se adjudica; a una letra único -> resuelto con
+ * aviso; a una letra ambiguo -> nunca se adjudica; nada -> fuera del roster.
+ * Cotejar el nombre de una corrección con un algoritmo DISTINTO al que
+ * cotejó la foto original sería inconsistente sin motivo -- por eso una sola
+ * función, no dos parecidas.
+ */
+export function resolverNombreEnRosterPesaje(nombreCrudo: string, roster: RosterPesaje): ResultadoAnclaPesaje {
+  const leido = normalizarNombrePesaje(nombreCrudo);
   if (leido === '') {
     return {
       ok: false,
       motivo: 'nombre_ilegible',
-      detalle: `el nombre impreso se leyó como '${fila.nombreImpreso}', que no es un nombre -- la fila no se puede anclar`,
+      detalle: `'${nombreCrudo}' no es un nombre -- no se puede anclar`,
     };
   }
 
@@ -336,7 +348,7 @@ export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje
     return {
       ok: false,
       motivo: 'nombre_ambiguo_en_roster',
-      detalle: `${exactos.length} vacas en ordeño se llaman '${fila.nombreImpreso}' -- no se adjudica sola (regla del módulo), la fila queda para revisión humana`,
+      detalle: `${exactos.length} vacas en ordeño se llaman '${nombreCrudo}' -- no se adjudica sola (regla del módulo), queda para revisión humana`,
     };
   }
 
@@ -347,22 +359,26 @@ export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje
     return {
       ok: true,
       entrada: cercanos[0],
-      avisos: [`el nombre impreso se leyó como '${fila.nombreImpreso}' y el roster dice '${cercanos[0].nombre}' (una letra de diferencia) -- revisar`],
+      avisos: [`'${nombreCrudo}' y el roster dice '${cercanos[0].nombre}' (una letra de diferencia) -- revisar`],
     };
   }
   if (cercanos.length > 1) {
     return {
       ok: false,
       motivo: 'nombre_ambiguo_en_roster',
-      detalle: `'${fila.nombreImpreso}' está a una letra de ${cercanos.length} vacas en ordeño distintas -- no se adjudica sola`,
+      detalle: `'${nombreCrudo}' está a una letra de ${cercanos.length} vacas en ordeño distintas -- no se adjudica sola`,
     };
   }
 
   return {
     ok: false,
     motivo: 'nombre_fuera_del_roster',
-    detalle: `ninguna vaca en ordeño activa se llama '${fila.nombreImpreso}' -- puede ser una vaca vendida, una novilla anotada a mano, o un nombre mal leído`,
+    detalle: `ninguna vaca en ordeño activa se llama '${nombreCrudo}' -- puede ser una vaca vendida, una novilla anotada a mano, o un nombre mal escrito/leído`,
   };
+}
+
+export function validarAnclaFilaPesaje(fila: FilaOcrPesaje, roster: RosterPesaje): ResultadoAnclaPesaje {
+  return resolverNombreEnRosterPesaje(fila.nombreImpreso, roster);
 }
 
 // ---------------------------------------------------------------------------

--- a/supabase/functions/make-server-1ccce916/importHato/ocrPesajeCorreccion.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/ocrPesajeCorreccion.ts
@@ -1,0 +1,419 @@
+// ARCHIVO: supabase/functions/make-server-1ccce916/importHato/ocrPesajeCorreccion.ts
+// GENERADO por docs/hato/regenerar-copias-importhato.py -- NUNCA edites este
+// archivo a mano. Editá `src/utils/importHato/ocrPesajeCorreccion.ts` y volvé a correr el script.
+//
+// POR QUÉ EXISTE ESTE DUPLICADO: el endpoint B0/V10 (`POST
+// .../hato/chequeo/preview`, `hato-chequeo-preview.ts`) corre en el árbol de
+// despliegue de la edge function y no puede importar desde `src/utils/` --
+// cruzaría la frontera del árbol de despliegue de Deno. Misma restricción
+// que ya produjo `priorizacion-scouting.ts` y `calculos-hato.ts`.
+//
+// Contenido idéntico al original salvo los especificadores de import
+// (reescritos para Deno: `@/utils/calculosHato` -> `../calculos-hato.ts`,
+// `./xxx` -> `./xxx.ts`). `src/__tests__/importHatoParidadServidor.test.ts`
+// corre este mismo script en modo `--check` y falla si alguien hand-editó
+// una copia en vez de regenerarla.
+
+// ARCHIVO: utils/importHato/ocrPesajeCorreccion.ts
+// DESCRIPCIÓN: N12 de `docs/plan_hato_telegram_estados_agosto_2026.md` --
+// decisión D-C del dueño: el bot de Telegram muestra en texto plano la
+// lectura de la planilla de pesaje (`ocrPesaje.ts`), Fernando responde en
+// LENGUAJE NATURAL ("MONZA sem 2 AM son 6.5 y BONITA no se pesó"), un modelo
+// traduce esa frase a celdas concretas y el bot vuelve a mostrar el resumen
+// YA CORREGIDO -- solo se persiste tras un "ok" explícito.
+//
+// LA MISMA SEPARACIÓN que el resto del módulo (`ocrChequeo.ts`,
+// `ocrPesaje.ts`): el modelo SOLO extrae entidades del texto (qué vaca, qué
+// semana, qué sub-celda, qué valor o "sin dato"); este archivo es quien
+// VALIDA esas entidades contra el roster y la grilla de semanas del mes --
+// nunca al revés. La llamada HTTP al modelo vive en el árbol Deno
+// (`hato-pesaje-pipeline.ts`); acá no hay I/O ni `Date.now()`.
+//
+// REGLA DURA (idéntica a la del ancla por foto): un ítem que el modelo no
+// logre anclar a UNA vaca del roster, a UNA semana válida de la grilla o a
+// UN valor de litros interpretable NUNCA se aplica -- se reporta como no
+// entendido para que Fernando lo aclare. Nunca se adivina.
+//
+// El cotejo de nombre reusa `resolverNombreEnRosterPesaje` de `./ocrPesaje`
+// -- el MISMO algoritmo que ancla la foto, para que un nombre se resuelva
+// igual sin importar si vino impreso o hablado. Los litros se interpretan
+// con `parseValorNumerico` (`calculosHato.ts`), el único parser numérico.
+//
+// Puro, cero I/O, cero Date.now().
+
+import { parseValorNumerico } from '../calculos-hato.ts';
+import {
+  resolverNombreEnRosterPesaje,
+  SEMANAS_PESAJE,
+  type CeldaDiffPesaje,
+  type ClasificacionCeldaPesaje,
+  type RosterPesaje,
+  type SemanaPesaje,
+} from './ocrPesaje.ts';
+
+// ---------------------------------------------------------------------------
+// 1. Lo que el modelo devuelve -- entidades extraídas del texto, SIN validar.
+// ---------------------------------------------------------------------------
+
+export type SubceldaCorreccionPesaje = 'am' | 'pm' | 'ambos';
+
+export interface ItemCorreccionModeloPesaje {
+  /** El nombre de vaca tal como el usuario lo escribió, verbatim -- para
+   * poder reportar "no encontré a X" con el texto real, nunca el
+   * normalizado. */
+  nombreMencionado: string;
+  /** Semana 1-5 mencionada en el texto, o `null` si el texto no la
+   * especifica. Nunca se infiere -- una corrección sin semana se reporta
+   * como no entendida (mismo criterio que un nombre sin ancla). */
+  semana: number | null;
+  /** Qué sub-celda(s) afecta. `'ambos'` cuando el texto habla de la vaca sin
+   * distinguir AM/PM (p. ej. "no se pesó"). `null` si el texto no lo dice. */
+  subcelda: SubceldaCorreccionPesaje | null;
+  /** `true` cuando el texto dice explícitamente que la vaca no se pesó / no
+   * hay dato para esa celda -- el valor resultante es `null`, nunca 0. */
+  sinDato: boolean;
+  /** Texto crudo del valor de litros, tal como lo dijo el usuario (puede
+   * traer coma, fracción, etc. -- se interpreta con `parseValorNumerico`).
+   * Vacío o ausente cuando `sinDato` es `true`. */
+  valorTexto: string | null;
+}
+
+function textoPlano(valor: unknown): string {
+  if (valor === null || valor === undefined) return '';
+  if (typeof valor === 'string') return valor.trim();
+  if (typeof valor === 'number' || typeof valor === 'boolean') return String(valor);
+  return '';
+}
+
+function semanaPlana(valor: unknown): number | null {
+  if (typeof valor === 'number' && Number.isInteger(valor)) return valor;
+  if (typeof valor === 'string' && valor.trim() !== '') {
+    const n = Number(valor.trim());
+    if (Number.isInteger(n)) return n;
+  }
+  return null;
+}
+
+function subceldaPlana(valor: unknown): SubceldaCorreccionPesaje | null {
+  return valor === 'am' || valor === 'pm' || valor === 'ambos' ? valor : null;
+}
+
+/**
+ * Convierte el JSON crudo que devolvió el modelo (ya des-serializado) en una
+ * lista de `ItemCorreccionModeloPesaje`. Tolerante por diseño, mismo
+ * criterio que `parsearRespuestaModeloOcrPesaje`: un ítem mal formado NUNCA
+ * aborta el resto -- se conserva con lo que se pueda leer (y lo demás en
+ * `null`, que `interpretarCorreccionPesaje` reportará como no entendido en
+ * vez de fallar en silencio). Solo `items` ausente/no-arreglo es fatal: ahí
+ * no hay nada que rescatar.
+ */
+export function parsearRespuestaModeloCorreccionPesaje(bruto: unknown): {
+  items: ItemCorreccionModeloPesaje[];
+  avisos: string[];
+} {
+  const avisos: string[] = [];
+  if (bruto === null || typeof bruto !== 'object') {
+    throw new Error('La respuesta del modelo de corrección no es un objeto JSON.');
+  }
+  const raiz = bruto as Record<string, unknown>;
+  const itemsBrutos = raiz.items;
+  if (!Array.isArray(itemsBrutos)) {
+    throw new Error("La respuesta del modelo de corrección no trae el arreglo 'items'.");
+  }
+
+  const items: ItemCorreccionModeloPesaje[] = itemsBrutos.map((itemBruto, i) => {
+    if (itemBruto === null || typeof itemBruto !== 'object') {
+      avisos.push(`ítem ${i + 1}: no es un objeto -- se descarta su contenido, queda como no entendido`);
+      return { nombreMencionado: '', semana: null, subcelda: null, sinDato: false, valorTexto: null };
+    }
+    const item = itemBruto as Record<string, unknown>;
+    return {
+      nombreMencionado: textoPlano(item.nombre_mencionado),
+      semana: semanaPlana(item.semana),
+      subcelda: subceldaPlana(item.subcelda),
+      sinDato: item.sin_dato === true,
+      valorTexto: item.sin_dato === true ? null : textoPlano(item.valor_texto) || null,
+    };
+  });
+
+  return { items, avisos };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Validación: entidades del modelo -> celdas concretas, o "no entendida".
+// ---------------------------------------------------------------------------
+
+export interface CorreccionPesajeAplicable {
+  animalId: string;
+  nombre: string;
+  semana: SemanaPesaje;
+  fecha: string;
+  subcelda: 'am' | 'pm';
+  /** `null` = limpia la celda ("no se pesó"), nunca 0. */
+  valor: number | null;
+}
+
+export interface CorreccionPesajeNoEntendida {
+  nombreMencionado: string;
+  semana: number | null;
+  detalle: string;
+}
+
+export interface ResultadoInterpretacionCorreccionPesaje {
+  aplicables: CorreccionPesajeAplicable[];
+  noEntendidas: CorreccionPesajeNoEntendida[];
+}
+
+/**
+ * Valida cada ítem que el modelo extrajo del texto libre contra el roster
+ * (nombre) y la grilla de semanas del mes (`fechasPorSemana`, la MISMA que
+ * ya resolvió `fechasPesajeMensuales` para la lectura por foto -- nunca se
+ * vuelve a derivar). Un ítem que falle CUALQUIERA de las tres anclas (vaca,
+ * semana, valor) va a `noEntendidas` -- nunca se aplica a medias ni se
+ * adivina la parte que falta.
+ */
+export function interpretarCorreccionPesaje(
+  items: readonly ItemCorreccionModeloPesaje[],
+  roster: RosterPesaje,
+  fechasPorSemana: Readonly<Record<SemanaPesaje, string | null>>,
+): ResultadoInterpretacionCorreccionPesaje {
+  const aplicables: CorreccionPesajeAplicable[] = [];
+  const noEntendidas: CorreccionPesajeNoEntendida[] = [];
+
+  for (const item of items) {
+    const ancla = resolverNombreEnRosterPesaje(item.nombreMencionado, roster);
+    if (!ancla.ok) {
+      noEntendidas.push({ nombreMencionado: item.nombreMencionado, semana: item.semana, detalle: ancla.detalle });
+      continue;
+    }
+    const nombre = ancla.entrada.nombre;
+
+    if (item.semana === null || !(SEMANAS_PESAJE as readonly number[]).includes(item.semana)) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana: item.semana,
+        detalle: `no especifica una semana válida (1 a 5) para ${nombre} -- dila explícita, p. ej. "semana 2"`,
+      });
+      continue;
+    }
+    const semana = item.semana as SemanaPesaje;
+
+    const fecha = fechasPorSemana[semana];
+    if (fecha === null) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `la semana ${semana} no existe en la planilla de este mes`,
+      });
+      continue;
+    }
+
+    // "no se pesó" sin AM/PM explícito limpia AMBAS -- ninguno de los dos
+    // ordeños pasó esa semana. Con valor (no sinDato) sí hace falta que el
+    // texto diga cuál de los dos: escribir el mismo número en AM y PM sin que
+    // el usuario lo haya dicho sería adivinar.
+    const subceldas: Array<'am' | 'pm'> =
+      item.subcelda === 'ambos' || (item.sinDato && item.subcelda === null)
+        ? ['am', 'pm']
+        : item.subcelda === 'am' || item.subcelda === 'pm'
+          ? [item.subcelda]
+          : [];
+
+    if (subceldas.length === 0) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `no especifica si es AM, PM o ambos para ${nombre} semana ${semana}`,
+      });
+      continue;
+    }
+
+    if (item.sinDato) {
+      for (const sub of subceldas) {
+        aplicables.push({ animalId: ancla.entrada.id, nombre, semana, fecha, subcelda: sub, valor: null });
+      }
+      continue;
+    }
+
+    const parseado = item.valorTexto ? parseValorNumerico(item.valorTexto, { fracciones: true }) : null;
+    if (!item.valorTexto || !parseado || parseado.valor === null) {
+      noEntendidas.push({
+        nombreMencionado: item.nombreMencionado,
+        semana,
+        detalle: `no pude interpretar '${item.valorTexto ?? ''}' como litros para ${nombre} semana ${semana}`,
+      });
+      continue;
+    }
+    for (const sub of subceldas) {
+      aplicables.push({ animalId: ancla.entrada.id, nombre, semana, fecha, subcelda: sub, valor: parseado.valor });
+    }
+  }
+
+  return { aplicables, noEntendidas };
+}
+
+// ---------------------------------------------------------------------------
+// 3. Aplicar correcciones YA validadas sobre el diff en memoria.
+// ---------------------------------------------------------------------------
+
+/**
+ * Aplica correcciones validadas sobre el diff que ya se le mostró al
+ * usuario -- SIEMPRE en memoria, nunca contra la base de datos: el
+ * commit (N13) es un paso posterior y separado, gateado por el "ok"
+ * explícito. Una corrección que no toca una celda del diff (animal/semana
+ * que no vino en la lectura original) la agrega -- puede ser una vaca que
+ * el OCR no leyó y que Fernando corrige a mano en el mismo mensaje.
+ *
+ * `clasificacion` se recalcula con la MISMA regla que `construirDiffPesaje`
+ * (litrosTotal null -> 'sin_dato'; sin fila existente -> 'nuevo'; con fila
+ * existente -> 'cambio' -- nunca hace falta distinguir 'cambio' de
+ * 'sin_cambio' después de una corrección humana, ambas son escribibles por
+ * igual). `noConfiable` pasa a `false`: un humano confirmó la celda, ya no
+ * es "el modelo dudó".
+ */
+export function aplicarCorreccionesADiff(
+  diff: readonly CeldaDiffPesaje[],
+  aplicables: readonly CorreccionPesajeAplicable[],
+): CeldaDiffPesaje[] {
+  if (aplicables.length === 0) return [...diff];
+
+  type Cambio = { am?: number | null; pm?: number | null };
+  const porCelda = new Map<string, Cambio>();
+  for (const correccion of aplicables) {
+    const clave = `${correccion.animalId}|${correccion.semana}`;
+    const actual = porCelda.get(clave) ?? {};
+    if (correccion.subcelda === 'am') actual.am = correccion.valor;
+    else actual.pm = correccion.valor;
+    porCelda.set(clave, actual);
+  }
+
+  const resultado = diff.map((celda): CeldaDiffPesaje => {
+    const clave = `${celda.animalId}|${celda.semana}`;
+    const cambio = porCelda.get(clave);
+    if (!cambio) return celda;
+    porCelda.delete(clave); // lo que sobrevive al final son celdas NUEVAS (ver abajo)
+
+    const litrosAm = 'am' in cambio ? (cambio.am as number | null) : celda.litrosAm;
+    const litrosPm = 'pm' in cambio ? (cambio.pm as number | null) : celda.litrosPm;
+    return recalcularCelda({ ...celda, litrosAm, litrosPm });
+  });
+
+  // Correcciones que no calzaron con ninguna celda ya presente en el diff
+  // (p. ej. una vaca que la foto no leyó y que Fernando agrega a mano en la
+  // misma corrección) -- se agregan como celdas nuevas, nunca se descartan.
+  for (const [clave, cambio] of porCelda) {
+    const [animalId, semanaTexto] = clave.split('|');
+    const semana = Number(semanaTexto) as SemanaPesaje;
+    const nombre = aplicables.find((a) => a.animalId === animalId && a.semana === semana)?.nombre ?? '';
+    const fecha = aplicables.find((a) => a.animalId === animalId && a.semana === semana)?.fecha ?? '';
+    resultado.push(
+      recalcularCelda({
+        animalId,
+        nombre,
+        semana,
+        fecha,
+        litrosAm: 'am' in cambio ? (cambio.am as number | null) : null,
+        litrosPm: 'pm' in cambio ? (cambio.pm as number | null) : null,
+        litrosTotal: null,
+        soloUnOrdeno: false,
+        existenteId: null,
+        clasificacion: 'sin_dato',
+        noConfiable: false,
+      }),
+    );
+  }
+
+  return resultado;
+}
+
+function recalcularCelda(celda: CeldaDiffPesaje): CeldaDiffPesaje {
+  const litrosTotal = celda.litrosAm === null && celda.litrosPm === null ? null : (celda.litrosAm ?? 0) + (celda.litrosPm ?? 0);
+  const clasificacion: ClasificacionCeldaPesaje =
+    litrosTotal === null ? 'sin_dato' : celda.existenteId ? 'cambio' : 'nuevo';
+  return {
+    ...celda,
+    litrosTotal,
+    soloUnOrdeno: (celda.litrosAm === null) !== (celda.litrosPm === null),
+    clasificacion,
+    noConfiable: false,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 4. Prompt y esquema de salida del modelo de interpretación.
+// ---------------------------------------------------------------------------
+
+/** Esquema JSON estricto -- mismo criterio que `esquemaJsonOcrPesaje`: sin
+ * uniones de tipo abiertas donde se pueda evitar, ausencia = `null`. */
+export function esquemaJsonCorreccionPesaje(): Record<string, unknown> {
+  return {
+    type: 'object',
+    properties: {
+      items: {
+        type: 'array',
+        description: 'Una entrada por cada corrección/aclaración que el texto menciona.',
+        items: {
+          type: 'object',
+          properties: {
+            nombre_mencionado: {
+              type: 'string',
+              description: 'El nombre de la vaca tal como aparece en el texto, verbatim.',
+            },
+            semana: {
+              type: ['integer', 'null'],
+              description: 'Número de semana (1 a 5) que el texto menciona explícitamente. null si no lo dice.',
+            },
+            subcelda: {
+              type: ['string', 'null'],
+              enum: ['am', 'pm', 'ambos', null],
+              description:
+                "'am' u 'pm' si el texto distingue el ordeño; 'ambos' cuando habla de la vaca sin distinguir (p. ej. 'no se pesó'); null si no se puede determinar.",
+            },
+            sin_dato: {
+              type: 'boolean',
+              description: "true cuando el texto dice que la vaca NO se pesó / no hay dato para esa celda.",
+            },
+            valor_texto: {
+              type: ['string', 'null'],
+              description:
+                'El valor de litros tal como lo escribió el usuario (puede traer coma o fracción). null cuando sin_dato es true.',
+            },
+          },
+          required: ['nombre_mencionado', 'semana', 'subcelda', 'sin_dato', 'valor_texto'],
+          additionalProperties: false,
+        },
+      },
+    },
+    required: ['items'],
+    additionalProperties: false,
+  };
+}
+
+/**
+ * Prompt de interpretación. Deliberadamente NO incluye el roster de vacas
+ * activas (mismo criterio que `construirPromptOcrPesaje`): el modelo solo
+ * EXTRAE entidades del texto -- el nombre exacto que Fernando escribió, tal
+ * cual -- y es `interpretarCorreccionPesaje` quien lo valida contra el
+ * roster real. Pasarle el roster al modelo volvería la extracción un espejo
+ * de sí misma en vez de una lectura honesta del texto.
+ */
+export function construirPromptCorreccionPesaje(): string {
+  return [
+    'Eres un asistente que interpreta correcciones en español, dichas en lenguaje natural, sobre una planilla de pesaje de leche de un hato lechero en Colombia.',
+    '',
+    'El usuario acaba de ver un resumen de lo que se leyó de una foto de la planilla (vaca, semana, litros AM/PM) y ahora escribe correcciones o aclaraciones en texto libre. Tu único trabajo es EXTRAER, para cada corrección que menciona, estos datos: el nombre de la vaca (tal como lo escribió, sin corregirlo ni normalizarlo), la semana (1 a 5) si la menciona, si habla de AM, PM o de la vaca en general, si dice que la vaca NO se pesó, y el valor de litros si da uno.',
+    '',
+    'EJEMPLOS (los nombres son solo ilustrativos, no una lista real):',
+    '- "LUNA sem 2 AM son 6.5" -> {nombre_mencionado: "LUNA", semana: 2, subcelda: "am", sin_dato: false, valor_texto: "6.5"}',
+    '- "PRINCESA no se pesó" -> {nombre_mencionado: "PRINCESA", semana: null, subcelda: null, sin_dato: true, valor_texto: null} (semana null porque el texto no la menciona -- NO la adivines)',
+    '- "la vaca REINA semana 3 no se pesó" -> {nombre_mencionado: "REINA", semana: 3, subcelda: "ambos", sin_dato: true, valor_texto: null}',
+    '',
+    'REGLAS DURAS:',
+    '1. NUNCA inventes una semana, un AM/PM o un valor que el texto no diga explícita o inequívocamente. Si no está claro, deja ese campo en null (o sin_dato en false con valor_texto null) -- es preferible reportar que no se entendió a adivinar.',
+    '2. Copia el nombre EXACTAMENTE como aparece en el texto, sin corregir ortografía ni completar el nombre real de una vaca -- eso lo hace otro paso, no tú.',
+    '3. El valor de litros se copia tal cual está escrito (puede traer coma, punto o fracción como "6 1/2"); no lo conviertas ni lo redondees.',
+    '4. Una sola frase puede traer varias correcciones (una por vaca) -- devuelve un ítem por cada una.',
+    '',
+    'Responde ÚNICAMENTE con el JSON del esquema pedido. Sin explicaciones, sin markdown.',
+  ].join('\n');
+}

--- a/supabase/functions/make-server-1ccce916/importHato/tipos.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/tipos.ts
@@ -55,6 +55,14 @@ export interface CrudoFilaChequeo {
   sx: string | null;
   fechaServicio: string | null;
   toro: string | null;
+  /** "Estado registrado" (D-E, B5.4): el texto VERBATIM impreso en la
+   * columna de referencia -- la etiqueta de `EstadoReproductivo`
+   * (`etiquetaEstadoReproductivo`, calculosHato.ts) que el sistema creía
+   * cierta al momento de exportar/imprimir la planilla. Nunca se interpreta
+   * acá (ni se convierte a un `EstadoReproductivo`): es evidencia cruda que
+   * el diff compara contra lo que el sistema cree AHORA (N23). `null` en
+   * cualquier generación histórica -- esa columna no existía. */
+  estadoRegistrado: string | null;
   /** Se conserva por trazabilidad pero NUNCA se interpreta: es una fórmula
    * `TODAY()` congelada, no un dato del chequeo (doc S2 QA §2.4). */
   tp: string | null;
@@ -99,6 +107,13 @@ export interface FilaChequeoNormalizada {
   fechaProbableParto: string | null;
   toroNombre: string | null;
   tipoServicio: 'monta' | 'inseminacion' | null;
+  /** Copia trimeada de `raw.estadoRegistrado` -- lo que estaba impreso en
+   * "Estado registrado" cuando se exportó esta planilla (D-E, B5.4). `null`
+   * cuando la hoja no trae esa columna (toda generación histórica) o la
+   * celda vino vacía. El diff (`diffChequeo.ts`) la compara contra el
+   * `EstadoReproductivo` que el sistema deriva HOY -- nunca contra otro
+   * campo, y nunca se reinterpreta a un tipo cerrado acá. */
+  estadoRegistrado: string | null;
 
   issues: ParseIssue[];
 }

--- a/supabase/functions/make-server-1ccce916/telegram/bot.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/bot.ts
@@ -333,7 +333,7 @@ function getBot(): Bot<BotContext> {
         "/monitoreo — Registrar monitoreo",
         "/gasto — Registrar un gasto",
         "/ingreso — Registrar un ingreso",
-        "/pesaje — Pesaje semanal de leche por vaca",
+        "/pesaje — Cargar la planilla de pesaje de leche por foto",
         "/evento — Registrar monta, inseminación, secado, parto o aborto",
         "/cancelar — Cancelar operación actual",
         "/ayuda — Ver esta ayuda",
@@ -903,7 +903,8 @@ function getBot(): Bot<BotContext> {
     { command: "monitoreo", description: "Registrar monitoreo" },
     { command: "gasto", description: "Registrar un gasto" },
     { command: "ingreso", description: "Registrar un ingreso" },
-    { command: "pesaje", description: "Pesaje semanal de leche" },
+    { command: "pesaje", description: "Cargar pesaje de leche por foto" },
+    { command: "evento", description: "Registrar evento del hato" },
     { command: "cancelar", description: "Cancelar operación actual" },
     { command: "ayuda", description: "Ver ayuda" },
   ]).catch((err) => console.error("[Telegram] setMyCommands error:", err));

--- a/supabase/functions/make-server-1ccce916/telegram/bot.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/bot.ts
@@ -18,6 +18,7 @@ import { monitoreoConversation } from "./conversations/monitoreo.ts";
 import { gastoConversation } from "./conversations/gasto.ts";
 import { ingresoConversation } from "./conversations/ingreso.ts";
 import { pesajeLecheConversation } from "./conversations/pesajeLeche.ts";
+import { eventoHatoConversation } from "./conversations/eventoHato.ts";
 // `produccionQuincenal` (litros al camión) se retiró del bot -- SOW 3 de
 // docs/plan_hato_produccion_rework.md §2.3: la quincena pasó a ser un
 // registro financiero (`fin_ingreso_id NOT NULL`, migración 070) y el bot
@@ -140,6 +141,7 @@ function getBot(): Bot<BotContext> {
   bot.use(createConversation(gastoConversation, "gasto"));
   bot.use(createConversation(ingresoConversation, "ingreso"));
   bot.use(createConversation(pesajeLecheConversation, "pesajeLeche"));
+  bot.use(createConversation(eventoHatoConversation, "eventoHato"));
 
   // ==========================================================================
   // HELPERS
@@ -163,6 +165,7 @@ function getBot(): Bot<BotContext> {
     }
     if (mods.includes("hato_produccion")) {
       kb.text("🐄 Pesaje semanal (leche)", "start_pesajeLeche").row();
+      kb.text("📋 Registrar evento del hato", "start_eventoHato").row();
     }
     if (mods.includes("consultas")) {
       kb.text("💬 Preguntarle a Esco", "start_consulta").row();
@@ -301,6 +304,20 @@ function getBot(): Bot<BotContext> {
     await ctx.conversation.enter("pesajeLeche");
   });
 
+  // /evento — registro en campo del ciclo reproductivo (monta, inseminación,
+  // secado, parto, aborto). Se gatea con el MISMO módulo que el pesaje
+  // (`hato_produccion`) a propósito: es el módulo que Fernando ya tiene, así
+  // que el flujo sirve desde el primer despliegue sin tocar configuración.
+  // Separarlo en un módulo propio es un cambio de `modulos_permitidos`, no
+  // de código.
+  bot.command("evento", async (ctx) => {
+    if (!ctx.telegramUser?.modulos_permitidos?.includes("hato_produccion")) {
+      await ctx.reply("No tienes acceso a este módulo.");
+      return;
+    }
+    await ctx.conversation.enter("eventoHato");
+  });
+
   bot.command("cancelar", async (ctx) => {
     await ctx.conversation.exit();
     await ctx.reply("Operación cancelada.");
@@ -317,6 +334,7 @@ function getBot(): Bot<BotContext> {
         "/gasto — Registrar un gasto",
         "/ingreso — Registrar un ingreso",
         "/pesaje — Pesaje semanal de leche por vaca",
+        "/evento — Registrar monta, inseminación, secado, parto o aborto",
         "/cancelar — Cancelar operación actual",
         "/ayuda — Ver esta ayuda",
         "",
@@ -372,6 +390,15 @@ function getBot(): Bot<BotContext> {
       return;
     }
     await ctx.conversation.enter("pesajeLeche");
+  });
+
+  bot.callbackQuery("start_eventoHato", async (ctx) => {
+    await ctx.answerCallbackQuery();
+    if (!ctx.telegramUser?.modulos_permitidos?.includes("hato_produccion")) {
+      await ctx.reply("No tienes acceso a este módulo.");
+      return;
+    }
+    await ctx.conversation.enter("eventoHato");
   });
 
   bot.callbackQuery("start_consulta", async (ctx) => {
@@ -470,6 +497,67 @@ function getBot(): Bot<BotContext> {
   // Toda respuesta escribe un evento auditado (quién, cuándo, qué) — plan
   // §6 Épica C "toda respuesta escribe evento auditado".
   // --------------------------------------------------------------------------
+
+  // --------------------------------------------------------------------------
+  // DESHACER un evento recién registrado por /evento (N9).
+  //
+  // Es la contraparte de la decisión D-B (Telegram escribe DIRECTO, sin cola
+  // de aprobación): el error probable en el corral no es inventarse un
+  // evento, es elegir la vaca equivocada de una lista de homónimas — y eso se
+  // ve en el resumen al instante. Sin este botón, corregirlo exigiría entrar
+  // a la app desde una finca sin internet.
+  //
+  // Solo borra eventos de `fuente='telegram'`: el id viaja en el callback, y
+  // un callback puede reenviarse. Nunca puede convertirse en una vía para
+  // borrar un evento derivado de un chequeo aprobado.
+  // --------------------------------------------------------------------------
+
+  bot.callbackQuery(/^hato_ev_undo:([0-9a-f-]+):([0-9a-f-]+|-)$/, async (ctx) => {
+    const eventoId = ctx.match?.[1];
+    const usoId = ctx.match?.[2];
+    if (!eventoId) {
+      await ctx.answerCallbackQuery({ text: "No se pudo procesar." });
+      return;
+    }
+
+    const sb = getSupabaseAdmin();
+    const { data: evento } = await sb
+      .from("hato_eventos")
+      .select("id, fuente")
+      .eq("id", eventoId)
+      .maybeSingle();
+
+    if (!evento) {
+      await ctx.answerCallbackQuery({ text: "Ese registro ya no existe." });
+      return;
+    }
+    if (evento.fuente !== "telegram") {
+      await ctx.answerCallbackQuery({ text: "Ese registro no se puede deshacer desde aquí." });
+      return;
+    }
+
+    // El uso de pajilla se borra PRIMERO: si fallara después del evento, el
+    // inventario quedaría descontado por un servicio que ya no existe.
+    if (usoId && usoId !== "-") {
+      const { error: errorUso } = await sb.from("hato_pajillas_uso").delete().eq("id", usoId);
+      if (errorUso) {
+        await ctx.answerCallbackQuery({ text: "No se pudo devolver la pajilla. No borré nada." });
+        return;
+      }
+    }
+
+    const { error } = await sb.from("hato_eventos").delete().eq("id", eventoId);
+    if (error) {
+      await ctx.answerCallbackQuery({ text: "No se pudo deshacer. Intenta de nuevo." });
+      return;
+    }
+
+    await ctx.answerCallbackQuery({ text: "Deshecho." });
+    // Se edita el mensaje para quitar el botón: un segundo toque sobre un id
+    // ya borrado solo diría "ya no existe", pero deja al usuario dudando de
+    // si borró dos cosas.
+    await ctx.editMessageText("↩️ Registro deshecho. No quedó nada guardado.\n\nUsa /evento para registrarlo de nuevo.");
+  });
 
   bot.callbackQuery(/^hato_alerta:(.+):(si|no|otro)$/, async (ctx) => {
     const alertaId = ctx.match?.[1];

--- a/supabase/functions/make-server-1ccce916/telegram/bot.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/bot.ts
@@ -26,6 +26,8 @@ import { eventoHatoConversation } from "./conversations/eventoHato.ts";
 // ese NOT NULL ni restringirse a Gerencia (decisión 5 del dueño). `/pesaje`
 // no toca dinero y se mantiene intacto.
 import { llmToolLoop, getSystemPrompt } from "../chat.tsx";
+import { construirMensajeAlertaYaResuelta, construirMensajeCierreAlertaBroadcast } from "../hato-alertas.ts";
+import { cerrarAlertaEnEnvios } from "./enviar.ts";
 
 // ============================================================================
 // SUPABASE CLIENT (service role — same pattern as chat.ts)
@@ -496,6 +498,18 @@ function getBot(): Bot<BotContext> {
   // (`hato_alerta:{alertaId}:{si|no|otro}`), mismo patrón que `mem_save:`.
   // Toda respuesta escribe un evento auditado (quién, cuándo, qué) — plan
   // §6 Épica C "toda respuesta escribe evento auditado".
+  //
+  // BROADCAST CON CIERRE POR EL PRIMERO (migración 096, 2026-08-14): desde
+  // que una alerta se manda a TODOS los suscritos de su tipo
+  // (`hato_alertas_envios`, una fila por suscrito), este handler puede
+  // recibir el mismo `hato_alerta:{id}:...` de MÁS DE UNA persona. La
+  // primera respuesta cierra la alerta para todos; cualquier respuesta
+  // posterior a la misma alerta se trata "amablemente" (no es un error, es
+  // el diseño) y NUNCA repite el efecto de dominio ni el evento auditado.
+  // La atomicidad de "quién llegó primero" la da el propio UPDATE de abajo:
+  // solo tiene efecto si la alerta TODAVÍA está `pendiente`/`enviada`
+  // (`.in('estado', ...)` + `.select()` para saber si de verdad afectó una
+  // fila) — dos respuestas casi simultáneas no pueden colarse las dos.
   // --------------------------------------------------------------------------
 
   // --------------------------------------------------------------------------
@@ -568,40 +582,65 @@ function getBot(): Bot<BotContext> {
     }
 
     const sb = getSupabaseAdmin();
-    const { data: alerta, error: errorAlerta } = await sb
+    const respondidaPor = ctx.telegramUser?.nombre_display ?? String(ctx.from?.id ?? "desconocido");
+    const nuevoEstado = respuesta === "si" ? "confirmada" : "respondida";
+
+    // Reclamo atómico de "quién llegó primero" (096): el UPDATE solo afecta
+    // una fila si la alerta TODAVÍA está pendiente/enviada -- si otro
+    // suscrito ya la cerró (o la cerró este mismo dos veces, doble-tap),
+    // `.in('estado', ...)` no matchea nada y `actualizada` viene null. Un
+    // read-then-write habría dejado una ventana de carrera entre dos
+    // suscritos respondiendo casi a la vez; este single UPDATE no la tiene.
+    const { data: actualizada, error: errorUpdate } = await sb
       .from("hato_alertas")
-      .select("id, tipo, animal_id, paso_id, estado")
+      .update({ estado: nuevoEstado, respuesta, respondida_por: respondidaPor })
       .eq("id", alertaId)
+      .in("estado", ["pendiente", "enviada"])
+      .select("id, tipo, animal_id, paso_id, datos")
       .maybeSingle();
 
-    if (errorAlerta || !alerta) {
-      await ctx.answerCallbackQuery({ text: "No encontré esa alerta -- puede que ya no exista." });
+    if (errorUpdate) {
+      console.error("[Telegram] hato_alerta update error:", errorUpdate.message);
+      await ctx.answerCallbackQuery({ text: "No pude guardar tu respuesta. Intenta de nuevo." });
       return;
     }
 
-    const respondidaPor = ctx.telegramUser?.nombre_display ?? String(ctx.from?.id ?? "desconocido");
+    if (!actualizada) {
+      // O la alerta no existe, o ya la cerró otro suscrito (o este mismo,
+      // doble-tap) -- se distingue leyendo el estado actual, "amablemente",
+      // SIN repetir el efecto de dominio ni el evento auditado.
+      const { data: alertaExistente } = await sb
+        .from("hato_alertas")
+        .select("id, estado, respuesta, respondida_por")
+        .eq("id", alertaId)
+        .maybeSingle();
+      if (!alertaExistente) {
+        await ctx.answerCallbackQuery({ text: "No encontré esa alerta -- puede que ya no exista." });
+        return;
+      }
+      await ctx.answerCallbackQuery({
+        text: construirMensajeAlertaYaResuelta(
+          alertaExistente.estado,
+          alertaExistente.respondida_por,
+          alertaExistente.respuesta as "si" | "no" | "otro" | null,
+        ),
+      });
+      await ctx.editMessageReplyMarkup().catch(() => {});
+      return;
+    }
+
     const hoyIso = new Date().toISOString().slice(0, 10);
 
     if (respuesta === "si") {
-      const { error: errorUpdate } = await sb
-        .from("hato_alertas")
-        .update({ estado: "confirmada", respuesta: "si", respondida_por: respondidaPor })
-        .eq("id", alertaId);
-      if (errorUpdate) {
-        console.error("[Telegram] hato_alerta 'si' update error:", errorUpdate.message);
-        await ctx.answerCallbackQuery({ text: "No pude guardar tu respuesta. Intenta de nuevo." });
-        return;
-      }
-
       // Efectos de dominio, append-only -- nunca se borra ni se sobreescribe
       // evidencia. Solo dos tipos tienen un efecto de dominio definido más
       // allá de marcar la alerta -- el resto (rechequeo_due,
       // servicio_sin_confirmacion, parto_proximo) se resuelve con la sola
       // confirmación (Martha/Fernando ya lo dejan constar por otra vía --
       // chequeo, ficha -- este "sí" solo cierra el lazo de la alerta).
-      if (alerta.tipo === "secado_due" && alerta.animal_id) {
+      if (actualizada.tipo === "secado_due" && actualizada.animal_id) {
         const { error: errorEvento } = await sb.from("hato_eventos").insert({
-          animal_id: alerta.animal_id,
+          animal_id: actualizada.animal_id,
           tipo: "secado_real",
           fecha: hoyIso,
           fecha_confianza: "aproximada",
@@ -609,37 +648,45 @@ function getBot(): Bot<BotContext> {
           fuente: "alerta",
         });
         if (errorEvento) console.error("[Telegram] hato_eventos (secado_real) insert error:", errorEvento.message);
-      } else if (alerta.tipo === "tratamiento_paso" && alerta.paso_id) {
+      } else if (actualizada.tipo === "tratamiento_paso" && actualizada.paso_id) {
         // hato_eventos.tipo (CHECK de la migración 053) no tiene ninguna
         // variante de "tratamiento" -- no hay un evento que insertar aquí,
         // solo se marca ejecutado el paso mismo (055).
         const { error: errorPaso } = await sb
           .from("hato_tratamiento_pasos")
           .update({ fecha_ejecutada: hoyIso })
-          .eq("id", alerta.paso_id);
+          .eq("id", actualizada.paso_id);
         if (errorPaso) console.error("[Telegram] hato_tratamiento_pasos update error:", errorPaso.message);
       }
-
-      await ctx.answerCallbackQuery({ text: "Gracias, quedó registrado." });
-      await ctx.editMessageReplyMarkup().catch(() => {});
-      return;
     }
-
     // "no"/"otro" -- NUNCA se auto-resuelve: Martha lo revisa desde
     // AlertasView (plan §6 Épica C, C4 "supervisión por excepción").
-    const { error: errorUpdate } = await sb
-      .from("hato_alertas")
-      .update({ estado: "respondida", respuesta, respondida_por: respondidaPor })
-      .eq("id", alertaId);
-    if (errorUpdate) {
-      console.error("[Telegram] hato_alerta respuesta update error:", errorUpdate.message);
-      await ctx.answerCallbackQuery({ text: "No pude guardar tu respuesta. Intenta de nuevo." });
-      return;
-    }
+
     await ctx.answerCallbackQuery({
-      text: respuesta === "no" ? "Anotado, seguimos pendientes." : "Anotado -- Martha lo revisa.",
+      text: respuesta === "si"
+        ? "Gracias, quedó registrado."
+        : respuesta === "no"
+        ? "Anotado, seguimos pendientes."
+        : "Anotado -- Martha lo revisa.",
     });
     await ctx.editMessageReplyMarkup().catch(() => {});
+
+    // Broadcast (096): editar el mensaje de CADA OTRO suscrito al que se le
+    // mandó esta alerta, para que vea que ya se resolvió y por quién --
+    // `hato_alertas_envios` guarda el `message_id` de cada uno. El propio
+    // chat de quien respondió queda excluido (ya se editó arriba, vía ctx).
+    const mensajeOriginal = (actualizada.datos as { mensaje?: string } | null)?.mensaje ??
+      "Alerta del hato lechero (sin mensaje generado).";
+    const telegramIdRespondio = ctx.from?.id != null ? String(ctx.from.id) : null;
+    const { fallidos } = await cerrarAlertaEnEnvios(
+      sb,
+      alertaId,
+      telegramIdRespondio,
+      construirMensajeCierreAlertaBroadcast(mensajeOriginal, respondidaPor, respuesta),
+    );
+    if (fallidos > 0) {
+      console.error(`[Telegram] hato_alerta ${alertaId}: ${fallidos} mensaje(s) de otros suscritos no se pudieron editar al cerrar.`);
+    }
   });
 
   // ==========================================================================

--- a/supabase/functions/make-server-1ccce916/telegram/conversations/eventoHato.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/conversations/eventoHato.ts
@@ -57,6 +57,28 @@ function hoyBogota(): string {
   return bogota.toISOString().slice(0, 10);
 }
 
+/**
+ * ¿El usuario está pidiendo salirse?
+ *
+ * Mientras una conversación está activa, el `bot.command("cancelar")` global de
+ * `bot.ts` **NUNCA se dispara**: el plugin de conversaciones consume el update
+ * antes de que llegue a los handlers de comandos. Así que cada paso que espera
+ * texto libre tiene que reconocer la cancelación por su cuenta, o el usuario
+ * queda encerrado sin más salida que bloquear el bot.
+ *
+ * No es hipotético: el dueño lo encontró el 2026-08-14 en el paso de fecha —
+ * `/cancelar`, `/pesaje` y "Cancelar" respondían "Formato inválido" en bucle.
+ *
+ * Se acepta con y sin barra a propósito. Con barra es lo que el usuario escribe
+ * por instinto (y lo que el propio mensaje del paso de la vaca le promete); sin
+ * barra es lo que escribe quien viene de tocar un botón "❌ Cancelar". Ninguna
+ * de las dos formas puede confundirse con una fecha DD/MM.
+ */
+function esCancelar(texto: string): boolean {
+  const t = texto.trim().toLowerCase();
+  return t === "/cancelar" || t === "cancelar" || t === "/cancel";
+}
+
 function parseDDMM(texto: string): string | null {
   const m = texto.trim().match(/^(\d{1,2})[/\-.](\d{1,2})$/);
   if (!m) return null;
@@ -253,6 +275,10 @@ export async function eventoHatoConversation(
     while (!vaca) {
       const txt = await conversation.waitFor("message:text");
       const consulta = txt.message.text.trim();
+      if (esCancelar(consulta)) {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
       if (consulta.startsWith("/")) {
         await txt.reply("Escribe el nombre o la chapeta, sin comandos. Usa /cancelar para salir.");
         continue;
@@ -308,15 +334,46 @@ export async function eventoHatoConversation(
 
     let fecha = hoy;
     if (cbFecha.callbackQuery.data === "fecha_otra") {
-      await cbFecha.editMessageText("📅 Escribe la fecha como DD/MM (ej: 12/08)");
+      // El `editMessageText` reemplaza el teclado anterior, así que sin esto el
+      // paso se queda SIN ningún botón de salida y el único escape es acertar
+      // una fecha válida. Se repone el "❌ Cancelar" y además se acepta la
+      // cancelación escrita (ver `esCancelar`).
+      const kbCancelarFecha = new InlineKeyboard().text("❌ Cancelar", "cancel_flow");
+      await cbFecha.editMessageText(
+        "📅 Escribe la fecha como DD/MM (ej: 12/08)\n\nO escribe /cancelar para salir.",
+        { reply_markup: kbCancelarFecha },
+      );
+      // `conversation.wait()` a secas, no un filtro: este paso tiene que poder
+      // atender DOS cosas (el texto de la fecha y el botón de cancelar) y es la
+      // única primitiva que el resto del bot ya usa de forma indiscutible. Lo
+      // que no sea ni una ni otra (una foto, un sticker) se ignora y se vuelve
+      // a preguntar, en vez de romper el flujo.
       while (true) {
-        const t = await conversation.waitFor("message:text");
-        const parsed = parseDDMM(t.message.text);
+        const paso = await conversation.wait();
+
+        const dataBoton = paso.callbackQuery?.data;
+        if (dataBoton) {
+          await paso.answerCallbackQuery();
+          if (dataBoton === "cancel_flow") {
+            await ctx.reply("Operación cancelada.");
+            return conversation.halt();
+          }
+          continue;
+        }
+
+        const texto = paso.message?.text;
+        if (!texto) continue;
+
+        if (esCancelar(texto)) {
+          await ctx.reply("Operación cancelada.");
+          return conversation.halt();
+        }
+        const parsed = parseDDMM(texto);
         if (parsed) {
           fecha = parsed;
           break;
         }
-        await t.reply("Formato inválido. Escribe DD/MM (ej: 12/08).");
+        await paso.reply("Formato inválido. Escribe DD/MM (ej: 12/08), o /cancelar para salir.");
       }
     } else {
       await cbFecha.editMessageText(`📅 Fecha: ${fechaLegible(fecha)}`);

--- a/supabase/functions/make-server-1ccce916/telegram/conversations/eventoHato.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/conversations/eventoHato.ts
@@ -1,0 +1,538 @@
+// telegram/conversations/eventoHato.ts — Registro en campo de eventos del
+// ciclo reproductivo (N5-N9 del plan
+// docs/plan_hato_telegram_estados_agosto_2026.md).
+//
+// ORIGEN: visita del dueño a la finca, 2026-08-13. Fernando vio una vaca en
+// celo, llevó el toro y la montó — y no tenía ninguna forma de dejarlo
+// asentado hasta el chequeo bimensual de la veterinaria. Este flujo es esa
+// forma.
+//
+// DECISIÓN D-B (dueño, en chips): **Telegram escribe DIRECTO**, sin cola de
+// aprobación. El evento existe apenas Fernando lo registra y Martha lo
+// corrige después desde la Hoja de Vida. Lo que hace tolerable esa decisión
+// es el "Deshacer" del final: el error más probable no es inventarse un
+// evento, es elegir la vaca equivocada del listado, y eso se ve en el
+// resumen inmediatamente.
+//
+// CONTRATOS QUE ESTE ARCHIVO RESPETA
+// ----------------------------------
+// 1. **`created_by` explícito** desde `telegram_usuarios.usuario_id`. El bot
+//    escribe con `service_role`, donde `auth.uid()` es NULL: ni los triggers
+//    de atribución (040/050/063/074) ni la traza de `hato_correcciones`
+//    (084) se disparan solos. Sin esto, todo lo que registre Fernando queda
+//    sin autor, que es la brecha conocida del módulo.
+// 2. **`chequeo_vaca_id` queda en NULL** (no se toca). Es lo que hace estos
+//    eventos INTOCABLES por `fn_hato_commit_chequeo` (065): re-aprobar un
+//    chequeo borra y reinserta solo SUS propios eventos.
+// 3. **Nunca se inventa una fecha.** Por defecto hoy en hora de Bogotá
+//    (`hoyBogota()`), nunca `new Date().toISOString()` a secas: el servidor
+//    Deno corre en UTC y de 19:00 en adelante eso ya es mañana — la misma
+//    trampa que documenta el CLAUDE.md raíz para el navegador.
+// 4. **Advertir, nunca bloquear** (regla general del módulo): un secado
+//    antes de lo proyectado se avisa con los días de diferencia y se
+//    registra igual. Es justamente el caso que motivó este flujo (dos vacas
+//    con producción muy baja que hubo que secar antes de lo presupuestado).
+
+import { Conversation } from "npm:@grammyjs/conversations@2";
+import { InlineKeyboard } from "npm:grammy@1";
+import { createClient } from "npm:@supabase/supabase-js@2";
+import type { BotContext } from "../types.ts";
+import {
+  derivarEstadoReproductivo,
+  type EstadoActualHatoRow,
+  type HatoConfig,
+} from "../../calculos-hato.ts";
+import { construirHatoConfigDesdeFilas } from "../../hato-config-desde-tabla.ts";
+
+function getSupabaseAdmin() {
+  const url = Deno.env.get("SUPABASE_URL")!;
+  const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
+  return createClient(url, serviceKey, { auth: { persistSession: false } });
+}
+
+/** "Hoy" en Bogotá (UTC-5), no en UTC. Ver contrato 3 de la cabecera. */
+function hoyBogota(): string {
+  const ahora = new Date();
+  const bogota = new Date(ahora.getTime() - 5 * 60 * 60 * 1000);
+  return bogota.toISOString().slice(0, 10);
+}
+
+function parseDDMM(texto: string): string | null {
+  const m = texto.trim().match(/^(\d{1,2})[/\-.](\d{1,2})$/);
+  if (!m) return null;
+  const dia = parseInt(m[1], 10);
+  const mes = parseInt(m[2], 10);
+  if (mes < 1 || mes > 12 || dia < 1 || dia > 31) return null;
+  const anio = Number(hoyBogota().slice(0, 4));
+  const iso = `${anio}-${String(mes).padStart(2, "0")}-${String(dia).padStart(2, "0")}`;
+  // Una fecha futura casi siempre es el año pasado mal escrito (p. ej. "28/12"
+  // registrado en enero). Se corrige al año anterior en vez de guardar un
+  // hecho que todavía no ocurrió.
+  return iso > hoyBogota() ? `${anio - 1}-${iso.slice(5)}` : iso;
+}
+
+function fechaLegible(iso: string): string {
+  const [a, m, d] = iso.split("-").map(Number);
+  const meses = [
+    "enero", "febrero", "marzo", "abril", "mayo", "junio",
+    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+  ];
+  return `${d} de ${meses[m - 1]} ${a}`;
+}
+
+// ============================================================================
+// Tipos de evento que este flujo sabe registrar
+// ============================================================================
+
+type ClaveEvento = "monta" | "inseminacion" | "secado" | "parto" | "aborto";
+
+interface DefinicionEvento {
+  etiqueta: string;
+  /** `hato_eventos.tipo` real. `monta`/`inseminacion` son el MISMO tipo
+   * (`servicio`) distinguidos por `tipo_servicio` — el CHECK de la tabla ya
+   * lo modela así desde 053, no se agrega ningún tipo nuevo. */
+  tipo: "servicio" | "secado_real" | "parto" | "aborto";
+  tipoServicio?: "monta" | "inseminacion";
+  /** ¿Pide toro del catálogo? */
+  pideToro: boolean;
+}
+
+const EVENTOS: Record<ClaveEvento, DefinicionEvento> = {
+  monta: { etiqueta: "🐂 Monta", tipo: "servicio", tipoServicio: "monta", pideToro: true },
+  inseminacion: { etiqueta: "💉 Inseminación", tipo: "servicio", tipoServicio: "inseminacion", pideToro: true },
+  secado: { etiqueta: "🌾 Secado", tipo: "secado_real", pideToro: false },
+  parto: { etiqueta: "🐄 Parto", tipo: "parto", pideToro: false },
+  aborto: { etiqueta: "⚠️ Aborto", tipo: "aborto", pideToro: false },
+};
+
+/** Destinos de cría del CHECK de `hato_eventos.cria_destino` (053). */
+const DESTINOS_CRIA: Array<{ clave: string; etiqueta: string }> = [
+  { clave: "retenida", etiqueta: "Hembra, se queda" },
+  { clave: "hembra_vendida", etiqueta: "Hembra, se vende" },
+  { clave: "macho_vendido", etiqueta: "Macho, se vende" },
+  { clave: "muerta", etiqueta: "Nació muerta" },
+];
+
+// ============================================================================
+// Datos que el flujo lee de la base
+// ============================================================================
+
+interface VacaCandidata {
+  animal_id: string;
+  numero: number | null;
+  nombre: string | null;
+  fila: EstadoActualHatoRow;
+}
+
+interface ToroCatalogo {
+  id: string;
+  nombre: string;
+  raza: string | null;
+  /** Solo para inseminación: lote de pajillas y stock restante. */
+  pajillaId: string | null;
+  stock: number | null;
+}
+
+function etiquetaVaca(v: { numero: number | null; nombre: string | null }): string {
+  // Lidera con el NOMBRE, no con la chapeta: Fernando lee el nombre en el
+  // corral y una parte del hato carga números provisionales (800-999) que no
+  // corresponden a ninguna caravana física (migración 066).
+  const nombre = v.nombre ?? "sin nombre";
+  return v.numero != null ? `${nombre} (#${v.numero})` : `${nombre} (sin caravana)`;
+}
+
+/** Normaliza para buscar: sin acentos, sin mayúsculas, sin espacios extra. */
+function normalizar(texto: string): string {
+  return texto
+    .normalize("NFD")
+    .replace(/[\u0300-\u036f]/g, "")
+    .toLowerCase()
+    .trim();
+}
+
+/**
+ * N4 — búsqueda de la vaca por nombre o chapeta. Devuelve TODAS las
+ * coincidencias: dos vacas activas pueden llamarse igual (el caso real MOCA
+ * #177/#183 del módulo), y adjudicar una sola sería elegir por el usuario.
+ */
+export function buscarVacas(vacas: VacaCandidata[], consulta: string): VacaCandidata[] {
+  const q = normalizar(consulta);
+  if (!q) return [];
+  const comoNumero = /^#?\d+$/.test(q) ? Number(q.replace("#", "")) : null;
+  if (comoNumero !== null) {
+    const porNumero = vacas.filter((v) => v.numero === comoNumero);
+    if (porNumero.length > 0) return porNumero;
+  }
+  const exactas = vacas.filter((v) => normalizar(v.nombre ?? "") === q);
+  if (exactas.length > 0) return exactas;
+  return vacas.filter((v) => normalizar(v.nombre ?? "").includes(q));
+}
+
+// ============================================================================
+// Conversación
+// ============================================================================
+
+export async function eventoHatoConversation(
+  conversation: Conversation<BotContext>,
+  ctx: BotContext,
+) {
+  const usuarioId = ctx.telegramUser?.usuario_id ?? null;
+
+  try {
+    // ── Paso 1: ¿qué pasó? ────────────────────────────────────────────
+    const kbTipo = new InlineKeyboard()
+      .text(EVENTOS.monta.etiqueta, "ev_monta")
+      .text(EVENTOS.inseminacion.etiqueta, "ev_inseminacion")
+      .row()
+      .text(EVENTOS.secado.etiqueta, "ev_secado")
+      .text(EVENTOS.parto.etiqueta, "ev_parto")
+      .row()
+      .text(EVENTOS.aborto.etiqueta, "ev_aborto")
+      .text("❌ Cancelar", "cancel_flow");
+
+    await ctx.reply("📋 *Registrar evento del hato*\n\n¿Qué pasó?", {
+      reply_markup: kbTipo,
+      parse_mode: "Markdown",
+    });
+
+    const cbTipo = await conversation.waitForCallbackQuery([
+      "ev_monta", "ev_inseminacion", "ev_secado", "ev_parto", "ev_aborto", "cancel_flow",
+    ]);
+    await cbTipo.answerCallbackQuery();
+    if (cbTipo.callbackQuery.data === "cancel_flow") {
+      await ctx.reply("Operación cancelada.");
+      return conversation.halt();
+    }
+    const clave = cbTipo.callbackQuery.data.replace("ev_", "") as ClaveEvento;
+    const def = EVENTOS[clave];
+    await cbTipo.editMessageText(`📋 Evento: *${def.etiqueta}*`, { parse_mode: "Markdown" });
+
+    // ── Paso 2: cargar hato + config ──────────────────────────────────
+    const { vacas, config } = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      const [estadoRes, configRes] = await Promise.all([
+        sb
+          .from("v_hato_estado_actual")
+          .select(
+            "animal_id, numero, nombre, etapa, raza, estado, num_partos, ultimo_chequeo_fecha, " +
+              "ultimo_servicio_fecha, ultimo_parto_fecha, ultimo_secado_real_fecha, " +
+              "ultima_confirmacion_prenez_fecha, ultimo_evento_fecha, ultimo_estado_chequeo, " +
+              "ultima_confirmacion_prenez_metodo, ultimo_aborto_fecha",
+          )
+          .eq("estado", "activa")
+          .neq("etapa", "ternera"),
+        sb.from("hato_config").select("clave, valor"),
+      ]);
+      if (estadoRes.error) throw new Error(`Error cargando el hato: ${estadoRes.error.message}`);
+      if (configRes.error) throw new Error(`Error cargando configuración: ${configRes.error.message}`);
+
+      const filas = (estadoRes.data ?? []) as Array<Record<string, unknown>>;
+      const candidatas: VacaCandidata[] = filas.map((f) => ({
+        animal_id: f.animal_id as string,
+        numero: (f.numero as number | null) ?? null,
+        nombre: (f.nombre as string | null) ?? null,
+        fila: f as unknown as EstadoActualHatoRow,
+      }));
+      return {
+        vacas: candidatas,
+        config: construirHatoConfigDesdeFilas(
+          (configRes.data ?? []) as Array<{ clave: string; valor: unknown }>,
+        ) as HatoConfig,
+      };
+    });
+
+    if (vacas.length === 0) {
+      await ctx.reply("No hay vacas ni novillas activas en el hato.");
+      return;
+    }
+
+    // ── Paso 3: ¿cuál vaca? ───────────────────────────────────────────
+    await ctx.reply("🔎 Escribe el *nombre* o la *chapeta* de la vaca.", { parse_mode: "Markdown" });
+
+    let vaca: VacaCandidata | null = null;
+    while (!vaca) {
+      const txt = await conversation.waitFor("message:text");
+      const consulta = txt.message.text.trim();
+      if (consulta.startsWith("/")) {
+        await txt.reply("Escribe el nombre o la chapeta, sin comandos. Usa /cancelar para salir.");
+        continue;
+      }
+
+      const encontradas = buscarVacas(vacas, consulta);
+      if (encontradas.length === 0) {
+        await txt.reply(`No encontré ninguna vaca activa que coincida con "${consulta}". Intenta de nuevo.`);
+        continue;
+      }
+      if (encontradas.length === 1) {
+        vaca = encontradas[0];
+        break;
+      }
+
+      // Homónimas o coincidencias parciales: SIEMPRE elige el humano.
+      const kb = new InlineKeyboard();
+      encontradas.slice(0, 10).forEach((v, i) => {
+        kb.text(etiquetaVaca(v), `vaca_${i}`).row();
+      });
+      kb.text("❌ Cancelar", "cancel_flow");
+      await txt.reply(`Hay ${encontradas.length} coincidencias. ¿Cuál es?`, { reply_markup: kb });
+
+      const cbVaca = await conversation.waitForCallbackQuery(/^(vaca_\d+|cancel_flow)$/);
+      await cbVaca.answerCallbackQuery();
+      if (cbVaca.callbackQuery.data === "cancel_flow") {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      vaca = encontradas[Number(cbVaca.callbackQuery.data.replace("vaca_", ""))];
+    }
+
+    const estadoActual = derivarEstadoReproductivo(vaca.fila, config, hoyBogota());
+
+    // ── Paso 4: fecha ─────────────────────────────────────────────────
+    const hoy = hoyBogota();
+    const kbFecha = new InlineKeyboard()
+      .text(`✅ Hoy (${fechaLegible(hoy)})`, "fecha_hoy")
+      .row()
+      .text("📅 Otra fecha", "fecha_otra")
+      .text("❌ Cancelar", "cancel_flow");
+    await ctx.reply(`🐄 *${etiquetaVaca(vaca)}*\n¿Cuándo fue?`, {
+      reply_markup: kbFecha,
+      parse_mode: "Markdown",
+    });
+
+    const cbFecha = await conversation.waitForCallbackQuery(["fecha_hoy", "fecha_otra", "cancel_flow"]);
+    await cbFecha.answerCallbackQuery();
+    if (cbFecha.callbackQuery.data === "cancel_flow") {
+      await ctx.reply("Operación cancelada.");
+      return conversation.halt();
+    }
+
+    let fecha = hoy;
+    if (cbFecha.callbackQuery.data === "fecha_otra") {
+      await cbFecha.editMessageText("📅 Escribe la fecha como DD/MM (ej: 12/08)");
+      while (true) {
+        const t = await conversation.waitFor("message:text");
+        const parsed = parseDDMM(t.message.text);
+        if (parsed) {
+          fecha = parsed;
+          break;
+        }
+        await t.reply("Formato inválido. Escribe DD/MM (ej: 12/08).");
+      }
+    } else {
+      await cbFecha.editMessageText(`📅 Fecha: ${fechaLegible(fecha)}`);
+    }
+
+    // ── Paso 5: datos propios del tipo de evento ──────────────────────
+    let toro: ToroCatalogo | null = null;
+    let criaDestino: string | null = null;
+
+    if (def.pideToro) {
+      const toros = await conversation.external(async () => {
+        const sb = getSupabaseAdmin();
+        const { data: torosData, error } = await sb
+          .from("hato_toros")
+          .select("id, nombre, raza")
+          .eq("activo", true)
+          .eq("tipo", def.tipoServicio === "monta" ? "monta" : "inseminacion")
+          .order("nombre");
+        if (error) throw new Error(`Error cargando toros: ${error.message}`);
+
+        // Para inseminación se anexa el stock de pajillas del lote, que es lo
+        // que hay que descontar. La vista puede dar negativo: se avisa, NUNCA
+        // se bloquea (Épica G3).
+        let stockPorToro = new Map<string, { pajillaId: string; stock: number }>();
+        if (def.tipoServicio === "inseminacion") {
+          const { data: stockData, error: stockErr } = await sb
+            .from("v_hato_pajillas_stock")
+            .select("pajilla_id, toro_id, cantidad_actual");
+          if (stockErr) throw new Error(`Error cargando pajillas: ${stockErr.message}`);
+          for (const s of (stockData ?? []) as Array<Record<string, unknown>>) {
+            stockPorToro.set(s.toro_id as string, {
+              pajillaId: s.pajilla_id as string,
+              stock: Number(s.cantidad_actual ?? 0),
+            });
+          }
+        }
+
+        return ((torosData ?? []) as Array<Record<string, unknown>>).map((t): ToroCatalogo => {
+          const s = stockPorToro.get(t.id as string);
+          return {
+            id: t.id as string,
+            nombre: t.nombre as string,
+            raza: (t.raza as string | null) ?? null,
+            pajillaId: s?.pajillaId ?? null,
+            stock: s?.stock ?? null,
+          };
+        });
+      });
+
+      if (toros.length === 0) {
+        await ctx.reply(
+          `No hay toros de ${def.tipoServicio} activos en el catálogo. Avisa a un administrador.`,
+        );
+        return;
+      }
+
+      const kbToro = new InlineKeyboard();
+      toros.forEach((t, i) => {
+        const stock = t.stock !== null ? ` — ${t.stock} pajilla${t.stock === 1 ? "" : "s"}` : "";
+        const raza = t.raza ? ` (${t.raza})` : "";
+        kbToro.text(`${t.nombre}${raza}${stock}`, `toro_${i}`).row();
+      });
+      kbToro.text("❌ Cancelar", "cancel_flow");
+      await ctx.reply(def.tipoServicio === "monta" ? "🐂 ¿Con cuál toro?" : "💉 ¿Con cuál pajilla?", {
+        reply_markup: kbToro,
+      });
+
+      const cbToro = await conversation.waitForCallbackQuery(/^(toro_\d+|cancel_flow)$/);
+      await cbToro.answerCallbackQuery();
+      if (cbToro.callbackQuery.data === "cancel_flow") {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      toro = toros[Number(cbToro.callbackQuery.data.replace("toro_", ""))];
+      await cbToro.editMessageText(`🐂 ${toro.nombre}`);
+    }
+
+    if (clave === "parto") {
+      const kbCria = new InlineKeyboard();
+      DESTINOS_CRIA.forEach((d, i) => kbCria.text(d.etiqueta, `cria_${i}`).row());
+      kbCria.text("No sé todavía", "cria_none").text("❌ Cancelar", "cancel_flow");
+      await ctx.reply("🍼 ¿Cómo fue la cría?", { reply_markup: kbCria });
+
+      const cbCria = await conversation.waitForCallbackQuery(/^(cria_\d+|cria_none|cancel_flow)$/);
+      await cbCria.answerCallbackQuery();
+      if (cbCria.callbackQuery.data === "cancel_flow") {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      if (cbCria.callbackQuery.data !== "cria_none") {
+        criaDestino = DESTINOS_CRIA[Number(cbCria.callbackQuery.data.replace("cria_", ""))].clave;
+      }
+    }
+
+    // ── Paso 6: advertencias (nunca bloquean) ─────────────────────────
+    const advertencias: string[] = [];
+
+    if (clave === "secado" && estadoActual.fecha_secar) {
+      const dias = Math.round(
+        (Date.parse(`${estadoActual.fecha_secar}T00:00:00Z`) - Date.parse(`${fecha}T00:00:00Z`)) / 86400000,
+      );
+      if (dias > 7) {
+        // El caso que motivó este flujo: dos vacas de producción muy baja que
+        // hubo que secar antes de lo presupuestado.
+        advertencias.push(
+          `Se está secando ${dias} días antes de lo proyectado (${fechaLegible(estadoActual.fecha_secar)}).`,
+        );
+      }
+    }
+
+    if (clave === "parto" && vaca.fila.ultimo_parto_fecha) {
+      const diasEntrePartos = Math.round(
+        (Date.parse(`${fecha}T00:00:00Z`) - Date.parse(`${vaca.fila.ultimo_parto_fecha}T00:00:00Z`)) / 86400000,
+      );
+      if (Math.abs(diasEntrePartos) < 270) {
+        // 270 días es el mínimo biológico real, el mismo umbral de la
+        // migración 080 (partos biológicamente imposibles).
+        advertencias.push(
+          `Ya hay un parto registrado el ${fechaLegible(vaca.fila.ultimo_parto_fecha)}, hace ${Math.abs(diasEntrePartos)} días. Dos partos tan seguidos no son posibles.`,
+        );
+      }
+    }
+
+    if ((clave === "monta" || clave === "inseminacion") && estadoActual.estado === "preñada") {
+      advertencias.push("Esta vaca figura como preñez CONFIRMADA por palpación.");
+    }
+
+    if (toro && toro.stock !== null && toro.stock <= 0) {
+      advertencias.push(`El lote de ${toro.nombre} ya está en ${toro.stock} pajillas.`);
+    }
+
+    // ── Paso 7: confirmar ─────────────────────────────────────────────
+    const resumen = [
+      `📋 *${def.etiqueta.replace(/^\S+\s/, "")}*`,
+      `🐄 ${etiquetaVaca(vaca)}`,
+      `📅 ${fechaLegible(fecha)}`,
+      toro ? `🐂 ${toro.nombre}` : null,
+      criaDestino ? `🍼 ${DESTINOS_CRIA.find((d) => d.clave === criaDestino)?.etiqueta}` : null,
+      advertencias.length > 0 ? `\n⚠️ ${advertencias.join("\n⚠️ ")}` : null,
+    ]
+      .filter(Boolean)
+      .join("\n");
+
+    const kbConfirmar = new InlineKeyboard()
+      .text("✅ Guardar", "ok")
+      .text("❌ Cancelar", "cancel_flow");
+    await ctx.reply(`${resumen}\n\n¿Guardo?`, { reply_markup: kbConfirmar, parse_mode: "Markdown" });
+
+    const cbOk = await conversation.waitForCallbackQuery(["ok", "cancel_flow"]);
+    await cbOk.answerCallbackQuery();
+    if (cbOk.callbackQuery.data === "cancel_flow") {
+      await ctx.reply("Nada se guardó.");
+      return conversation.halt();
+    }
+
+    // ── Paso 8: escribir ──────────────────────────────────────────────
+    const guardado = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      const { data, error } = await sb
+        .from("hato_eventos")
+        .insert({
+          animal_id: vaca!.animal_id,
+          tipo: def.tipo,
+          fecha,
+          // El humano estuvo ahí: la fecha es exacta, no una reconstrucción
+          // a partir de una planilla.
+          fecha_confianza: "exacta",
+          tipo_servicio: def.tipoServicio ?? null,
+          toro_id: toro?.id ?? null,
+          cria_destino: criaDestino,
+          fuente: "telegram",
+          // chequeo_vaca_id se deja NULL: es lo que vuelve este evento
+          // intocable por fn_hato_commit_chequeo (065).
+          datos: { origen: "telegram", registrado_por: ctx.telegramUser?.nombre_display ?? null },
+          created_by: usuarioId,
+        })
+        .select("id")
+        .single();
+      if (error) throw new Error(`No se pudo guardar: ${error.message}`);
+
+      // Uso de pajilla: se registra DESPUÉS del evento y su fallo no tumba el
+      // evento — la preñez es el hecho importante, el descuento de inventario
+      // es contabilidad que Martha puede corregir.
+      let usoId: string | null = null;
+      if (toro?.pajillaId) {
+        const { data: uso, error: usoErr } = await sb
+          .from("hato_pajillas_uso")
+          .insert({
+            pajilla_id: toro.pajillaId,
+            fecha_uso: fecha,
+            animal_id: vaca!.animal_id,
+            created_by: usuarioId,
+          })
+          .select("id")
+          .single();
+        if (usoErr) {
+          console.error("[Telegram] No se pudo descontar la pajilla:", usoErr.message);
+        } else {
+          usoId = uso!.id as string;
+        }
+      }
+      return { eventoId: data!.id as string, usoId };
+    });
+
+    const kbDeshacer = new InlineKeyboard().text(
+      "↩️ Deshacer",
+      `hato_ev_undo:${guardado.eventoId}:${guardado.usoId ?? "-"}`,
+    );
+    await ctx.reply(
+      `✅ Registrado.\n\n${resumen}\n\nSi te equivocaste de vaca, usa Deshacer.\nUsa /start para volver al menú.`,
+      { reply_markup: kbDeshacer, parse_mode: "Markdown" },
+    );
+  } catch (err: unknown) {
+    if (err instanceof Error && err.message === "Conversation already halted") return;
+    const msg = err instanceof Error ? err.message : "Error desconocido";
+    console.error("[Telegram] Evento hato conversation error:", msg);
+    await ctx.reply(`Error registrando el evento: ${msg}\n\nUsa /start para volver al menú.`);
+  }
+}

--- a/supabase/functions/make-server-1ccce916/telegram/conversations/pesajeLeche.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/conversations/pesajeLeche.ts
@@ -1,24 +1,76 @@
-// telegram/conversations/pesajeLeche.ts — Weekly per-cow milk weighing (S5,
-// Épica D1/V2 — docs/plan_hato_lechero_module.md §7.2/§7.5).
+// telegram/conversations/pesajeLeche.ts — N11-N13 de
+// `docs/plan_hato_telegram_estados_agosto_2026.md` §3 Capa 2 / §8.2.
 //
-// Iterates active cows (hato_animales.etapa='vaca', estado='activa') asking
-// for ONE total figure per cow (litros_total — am+pm already summed,
-// migración 061; NEVER a split am/pm entry, that concept does not exist).
-// Each answer is saved immediately (UPDATE-by-id if the row already exists
-// for that date, INSERT otherwise) so a mid-conversation /cancelar never
-// loses what was already entered — the natural way "salteable, reanudable"
-// (plan §7.2) is honored without extra resume-state machinery: grammy
-// conversations already persist progress across webhook calls, and
-// per-answer saves mean there is nothing left to lose on exit.
+// REEMPLAZA la conversación anterior (vaca-por-vaca, ~65 preguntas por
+// chat: inviable en el corral) por el MISMO flujo de foto que ya usa la
+// ruta web (`SubirPesajeFoto.tsx` -> `POST /hato/pesaje/foto` ->
+// `POST /hato/pesaje/commit`): Fernando fotografía la planilla mensual (1
+// a 6 fotos, por franjas si hace falta), el bot muestra en texto plano lo
+// que leyó, Fernando corrige en LENGUAJE NATURAL (decisión D-C del dueño,
+// "MONZA sem 2 AM son 6.5 y BONITA no se pesó") y solo tras un "ok"
+// explícito se persiste -- por celda, no todo-o-nada.
 //
-// A cow the user skips gets NO row for that date — "no pesada", never 0
-// (regla D del plan §6 Épica D, misma que rige monitoreo/ganado).
+// N11 — NO es un segundo lector de celdas ni un segundo armado de roster:
+// toda la orquestación (Storage, modelo de visión, ancla por nombre, diff)
+// viene de `../../hato-pesaje-pipeline.ts::ejecutarPipelinePesajeFoto`, la
+// MISMA función que usa el endpoint HTTP. `anio`/`mes` se preguntan acá con
+// un default sensato al mes en curso -- nunca se adivinan del papel (la
+// planilla nunca trae fecha legible por sí sola sin ese dato).
+//
+// N12 — La interpretación de la corrección en texto libre es una llamada al
+// modelo (`../../hato-pesaje-pipeline.ts::llamarModeloCorreccionPesaje`)
+// seguida de la validación PURA `interpretarCorreccionPesaje`
+// (`../../importHato/ocrPesajeCorreccion.ts`, testeada desde Vitest): un
+// ítem que no ancla a una vaca del roster, a una semana válida o a un valor
+// interpretable NUNCA se aplica -- se reporta como no entendido y se vuelve
+// a preguntar. Nada se escribe antes del "ok" explícito; el loop
+// corregir/mostrar se puede repetir cuantas veces haga falta.
+//
+// N13 — El commit reusa la MISMA revalidación fresca de
+// `hato-pesaje-commit.ts` vía `ejecutarCommitPesaje` (vaca sigue activa,
+// fecha sigue siendo una ocurrencia real del mes) -- por CELDA, una celda
+// inválida se rechaza sola. `fuente: 'telegram'` y `created_by` EXPLÍCITO
+// desde `telegram_usuarios.usuario_id` (riesgo R-6 del plan: el bot escribe
+// con service_role, `auth.uid()` es NULL, ningún trigger de atribución se
+// dispara solo).
+//
+// REPLAY-SAFETY (grammy conversations): cada webhook es una invocación
+// nueva de la function serverless -- el estado de la conversación se
+// reconstruye REEJECUTANDO esta función desde el principio, reproduciendo
+// los resultados ya cacheados de cada `conversation.external()`/`wait()`.
+// Eso impone dos reglas that este archivo respeta:
+//   1. Todo resultado de `external()` debe ser JSON-serializable (viaja por
+//      el storage jsonb de `telegram_conversations`). Los bytes de las
+//      fotos NUNCA salen de un `external()` como valor de retorno -- se
+//      descargan y se consumen DENTRO del mismo `external()` que llama al
+//      pipeline, nunca por separado.
+//   2. Mientras una conversación está activa, `bot.command("cancelar")`
+//      global NUNCA se dispara (el plugin de conversaciones consume el
+//      update antes) -- cada paso que espera texto o foto reconoce
+//      "cancelar"/"/cancelar" por su cuenta (`esCancelacionTexto`).
 
 import { Conversation } from "npm:@grammyjs/conversations@2";
 import { InlineKeyboard } from "npm:grammy@1";
 import { createClient } from "npm:@supabase/supabase-js@2";
 import type { BotContext } from "../types.ts";
-import { calcularFechaUltimoDiaPesaje } from "../../calculos-hato.ts";
+import {
+  ejecutarCommitPesaje,
+  ejecutarPipelinePesajeFoto,
+  llamarModeloCorreccionPesaje,
+  MAXIMO_FOTOS_PESAJE,
+  TIPOS_ACEPTADOS_FOTO_PESAJE,
+  type CeldaCommitPesajeEntrada,
+  type FotoPesajeEntrada,
+  type PipelinePesajeFotoResultado,
+} from "../../hato-pesaje-pipeline.ts";
+import {
+  construirFilasPesajeInsertables,
+  construirRosterPesaje,
+  SEMANAS_PESAJE,
+  type CeldaDiffPesaje,
+  type SemanaPesaje,
+} from "../../importHato/ocrPesaje.ts";
+import { aplicarCorreccionesADiff, interpretarCorreccionPesaje } from "../../importHato/ocrPesajeCorreccion.ts";
 
 function getSupabaseAdmin() {
   const url = Deno.env.get("SUPABASE_URL")!;
@@ -26,227 +78,443 @@ function getSupabaseAdmin() {
   return createClient(url, serviceKey, { auth: { persistSession: false } });
 }
 
-function todayISO(): string {
-  return new Date().toISOString().slice(0, 10);
+/** "Hoy" en Bogotá (UTC-5), no en UTC -- mismo criterio que `eventoHato.ts`. */
+function hoyBogota(): string {
+  const ahora = new Date();
+  const bogota = new Date(ahora.getTime() - 5 * 60 * 60 * 1000);
+  return bogota.toISOString().slice(0, 10);
 }
 
-function parseDDMM(text: string): string | null {
-  const match = text.trim().match(/^(\d{1,2})[/\-.](\d{1,2})$/);
-  if (!match) return null;
-  const day = parseInt(match[1], 10);
-  const month = parseInt(match[2], 10);
-  if (month < 1 || month > 12 || day < 1 || day > 31) return null;
-  const year = new Date().getFullYear();
-  return `${year}-${String(month).padStart(2, "0")}-${String(day).padStart(2, "0")}`;
+const MESES = [
+  "enero", "febrero", "marzo", "abril", "mayo", "junio",
+  "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
+];
+
+function nombreMes(mes: number): string {
+  return MESES[mes - 1] ?? String(mes);
 }
 
-function formatDateSpanish(isoDate: string): string {
-  const [y, m, d] = isoDate.split("-").map(Number);
-  const months = [
-    "enero", "febrero", "marzo", "abril", "mayo", "junio",
-    "julio", "agosto", "septiembre", "octubre", "noviembre", "diciembre",
-  ];
-  return `${d} de ${months[m - 1]} ${y}`;
+/** Reconoce la cancelación escrita a mano -- el `/cancelar` global NUNCA se
+ * dispara mientras esta conversación está activa (ver cabecera del
+ * archivo). Se comprueba en TODOS los pasos que esperan texto o foto. */
+function esCancelacionTexto(texto: string): boolean {
+  const t = texto.trim().toLowerCase();
+  return t === "cancelar" || t === "/cancelar";
 }
 
-interface VacaActiva {
-  id: string;
-  numero: number | null;
-  nombre: string | null;
+function esConfirmacionGuardar(texto: string): boolean {
+  const t = texto.trim().toLowerCase();
+  return t === "ok" || t === "listo" || t === "guardar" || t === "si" || t === "sí";
 }
+
+/** "MM/AAAA" o "MM-AAAA" -- formato numérico simple, sin adivinar nada que
+ * el usuario no haya escrito (mismo criterio que `parseDDMM` de
+ * `eventoHato.ts`). */
+function parseMesAnio(texto: string): { anio: number; mes: number } | null {
+  const m = texto.trim().match(/^(\d{1,2})[/\-](\d{4})$/);
+  if (!m) return null;
+  const mes = parseInt(m[1], 10);
+  const anio = parseInt(m[2], 10);
+  if (mes < 1 || mes > 12 || anio < 2020 || anio > 2100) return null;
+  return { anio, mes };
+}
+
+function partirTexto(texto: string, maximo = 3500): string[] {
+  if (texto.length <= maximo) return [texto];
+  const lineas = texto.split("\n");
+  const partes: string[] = [];
+  let actual = "";
+  for (const linea of lineas) {
+    if (actual && (actual + "\n" + linea).length > maximo) {
+      partes.push(actual);
+      actual = linea;
+    } else {
+      actual = actual ? `${actual}\n${linea}` : linea;
+    }
+  }
+  if (actual) partes.push(actual);
+  return partes;
+}
+
+/** Resumen en texto plano de la lectura -- lo que Fernando ve para corregir
+ * o confirmar (D-C). Agrupado por vaca, en orden alfabético; solo aparecen
+ * las vacas que SÍ se leyeron en alguna foto (`diff` viene de
+ * `ocr.filasConfirmadas`) -- las que faltaron van aparte, en
+ * `vacasSinLeer`. `—` para "sin dato", nunca 0 (regla del módulo). */
+function construirResumenPesajeTexto(diff: readonly CeldaDiffPesaje[]): string {
+  if (diff.length === 0) return "(ninguna vaca se pudo leer)";
+  const porAnimal = new Map<string, { nombre: string; celdas: Map<SemanaPesaje, CeldaDiffPesaje> }>();
+  for (const c of diff) {
+    if (!porAnimal.has(c.animalId)) porAnimal.set(c.animalId, { nombre: c.nombre, celdas: new Map() });
+    porAnimal.get(c.animalId)!.celdas.set(c.semana, c);
+  }
+  const filas = [...porAnimal.values()].sort((a, b) => a.nombre.localeCompare(b.nombre));
+  return filas
+    .map(({ nombre, celdas }) => {
+      const partes = SEMANAS_PESAJE.filter((s) => celdas.has(s)).map((s) => {
+        const c = celdas.get(s)!;
+        const am = c.litrosAm ?? "—";
+        const pm = c.litrosPm ?? "—";
+        return `S${s}:${am}/${pm}`;
+      });
+      return `• ${nombre} — ${partes.join("  ")}`;
+    })
+    .join("\n");
+}
+
+function construirAdvertenciasLectura(resultado: PipelinePesajeFotoResultado): string[] {
+  const advertencias: string[] = [];
+  if (resultado.ocr.filasNoLeidas.length > 0) {
+    const lista = resultado.ocr.filasNoLeidas
+      .slice(0, 10)
+      .map((f) => `"${f.nombreImpreso || "(sin nombre)"}"`)
+      .join(", ");
+    advertencias.push(
+      `⚠️ ${resultado.ocr.filasNoLeidas.length} fila(s) no se pudieron identificar: ${lista}${
+        resultado.ocr.filasNoLeidas.length > 10 ? "…" : ""
+      }`,
+    );
+  }
+  if (resultado.ocr.vacasSinLeer.length > 0) {
+    const lista = resultado.ocr.vacasSinLeer.slice(0, 15).map((v) => v.nombre).join(", ");
+    advertencias.push(
+      `⚠️ ${resultado.ocr.vacasSinLeer.length} vaca(s) no aparecen en ninguna foto: ${lista}${
+        resultado.ocr.vacasSinLeer.length > 15 ? "…" : ""
+      }`,
+    );
+  }
+  if (resultado.ocr.paginasNoLeidas.length > 0) {
+    advertencias.push(`⚠️ ${resultado.ocr.paginasNoLeidas.length} foto(s) no se pudieron leer.`);
+  }
+  return advertencias;
+}
+
+interface OpcionesEnvio {
+  reply_markup?: InlineKeyboard;
+  parse_mode?: "Markdown";
+}
+
+async function enviarPorPartes(ctx: BotContext, texto: string, opciones?: OpcionesEnvio) {
+  const partes = partirTexto(texto);
+  for (let i = 0; i < partes.length; i++) {
+    await ctx.reply(partes[i], i === partes.length - 1 ? opciones : undefined);
+  }
+}
+
+// ============================================================================
+// Descarga de fotos de Telegram (SIEMPRE dentro de un solo `external()` junto
+// al pipeline -- ver regla 1 de la cabecera: los bytes nunca salen solos de
+// un `external()`).
+// ============================================================================
+
+interface FotoTelegramReferencia {
+  fileId: string;
+  tipo: string;
+  nombre: string;
+}
+
+async function descargarBytesTelegram(fileId: string, botToken: string): Promise<Uint8Array> {
+  const fileRes = await fetch(`https://api.telegram.org/bot${botToken}/getFile?file_id=${fileId}`);
+  const fileData = await fileRes.json();
+  const filePath = fileData?.result?.file_path;
+  if (!filePath) throw new Error(`Telegram no devolvió la ruta del archivo ${fileId}`);
+  const descarga = await fetch(`https://api.telegram.org/file/bot${botToken}/${filePath}`);
+  if (!descarga.ok) throw new Error(`No se pudo descargar el archivo de Telegram (${descarga.status})`);
+  return new Uint8Array(await descarga.arrayBuffer());
+}
+
+// ============================================================================
+// Conversación
+// ============================================================================
 
 export async function pesajeLecheConversation(
   conversation: Conversation<BotContext>,
   ctx: BotContext,
 ) {
+  const usuarioId = ctx.telegramUser?.usuario_id ?? null;
+
   try {
-    // ── Step 1: hato_config.dia_pesaje_semanal (nunca hardcodeado) ──────
-
-    const config = await conversation.external(async () => {
-      const sb = getSupabaseAdmin();
-      const { data, error } = await sb
-        .from("hato_config")
-        .select("valor")
-        .eq("clave", "dia_pesaje_semanal")
-        .maybeSingle();
-      if (error) throw new Error(`Error leyendo configuración: ${error.message}`);
-      const valor = data?.valor as { iso?: unknown; nombre?: unknown } | undefined;
-      if (!valor || typeof valor.iso !== "number") {
-        throw new Error("CONFIG_FALTANTE");
-      }
-      return { iso: valor.iso, nombre: typeof valor.nombre === "string" ? valor.nombre : `día ISO ${valor.iso}` };
-    }).catch((err: unknown) => {
-      if (err instanceof Error && err.message === "CONFIG_FALTANTE") return null;
-      throw err;
-    });
-
-    if (!config) {
+    if (!usuarioId) {
       await ctx.reply(
-        "⚠️ No encontré la configuración del día de pesaje (hato_config.dia_pesaje_semanal). " +
-          "Avisa a un administrador antes de continuar.",
+        "Tu cuenta de Telegram no está vinculada a un usuario del sistema -- avisa a un administrador antes de registrar un pesaje.",
       );
       return;
     }
 
-    const fechaSugerida = calcularFechaUltimoDiaPesaje(todayISO(), config.iso);
+    const apiKey = Deno.env.get("OPENROUTER_API_KEY");
+    if (!apiKey) {
+      await ctx.reply("La lectura por foto no está disponible ahora mismo (falta configuración del servidor). Avisa a un administrador.");
+      return;
+    }
+    const botToken = Deno.env.get("TELEGRAM_BOT_TOKEN")!;
 
-    // ── Step 2: confirmar/ajustar fecha ──────────────────────────────
+    // ── Paso 1: ¿qué mes es la planilla? ──────────────────────────────
+    const hoy = hoyBogota();
+    const anioActual = Number(hoy.slice(0, 4));
+    const mesActual = Number(hoy.slice(5, 7));
 
-    const fechaKb = new InlineKeyboard()
-      .text(`✅ ${formatDateSpanish(fechaSugerida)}`, "fecha_sugerida")
+    const kbMes = new InlineKeyboard()
+      .text(`✅ ${nombreMes(mesActual)} ${anioActual}`, "mes_actual")
       .row()
-      .text("📅 Otra fecha", "fecha_otra")
+      .text("📅 Otro mes", "mes_otro")
       .text("❌ Cancelar", "cancel_flow");
-
     await ctx.reply(
-      `🐄 *Pesaje semanal de leche*\n\nSe pesa los ${config.nombre}. Fecha sugerida: *${formatDateSpanish(fechaSugerida)}*.`,
-      { reply_markup: fechaKb, parse_mode: "Markdown" },
+      "🐄 *Pesaje de leche -- carga por foto*\n\n¿La planilla que vas a fotografiar es de qué mes?",
+      { reply_markup: kbMes, parse_mode: "Markdown" },
     );
 
-    const fechaCbCtx = await conversation.waitForCallbackQuery(["fecha_sugerida", "fecha_otra", "cancel_flow"]);
-    await fechaCbCtx.answerCallbackQuery();
+    let anio = anioActual;
+    let mes = mesActual;
+    while (true) {
+      const respuesta = await conversation.wait();
 
-    if (fechaCbCtx.callbackQuery.data === "cancel_flow") {
-      await ctx.reply("Operación cancelada.");
-      return conversation.halt();
-    }
-
-    let fecha = fechaSugerida;
-    if (fechaCbCtx.callbackQuery.data === "fecha_otra") {
-      await fechaCbCtx.editMessageText("📅 Escribe la fecha en formato DD/MM (ej: 22/07)");
-      while (true) {
-        const textCtx = await conversation.waitFor("message:text");
-        const parsed = parseDDMM(textCtx.message.text);
+      if (respuesta.callbackQuery?.data === "cancel_flow") {
+        await respuesta.answerCallbackQuery();
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+      if (respuesta.callbackQuery?.data === "mes_actual") {
+        await respuesta.answerCallbackQuery();
+        await respuesta.editMessageText(`📅 Mes: ${nombreMes(mesActual)} ${anioActual}`);
+        break;
+      }
+      if (respuesta.callbackQuery?.data === "mes_otro") {
+        await respuesta.answerCallbackQuery();
+        await respuesta.editMessageText("📅 Escribe el mes como MM/AAAA (ej: 08/2026), o *cancelar*.", {
+          parse_mode: "Markdown",
+        });
+        continue;
+      }
+      const texto = respuesta.message?.text;
+      if (texto) {
+        if (esCancelacionTexto(texto)) {
+          await ctx.reply("Operación cancelada.");
+          return conversation.halt();
+        }
+        const parsed = parseMesAnio(texto);
         if (parsed) {
-          fecha = parsed;
+          anio = parsed.anio;
+          mes = parsed.mes;
+          await ctx.reply(`📅 Mes: ${nombreMes(mes)} ${anio}`);
           break;
         }
-        await textCtx.reply("Formato inválido. Escribe la fecha como DD/MM (ej: 22/07)");
+        await ctx.reply("Formato inválido. Escribe MM/AAAA (ej: 08/2026), o *cancelar*.", { parse_mode: "Markdown" });
+        continue;
       }
-    } else {
-      await fechaCbCtx.editMessageText(`📅 Fecha: ${formatDateSpanish(fecha)}`);
+      // callback/mensaje no reconocido -- se ignora, se sigue esperando.
     }
 
-    // ── Step 3: cargar vacas activas + pesajes existentes de esa fecha ──
+    // ── Paso 2: recolectar 1..6 fotos ─────────────────────────────────
+    const fotos: FotoTelegramReferencia[] = [];
+    const kbFotos = new InlineKeyboard()
+      .text("✅ Listo", "fotos_listo")
+      .text("❌ Cancelar", "cancel_flow");
+    await ctx.reply(
+      `📸 Envía las fotos de la planilla de *${nombreMes(mes)} ${anio}* (1 a ${MAXIMO_FOTOS_PESAJE}, puede ser por franjas si no cabe en una toma). Cuando termines, toca *Listo*.`,
+      { reply_markup: kbFotos, parse_mode: "Markdown" },
+    );
 
-    const { vacas, existentes } = await conversation.external(async () => {
-      const sb = getSupabaseAdmin();
-      const { data: vacasData, error: vacasErr } = await sb
-        .from("hato_animales")
-        .select("id, numero, nombre")
-        .eq("etapa", "vaca")
-        .eq("estado", "activa")
-        .order("numero", { ascending: true });
-      if (vacasErr) throw new Error(`Error cargando vacas: ${vacasErr.message}`);
+    while (true) {
+      const respuesta = await conversation.wait();
 
-      const { data: pesajesData, error: pesajesErr } = await sb
-        .from("hato_pesajes_leche")
-        .select("id, animal_id, litros_total")
-        .eq("fecha", fecha);
-      if (pesajesErr) throw new Error(`Error cargando pesajes existentes: ${pesajesErr.message}`);
-
-      const mapa = new Map<string, { id: string; litros_total: number }>();
-      for (const p of pesajesData ?? []) {
-        mapa.set(p.animal_id, { id: p.id, litros_total: p.litros_total });
+      if (respuesta.callbackQuery?.data === "cancel_flow") {
+        await respuesta.answerCallbackQuery();
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
       }
-      return { vacas: (vacasData ?? []) as VacaActiva[], existentes: mapa };
+      if (respuesta.callbackQuery?.data === "fotos_listo") {
+        await respuesta.answerCallbackQuery();
+        if (fotos.length === 0) {
+          await ctx.reply("Todavía no recibí ninguna foto. Envía al menos una, o toca Cancelar.");
+          continue;
+        }
+        break;
+      }
+
+      const texto = respuesta.message?.text;
+      if (texto && esCancelacionTexto(texto)) {
+        await ctx.reply("Operación cancelada.");
+        return conversation.halt();
+      }
+
+      const photoSizes = respuesta.message?.photo;
+      if (photoSizes && photoSizes.length > 0) {
+        if (fotos.length >= MAXIMO_FOTOS_PESAJE) {
+          await ctx.reply(`Ya tengo ${MAXIMO_FOTOS_PESAJE} fotos, el máximo. Toca Listo para continuar.`);
+          continue;
+        }
+        const masGrande = photoSizes[photoSizes.length - 1];
+        fotos.push({ fileId: masGrande.file_id, tipo: "image/jpeg", nombre: `foto-${fotos.length + 1}.jpg` });
+        await ctx.reply(`📸 Foto ${fotos.length} recibida. Envía otra o toca Listo.`);
+        continue;
+      }
+
+      const documento = respuesta.message?.document;
+      if (documento) {
+        const tipo = (documento.mime_type ?? "").toLowerCase();
+        if (!TIPOS_ACEPTADOS_FOTO_PESAJE.has(tipo)) {
+          await ctx.reply(
+            `Ese archivo es de tipo '${documento.mime_type ?? "desconocido"}'. Envía JPEG, PNG, WEBP o HEIC, o toca Listo/Cancelar.`,
+          );
+          continue;
+        }
+        if (fotos.length >= MAXIMO_FOTOS_PESAJE) {
+          await ctx.reply(`Ya tengo ${MAXIMO_FOTOS_PESAJE} fotos, el máximo. Toca Listo para continuar.`);
+          continue;
+        }
+        fotos.push({ fileId: documento.file_id, tipo, nombre: documento.file_name ?? `foto-${fotos.length + 1}` });
+        await ctx.reply(`📸 Foto ${fotos.length} recibida. Envía otra o toca Listo.`);
+        continue;
+      }
+
+      await ctx.reply("No entendí. Envía una foto de la planilla, toca Listo, o escribe cancelar.");
+    }
+
+    // ── Paso 3: descargar + correr el pipeline (N11) ──────────────────
+    await ctx.replyWithChatAction("upload_photo");
+    const anioFinal = anio;
+    const mesFinal = mes;
+    const lectura = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      const fotosEntrada: FotoPesajeEntrada[] = [];
+      for (let i = 0; i < fotos.length; i++) {
+        const bytes = await descargarBytesTelegram(fotos[i].fileId, botToken);
+        fotosEntrada.push({ pagina: i + 1, nombre: fotos[i].nombre, tipo: fotos[i].tipo, bytes });
+      }
+      return await ejecutarPipelinePesajeFoto({ supabase: sb, apiKey, fotos: fotosEntrada, anio: anioFinal, mes: mesFinal });
     });
 
-    if (vacas.length === 0) {
-      await ctx.reply("No hay vacas activas registradas en el hato.");
+    if (!lectura.ok) {
+      await ctx.reply(`❌ No se pudo leer la planilla: ${lectura.error}\n\nUsa /pesaje para intentar de nuevo.`);
       return;
     }
 
-    // ── Step 4: iterar vacas ─────────────────────────────────────────
+    const roster = construirRosterPesaje(lectura.resultado.rosterAnimales);
+    const fechasPorSemana = lectura.resultado.fechasPorSemana;
+    let diffActual = lectura.resultado.diff;
 
-    let guardadas = 0;
-    let saltadas = 0;
-    let terminarTemprano = false;
+    // ── Paso 4/5: mostrar resumen + loop de corrección en texto libre (N12,
+    //    decisión D-C) hasta un "ok" explícito. Nada se escribe antes. ─────
+    const kbGuardar = new InlineKeyboard()
+      .text("✅ Guardar", "guardar_pesaje")
+      .text("❌ Cancelar", "cancel_flow");
 
-    for (const vaca of vacas) {
-      if (terminarTemprano) break;
+    const advertenciasIniciales = construirAdvertenciasLectura(lectura.resultado);
+    await enviarPorPartes(
+      ctx,
+      [
+        `📋 *Lectura de la planilla -- ${nombreMes(mesFinal)} ${anioFinal}*`,
+        "",
+        construirResumenPesajeTexto(diffActual),
+        ...(advertenciasIniciales.length > 0 ? ["", ...advertenciasIniciales] : []),
+        "",
+        'Escribe correcciones en lenguaje natural (ej: "MONZA sem 2 AM son 6.5" o "BONITA no se pesó"), o toca *Guardar* cuando esté bien.',
+      ].join("\n"),
+      { reply_markup: kbGuardar, parse_mode: "Markdown" },
+    );
 
-      const etiqueta = `#${vaca.numero ?? "?"} ${vaca.nombre ?? "sin nombre"}`;
-      const existente = existentes.get(vaca.id);
-      const actual = existente ? ` (actual: ${existente.litros_total} L)` : "";
+    while (true) {
+      const respuesta = await conversation.wait();
 
-      const kb = new InlineKeyboard()
-        .text("⏭ Saltar", "vaca_skip")
-        .text("✅ Terminar aquí", "vaca_finish")
-        .row()
-        .text("❌ Cancelar", "cancel_flow");
-
-      await ctx.reply(`🐄 *${etiqueta}*${actual}\n¿Cuántos litros dio?`, {
-        reply_markup: kb,
-        parse_mode: "Markdown",
-      });
-
-      // Loop until this cow resolves to skip/finish/cancel/valid-number —
-      // an invalid text answer re-prompts the SAME cow, it never silently
-      // advances to the next one.
-      while (true) {
-        const respuesta = await conversation.wait();
-
-        if (respuesta.callbackQuery?.data === "cancel_flow") {
-          await respuesta.answerCallbackQuery();
-          await ctx.reply(
-            `Operación cancelada. Los pesajes ya guardados (${guardadas}) quedan registrados — solo se descarta lo que faltaba.`,
-          );
-          return conversation.halt();
-        }
-
-        if (respuesta.callbackQuery?.data === "vaca_finish") {
-          await respuesta.answerCallbackQuery();
-          terminarTemprano = true;
-          break;
-        }
-
-        if (respuesta.callbackQuery?.data === "vaca_skip") {
-          await respuesta.answerCallbackQuery();
-          saltadas++;
-          break;
-        }
-
-        if (respuesta.message?.text) {
-          const litros = parseFloat(respuesta.message.text.trim().replace(",", "."));
-          if (isNaN(litros) || litros < 0) {
-            await respuesta.reply("Ingresa un número válido (0 o más), o usa los botones.");
-            continue;
-          }
-
-          const idGuardado = await conversation.external(async () => {
-            const sb = getSupabaseAdmin();
-            if (existente) {
-              const { error } = await sb
-                .from("hato_pesajes_leche")
-                .update({ litros_total: litros })
-                .eq("id", existente.id);
-              if (error) throw new Error(`Error guardando: ${error.message}`);
-              return existente.id;
-            }
-            const { data, error } = await sb
-              .from("hato_pesajes_leche")
-              .insert({ animal_id: vaca.id, fecha, litros_total: litros, fuente: "telegram" })
-              .select("id")
-              .single();
-            if (error) throw new Error(`Error guardando: ${error.message}`);
-            return data!.id as string;
-          });
-
-          existentes.set(vaca.id, { id: idGuardado, litros_total: litros });
-          guardadas++;
-          break;
-        }
-
-        await ctx.reply("No entendí la respuesta. Usa un número o los botones.");
+      if (respuesta.callbackQuery?.data === "cancel_flow") {
+        await respuesta.answerCallbackQuery();
+        await ctx.reply("Operación cancelada -- nada se guardó.");
+        return conversation.halt();
       }
+      if (respuesta.callbackQuery?.data === "guardar_pesaje") {
+        await respuesta.answerCallbackQuery();
+        break;
+      }
+
+      const texto = respuesta.message?.text;
+      if (!texto) {
+        await ctx.reply('No entendí. Escribe una corrección, "ok" para guardar, o toca los botones de arriba.');
+        continue;
+      }
+      if (esCancelacionTexto(texto)) {
+        await ctx.reply("Operación cancelada -- nada se guardó.");
+        return conversation.halt();
+      }
+      if (esConfirmacionGuardar(texto)) break;
+
+      // ── Interpretar la corrección: llamada al modelo (N12) + validación
+      //    PURA contra el roster y la grilla de semanas del mes. ──────────
+      await ctx.replyWithChatAction("typing");
+      const interpretacion = await conversation.external(() => llamarModeloCorreccionPesaje(texto, apiKey));
+
+      if (!interpretacion.ok) {
+        await ctx.reply(`No pude interpretar eso: ${interpretacion.error}\n\nIntenta de nuevo, o toca Guardar/Cancelar.`);
+        continue;
+      }
+
+      const { aplicables, noEntendidas } = interpretarCorreccionPesaje(interpretacion.items, roster, fechasPorSemana);
+
+      if (aplicables.length === 0 && noEntendidas.length === 0) {
+        await ctx.reply('No encontré ninguna corrección en ese mensaje. Intenta de nuevo, o escribe "ok" para guardar.');
+        continue;
+      }
+
+      diffActual = aplicarCorreccionesADiff(diffActual, aplicables);
+
+      const bloques = [
+        aplicables.length > 0 ? `✏️ Apliqué ${aplicables.length} corrección(es).` : null,
+        noEntendidas.length > 0
+          ? `⚠️ No entendí ${noEntendidas.length}:\n${noEntendidas.map((n) => `  - "${n.nombreMencionado}": ${n.detalle}`).join("\n")}`
+          : null,
+        "",
+        "📋 *Resumen actualizado*",
+        construirResumenPesajeTexto(diffActual),
+      ].filter((b): b is string => b !== null);
+
+      await enviarPorPartes(ctx, bloques.join("\n"), { reply_markup: kbGuardar, parse_mode: "Markdown" });
     }
 
-    await ctx.reply(
-      `✅ Pesaje del ${formatDateSpanish(fecha)} completado: ${guardadas} vaca${guardadas === 1 ? "" : "s"} pesada${guardadas === 1 ? "" : "s"}` +
-        (saltadas > 0 ? `, ${saltadas} saltada${saltadas === 1 ? "" : "s"}.` : ".") +
-        "\n\nUsa /start para volver al menú.",
-    );
+    // ── Paso 6: commit por celda (N13) ────────────────────────────────
+    const celdasParaGuardar: CeldaCommitPesajeEntrada[] = construirFilasPesajeInsertables(diffActual).map((f) => ({
+      animalId: f.animal_id,
+      fecha: f.fecha,
+      litrosAm: f.litros_am,
+      litrosPm: f.litros_pm,
+    }));
+
+    if (celdasParaGuardar.length === 0) {
+      await ctx.reply("No hay ninguna celda con datos para guardar (todo quedó en 'sin dato'). No se escribió nada.");
+      return;
+    }
+
+    const commit = await conversation.external(async () => {
+      const sb = getSupabaseAdmin();
+      return await ejecutarCommitPesaje({
+        supabase: sb,
+        anio: anioFinal,
+        mes: mesFinal,
+        celdas: celdasParaGuardar,
+        createdBy: usuarioId,
+        fuente: "telegram",
+      });
+    });
+
+    if (!commit.ok) {
+      const rechazadas = "celdasRechazadas" in commit ? commit.celdasRechazadas : [];
+      await ctx.reply(
+        `❌ No se pudo guardar: ${commit.error}${
+          rechazadas.length > 0 ? `\n\nRechazadas:\n${rechazadas.map((r) => `  - ${r.motivo}`).join("\n")}` : ""
+        }`,
+      );
+      return;
+    }
+
+    const resumenFinal = [
+      `✅ Pesaje de *${nombreMes(mesFinal)} ${anioFinal}* guardado: ${commit.guardados} celda(s) (${commit.actualizados} actualizadas, ${commit.creados} nuevas).`,
+      commit.celdasRechazadas.length > 0
+        ? `⚠️ ${commit.celdasRechazadas.length} celda(s) rechazadas al guardar:\n${commit.celdasRechazadas.map((r) => `  - ${r.motivo}`).join("\n")}`
+        : null,
+      "",
+      "Usa /pesaje para cargar otra planilla, o /start para el menú.",
+    ]
+      .filter((b): b is string => b !== null)
+      .join("\n");
+    await enviarPorPartes(ctx, resumenFinal, { parse_mode: "Markdown" });
   } catch (err: unknown) {
     if (err instanceof Error && err.message === "Conversation already halted") return;
     const msg = err instanceof Error ? err.message : "Error desconocido";

--- a/supabase/functions/make-server-1ccce916/telegram/enviar.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/enviar.ts
@@ -5,6 +5,16 @@
 // escribe a alguien SIN que haya escrito primero (el tick diario cron ->
 // `hato-alertas-tick.ts`).
 //
+// Migración 096 (2026-08-14, suscripciones + broadcast con cierre por el
+// primero) agrega `editarMensajeTelegram`/`cerrarAlertaEnEnvios`: cuando un
+// suscrito responde una alerta que se mandó a VARIOS suscritos, los mensajes
+// de los DEMÁS hay que editarlos para que se vea que ya se resolvió y por
+// quién — pero esos mensajes viven en OTROS chats, no en el del que
+// respondió, así que `ctx.editMessageText` (que solo edita el mensaje del
+// `Context` actual) no alcanza. Estas dos funciones llaman directo a la Bot
+// API con el `chat_id`/`message_id` guardados en `hato_alertas_envios` (la
+// tabla de envíos del broadcast, una fila por (alerta, suscrito)).
+//
 // Deliberadamente NO reutiliza la instancia interna de `getBot()` de
 // `bot.ts` (no está exportada, y exportarla acoplaría el tick al ciclo de
 // vida completo del bot -- sesiones persistidas, plugin de conversations,
@@ -129,4 +139,102 @@ export async function enviarMensajeTelegram(
 
   await registrarEnvio(supabase, opciones, resultado);
   return resultado;
+}
+
+// ----------------------------------------------------------------------------
+// Edición de un mensaje YA enviado, en un chat que puede no ser el que
+// disparó el callback (migración 096, broadcast con cierre por el primero).
+// ----------------------------------------------------------------------------
+
+export interface OpcionesEdicionTelegram {
+  /** `chat_id` de Telegram del mensaje a editar -- NO necesariamente el chat
+   * de quien respondió la alerta (ese es el punto: se editan los mensajes de
+   * los DEMÁS suscritos). */
+  telegramId: string;
+  /** `message_id` devuelto por `sendMessage` en su momento (guardado en
+   * `hato_alertas_envios.message_id`). */
+  messageId: number;
+  texto: string;
+}
+
+/**
+ * Edita el texto de un mensaje ya enviado, vía la Bot API (`editMessageText`)
+ * -- nunca `ctx.editMessageText`, que solo sabe editar el mensaje del
+ * `Context` en curso. Mismo contrato duro que `enviarMensajeTelegram`: NUNCA
+ * lanza. Telegram rechaza editar un mensaje de más de 48h -- ese fallo (como
+ * cualquier otro: chat bloqueado, mensaje borrado por el usuario) se
+ * devuelve como `{ ok: false, error }` y el caller decide si sigue con el
+ * siguiente destinatario del broadcast.
+ *
+ * No se audita en `telegram_mensajes` (a diferencia de `enviarMensajeTelegram`):
+ * esa tabla registra mensajes NUEVOS, y una edición no es un mensaje nuevo --
+ * el mensaje original ya quedó auditado cuando se mandó.
+ */
+export async function editarMensajeTelegram(opciones: OpcionesEdicionTelegram): Promise<ResultadoEnvioTelegram> {
+  try {
+    const respuesta = await fetch(urlApiTelegram('editMessageText'), {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        chat_id: opciones.telegramId,
+        message_id: opciones.messageId,
+        text: opciones.texto,
+      }),
+    });
+    const json = await respuesta.json().catch(() => null);
+    if (!respuesta.ok || !json?.ok) {
+      return { ok: false, error: json?.description ?? `Telegram respondió HTTP ${respuesta.status}` };
+    }
+    return { ok: true, telegramMessageId: opciones.messageId };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+export interface ResultadoCierreAlertaEnvios {
+  editados: number;
+  fallidos: number;
+}
+
+/**
+ * Edita el mensaje de CADA suscrito al que se le mandó una alerta
+ * (`hato_alertas_envios`, una fila por (alerta_id, telegram_id)) para
+ * mostrar que ya se resolvió -- el corazón del broadcast "cierre por el
+ * primero" (migración 096). `excluirTelegramId` deja afuera el chat de quien
+ * ACABA de responder: ese mensaje ya lo edita el propio callback vía
+ * `ctx.editMessageReplyMarkup()` (más rápido, no necesita ir por la Bot API
+ * con un `chat_id` explícito) -- editarlo dos veces por dos caminos distintos
+ * es una carrera innecesaria contra el mismo mensaje.
+ *
+ * Un fallo puntual (mensaje ya editado más de 48h, chat bloqueado) no aborta
+ * el resto -- se cuenta en `fallidos` y el caller decide si lo loguea.
+ */
+export async function cerrarAlertaEnEnvios(
+  supabase: SupabaseClient,
+  alertaId: string,
+  excluirTelegramId: string | null,
+  texto: string,
+): Promise<ResultadoCierreAlertaEnvios> {
+  const { data: envios, error } = await supabase
+    .from('hato_alertas_envios')
+    .select('telegram_id, message_id')
+    .eq('alerta_id', alertaId);
+  if (error) {
+    console.error('[hato-alertas][hato_alertas_envios] no se pudieron leer los envíos para cerrar la alerta:', error.message);
+    return { editados: 0, fallidos: 0 };
+  }
+
+  let editados = 0;
+  let fallidos = 0;
+  for (const envio of (envios ?? []) as Array<{ telegram_id: string; message_id: number | null }>) {
+    if (excluirTelegramId && envio.telegram_id === excluirTelegramId) continue;
+    if (envio.message_id == null) {
+      fallidos += 1;
+      continue;
+    }
+    const resultado = await editarMensajeTelegram({ telegramId: envio.telegram_id, messageId: envio.message_id, texto });
+    if (resultado.ok) editados += 1;
+    else fallidos += 1;
+  }
+  return { editados, fallidos };
 }


### PR DESCRIPTION
Cierra el grafo de `docs/plan_hato_telegram_estados_agosto_2026.md`, nacido de la visita del dueño a la finca el 2026-08-13: Fernando registró una monta en vivo y no tenía forma de dejarla asentada hasta el chequeo bimensual dos meses después.

**Los 26 nodos del grafo están hechos.** Encima, dos cosas que aparecieron en el camino: un bug de manejo de errores que dejaba al usuario encerrado en Telegram, y el andamiaje de suscripciones a alertas que el dueño pidió al final.

## Ya está en producción

Estas partes **no esperan al merge** — se aplicaron y desplegaron durante la sesión:

| | |
|---|---|
| Migración **094** | `v_hato_estado_actual` expone el método de preñez y el último aborto |
| Migración **095** | catálogo de toros vigente: 8 activos / 57 totales, 6 lotes / 27 pajillas |
| Migración **096** | catálogo de alertas + suscripciones por usuario de Telegram |
| Edge function | desplegada 3 veces; `/health` 200 y las rutas nuevas responden 401, no 404 |

**Lo que este PR lleva a producción al mezclarse es el frontend**: la lista del hato (edad, partos, estado, próximo evento), la planilla del chequeo y las casillas de alertas. Vercel construye desde `main`.

## Qué trae

**Eventos por Telegram (N4–N10).** `/evento` registra monta, inseminación, secado, parto y aborto, con Deshacer. Escribe directo con `fuente='telegram'` y `created_by` explícito — el bot usa `service_role`, donde `auth.uid()` es NULL y ningún trigger de atribución se dispara.

**Pesaje por foto (N11–N13).** `/pesaje` deja de ser vaca-por-vaca (256 líneas iterando 65 animales en un chat, inviable en el corral) y pasa a ser foto de la planilla mensual. El pipeline salió de `hato-pesaje-foto.ts` a `hato-pesaje-pipeline.ts`, compartido por el endpoint HTTP y el bot: **no hay un segundo lector de celdas**. La corrección en lenguaje natural exige vaca + semana + AM/PM explícitos; si el modelo no puede extraer alguno, lo reporta como no entendido en vez de adivinar.

**Planilla del chequeo (N21–N23).** Sale pre-impresa con lo que el sistema cree ("Estado registrado") y el diff marca conflicto explícito cuando el papel dice otra cosa. El chequeo deja de ser captura en blanco y pasa a ser verificación.

**Suscripciones a alertas.** `alertas_catalogo` + `telegram_alertas_suscripciones`: quién recibe qué se marca con casillas. Genérico desde el día uno — agregar una alerta de aguacate es un `INSERT`, la UI la agrupa sola. Broadcast con cierre por el primero. Esto **absorbe N27**, que era el último nodo abierto.

## Lo que un revisor debería mirar

**La migración 095 abortó en su primera corrida, y estuvo bien.** Su guarda de salida ("deberían quedar 8 toros activos, quedaron 7") revirtió todo sin tocar producción. La causa era fina: `toros_vigentes` guarda la grafía actual (`marquez`) y la final (`Márquez`); el paso 4 renombraba y los pasos 5–6 seguían buscando por la clave vieja, así que el paso 6 desactivaba al toro que el paso 4 acababa de normalizar. Se editó la 095 en vez de escribir una 096 **porque nunca llegó a aplicarse**: la regla de no tocar migraciones protege lo que ya corrió.

**El escalamiento de alertas lleva muerto desde julio.** `HATO_ALERTAS_ESCALAMIENTO_TELEGRAM_ID` nunca se configuró, así que una alerta sin responder a las 48h se marca `escalada` y no le llega a nadie. La 096 sembraba `escalamiento=true` afirmando que "el comportamiento no cambia" — es al revés: habría encendido esa función de refilón. Queda en `false`, y ahora hay una casilla para encenderla a propósito.

**Se revocó un requisito duro del dueño, con su decisión explícita.** El código registraba que la letra de la planilla debía ser ≥11pt y que "si el layout no cupiera, la salida son más páginas, NUNCA letra más chica". A 11pt la planilla estaba **sobre-suscrita** (261,4mm de mínimo contra 259,4 útiles): `BRILLANTINA`, el nombre más largo del hato, no cabía por 0,3mm. El dueño lo revocó viendo el render. La regla no se borró: quedó documentada con quién, cuándo y por qué, y con piso nuevo en 9pt.

**Dos trampas de Telegram cerradas.** `/evento` encerraba al usuario: en el paso de fecha, `/cancelar` respondía "Formato inválido" en bucle y el `editMessageText` había borrado el botón de salida. La causa aplica a todo el bot — mientras una conversación de grammY está activa, el `bot.command("cancelar")` global nunca se dispara.

## Verificación

- `npm test` → **2.219 tests, 92 archivos**, todos en verde
- `npm run lint` → 0 errores · `npx tsc --noEmit` → limpio
- Los **4 generadores de espejos** en sincronía (`--check`), los dos árboles de edge function idénticos
- Migraciones ensayadas con `ROLLBACK` contra datos vivos antes de cada pase real

## Lo que queda abierto (§8.5 del plan)

1. **Imprimir la planilla en papel.** Rehecha dos veces con el dueño a la vista del render, pero nadie la ha puesto en una impresora. 3,4mm de holgura.
2. **Probar `/pesaje` por foto en el corral**, contra una foto real. Está desplegado y con tests, pero ya se vio hoy que un flujo de Telegram puede estar perfecto en los tests y tener una trampa que sólo aparece usándolo.
3. Dos huecos menores del diff del chequeo, documentados y sin riesgo de corrupción.
4. `hato_alertas_config.destinatario_telegram_id` quedó vestigial — el motor ya no la lee. No se borró: tiene historia y merece su propia migración.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
