### PR TITLE
Ganado: cambiar la etapa del potrero desde el inventario

### DIFF
--- a/src/components/ganado/GanadoDashboard.tsx
+++ b/src/components/ganado/GanadoDashboard.tsx
@@ -29,6 +29,7 @@ import type {
   GanLote,
   VariacionInventario,
   EtapaBucket,
+  EtapaProductiva,
 } from '@/types/ganado';
 
 const selectClass =
@@ -54,6 +55,7 @@ export function GanadoDashboard() {
     fetchInventarioFincasInactivas,
     fetchMovimientos,
     countPendientes,
+    actualizarEtapaPotrero,
   } = useGanadoInventario();
 
   const [rows, setRows] = useState<InventarioPotreroRow[]>([]);
@@ -115,6 +117,27 @@ export function GanadoDashboard() {
       setCargando(false);
     }
   }, [fetchInventario, fetchInventarioFincasInactivas, fetchEstructura, countPendientes, fetchMovimientos]);
+
+  /**
+   * Edición en línea de la etapa desde el árbol. Optimista para que el
+   * chip cambie al instante, pero **si la escritura falla se revierte**:
+   * dejar la pantalla mostrando una etapa que la base no tiene es la
+   * misma clase de mentira que mostrar 0 cuando no se pudo leer.
+   */
+  const cambiarEtapaPotrero = useCallback(
+    async (potreroId: string, etapa: EtapaProductiva | null) => {
+      const anterior = rows.find((r) => r.potrero_id === potreroId)?.etapa ?? null;
+      setRows((prev) => prev.map((r) => (r.potrero_id === potreroId ? { ...r, etapa } : r)));
+      try {
+        await actualizarEtapaPotrero(potreroId, etapa);
+      } catch (error: unknown) {
+        setRows((prev) => prev.map((r) => (r.potrero_id === potreroId ? { ...r, etapa: anterior } : r)));
+        const message = error instanceof Error ? error.message : 'Error desconocido';
+        toast.error('No se pudo cambiar la etapa: ' + message);
+      }
+    },
+    [rows, actualizarEtapaPotrero]
+  );
 
   useEffect(() => {
     loadData();
@@ -394,7 +417,11 @@ export function GanadoDashboard() {
         </div>
 
         {/* Árbol de inventario */}
-        <InventarioArbol ubicaciones={arbol} loading={cargando} />
+        <InventarioArbol
+          ubicaciones={arbol}
+          loading={cargando}
+          onCambiarEtapa={canWrite ? cambiarEtapaPotrero : undefined}
+        />
         </>
         )}
 

--- a/src/components/ganado/components/InventarioArbol.tsx
+++ b/src/components/ganado/components/InventarioArbol.tsx
@@ -6,11 +6,14 @@ import { ChevronRight, Loader2 } from 'lucide-react';
 import { formatNumber, formatWeight } from '@/utils/format';
 import { formatearFechaCorta } from '@/utils/fechas';
 import { ChipsEtapa, BarraEtapa, EtapaChip } from './ChipsEtapa';
-import type { NodoUbicacion, NodoFinca, NodoLote } from '@/types/ganado';
+import { MenuEtapaPotrero } from './MenuEtapaPotrero';
+import type { NodoUbicacion, NodoFinca, NodoLote, EtapaProductiva } from '@/types/ganado';
 
 interface InventarioArbolProps {
   ubicaciones: NodoUbicacion[];
   loading: boolean;
+  /** Edición en línea de la etapa. Ausente = solo lectura (rol sin escritura). */
+  onCambiarEtapa?: (potreroId: string, etapa: EtapaProductiva | null) => Promise<void>;
 }
 
 /**
@@ -20,7 +23,7 @@ interface InventarioArbolProps {
  * caso "lista" y ya envuelve en scroll horizontal propio — el body nunca
  * scrollea en horizontal.
  */
-export function InventarioArbol({ ubicaciones, loading }: InventarioArbolProps) {
+export function InventarioArbol({ ubicaciones, loading, onCambiarEtapa }: InventarioArbolProps) {
   const totalFincas = ubicaciones.reduce((s, u) => s + u.fincas.length, 0);
 
   const fincaMasGrande = useMemo(() => {
@@ -84,6 +87,7 @@ export function InventarioArbol({ ubicaciones, loading }: InventarioArbolProps) 
                 finca={finca}
                 abierta={abiertas.has(finca.finca_id)}
                 onToggle={() => toggleFinca(finca.finca_id)}
+                onCambiarEtapa={onCambiarEtapa}
               />
             ))}
           </div>
@@ -93,7 +97,7 @@ export function InventarioArbol({ ubicaciones, loading }: InventarioArbolProps) 
   );
 }
 
