### PR TITLE
feat(esco): traza en vivo del tool-calling y estado vacío por ruta

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -341,6 +341,12 @@ Key behaviors:
 
 Esco's system prompt carries the accounting rules verbatim (cattle purchases are inventory not expense, cosecha semesters cross calendar years, no prorrateo of Oficina Central) so the model explains discrepancies instead of inventing them. `get_financial_summary`'s description now explicitly steers away from profitability questions: subtracting its gastos from its ingresos contradicts the P&G, because there cattle purchases count as an outflow.
 
+**Traza en vivo del tool-calling loop (`tool_start` / `tool_done`).** `llmToolLoop` acepta un tercer parámetro opcional `onEvent`, y `handleChatMessage` lo reenvía por el SSE. Antes el cliente solo conocía `text_delta | done | error` y mostraba un spinner estático durante toda la espera (medido: 27 s de 30,4 s). **Los eventos son aditivos por contrato** — el bot de Telegram llama `llmToolLoop(messages, userId)` sin `onEvent` y se comporta igual que siempre; cualquier cliente que no los conozca los ignora.
+
+- **No se reporta conteo de filas**, solo `ms` y `ok`. Habría que adivinarlo hurgando el JSON de cada herramienta, y un número inventado es peor que ninguno en un sistema que distingue «sin dato» de «0». `ok` sale de `toolResultOk()`, que detecta el `{ error }` que `executeTool` devuelve en vez de lanzar.
+- **La traducción de los 33 nombres técnicos vive en el cliente** (`src/utils/escoHerramientas.ts`), no en el edge function: así no paga el costo de mantenerse sincronizada entre los dos árboles duplicados, y Telegram queda libre de formatear distinto. `src/__tests__/escoHerramientas.test.ts` lee los `case` de `executeTool` y falla si alguna herramienta ejecutable se queda sin etiqueta, o si sobra una etiqueta huérfana.
+- **La traza medió algo que no se sabía**: las herramientas tardan 24–229 ms. Prácticamente toda la espera es el round-trip del LLM, no la base de datos — por eso el estado que más se ve es «Redactando la respuesta…».
+
 **Required edge function secrets** (set via Supabase Dashboard → Project Settings → Edge Functions):
 - `OPENROUTER_API_KEY` — OpenRouter API key (used for DeepSeek and Gemini 2.5 Flash via OpenRouter)
 - `NOTION_TOKEN` — Notion integration token (for owner call summaries; optional, graceful fallback if absent)

--- a/docs/README.md
+++ b/docs/README.md
@@ -19,6 +19,7 @@ Esta carpeta contiene documentación vigente para operar, mantener y extender el
 - [`plan_hato_produccion_rework.md`](./plan_hato_produccion_rework.md) — contrato del rework del submódulo Producción (Hato Lechero): grano quincenal, vínculo duro Producción↔Finanzas, clasificación del backfill histórico, y los dos hallazgos medidos contra producción que gobiernan el tablero (desfase pago→producción = 0; cobertura de pesaje incompleta hasta junio 2026).
 - [`hato/qa-produccion-rework.md`](./hato/qa-produccion-rework.md) — 45 criterios Given/When/Then del rework de Producción, escritos ANTES de la implementación, más los hallazgos adversariales sobre el propio brief.
 - [`plan_sidebar_modulos.md`](./plan_sidebar_modulos.md) — diseño implementado de navegación y acceso por módulo.
+- [`plan_esco_facelift.md`](./plan_esco_facelift.md) — auditoría medida de la experiencia de Esco y sus ocho puntos de intervención. Fase 1 (traza en vivo del tool-calling, estado vacío por ruta) implementada; fases 2 y 3 pendientes. Incluye las reglas para vendorizar más primitivos de Beautiful UI sin romper los tokens de la app.
 - [`PLAN_PRIORIZACION_MONITOREO.md`](./PLAN_PRIORIZACION_MONITOREO.md) — razonamiento y contrato de priorización de scouting.
 - [`POC_PREDICCION_PLAGAS.md`](./POC_PREDICCION_PLAGAS.md) — POC cerrado; conserva el resultado NO-GO y la evidencia metodológica.
 