-function FincaCard({ finca, abierta, onToggle }: { finca: NodoFinca; abierta: boolean; onToggle: () => void }) {
+function FincaCard({ finca, abierta, onToggle, onCambiarEtapa }: { finca: NodoFinca; abierta: boolean; onToggle: () => void; onCambiarEtapa?: (potreroId: string, etapa: EtapaProductiva | null) => Promise<void> }) {
   const lotesReales = finca.lotes.filter((l) => l.lote_id !== null).length;
   const potrerosCount = finca.lotes.reduce((s, l) => s + l.potreros.length, 0);
 
@@ -147,7 +151,7 @@ function FincaCard({ finca, abierta, onToggle }: { finca: NodoFinca; abierta: bo
 
         <CollapsibleContent>
           <div className="border-t border-primary/10 bg-gray-50/40 px-2 sm:px-3 py-2">
-            <PotrerosTabla lotes={finca.lotes} />
+            <PotrerosTabla lotes={finca.lotes} onCambiarEtapa={onCambiarEtapa} />
           </div>
         </CollapsibleContent>
       </div>
@@ -155,7 +159,7 @@ function FincaCard({ finca, abierta, onToggle }: { finca: NodoFinca; abierta: bo
   );
 }
 
-function PotrerosTabla({ lotes }: { lotes: NodoLote[] }) {
+function PotrerosTabla({ lotes, onCambiarEtapa }: { lotes: NodoLote[]; onCambiarEtapa?: (potreroId: string, etapa: EtapaProductiva | null) => Promise<void> }) {
   if (lotes.length === 0) {
     return <p className="text-sm text-brand-brown/40 text-center py-4">Sin potreros en esta finca</p>;
   }
@@ -171,14 +175,14 @@ function PotrerosTabla({ lotes }: { lotes: NodoLote[] }) {
       </TableHeader>
       <TableBody>
         {lotes.map((lote) => (
-          <LoteFilas key={lote.lote_id ?? 'sin-lote'} lote={lote} />
+          <LoteFilas key={lote.lote_id ?? 'sin-lote'} lote={lote} onCambiarEtapa={onCambiarEtapa} />
         ))}
       </TableBody>
     </Table>
   );
 }
 
-function LoteFilas({ lote }: { lote: NodoLote }) {
+function LoteFilas({ lote, onCambiarEtapa }: { lote: NodoLote; onCambiarEtapa?: (potreroId: string, etapa: EtapaProductiva | null) => Promise<void> }) {
   return (
     <>
       <TableRow className="bg-gray-50/80 hover:bg-gray-50/80">
@@ -198,9 +202,33 @@ function LoteFilas({ lote }: { lote: NodoLote }) {
       </TableRow>
       {lote.potreros.map((p) => (
         <TableRow key={p.potrero_id}>
-          <TableCell className="pl-8 text-brand-brown/80">{p.potrero}</TableCell>
+          <TableCell className="pl-8 text-brand-brown/80">
+            {onCambiarEtapa ? (
+              <MenuEtapaPotrero
+                potreroId={p.potrero_id}
+                nombrePotrero={p.potrero}
+                etapaActual={p.etapa ?? null}
+                onCambiar={onCambiarEtapa}
+              >
+                <span>{p.potrero}</span>
+              </MenuEtapaPotrero>
+            ) : (
+              p.potrero
+            )}
+          </TableCell>
           <TableCell>
-            <EtapaChip etapa={p.etapa ?? 'sin_clasificar'} />
+            {onCambiarEtapa ? (
+              <MenuEtapaPotrero
+                potreroId={p.potrero_id}
+                nombrePotrero={p.potrero}
+                etapaActual={p.etapa ?? null}
+                onCambiar={onCambiarEtapa}
+              >
+                <EtapaChip etapa={p.etapa ?? 'sin_clasificar'} />
+              </MenuEtapaPotrero>
+            ) : (
+              <EtapaChip etapa={p.etapa ?? 'sin_clasificar'} />
+            )}
           </TableCell>
           <TableCell className="text-right tabular-nums">{formatNumber(p.cabezas)}</TableCell>
           <TableCell className="text-right hidden sm:table-cell tabular-nums">

--- a/src/components/ganado/components/MenuEtapaPotrero.tsx
+++ b/src/components/ganado/components/MenuEtapaPotrero.tsx
@@ -1,0 +1,97 @@
+import { useState } from 'react';
+import {
+  DropdownMenu,
+  DropdownMenuContent,
+  DropdownMenuItem,
+  DropdownMenuLabel,
+  DropdownMenuSeparator,
+  DropdownMenuTrigger,
+} from '@/components/ui/dropdown-menu';
+import { Check, Loader2 } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+import { ORDEN_ETAPAS, ETIQUETA_ETAPA } from '@/types/ganado';
+import { ETAPA_DOT } from './ChipsEtapa';
+import type { EtapaProductiva } from '@/types/ganado';
+
+/** Las 4 etapas reales; "sin_clasificar" no es una etapa, es su ausencia. */
+const ETAPAS_ASIGNABLES = ORDEN_ETAPAS.filter(
+  (e): e is EtapaProductiva => e !== 'sin_clasificar'
+);
+
+interface MenuEtapaPotreroProps {
+  potreroId: string;
+  nombrePotrero: string;
+  etapaActual: EtapaProductiva | null;
+  onCambiar: (potreroId: string, etapa: EtapaProductiva | null) => Promise<void>;
+  children: React.ReactNode;
+}
+
+/**
+ * Menú de edición en línea de la etapa de un potrero. Se usa dos veces por
+ * fila —envolviendo el nombre y envolviendo el chip— para que el clic
+ * funcione donde el usuario lo intente; la lista de opciones vive una sola
+ * vez, acá.
+ *
+ * "Sin clasificar" es una opción explícita y no un hueco: dejar un potrero
+ * sin etapa es una respuesta legítima («todavía no sé»), distinta de
+ * elegir mal por salir del paso.
+ */
+export function MenuEtapaPotrero({
+  potreroId,
+  nombrePotrero,
+  etapaActual,
+  onCambiar,
+  children,
+}: MenuEtapaPotreroProps) {
+  const [guardando, setGuardando] = useState(false);
+
+  const cambiar = async (etapa: EtapaProductiva | null) => {
+    if (etapa === etapaActual || guardando) return;
+    setGuardando(true);
+    try {
+      await onCambiar(potreroId, etapa);
+    } finally {
+      setGuardando(false);
+    }
+  };
+
+  return (
+    <DropdownMenu>
+      <DropdownMenuTrigger asChild disabled={guardando}>
+        <button
+          type="button"
+          aria-label={`Cambiar etapa de ${nombrePotrero}`}
+          className={cn(
+            'inline-flex items-center gap-1.5 rounded-md text-left transition-colors',
+            'hover:bg-primary/5 focus-visible:outline-none focus-visible:ring-2 focus-visible:ring-primary/40',
+            'px-1 -mx-1 cursor-pointer',
+            guardando && 'opacity-60 cursor-wait'
+          )}
+        >
+          {children}
+          {guardando && <Loader2 className="w-3 h-3 animate-spin text-primary shrink-0" />}
+        </button>
+      </DropdownMenuTrigger>
+
+      <DropdownMenuContent align="start" className="w-52">
+        <DropdownMenuLabel className="text-xs font-normal text-brand-brown/60">
+          Etapa de {nombrePotrero}
+        </DropdownMenuLabel>
+        <DropdownMenuSeparator />
+        {ETAPAS_ASIGNABLES.map((etapa) => (
+          <DropdownMenuItem key={etapa} onSelect={() => cambiar(etapa)} className="gap-2">
+            <span className={cn('w-2 h-2 rounded-full shrink-0', ETAPA_DOT[etapa])} />
+            <span className="flex-1">{ETIQUETA_ETAPA[etapa]}</span>
+            {etapaActual === etapa && <Check className="w-3.5 h-3.5 text-primary" />}
+          </DropdownMenuItem>
+        ))}
+        <DropdownMenuSeparator />
+        <DropdownMenuItem onSelect={() => cambiar(null)} className="gap-2">
+          <span className={cn('w-2 h-2 rounded-full shrink-0', ETAPA_DOT.sin_clasificar)} />
+          <span className="flex-1 italic text-brand-brown/60">Sin clasificar</span>
+          {etapaActual == null && <Check className="w-3.5 h-3.5 text-primary" />}
+        </DropdownMenuItem>
+      </DropdownMenuContent>
+    </DropdownMenu>
+  );
+}

--- a/src/components/ganado/hooks/useGanadoInventario.ts
+++ b/src/components/ganado/hooks/useGanadoInventario.ts
@@ -426,6 +426,22 @@ export function useGanadoInventario() {
   // con llamadas directas a Supabase, que es el patrón de Configuración desde
   // siempre. No se duplican acá para no dejar dos caminos de escritura.
 
+  /**
+   * Cambia la etapa productiva de un potrero (edición en línea desde el
+   * árbol de inventario). `null` la deja sin clasificar — es un estado
+   * legítimo, no un borrado a medias.
+   *
+   * No hay historia de etapa por diseño (ver CLAUDE.md): esto pisa el
+   * valor anterior y el inventario de ayer se lee con la etapa de hoy.
+   */
+  const actualizarEtapaPotrero = useCallback(async (potreroId: string, etapa: EtapaProductiva | null) => {
+    const { error } = await supabase
+      .from('gan_potreros')
+      .update({ etapa })
+      .eq('id', potreroId);
+    if (error) throw error;
+  }, []);
+
   return {
     loading,
     fetchEstructura,
@@ -441,5 +457,6 @@ export function useGanadoInventario() {
     cargarInventarioInicial,
     confirmarPendiente,
     descartarPendiente,
+    actualizarEtapaPotrero,
   };
 }


### PR DESCRIPTION
Un solo commit que quedó fuera del [PR #125](https://github.com/sforero94/Escociaos/pull/125): se pusheó 45 minutos después de que ese PR se mergeara, y GitHub no reabre un PR ya mergeado.

## Qué trae

Click sobre el **nombre del potrero** o sobre su **chip de etapa**, en el árbol de inventario → desplegable con las cuatro etapas → se guarda. Antes había que ir hasta Configuración → Ganado para cambiar un dato que se mira acá.

- **El nombre y el chip abren el mismo menú.** El usuario hace click donde le parece, no donde nosotros decidimos. La lista de opciones vive una sola vez, en `MenuEtapaPotrero`.
- **«Sin clasificar» es una opción explícita**, no un hueco. Dejar un potrero sin etapa es una respuesta legítima —«todavía no sé»— y es distinta de elegir mal por salir del paso. Sin ella, deshacer un error obligaría a volver a Configuración.
- **Optimista pero honesto**: el chip cambia al instante y **se revierte si la escritura falla**, mostrando el motivo real. Dejar la pantalla con una etapa que la base no tiene es la misma clase de mentira que mostrar 0 cuando no se pudo leer.
- **Solo Administrador y Gerencia.** Para el resto el chip es texto, no un control muerto que no responde.

Repone `actualizarEtapaPotrero` en el hook, que se había quitado por código muerto cuando nadie la llamaba.

## Verificación

Probado en el navegador contra datos reales, no solo con tests: se cambió Bosque de `terneros` a `levante` desde el nombre, se confirmó en la base que había persistido, y se devolvió a `terneros` desde el chip. La distribución quedó idéntica a antes de la prueba — Ceba 139 · Terneros 119 · Repele 91 · Levante 20 · sin clasificar 0.

`tsc` limpio · lint 0 errores · 2335/2335 tests.

## Contexto

No necesita migración: `gan_potreros.etapa` existe en producción desde la 098, ya aplicada. Hasta que esto entre, la columna está en la base pero no se puede editar desde el inventario.

🤖 Generated with [Claude Code](https://claude.com/claude-code)