--- a/docs/plan_esco_facelift.md
+++ b/docs/plan_esco_facelift.md
@@ -1,0 +1,109 @@
+# Plan — Facelift de Esco
+
+Rediseño de la experiencia del asistente Esco en la web (`src/components/chat/`).
+Auditoría hecha el **2026-08-16** midiendo en vivo contra producción, no leyendo código.
+
+**Estado**: fase 1 implementada y desplegada. Fases 2 y 3 pendientes.
+
+---
+
+## 1. Lo que se midió
+
+Una pregunta real de finanzas («gastos por categoría de los últimos 3 meses»), sesión
+Gerencia, datos de producción:
+
+| Medición | Valor |
+|---|---|
+| Respuesta completa | **30,4 s** |
+| De eso, spinner estático «Consultando datos…» | **~27 s** |
+| Máquina de escribir simulada al final | 2,7 s (1.444 chars ÷ 8 por cada 15 ms) |
+| Ancho real de una gráfica en un teléfono de 375 px | **226 px** |
+| Herramientas de Esco | 33 |
+| Acciones disponibles sobre una respuesta | 0 |
+
+**Hallazgo que cambió el plan** (medido *después* de instrumentar la traza en la fase 1):
+las herramientas tardan **24–229 ms**. Prácticamente toda la espera es round-trip del
+LLM, no la base de datos. La fase 1 volvió la espera legible; **no la acortó**, y la
+palanca real para acortarla es el modelo o el streaming de verdad, no las consultas.
+
+---
+
+## 2. Los ocho puntos
+
+Ordenados por cuánto cambian la sensación de uso.
+
+| # | Punto | Estado | Primitivo |
+|---|---|---|---|
+| 01 | Silencio de 27 s durante la consulta | **✅ fase 1** | ThinkingState · ToolChips |
+| 02 | La burbuja es el contenedor equivocado para un informe de 1.400 chars | pendiente · fase 2 | StreamingText · InsightCards |
+| 03 | Gráficas ilegibles en teléfono (226 px, leyenda «value») | pendiente · fase 2 | — (cambia el contenedor, Recharts se queda) |
+| 04 | «Guarda esto» no hace nada en la web — **función rota** | pendiente · fase 3 | ApprovalCard |
+| 05 | Sin trazabilidad: una cifra aparece sin de dónde salió | pendiente · fase 3 | ContextCards |
+| 06 | La respuesta es un callejón sin salida (no copiar/reintentar/detener) | pendiente · fase 2 | StreamingText |
+| 07 | El panel no es un diálogo real (Escape no cierra, sin trampa de foco) | pendiente · fase 3 | Radix `Sheet` — **no** Beautiful UI |
+| 08 | Estado vacío descentrado y ciego a la ruta | **✅ fase 1** | — |
+
+Los primitivos vienen de [Beautiful UI](https://beautiful-ui-five.vercel.app/) (Turbo),
+disponibles offline en el skill `beautiful-ui`.
+
+### Detalle de los puntos pendientes
+
+- **02 / 03** — La respuesta del asistente deja de ser burbuja y pasa a documento a ancho
+  completo. La cifra titular sube a tarjeta antes del párrafo que la explica. Las gráficas
+  salen de la burbuja y toman el ancho del panel; bajo 640 px, barras **horizontales** (el
+  nombre de la categoría es texto largo en español). La leyenda toma el título de la serie,
+  nunca la llave cruda del JSON.
+- **04** — `chat.tsx:1835` documenta el flujo: *«el cliente renderiza botones de confirmación
+  en línea con el token»*. Telegram los renderiza (`telegram/bot.ts:475` inserta en
+  `esco_memorias`); la web no tiene una sola línea. Le pedís a Esco que recuerde algo desde
+  el navegador, contesta que sí, y la fila nunca se inserta. `ApprovalCard` conectada a
+  `propose_memory_save` → `commit_memory_save` con el token que ya viaja.
+- **05** — `result_summary` (500 chars por herramienta) ya se persiste en
+  `chat_messages.metadata.tool_interactions` y se relee en el turno siguiente. Falta
+  mostrarlo: `ContextCards` colapsadas bajo la respuesta. Esto además hace que la traza
+  sobreviva al recargar una conversación vieja, cosa que la fase 1 **no** hace.
+- **06** — Barra de acciones al pie (copiar, reintentar, exportar gráfica) más
+  seguimientos sugeridos. Detener = `AbortController` en `sendChatMessage`.
+- **07** — Migrar a Radix `Sheet`, que ya está en `src/components/ui/`. Aquí la guía del
+  propio skill manda: cualquier cosa con forma de overlay va con Radix y se le aplican los
+  tokens encima, porque la trampa de foco y la capa de descarte son la parte cara de
+  rehacer y la fácil de equivocar.
+
+---
+
+## 3. Lo que entregó la fase 1
+
+- **Protocolo**: `llmToolLoop` acepta un tercer parámetro opcional `onEvent`; emite
+  `tool_start` / `tool_done` con `tool`, `index`, `args`, `ms` y `ok`. Aditivo por contrato
+  — Telegram llama sin `onEvent` y se comporta igual. Detalle en el `CLAUDE.md` raíz.
+- **`src/utils/escoHerramientas.ts`**: mapa de las 33 herramientas a etiquetas en español,
+  formateo del rango de fechas y de la duración. Vive en el cliente para no pagar el costo
+  de sincronizar los dos árboles del edge function.
+- **`src/components/chat/EscoTraza.tsx`**: adaptación de `ThinkingState`.
+- **`src/__tests__/escoHerramientas.test.ts`**: guarda de paridad — lee los `case` de
+  `executeTool` y falla si una herramienta ejecutable se queda sin etiqueta o si sobra una
+  huérfana.
+
+---
+
+## 4. Reglas al vendorizar más primitivos
+
+Vigentes para las fases 2 y 3.
+
+- **El choque de `--accent`.** En Beautiful UI es el color de marca; en shadcn es la
+  superficie de hover de los menús. Importar su `theme.css` tal cual pone **todos** los
+  dropdowns de la app en azul de golpe. Se remapea al entrar y `--primary` sigue siendo
+  `#73991C`. La fase 1 lo evitó escribiendo los componentes contra los tokens de Escocia
+  directamente en vez de importar la capa de tokens de la librería — **seguir así**.
+- **No copiar el bloque `.dark`.** Escocia OS borró su modo oscuro a propósito (F3,
+  agosto 2026). El `theme.css` del skill lo trae.
+- **Los primitivos son demo, no producción.** Medido sobre los 19: `focus-visible` en 1
+  archivo, 5 matan el `outline` sin reponer nada, 43 animaciones en línea que ningún
+  `prefers-reduced-motion` alcanza, botones de 28 px contra un piso táctil de 44. La fase 1
+  cerró las tres cosas: animaciones como clases en `globals.css` (con su bloque de
+  reduced-motion), anillo de foco explícito, y la clase `touch-target` que ya existía.
+- **34 hex sueltos** sobreviven a cualquier remapeo de tokens. `InsightCards:110` trae
+  `#3d9aff` hardcodeado, que además es el acento de modo oscuro. Hacer `grep '#'` al
+  componente antes de asumir que el remapeo lo cubrió.
+- **Telegram no se toca.** Comparte `llmToolLoop` y el system prompt: todo evento nuevo
+  tiene que ser aditivo.

--- a/src/__tests__/escoHerramientas.test.ts
+++ b/src/__tests__/escoHerramientas.test.ts
@@ -1,0 +1,147 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import {
+  ETIQUETAS_HERRAMIENTAS,
+  detalleArgumentos,
+  etiquetaHerramienta,
+  formatearDuracion,
+  resumenTraza,
+} from '@/utils/escoHerramientas';
+
+const CHAT_TSX = resolve(__dirname, '../supabase/functions/server/chat.tsx');
+
+/**
+ * Nombres de herramienta declarados de verdad en el edge function.
+ *
+ * Se leen del `switch` de `executeTool`, que es el único lugar donde una
+ * herramienta se vuelve ejecutable: si no tiene `case`, el modelo puede pedirla
+ * pero nunca corre. Leer del archivo y no de una lista copiada es lo que hace
+ * que esta prueba detecte la deriva en vez de repetirla.
+ */
+function herramientasDelServidor(): string[] {
+  const src = readFileSync(CHAT_TSX, 'utf8');
+  const cuerpo = src.slice(src.indexOf('async function executeTool'));
+  const fin = cuerpo.indexOf('\n}');
+  return [...cuerpo.slice(0, fin).matchAll(/case '([a-z_]+)':/g)].map((m) => m[1]);
+}
+
+describe('escoHerramientas — paridad con el edge function', () => {
+  it('encuentra las herramientas en el servidor (si esto falla, el parser quedó obsoleto)', () => {
+    expect(herramientasDelServidor().length).toBeGreaterThanOrEqual(30);
+  });
+
+  it('toda herramienta ejecutable tiene etiqueta en español', () => {
+    const sinEtiqueta = herramientasDelServidor().filter((t) => !ETIQUETAS_HERRAMIENTAS[t]);
+    expect(sinEtiqueta).toEqual([]);
+  });
+
+  it('no hay etiquetas para herramientas que ya no existen', () => {
+    const reales = new Set(herramientasDelServidor());
+    const huerfanas = Object.keys(ETIQUETAS_HERRAMIENTAS).filter((t) => !reales.has(t));
+    expect(huerfanas).toEqual([]);
+  });
+
+  it('ninguna etiqueta se repite — dos fuentes distintas no pueden leerse igual en la traza', () => {
+    const vistas = Object.values(ETIQUETAS_HERRAMIENTAS);
+    expect(new Set(vistas).size).toBe(vistas.length);
+  });
+});
+
+describe('etiquetaHerramienta', () => {
+  it('traduce una herramienta conocida', () => {
+    expect(etiquetaHerramienta('get_labor_summary')).toBe('Jornales y mano de obra');
+  });
+
+  it('degrada legible ante una herramienta nueva sin registrar', () => {
+    expect(etiquetaHerramienta('get_algo_nuevo')).toBe('algo nuevo');
+  });
+});
+
+describe('detalleArgumentos — rangos de fecha', () => {
+  it('comprime un rango dentro del mismo año', () => {
+    expect(detalleArgumentos({ date_from: '2026-05-16', date_to: '2026-08-16' })).toBe('may–ago 2026');
+  });
+
+  it('colapsa un rango de un solo mes', () => {
+    expect(detalleArgumentos({ date_from: '2026-08-01', date_to: '2026-08-31' })).toBe('ago 2026');
+  });
+
+  it('conserva ambos años cuando el rango los cruza', () => {
+    expect(detalleArgumentos({ date_from: '2025-11-01', date_to: '2026-04-30' })).toBe(
+      'nov 2025 – abr 2026',
+    );
+  });
+
+  it('maneja un rango abierto por un extremo', () => {
+    expect(detalleArgumentos({ date_from: '2026-03-09' })).toBe('desde 9 mar 2026');
+    expect(detalleArgumentos({ date_to: '2026-03-09' })).toBe('hasta 9 mar 2026');
+  });
+
+  /**
+   * Regresión: `new Date('2026-05-01')` es medianoche UTC, que en Bogotá (UTC-5) cae
+   * el 30 de abril a las 19:00 — `getMonth()` habría devuelto abril. Es la misma
+   * trampa que documenta el CLAUDE.md para `obtenerFechaHoy()`, mirando al revés.
+   */
+  it('lee el primer día del mes sin correrse al mes anterior por UTC', () => {
+    expect(detalleArgumentos({ date_from: '2026-05-01', date_to: '2026-05-31' })).toBe('may 2026');
+    expect(detalleArgumentos({ date_from: '2026-01-01', date_to: '2026-01-31' })).toBe('ene 2026');
+  });
+
+  it('ignora una fecha con formato inválido', () => {
+    expect(detalleArgumentos({ date_from: 'hace tres meses' })).toBeNull();
+    expect(detalleArgumentos({ date_from: '2026-13-01' })).toBeNull();
+  });
+});
+
+describe('detalleArgumentos — otros argumentos', () => {
+  it('prefiere el rango de fechas sobre cualquier otro argumento', () => {
+    expect(detalleArgumentos({ lote_name: 'Lote 7', date_from: '2026-08-01', date_to: '2026-08-31' })).toBe(
+      'ago 2026',
+    );
+  });
+
+  it('cae al primer argumento con significado', () => {
+    expect(detalleArgumentos({ limit: 2000, lote_name: 'Lote 7' })).toBe('Lote 7');
+  });
+
+  it('no muestra plomería como detalle', () => {
+    expect(detalleArgumentos({ limit: 2000, include_config: true })).toBeNull();
+  });
+
+  it('recorta un valor largo en vez de romper el chip', () => {
+    const detalle = detalleArgumentos({ search_term: 'a'.repeat(60) });
+    expect(detalle).toHaveLength(28);
+    expect(detalle?.endsWith('…')).toBe(true);
+  });
+
+  it('devuelve null sin argumentos', () => {
+    expect(detalleArgumentos(undefined)).toBeNull();
+    expect(detalleArgumentos({})).toBeNull();
+  });
+});
+
+describe('formatearDuracion', () => {
+  it('usa milisegundos por debajo del segundo', () => {
+    expect(formatearDuracion(340)).toBe('340 ms');
+  });
+
+  it('usa segundos con coma decimal colombiana', () => {
+    expect(formatearDuracion(4200)).toBe('4,2 s');
+    expect(formatearDuracion(24_100)).toBe('24,1 s');
+  });
+});
+
+describe('resumenTraza', () => {
+  it('concuerda el singular', () => {
+    expect(resumenTraza([{ ms: 1200 }])).toBe('Consulté 1 fuente · 1,2 s');
+  });
+
+  it('suma las duraciones de todas las fuentes', () => {
+    expect(resumenTraza([{ ms: 1200 }, { ms: 800 }, { ms: 2000 }])).toBe('Consulté 3 fuentes · 4,0 s');
+  });
+
+  it('omite el total cuando ninguna fuente reportó duración', () => {
+    expect(resumenTraza([{}, {}])).toBe('Consulté 2 fuentes');
+  });
+});

--- a/src/components/chat/ChatEmptyState.tsx
+++ b/src/components/chat/ChatEmptyState.tsx
@@ -1,36 +1,120 @@
+import { useMemo } from 'react';
+import { useLocation } from 'react-router-dom';
 import { Sprout } from 'lucide-react';
 
-const SUGGESTED_PROMPTS = [
+/**
+ * Atajos por módulo.
+ *
+ * La ruta actual es la señal de intención más barata que tiene el sistema: si
+ * Santiago abre a Esco parado en Hato Lechero, casi nunca va a preguntar por los
+ * gastos del mes. Antes la lista era fija en toda la app.
+ *
+ * El orden importa: se elige el PRIMER prefijo que coincida, así que las rutas
+ * más específicas van antes que las más generales.
+ */
+const ATAJOS_POR_RUTA: Array<{ prefijo: string; prompts: string[] }> = [
+  {
+    prefijo: '/hato-lechero',
+    prompts: [
+      'Vacas próximas a parto',
+      'Litros de la última quincena',
+      'Vacas vacías hace más de 90 días',
+      'Alertas del hato sin responder',
+    ],
+  },
+  {
+    prefijo: '/finanzas',
+    prompts: [
+      'Gastos del mes por categoría',
+      'P&G de Aguacate Hass este año',
+      'Gastos pendientes de confirmar',
+      'Presupuesto vs ejecutado',
+    ],
+  },
+  {
+    prefijo: '/ganado',
+    prompts: [
+      'Cabezas por finca',
+      'Movimientos pendientes de confirmar',
+      'Variación de inventario en 30 días',
+    ],
+  },
+  {
+    prefijo: '/monitoreo',
+    prompts: [
+      'Plagas por encima del umbral',
+      'Qué sublotes priorizar esta semana',
+      'Tendencia de ácaro en las últimas rondas',
+    ],
+  },
+  {
+    prefijo: '/aplicaciones',
+    prompts: [
+      'Aplicaciones activas',
+      'Costo por árbol de la última aplicación',
+      'Productos más usados este trimestre',
+    ],
+  },
+  {
+    prefijo: '/inventario',
+    prompts: ['Productos con inventario bajo', 'Últimas compras registradas', 'Movimientos de esta semana'],
+  },
+  {
+    prefijo: '/labores',
+    prompts: ['Jornales de esta semana', 'Actividad por empleado', 'Costo de mano de obra por lote'],
+  },
+  {
+    prefijo: '/produccion',
+    prompts: ['Kg por lote de la última cosecha', 'Costo por kilo', 'Rendimiento kg/árbol por lote'],
+  },
+  {
+    prefijo: '/clima',
+    prompts: ['Lluvia acumulada del mes', 'Pronóstico de los próximos días', 'Radiación de la semana'],
+  },
+];
+
+/** Tablero general y cualquier ruta sin atajos propios. */
+const ATAJOS_GENERALES = [
   'Jornales de esta semana',
   'Estado del monitoreo',
   'Gastos del mes',
   'Inventario bajo',
-  'Produccion por lote',
+  'Producción por lote',
   'Aplicaciones activas',
 ];
+
+function atajosParaRuta(pathname: string): string[] {
+  return ATAJOS_POR_RUTA.find((a) => pathname.startsWith(a.prefijo))?.prompts ?? ATAJOS_GENERALES;
+}
 
 interface ChatEmptyStateProps {
   onSelectPrompt: (prompt: string) => void;
 }
 
 export function ChatEmptyState({ onSelectPrompt }: ChatEmptyStateProps) {
+  const { pathname } = useLocation();
+  const prompts = useMemo(() => atajosParaRuta(pathname), [pathname]);
+
   return (
-    <div className="flex flex-1 flex-col items-center justify-center gap-4 px-6 text-center">
+    // `min-h-full`, no `flex-1`: el contenedor padre es un bloque con
+    // `overflow-y-auto`, así que `flex-1` no aplicaba, la altura colapsaba al
+    // contenido y el saludo quedaba pegado arriba en vez de centrado.
+    <div className="flex min-h-full flex-col items-center justify-center gap-4 px-6 py-10 text-center">
       <div className="flex h-12 w-12 items-center justify-center rounded-full bg-primary/10">
         <Sprout className="h-6 w-6 text-primary" />
       </div>
       <div>
         <h3 className="font-semibold text-foreground">Hola, soy Esco</h3>
         <p className="mt-1 text-sm text-muted-foreground">
-          Tu asistente de datos de Escocia Hass. Preguntame sobre labores, monitoreo, finanzas y mas.
+          Tu asistente de datos de Escocia Hass. Pregúntame sobre labores, monitoreo, finanzas y más.
         </p>
       </div>
       <div className="flex flex-wrap justify-center gap-2.5 px-2">
-        {SUGGESTED_PROMPTS.map((prompt) => (
+        {prompts.map((prompt) => (
           <button
             key={prompt}
             onClick={() => onSelectPrompt(prompt)}
-            className="rounded-full border border-border bg-background px-4 py-2.5 text-sm text-foreground transition-colors hover:bg-muted active:bg-muted"
+            className="rounded-full border border-border bg-background px-4 py-2.5 text-sm text-foreground transition-colors hover:bg-muted active:bg-muted focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1"
           >
             {prompt}
           </button>

--- a/src/components/chat/ChatPanel.tsx
+++ b/src/components/chat/ChatPanel.tsx
@@ -1,9 +1,10 @@
 import { useState, useRef, useEffect, useCallback, useMemo } from 'react';
-import { Send, Plus, ArrowLeft, Trash2, Loader2, X, FileDown, Pencil, Check } from 'lucide-react';
+import { Send, Plus, ArrowLeft, Trash2, X, FileDown, Pencil, Check } from 'lucide-react';
 import { toast } from 'sonner';
 import { ScrollArea } from '@/components/ui/scroll-area';
 import { Button } from '@/components/ui/button';
 import { ChatMessageBubble, splitChartBlocks } from './ChatMessage';
+import { EscoTraza } from './EscoTraza';
 import { ExportarInformeDialog } from './ExportarInformeDialog';
 import type { ExportData } from './ExportarInformeDialog';
 import { ChatEmptyState } from './ChatEmptyState';
@@ -15,7 +16,7 @@ import {
   deleteConversation,
   renameConversation,
 } from '@/utils/chatService';
-import type { ChatConversation, ChatMessage } from '@/types/chat';
+import type { ChatConversation, ChatMessage, PasoTraza } from '@/types/chat';
 
 interface ChatPanelProps {
   open: boolean;
@@ -24,6 +25,19 @@ interface ChatPanelProps {
 
 const MOBILE_BREAKPOINT = 1024; // lg breakpoint — matches Layout.tsx
 
+/**
+ * Traza que quedó adjunta a un mensaje ya respondido.
+ *
+ * Se guarda en el `metadata` del mensaje temporal del cliente, así que sobrevive
+ * mientras dure la sesión pero no al recargar: el servidor persiste la misma
+ * información en `metadata.tool_interactions`, y leerla de ahí al reabrir una
+ * conversación vieja es trabajo de la fase 3 (trazabilidad), no de esta.
+ */
+function trazaDeMensaje(msg: ChatMessage): PasoTraza[] | null {
+  const traza = msg.metadata?.traza;
+  return Array.isArray(traza) && traza.length > 0 ? (traza as PasoTraza[]) : null;
+}
+
 export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
   const [conversations, setConversations] = useState<ChatConversation[]>([]);
   const [currentConversationId, setCurrentConversationId] = useState<string | null>(null);
@@ -31,6 +45,11 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
   const [input, setInput] = useState('');
   const [isStreaming, setIsStreaming] = useState(false);
   const [streamingContent, setStreamingContent] = useState('');
+  // La traza vive en un ref además del estado: el estado es para pintarla, y el
+  // ref para poder leerla al cerrar el mensaje sin quedar atrapado en el closure
+  // de `handleSend`.
+  const [traza, setTraza] = useState<PasoTraza[]>([]);
+  const trazaRef = useRef<PasoTraza[]>([]);
   const [showHistory, setShowHistory] = useState(false);
   const [exportData, setExportData] = useState<ExportData | null>(null);
   const [exportTitulo, setExportTitulo] = useState('');
@@ -129,14 +148,31 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
 
     setIsStreaming(true);
     setStreamingContent('');
+    trazaRef.current = [];
+    setTraza([]);
 
     let finalConversationId = currentConversationId;
+
+    const actualizarTraza = (mutar: (pasos: PasoTraza[]) => PasoTraza[]) => {
+      trazaRef.current = mutar(trazaRef.current);
+      setTraza(trazaRef.current);
+    };
 
     try {
       await sendChatMessage(currentConversationId, messageText, (event) => {
         if (event.type === 'text_delta' && event.content) {
           setStreamingContent((prev) => prev + event.content);
           scrollToBottom();
+        } else if (event.type === 'tool_start' && event.tool) {
+          actualizarTraza((pasos) => [
+            ...pasos,
+            { index: event.index ?? pasos.length, tool: event.tool!, args: event.args },
+          ]);
+          scrollToBottom();
+        } else if (event.type === 'tool_done') {
+          actualizarTraza((pasos) =>
+            pasos.map((p) => (p.index === event.index ? { ...p, ms: event.ms, ok: event.ok } : p)),
+          );
         } else if (event.type === 'done') {
           if (event.conversation_id) {
             finalConversationId = event.conversation_id;
@@ -153,6 +189,12 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
         }
       });
 
+      // Se captura ANTES del updater: React lo ejecuta en la fase de render, o sea
+      // después de que la línea que limpia el ref ya corrió. Leer `trazaRef.current`
+      // adentro devolvía siempre el array vacío y la traza desaparecía al llegar la
+      // respuesta, en vez de asentarse encima de ella.
+      const trazaDeEsteTurno = trazaRef.current;
+
       setStreamingContent((content) => {
         if (content) {
           const assistantMsg: ChatMessage = {
@@ -160,13 +202,17 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
             conversation_id: finalConversationId || '',
             role: 'assistant',
             content,
-            metadata: {},
+            // La traza queda pegada a su respuesta: al terminar se asienta
+            // colapsada arriba del mensaje en vez de desaparecer.
+            metadata: { traza: trazaDeEsteTurno },
             created_at: new Date().toISOString(),
           };
           setMessages((prev) => [...prev, assistantMsg]);
         }
         return '';
       });
+      trazaRef.current = [];
+      setTraza([]);
 
       if (finalConversationId && finalConversationId !== currentConversationId) {
         setCurrentConversationId(finalConversationId);
@@ -405,18 +451,34 @@ export function ChatPanel({ open, onOpenChange }: ChatPanelProps) {
                   <ChatEmptyState onSelectPrompt={(p) => handleSend(p)} />
                 ) : (
                   <div className="flex flex-col gap-4 p-5">
-                    {messages.map((msg) => (
-                      <div key={msg.id} data-role={msg.role}>
-                        <ChatMessageBubble role={msg.role} content={msg.content} />
-                      </div>
-                    ))}
-                    {streamingContent && (
-                      <ChatMessageBubble role="assistant" content={streamingContent} />
-                    )}
-                    {isStreaming && !streamingContent && (
-                      <div className="flex items-center gap-2 text-sm text-muted-foreground">
-                        <Loader2 className="h-4 w-4 animate-spin" />
-                        Consultando datos...
+                    {messages.map((msg) => {
+                      const trazaMsg = trazaDeMensaje(msg);
+                      return (
+                        // El `data-role` envuelve SOLO la burbuja: `handleExport` lo
+                        // usa para capturar el nodo del informe, y la traza no es
+                        // parte del informe.
+                        <div key={msg.id} className="flex flex-col gap-2">
+                          {trazaMsg && (
+                            <div className="pl-9">
+                              <EscoTraza pasos={trazaMsg} trabajando={false} />
+                            </div>
+                          )}
+                          <div data-role={msg.role}>
+                            <ChatMessageBubble role={msg.role} content={msg.content} />
+                          </div>
+                        </div>
+                      );
+                    })}
+                    {isStreaming && (
+                      <div className="flex flex-col gap-2">
+                        {/* `pl-9` alinea la traza con el texto de la burbuja
+                            (avatar de 28 px + 8 px de gap). */}
+                        <div className="pl-9">
+                          <EscoTraza pasos={traza} trabajando={!streamingContent} />
+                        </div>
+                        {streamingContent && (
+                          <ChatMessageBubble role="assistant" content={streamingContent} />
+                        )}
                       </div>
                     )}
                   </div>

--- a/src/components/chat/EscoTraza.tsx
+++ b/src/components/chat/EscoTraza.tsx
@@ -1,0 +1,153 @@
+/**
+ * Traza de Esco — qué está consultando, mientras lo consulta.
+ *
+ * Reemplaza el spinner de 16 px con la palabra "Consultando datos…", que era todo
+ * lo que se veía durante ~27 de los 30 segundos que tarda una respuesta con
+ * herramientas. Los datos ya existían: el tool-calling loop siempre supo qué
+ * estaba llamando, solo que no lo contaba hasta terminar.
+ *
+ * Adaptado del primitivo Thinking de Beautiful UI (Turbo,
+ * https://beautiful-ui-five.vercel.app/#thinking-state). Se conserva su gramática
+ * — encabezado con shimmer, hilo vertical, filas escalonadas, chevron que gira,
+ * se auto-expande al trabajar y se asienta colapsado al terminar — y se cambia
+ * todo lo demás:
+ *
+ *  - Tokens de Escocia OS, no los de la librería (evita el choque de `--accent`,
+ *    que en Beautiful UI es el color de marca y en shadcn la superficie de hover).
+ *  - Estado real desde eventos SSE, no la secuencia de `setTimeout` del demo.
+ *  - Animaciones en CSS (`globals.css`) para que `prefers-reduced-motion` las
+ *    alcance; en el original van en línea y el ajuste del sistema no las toca.
+ *  - Anillo de foco visible y área táctil de 44 px, que el original no trae.
+ */
+
+import { useState } from 'react';
+import { Check, ChevronDown, Sparkles, TriangleAlert } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+import {
+  detalleArgumentos,
+  etiquetaHerramienta,
+  formatearDuracion,
+  resumenTraza,
+} from '@/utils/escoHerramientas';
+import type { PasoTraza } from '@/types/chat';
+
+interface EscoTrazaProps {
+  pasos: PasoTraza[];
+  /** `true` mientras el loop sigue corriendo: encabezado con shimmer y auto-expandida. */
+  trabajando: boolean;
+}
+
+export function EscoTraza({ pasos, trabajando }: EscoTrazaProps) {
+  // `null` = seguir el comportamiento automático; un booleano = el usuario decidió.
+  const [expandidaManual, setExpandidaManual] = useState<boolean | null>(null);
+  const expandida = expandidaManual ?? trabajando;
+
+  if (pasos.length === 0 && !trabajando) return null;
+
+  const enCurso = pasos.find((p) => p.ms === undefined);
+
+  // Las herramientas son rápidas (decenas de ms); casi toda la espera se va en el
+  // modelo. Por eso "Redactando la respuesta…" es el estado que más se ve, y tiene
+  // que estar en el encabezado — que es lo único visible cuando está colapsada.
+  const titulo = !trabajando
+    ? resumenTraza(pasos)
+    : enCurso
+      ? etiquetaHerramienta(enCurso.tool)
+      : pasos.length === 0
+        ? 'Pensando…'
+        : 'Redactando la respuesta…';
+
+  return (
+    <div className="flex w-full flex-col">
+      <button
+        type="button"
+        aria-expanded={expandida}
+        onClick={() => setExpandidaManual((actual) => !(actual ?? trabajando))}
+        className={cn(
+          // `touch-target` (globals.css) sube el alto a 44 px solo bajo 1024 px:
+          // los primitivos originales traen botones de 28 px, muy por debajo del
+          // piso táctil, y Escocia OS se usa desde el celular en campo.
+          'touch-target group -mx-1.5 -my-1 flex w-fit items-center gap-2 rounded-lg px-1.5 py-2',
+          'transition-colors hover:bg-muted/60',
+          'focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-ring focus-visible:ring-offset-1',
+        )}
+      >
+        <Sparkles
+          className={cn('h-4 w-4 shrink-0', trabajando ? 'text-primary' : 'text-muted-foreground')}
+          aria-hidden
+        />
+        <span
+          className={cn(
+            'text-[13px] font-medium whitespace-nowrap',
+            trabajando ? 'esco-traza-activo' : 'text-muted-foreground',
+          )}
+        >
+          {titulo}
+        </span>
+        <ChevronDown
+          aria-hidden
+          className={cn(
+            'h-3.5 w-3.5 shrink-0 text-muted-foreground transition-transform duration-300',
+            expandida && 'rotate-180',
+          )}
+        />
+      </button>
+
+      <div className="esco-traza-caja" data-abierta={expandida}>
+        <div className="overflow-hidden">
+          {/* El hilo vertical ancla las filas al encabezado. */}
+          <div className="relative ml-[7px] mt-1 border-l border-border pl-4">
+            <div className="flex flex-col gap-0.5 py-1">
+              {pasos.map((paso, i) => {
+                const corriendo = paso.ms === undefined;
+                const fallo = paso.ok === false;
+                const detalle = detalleArgumentos(paso.args);
+
+                return (
+                  <div
+                    key={paso.index}
+                    className="esco-traza-fila flex min-h-7 items-center gap-2"
+                    style={{ '--i': i } as React.CSSProperties}
+                  >
+                    {corriendo ? (
+                      <span
+                        aria-hidden
+                        className="esco-traza-spinner h-3 w-3 shrink-0 rounded-full border-[1.5px] border-border border-t-muted-foreground"
+                      />
+                    ) : fallo ? (
+                      <TriangleAlert className="h-3.5 w-3.5 shrink-0 text-destructive" aria-hidden />
+                    ) : (
+                      <Check className="h-3.5 w-3.5 shrink-0 text-primary" aria-hidden />
+                    )}
+
+                    <span
+                      className={cn(
+                        'min-w-0 truncate text-[12.5px]',
+                        fallo ? 'text-destructive' : 'text-foreground',
+                      )}
+                    >
+                      {etiquetaHerramienta(paso.tool)}
+                    </span>
+
+                    {detalle && (
+                      <span className="shrink-0 truncate text-[11.5px] text-muted-foreground">
+                        {detalle}
+                      </span>
+                    )}
+
+                    {paso.ms !== undefined && (
+                      <span className="ml-auto shrink-0 pl-2 text-[11px] tabular-nums text-muted-foreground">
+                        {formatearDuracion(paso.ms)}
+                      </span>
+                    )}
+                  </div>
+                );
+              })}
+
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -378,6 +378,91 @@ input[type='number'] {
   padding: 0;
 }
 
+/* Traza de Esco — el bloque que reemplaza al spinner "Consultando datos…".
+   Adaptado de los primitivos Thinking / Tool Chips de Beautiful UI (Turbo,
+   beautiful-ui-five.vercel.app): se conserva la gramática visual — shimmer en el
+   encabezado mientras trabaja, línea de hilo vertical, filas que entran
+   escalonadas, easing `ease-out-strong` — pero sobre los tokens de Escocia OS,
+   no sobre los de la librería.
+
+   Las animaciones viven aquí y NO en el JSX a propósito. Los primitivos originales
+   llevan 43 declaraciones `animation:` en línea que ninguna media query puede
+   alcanzar, así que ignoran `prefers-reduced-motion` del sistema operativo. Al
+   declararlas como clases, el bloque de reduced-motion del final las apaga de
+   verdad. Son selectores de dominio (como `.chat-markdown`), no redefinen ninguna
+   utilidad de Tailwind. */
+
+@keyframes esco-shimmer {
+  from { background-position: 200% 0; }
+  to   { background-position: -200% 0; }
+}
+
+@keyframes esco-fade-up {
+  from { opacity: 0; transform: translateY(4px); }
+  to   { opacity: 1; transform: translateY(0); }
+}
+
+@keyframes esco-spin {
+  to { transform: rotate(360deg); }
+}
+
+/* Texto del encabezado mientras Esco todavía está consultando. */
+.esco-traza-activo {
+  background-image: linear-gradient(
+    90deg,
+    var(--muted-foreground) 35%,
+    var(--foreground) 50%,
+    var(--muted-foreground) 65%
+  );
+  background-size: 200% 100%;
+  -webkit-background-clip: text;
+  background-clip: text;
+  color: transparent;
+  animation: esco-shimmer 1.4s linear infinite;
+}
+
+/* Cada fuente consultada entra escalonada. El índice llega como `--i` desde el JSX. */
+.esco-traza-fila {
+  animation: esco-fade-up 320ms cubic-bezier(0.23, 1, 0.32, 1) both;
+  animation-delay: calc(var(--i, 0) * 90ms);
+}
+
+.esco-traza-spinner {
+  animation: esco-spin 700ms linear infinite;
+}
+
+/* El contenedor colapsable: grid de 0fr→1fr, la técnica que permite animar
+   hacia "altura automática" sin medir el contenido en JS. */
+.esco-traza-caja {
+  display: grid;
+  grid-template-rows: 0fr;
+  opacity: 0;
+  transition:
+    grid-template-rows 400ms cubic-bezier(0.23, 1, 0.32, 1),
+    opacity 400ms cubic-bezier(0.23, 1, 0.32, 1);
+}
+.esco-traza-caja[data-abierta='true'] {
+  grid-template-rows: 1fr;
+  opacity: 1;
+}
+
+@media (prefers-reduced-motion: reduce) {
+  .esco-traza-activo {
+    animation: none;
+    background-image: none;
+    -webkit-background-clip: border-box;
+    background-clip: border-box;
+    color: var(--muted-foreground);
+  }
+  .esco-traza-fila,
+  .esco-traza-spinner {
+    animation: none;
+  }
+  .esco-traza-caja {
+    transition: none;
+  }
+}
+
 /* Sidebar active state — soft highlight per the approved Figma design:
    #E7EDDD background + #73991C text/icons.
    Defined here (not as Tailwind utilities) because src/index.css is a FROZEN

--- a/src/supabase/functions/server/chat.tsx
+++ b/src/supabase/functions/server/chat.tsx
@@ -83,6 +83,48 @@ interface ToolInteraction {
   result_summary: string;
 }
 
+/**
+ * Traza en vivo del tool-calling loop.
+ *
+ * El loop siempre supo que herramientas estaba llamando — las acumula en
+ * `toolInteractions` y las persiste en `chat_messages.metadata` para reinyectarlas
+ * en el turno siguiente — pero nunca lo contaba MIENTRAS ocurria: el cliente veia
+ * un spinner estatico durante toda la espera (medido: 27 s de 30,4 s en una
+ * pregunta de 2 herramientas).
+ *
+ * `onEvent` es opcional a proposito. El bot de Telegram llama a `llmToolLoop`
+ * sin el y se comporta exactamente igual que antes: los eventos son aditivos,
+ * nunca un requisito.
+ *
+ * NO se reporta un conteo de filas. Habria que adivinarlo hurgando el JSON de
+ * cada herramienta, y un numero inventado es peor que ninguno en un sistema que
+ * distingue "sin dato" de "0" en monitoreo, hato y clima. Se reporta lo que si
+ * se sabe con certeza: duracion real y si la herramienta devolvio error.
+ */
+export interface ToolLoopEvent {
+  type: 'tool_start' | 'tool_done';
+  /** Nombre tecnico (`get_labor_summary`, …). La etiqueta legible vive en el cliente. */
+  tool: string;
+  /** Indice estable dentro de la respuesta, para parear `tool_start` con su `tool_done`. */
+  index: number;
+  /** Argumentos con los que se llamo. Solo en `tool_start`. */
+  args?: Record<string, unknown>;
+  /** Duracion real de la herramienta en ms. Solo en `tool_done`. */
+  ms?: number;
+  /** `false` si la herramienta devolvio `{ error }`. Solo en `tool_done`. */
+  ok?: boolean;
+}
+
+/** `executeTool` nunca lanza: ante un fallo devuelve `JSON.stringify({ error })`. */
+function toolResultOk(result: string): boolean {
+  try {
+    const parsed = JSON.parse(result);
+    return !(parsed && typeof parsed === 'object' && 'error' in parsed);
+  } catch {
+    return true; // no es JSON — es texto plano de una herramienta que respondio bien
+  }
+}
+
 // ============================================================================
 // SUPABASE ADMIN CLIENT
 // ============================================================================
@@ -3261,11 +3303,13 @@ function getToolsForAPI() {
 export async function llmToolLoop(
   messages: Array<{ role: string; content: string | null; tool_calls?: unknown[]; tool_call_id?: string; name?: string }>,
   userId?: string,
+  onEvent?: (event: ToolLoopEvent) => void,
 ): Promise<{ text: string; toolInteractions: ToolInteraction[] }> {
   const headers = getOpenRouterHeaders();
   const tools = getToolsForAPI();
   const maxRounds = 3;
   const toolInteractions: ToolInteraction[] = [];
+  let toolIndex = 0;
 
   for (let round = 0; round < maxRounds; round++) {
     const controller = new AbortController();
@@ -3324,7 +3368,20 @@ export async function llmToolLoop(
         }
 
         console.log(`[Esco] Tool call: ${fnName}`, JSON.stringify(fnArgs).slice(0, 200));
+
+        const index = toolIndex++;
+        onEvent?.({ type: 'tool_start', tool: fnName, index, args: fnArgs });
+        const iniciadaEn = Date.now();
+
         const toolResult = await executeTool(fnName, fnArgs, userId);
+
+        onEvent?.({
+          type: 'tool_done',
+          tool: fnName,
+          index,
+          ms: Date.now() - iniciadaEn,
+          ok: toolResultOk(toolResult),
+        });
         console.log(`[Esco] Tool result length: ${toolResult.length}`);
 
         // Track tool interaction for context persistence
@@ -3466,8 +3523,14 @@ export async function handleChatMessage(c: Context) {
       };
 
       try {
-        // Tool-calling loop (non-streaming) then stream the final answer
-        const { text: finalText, toolInteractions } = await llmToolLoop(llmMessages, userId);
+        // Tool-calling loop (non-streaming) then stream the final answer.
+        // `send` reenvia la traza tal cual: el cliente decide como mostrarla y
+        // como traducir el nombre tecnico de cada herramienta.
+        const { text: finalText, toolInteractions } = await llmToolLoop(
+          llmMessages,
+          userId,
+          (event) => send(event as unknown as Record<string, unknown>),
+        );
 
         // Stream the final text character by character in chunks
         const chunkSize = 8;

--- a/src/types/chat.ts
+++ b/src/types/chat.ts
@@ -16,11 +16,35 @@ export interface ChatMessage {
 }
 
 export interface ChatStreamEvent {
-  type: 'text_delta' | 'done' | 'error';
+  type: 'text_delta' | 'tool_start' | 'tool_done' | 'done' | 'error';
   content?: string;
   conversation_id?: string;
   title?: string;
   message?: string;
+  /** `tool_start` | `tool_done` — nombre tecnico de la herramienta. */
+  tool?: string;
+  /** `tool_start` | `tool_done` — indice estable para parear inicio y fin. */
+  index?: number;
+  /** `tool_start` — argumentos con los que se llamo. */
+  args?: Record<string, unknown>;
+  /** `tool_done` — duracion real en ms. */
+  ms?: number;
+  /** `tool_done` — `false` si la herramienta devolvio error. */
+  ok?: boolean;
+}
+
+/**
+ * Un paso de la traza que Esco muestra mientras consulta.
+ *
+ * Se arma en el cliente pareando `tool_start` con su `tool_done` por `index`.
+ * Un paso sin `ms` sigue corriendo.
+ */
+export interface PasoTraza {
+  index: number;
+  tool: string;
+  args?: Record<string, unknown>;
+  ms?: number;
+  ok?: boolean;
 }
 
 export interface ChartSpec {

--- a/src/utils/escoHerramientas.ts
+++ b/src/utils/escoHerramientas.ts
@@ -1,0 +1,173 @@
+/**
+ * Traduccion de la traza de Esco a algo que un administrador de finca reconozca.
+ *
+ * El edge function emite el nombre TECNICO de cada herramienta (`get_labor_summary`)
+ * y sus argumentos crudos. La copia vive aqui, en el cliente, a proposito:
+ *
+ *  - El protocolo SSE se mantiene estable y traducible sin redesplegar el edge function.
+ *  - `src/supabase/functions/server/` esta duplicado en `supabase/functions/make-server-1ccce916/`
+ *    y todo lo que se mete alli hay que mantenerlo sincronizado a mano. Este archivo no
+ *    paga ese costo.
+ *  - Telegram formatea distinto; compartir la copia lo habria forzado a este formato.
+ */
+
+import { formatNumber } from '@/utils/format';
+
+/**
+ * Las 33 herramientas de Esco, en el lenguaje del dominio.
+ *
+ * Cada etiqueta nombra LA FUENTE consultada, no la accion ("Gastos e ingresos", no
+ * "Consultando gastos"): el encabezado de la traza ya dice que se esta consultando, y
+ * repetir el verbo en cada fila la vuelve ruido.
+ */
+export const ETIQUETAS_HERRAMIENTAS: Record<string, string> = {
+  // Labores
+  get_labor_summary: 'Jornales y mano de obra',
+  get_employee_activity: 'Actividad de empleados',
+  get_tareas: 'Tareas y labores',
+
+  // Monitoreo
+  get_monitoring_data: 'Monitoreo de plagas',
+  get_pest_risk_priorizacion: 'Priorización de scouting',
+  get_conductivity_data: 'Conductividad del suelo',
+  get_beehive_data: 'Colmenas y apiarios',
+
+  // Aplicaciones
+  get_application_summary: 'Aplicaciones fitosanitarias',
+  get_application_details: 'Detalle de la aplicación',
+  get_application_cost_by_lote: 'Costo de aplicación por lote',
+
+  // Inventario y compras
+  get_inventory_status: 'Inventario de productos',
+  get_inventory_movements: 'Movimientos de inventario',
+  get_purchase_history: 'Historial de compras',
+
+  // Finanzas
+  get_financial_summary: 'Gastos e ingresos',
+  get_pyg_flujo_caja: 'P&G y flujo de caja',
+  get_budget_data: 'Presupuesto',
+  get_cost_by_lote: 'Costos por lote',
+
+  // Producción
+  get_production_data: 'Producción de aguacate',
+  get_harvest_shipments: 'Despachos de cosecha',
+  get_lot_info: 'Lotes y sublotes',
+
+  // Reportes
+  get_weekly_overview: 'Resumen de la semana',
+  get_weekly_reports: 'Reportes semanales',
+
+  // Clima
+  get_climate_data: 'Clima de la estación',
+  get_weather_forecast: 'Pronóstico del tiempo',
+  get_radiation_context: 'Radiación solar',
+
+  // Ganado y hato
+  get_ganado_inventory: 'Inventario de ganado',
+  get_hato_animal: 'Ficha del animal',
+  get_hato_reproduccion: 'Reproducción del hato',
+  get_hato_produccion: 'Producción de leche',
+
+  // Externas y memoria
+  web_search_agronomic: 'Búsqueda agronómica',
+  propose_memory_save: 'Propuesta de recordatorio',
+  commit_memory_save: 'Guardar en memoria',
+  forget_memory: 'Olvidar recordatorio',
+};
+
+/**
+ * Etiqueta legible de una herramienta. Si aparece una herramienta nueva en el
+ * servidor antes de registrarla aqui, se muestra su nombre tecnico legibilizado
+ * en vez de romperse o mostrar un hueco.
+ */
+export function etiquetaHerramienta(tool: string): string {
+  const etiqueta = ETIQUETAS_HERRAMIENTAS[tool];
+  if (etiqueta) return etiqueta;
+  return tool.replace(/^(get|exec)_/, '').replace(/_/g, ' ');
+}
+
+const MESES = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
+
+/**
+ * `AAAA-MM-DD` → `{ anio, mes, dia }` leyendo la cadena, nunca via `new Date()`.
+ *
+ * `new Date('2026-05-16')` se interpreta como medianoche UTC, que en Bogotá (UTC-5)
+ * es el 15 a las 19:00 — `getMonth()` puede devolver el mes anterior. Es la misma
+ * trampa que documenta el CLAUDE.md para `obtenerFechaHoy()`, del otro lado.
+ */
+function partesFecha(iso: string): { anio: number; mes: number; dia: number } | null {
+  const m = /^(\d{4})-(\d{2})-(\d{2})/.exec(iso);
+  if (!m) return null;
+  const mes = Number(m[2]);
+  if (mes < 1 || mes > 12) return null;
+  return { anio: Number(m[1]), mes, dia: Number(m[3]) };
+}
+
+/** Rango compacto para un chip: `may–ago 2026`, `2025 – ago 2026`, `desde 16 may 2026`. */
+function formatearRango(desde?: unknown, hasta?: unknown): string | null {
+  const a = typeof desde === 'string' ? partesFecha(desde) : null;
+  const b = typeof hasta === 'string' ? partesFecha(hasta) : null;
+  if (!a && !b) return null;
+
+  if (a && b) {
+    if (a.anio === b.anio) {
+      return a.mes === b.mes
+        ? `${MESES[a.mes - 1]} ${a.anio}`
+        : `${MESES[a.mes - 1]}–${MESES[b.mes - 1]} ${a.anio}`;
+    }
+    return `${MESES[a.mes - 1]} ${a.anio} – ${MESES[b.mes - 1]} ${b.anio}`;
+  }
+  const solo = (a ?? b)!;
+  return `${a ? 'desde' : 'hasta'} ${solo.dia} ${MESES[solo.mes - 1]} ${solo.anio}`;
+}
+
+/**
+ * Argumentos que valen como detalle de un chip, en orden de preferencia.
+ * Todo lo demas (`limit`, `top_n`, `include_config`, tokens) es plomería.
+ */
+const ARGS_INTERESANTES = [
+  'lote_name', 'pest_name', 'product_name', 'employee_name', 'worker_name',
+  'negocio_name', 'categoria_name', 'category', 'categoria', 'client_name',
+  'proveedor', 'finca_name', 'ubicacion_name', 'apiario_name', 'application_name',
+  'animal_numero', 'numero', 'nombre', 'search_term', 'query', 'cosecha_tipo',
+  'vista', 'metric', 'period', 'estado', 'tipo', 'type', 'anio', 'year',
+  'numero_semana', 'quarters', 'days', 'num_quincenas',
+];
+
+/**
+ * Detalle corto de una llamada, para la segunda columna del chip.
+ * Devuelve `null` cuando no hay nada que valga la pena mostrar — un chip sin
+ * detalle se ve mejor que uno con `limit: 2000`.
+ */
+export function detalleArgumentos(args?: Record<string, unknown>): string | null {
+  if (!args) return null;
+
+  const rango = formatearRango(args.date_from, args.date_to);
+  if (rango) return rango;
+
+  for (const clave of ARGS_INTERESANTES) {
+    const valor = args[clave];
+    if (typeof valor === 'string' && valor.trim()) {
+      return valor.length > 28 ? `${valor.slice(0, 27)}…` : valor;
+    }
+    if (typeof valor === 'number') return String(valor);
+  }
+  return null;
+}
+
+/** `4200` → `4,2 s`; `340` → `340 ms`. Coma decimal, como el resto de la app. */
+export function formatearDuracion(ms: number): string {
+  return ms < 1000 ? `${Math.round(ms)} ms` : `${formatNumber(ms / 1000, 1)} s`;
+}
+
+/**
+ * Encabezado de la traza una vez terminada: `Consulté 3 fuentes · 24,1 s`.
+ * En singular cuando fue una sola, y sin total cuando ninguna reportó duración.
+ */
+export function resumenTraza(pasos: Array<{ ms?: number }>): string {
+  const n = pasos.length;
+  const sustantivo = n === 1 ? 'fuente' : 'fuentes';
+  const total = pasos.reduce((suma, p) => suma + (p.ms ?? 0), 0);
+  if (total <= 0) return `Consulté ${n} ${sustantivo}`;
+  return `Consulté ${n} ${sustantivo} · ${formatearDuracion(total)}`;
+}

--- a/supabase/functions/make-server-1ccce916/chat.tsx
+++ b/supabase/functions/make-server-1ccce916/chat.tsx
@@ -83,6 +83,48 @@ interface ToolInteraction {
   result_summary: string;
 }
 
+/**
+ * Traza en vivo del tool-calling loop.
+ *
+ * El loop siempre supo que herramientas estaba llamando — las acumula en
+ * `toolInteractions` y las persiste en `chat_messages.metadata` para reinyectarlas
+ * en el turno siguiente — pero nunca lo contaba MIENTRAS ocurria: el cliente veia
+ * un spinner estatico durante toda la espera (medido: 27 s de 30,4 s en una
+ * pregunta de 2 herramientas).
+ *
+ * `onEvent` es opcional a proposito. El bot de Telegram llama a `llmToolLoop`
+ * sin el y se comporta exactamente igual que antes: los eventos son aditivos,
+ * nunca un requisito.
+ *
+ * NO se reporta un conteo de filas. Habria que adivinarlo hurgando el JSON de
+ * cada herramienta, y un numero inventado es peor que ninguno en un sistema que
+ * distingue "sin dato" de "0" en monitoreo, hato y clima. Se reporta lo que si
+ * se sabe con certeza: duracion real y si la herramienta devolvio error.
+ */
+export interface ToolLoopEvent {
+  type: 'tool_start' | 'tool_done';
+  /** Nombre tecnico (`get_labor_summary`, …). La etiqueta legible vive en el cliente. */
+  tool: string;
+  /** Indice estable dentro de la respuesta, para parear `tool_start` con su `tool_done`. */
+  index: number;
+  /** Argumentos con los que se llamo. Solo en `tool_start`. */
+  args?: Record<string, unknown>;
+  /** Duracion real de la herramienta en ms. Solo en `tool_done`. */
+  ms?: number;
+  /** `false` si la herramienta devolvio `{ error }`. Solo en `tool_done`. */
+  ok?: boolean;
+}
+
+/** `executeTool` nunca lanza: ante un fallo devuelve `JSON.stringify({ error })`. */
+function toolResultOk(result: string): boolean {
+  try {
+    const parsed = JSON.parse(result);
+    return !(parsed && typeof parsed === 'object' && 'error' in parsed);
+  } catch {
+    return true; // no es JSON — es texto plano de una herramienta que respondio bien
+  }
+}
+
 // ============================================================================
 // SUPABASE ADMIN CLIENT
 // ============================================================================
@@ -3261,11 +3303,13 @@ function getToolsForAPI() {
 export async function llmToolLoop(
   messages: Array<{ role: string; content: string | null; tool_calls?: unknown[]; tool_call_id?: string; name?: string }>,
   userId?: string,
+  onEvent?: (event: ToolLoopEvent) => void,
 ): Promise<{ text: string; toolInteractions: ToolInteraction[] }> {
   const headers = getOpenRouterHeaders();
   const tools = getToolsForAPI();
   const maxRounds = 3;
   const toolInteractions: ToolInteraction[] = [];
+  let toolIndex = 0;
 
   for (let round = 0; round < maxRounds; round++) {
     const controller = new AbortController();
@@ -3324,7 +3368,20 @@ export async function llmToolLoop(
         }
 
         console.log(`[Esco] Tool call: ${fnName}`, JSON.stringify(fnArgs).slice(0, 200));
+
+        const index = toolIndex++;
+        onEvent?.({ type: 'tool_start', tool: fnName, index, args: fnArgs });
+        const iniciadaEn = Date.now();
+
         const toolResult = await executeTool(fnName, fnArgs, userId);
+
+        onEvent?.({
+          type: 'tool_done',
+          tool: fnName,
+          index,
+          ms: Date.now() - iniciadaEn,
+          ok: toolResultOk(toolResult),
+        });
         console.log(`[Esco] Tool result length: ${toolResult.length}`);
 
         // Track tool interaction for context persistence
@@ -3466,8 +3523,14 @@ export async function handleChatMessage(c: Context) {
       };
 
       try {
-        // Tool-calling loop (non-streaming) then stream the final answer
-        const { text: finalText, toolInteractions } = await llmToolLoop(llmMessages, userId);
+        // Tool-calling loop (non-streaming) then stream the final answer.
+        // `send` reenvia la traza tal cual: el cliente decide como mostrarla y
+        // como traducir el nombre tecnico de cada herramienta.
+        const { text: finalText, toolInteractions } = await llmToolLoop(
+          llmMessages,
+          userId,
+          (event) => send(event as unknown as Record<string, unknown>),
+        );
 
         // Stream the final text character by character in chunks
         const chunkSize = 8;


### PR DESCRIPTION
## Qué hace

Fase 1 del facelift de Esco. Reemplaza el spinner estático que se veía durante casi toda la espera con una traza en vivo de qué está consultando.

**Antes** — 30,4 s medidos contra producción, de los cuales ~27 s así:

```
⟳ Consultando datos…
```

**Ahora** — mientras trabaja:

```
✨ Redactando la respuesta…            ⌄
  │ ✓ P&G y flujo de caja  aguacate          229 ms
  │ ✓ Inventario de productos                 43 ms
```

**Y al terminar** se asienta colapsada encima de su respuesta, expandible:

```
✨ Consulté 2 fuentes · 107 ms          ⌃
```

## Por qué era barato

Los datos ya existían. El tool-calling loop siempre acumuló cada llamada en `toolInteractions` y la persistió en `chat_messages.metadata` para reinyectarla en el turno siguiente — solo que el stream nunca la llevaba: el cliente conocía tres eventos (`text_delta`, `done`, `error`) y ninguno la incluía.

## Cambios

- **Protocolo aditivo.** `llmToolLoop` acepta un tercer parámetro opcional `onEvent` y emite `tool_start` / `tool_done`. Telegram llama `llmToolLoop(messages, userId)` sin él y se comporta exactamente igual que antes; cualquier cliente que no conozca los eventos los ignora.
- **No se reporta conteo de filas**, solo `ms` y `ok`. Habría que adivinarlo hurgando el JSON de cada herramienta, y un número inventado es peor que ninguno en un sistema que distingue «sin dato» de «0» en monitoreo, hato y clima.
- **`EscoTraza`** — adaptación del primitivo *Thinking* de [Beautiful UI](https://beautiful-ui-five.vercel.app/) escrita contra los tokens de Escocia OS, **no** importando su capa de tokens: en Beautiful UI `--accent` es el color de marca y en shadcn es la superficie de hover de los menús, así que importarla pondría todos los dropdowns de la app en azul de golpe.
- **`escoHerramientas.ts`** — las 33 herramientas traducidas al lenguaje del dominio. Vive en el cliente para no pagar la sincronía de los dos árboles del edge function, y porque Telegram formatea distinto.
- **Estado vacío** — estaba descentrado desde que se escribió: pedía `flex-1 … justify-center` sobre un padre que no es flex, así que la altura colapsaba al contenido y el saludo quedaba pegado arriba. Ahora además es consciente de la ruta.

## Endurecido respecto a los primitivos tal como vienen

Los 19 primitivos son demo en interacción, no producción. Cerrado en los dos que se adoptaron:

- Animaciones como clases en `globals.css` en vez de en línea en el JSX — los originales llevan 43 declaraciones `animation:` que ningún `prefers-reduced-motion` puede alcanzar.
- Anillo de foco visible (`focus-visible` aparece en 1 de 19 archivos originales).
- 44 px de área táctil vía la clase `touch-target` que ya existía en el proyecto; los originales traen botones de 28 px y Escocia OS se usa desde el celular en campo.

## Verificación

- `npx tsc --noEmit` limpio · `eslint` 0 errores · **2241 tests en 93 archivos**, todos verdes.
- `escoHerramientas.test.ts` (22 casos) incluye una **guarda de paridad**: lee los `case` de `executeTool` en el edge function y falla si una herramienta ejecutable se queda sin etiqueta, o si sobra una huérfana.
- Regresión de la trampa UTC: `new Date('2026-05-01')` es medianoche UTC, que en Bogotá cae el 30 de abril — el rango de fechas se lee de la cadena, nunca vía `Date`.
- Probado en vivo contra datos de producción en desktop (1440 px) y móvil (375 px), sin desborde horizontal. Los dos árboles del edge function verificados byte-idénticos.

## Un hallazgo que cambia la fase 2

Instrumentar la traza midió algo que no se sabía: **las herramientas tardan 24–229 ms**. Prácticamente los 30 segundos son round-trip del LLM, no la base de datos. La espera quedó legible, pero **no más corta** — y la palanca real para acortarla es el modelo o streaming de verdad, no las consultas. Por eso el estado que más se ve es «Redactando la respuesta…».

## Pendiente

- La traza no sobrevive a recargar una conversación vieja. El dato está en `metadata.tool_interactions`; leerlo de ahí es la fase 3 (trazabilidad).
- Fases 2 y 3 en [`docs/plan_esco_facelift.md`](docs/plan_esco_facelift.md), incluido el punto 04: **«guarda esto» no hace nada en la web** — Telegram inserta en `esco_memorias`, la web no tiene una sola línea.

## Despliegue

El edge function **ya está desplegado** a producción (`ywhtjwawnkeqlwxbvgup`), porque sin él el frontend nuevo no recibe los eventos. El cambio es aditivo, así que la versión anterior del frontend siguió funcionando entre el deploy y este merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
