### PR TITLE
fix(aplicaciones): los productos del movimiento diario no cargaban nunca

### DIFF
--- a/src/__tests__/movimientoDiarioProductosGuard.test.ts
+++ b/src/__tests__/movimientoDiarioProductosGuard.test.ts
@@ -1,0 +1,73 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Guarda estructural del bloque "Productos" de `DailyMovementForm`.
+ *
+ * **El bug (reportado por David, 2026-08-18).** Al registrar un movimiento diario
+ * de la fumigación y del drench en ejecución, los productos "no cargaban nunca":
+ * el formulario mostraba "Cargando productos..." de forma indefinida.
+ *
+ * No había ninguna carga en curso. Ese texto era el *empty state* del bloque, y
+ * el bloque está vacío hasta que la precarga corre — que sólo corría al elegir
+ * lote (`if (loteId && …)`). Es decir: el formulario nacía diciendo "cargando",
+ * lo decía para siempre si nadie tocaba el selector de lote, y no había nada en
+ * pantalla que dijera que el lote era el que destrababa la lista.
+ *
+ * Los logs de PostgREST de esa mañana lo confirman: las tres veces que David
+ * abrió el formulario, `aplicaciones_mezclas` y `aplicaciones_productos`
+ * respondieron 200 con las 4 filas de cada mezcla. Los datos siempre estuvieron.
+ *
+ * **Por qué bloquea y no sólo confunde**: este formulario no tiene forma manual
+ * de agregar un producto (`agregarProducto` existe pero no está renderizado), y
+ * `validarFormulario` exige al menos uno. Sin precarga, el movimiento no se
+ * puede guardar.
+ *
+ * Las tres reglas que esta prueba fija:
+ *  1. La precarga no depende de que haya lote elegido.
+ *  2. "Cargando productos..." sólo se muestra si de verdad hay una carga en
+ *     curso — nunca como estado vacío por defecto.
+ *  3. Cambiar de lote no borra las cantidades ya digitadas.
+ */
+
+const FORM = resolve(__dirname, '../components/aplicaciones/DailyMovementForm.tsx');
+const fuente = readFileSync(FORM, 'utf-8');
+
+describe('DailyMovementForm — bloque de productos', () => {
+  it('precarga los productos sin exigir que haya un lote seleccionado', () => {
+    // El guard viejo era `if (loteId && productosParaMostrar.length > 0)`.
+    expect(fuente).toMatch(/if \(productosParaMostrar\.length > 0\) \{\s*\n\s*precargarProductos\(productosParaMostrar\);/);
+    expect(fuente).not.toMatch(/if \(loteId && productosParaMostrar\.length > 0\)/);
+  });
+
+  it('"Cargando productos" está condicionado a un estado de carga real', () => {
+    expect(fuente).toContain('const [cargandoProductos, setCargandoProductos] = useState(true)');
+    // `cargarDatosAplicacion` tiene que cerrarlo pase lo que pase.
+    expect(fuente).toMatch(/finally \{\s*\n\s*setCargandoProductos\(false\);/);
+    // El texto sólo aparece dentro de la rama `cargandoProductos`.
+    const indiceRama = fuente.indexOf(') : cargandoProductos ? (');
+    const indiceTexto = fuente.indexOf('Cargando productos...');
+    expect(indiceRama).toBeGreaterThan(-1);
+    expect(indiceTexto).toBeGreaterThan(indiceRama);
+  });
+
+  it('sin productos y sin carga en curso explica el problema en vez de mentir', () => {
+    expect(fuente).toContain('no tiene productos configurados');
+    expect(fuente).toContain('errorProductos');
+  });
+
+  it('la precarga conserva las cantidades ya digitadas del mismo producto', () => {
+    expect(fuente).toContain('const cantidadesPrevias = new Map(');
+    expect(fuente).toContain("cantidadesPrevias.get(producto.producto_id) ?? ''");
+    // Y descarta precargas que perdieron la carrera al cambiar de lote.
+    expect(fuente).toContain('if (token !== precargaTokenRef.current) return;');
+  });
+
+  it('el perfil del responsable se busca por `usuarios.id`, que ES el uid de auth', () => {
+    // `usuarios` no tiene columna `user_id`: filtrar por ella devolvía 400 y el
+    // campo Responsable nunca se autocompletaba.
+    expect(fuente).not.toContain(".eq('user_id', user.id)");
+    expect(fuente).toContain(".eq('id', user.id)");
+  });
+});

--- a/src/components/aplicaciones/DailyMovementForm.tsx
+++ b/src/components/aplicaciones/DailyMovementForm.tsx
@@ -1,4 +1,4 @@
-import { useState, useEffect, useCallback } from 'react';
+import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useFormDraft } from '@/hooks/useFormDraft';
 import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
 import { Save, X, Calendar, Package, Droplet, User, Plus, Trash2, AlertTriangle, FileText, Cloud, Clock } from 'lucide-react';
@@ -73,6 +73,12 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
   const [bultosPorLote, setBultosPorLote] = useState<Record<string, number>>({});
   const [loteToMezclaMap, setLoteToMezclaMap] = useState<Record<string, string>>({});
   const [productosPorMezcla, setProductosPorMezcla] = useState<Record<string, any[]>>({});
+  // Estado real de carga del catalogo de la aplicacion: arranca en true y solo
+  // pasa a false cuando cargarDatosAplicacion termina (con exito o con error).
+  const [cargandoProductos, setCargandoProductos] = useState(true);
+  const [errorProductos, setErrorProductos] = useState<string | null>(null);
+  // Token para descartar precargas obsoletas cuando el lote cambia rapido.
+  const precargaTokenRef = useRef(0);
 
   // Worker tracking (employees + contractors)
   const [empleadosDisponibles, setEmpleadosDisponibles] = useState<Empleado[]>([]);
@@ -112,15 +118,14 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
 
   // 🔧 Productos filtrados según el lote seleccionado
   // Si hay un lote seleccionado, mostrar solo productos de su mezcla
-  // Si no hay lote seleccionado, mostrar todos
-  const productosParaMostrar = (() => {
-    if (!loteId || !loteToMezclaMap[loteId]) {
-      return productosDisponibles; // Mostrar todos si no hay lote seleccionado
+  // Si no hay lote seleccionado, mostrar todos los de la aplicación
+  const productosParaMostrar = useMemo(() => {
+    const mezclaId = loteId ? loteToMezclaMap[loteId] : undefined;
+    if (mezclaId) {
+      return productosPorMezcla[mezclaId] || [];
     }
-
-    const mezclaId = loteToMezclaMap[loteId];
-    return productosPorMezcla[mezclaId] || [];
-  })();
+    return productosDisponibles;
+  }, [loteId, loteToMezclaMap, productosPorMezcla, productosDisponibles]);
 
   // Cargar datos al montar
   useEffect(() => {
@@ -129,14 +134,20 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
     cargarTrabajadores();
   }, [aplicacion.id]);
 
-  // 🔧 Precargar productos cuando se selecciona un lote
+  // 🔧 Precargar productos apenas se conocen, sin esperar a que se elija lote.
+  // No hay forma manual de agregar productos en este formulario, así que si la
+  // precarga no corre el movimiento no se puede guardar (validarFormulario exige
+  // al menos un producto). Al cambiar de lote se recalcula la lista conservando
+  // las cantidades ya digitadas.
   useEffect(() => {
-    if (loteId && productosParaMostrar.length > 0) {
+    if (productosParaMostrar.length > 0) {
       precargarProductos(productosParaMostrar);
     }
-  }, [loteId, productosParaMostrar]);
+  }, [productosParaMostrar]);
 
   const cargarDatosAplicacion = async () => {
+    setCargandoProductos(true);
+    setErrorProductos(null);
     try {
       // Cargar lotes de la aplicación
       const { data: lotesData, error: errorLotes } = await supabase
@@ -262,56 +273,81 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
 
         const productosArray = Array.from(productosUnicos.values());
         setProductosDisponibles(productosArray);
+      } else {
+        setProductosPorMezcla({});
+        setProductosDisponibles([]);
       }
     } catch (err: any) {
       setError('Error al cargar los datos de la aplicación');
+      setErrorProductos('No se pudieron cargar los productos de la aplicación.');
+    } finally {
+      setCargandoProductos(false);
     }
   };
 
-  // 🆕 NUEVA FUNCIÓN: Precargar todos los productos
+  // 🆕 Precargar todos los productos de la mezcla que aplica al lote elegido.
+  // Conserva las cantidades ya digitadas (mismo producto_id) para que cambiar de
+  // lote no borre lo que el usuario venía escribiendo.
   const precargarProductos = async (productos: any[]) => {
-    const productosFormulario: ProductoFormulario[] = [];
+    const token = ++precargaTokenRef.current;
 
-    for (const producto of productos) {
-      // Cargar presentacion_kg_l del producto SOLO para fertilización
-      let presentacionKgL: number | undefined;
-      if (aplicacion.tipo_aplicacion === 'Fertilización') {
+    // presentacion_kg_l SOLO se usa en fertilización, y se pide en una sola
+    // consulta: antes era un select por producto, en serie.
+    const presentaciones = new Map<string, number>();
+    if (aplicacion.tipo_aplicacion === 'Fertilización') {
+      const ids = productos.map(p => p.producto_id).filter(Boolean);
+      if (ids.length > 0) {
         try {
-          const { data: productoData, error: errorProducto } = await supabase
+          const { data, error: errorProductos } = await supabase
             .from('productos')
-            .select('presentacion_kg_l')
-            .eq('id', producto.producto_id)
-            .single();
-          
-          if (!errorProducto && productoData) {
-            presentacionKgL = productoData.presentacion_kg_l ?? undefined;
+            .select('id, presentacion_kg_l')
+            .in('id', ids);
+
+          if (errorProductos) {
+            console.error('Failed to fetch productos presentacion_kg_l:', errorProductos);
+          } else {
+            (data || []).forEach((p: any) => {
+              if (p.presentacion_kg_l != null) {
+                presentaciones.set(p.id, p.presentacion_kg_l);
+              }
+            });
           }
         } catch (err) {
-          console.error('Failed to fetch product presentacion_kg_l:', err);
+          console.error('Failed to fetch productos presentacion_kg_l:', err);
         }
       }
+    }
 
-      productosFormulario.push({
+    // Una precarga posterior ya ganó la carrera: descartamos esta.
+    if (token !== precargaTokenRef.current) return;
+
+    setProductosAgregados(prev => {
+      const cantidadesPrevias = new Map(
+        prev.map(p => [p.producto_id, p.cantidad_utilizada])
+      );
+
+      return productos.map(producto => ({
         producto_id: producto.producto_id,
         producto_nombre: producto.producto_nombre,
         producto_categoria: producto.producto_categoria,
-        cantidad_utilizada: '',
+        cantidad_utilizada: cantidadesPrevias.get(producto.producto_id) ?? '',
         unidad_producto: producto.producto_unidad,
-        presentacion_kg_l: presentacionKgL
-      });
-    }
-
-    setProductosAgregados(productosFormulario);
+        presentacion_kg_l: presentaciones.get(producto.producto_id)
+      }));
+    });
   };
 
   const cargarUsuarioActual = async () => {
     try {
       const { data: { user } } = await supabase.auth.getUser();
       if (user) {
+        // `usuarios.id` ES el uid de auth (así lo asume get_user_role() en las
+        // políticas RLS). No existe columna `user_id`: filtrar por ella devolvía 400
+        // y el responsable nunca se autocompletaba.
         const { data: profile } = await supabase
           .from('usuarios')
           .select('nombre_completo')
-          .eq('user_id', user.id)
+          .eq('id', user.id)
           .single();
 
         if (profile?.nombre_completo) {
@@ -941,11 +977,25 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
                 </div>
               ))}
             </div>
-          ) : (
+          ) : cargandoProductos ? (
             <div className="p-8 text-center border-2 border-dashed border-primary/20 rounded-xl">
-              <Package className="w-12 h-12 text-primary/30 mx-auto mb-3" />
+              <Package className="w-12 h-12 text-primary/30 mx-auto mb-3 animate-pulse" />
               <p className="text-sm text-brand-brown/50">
                 Cargando productos...
+              </p>
+            </div>
+          ) : (
+            <div className="p-8 text-center border-2 border-dashed border-red-200 bg-red-50/50 rounded-xl">
+              <AlertTriangle className="w-12 h-12 text-red-400 mx-auto mb-3" />
+              <p className="text-sm text-red-700">
+                {errorProductos
+                  ? errorProductos
+                  : loteId
+                    ? 'La mezcla asignada a este lote no tiene productos configurados.'
+                    : 'Esta aplicación no tiene productos configurados en su mezcla.'}
+              </p>
+              <p className="text-xs text-red-600/70 mt-2">
+                Revisa la mezcla de la aplicación en la Calculadora antes de registrar el movimiento.
               </p>
             </div>
           )}


### PR DESCRIPTION
David reportó que al registrar un movimiento diario de la fumigación y del
drench en ejecución los productos "no cargan" y el bloque se queda en un
loading eterno.

No había ninguna carga en curso. "Cargando productos..." era el *empty state*
del bloque, y el bloque estaba vacío hasta que corría la precarga — que sólo
corría al elegir lote (`if (loteId && …)`). El formulario nacía diciendo
"cargando", lo decía para siempre si nadie tocaba el selector de lote, y nada
en pantalla indicaba que el lote era lo que destrababa la lista.

Los logs de PostgREST de esa mañana lo confirman: las tres veces que abrió el
formulario (12:19:08, 12:19:39, 12:20:02), `aplicaciones_mezclas` y
`aplicaciones_productos` respondieron 200 con las 4 filas de cada mezcla. Los
datos siempre estuvieron; nunca se pintaron.

Bloquea y no sólo confunde: el formulario no tiene forma manual de agregar un
producto (`agregarProducto` existe pero no está renderizado) y
`validarFormulario` exige al menos uno, así que sin precarga el movimiento no
se puede guardar.

Cambios:

- La precarga corre apenas se conocen los productos, sin esperar al lote. Sin
  lote elegido usa el catálogo completo de la aplicación; al elegirlo se acota
  a la mezcla de ese lote.
- `cargandoProductos` es un estado de carga real, cerrado en `finally`. El
  texto "Cargando productos..." queda condicionado a él.
- Sin productos y sin carga en curso, el bloque explica el problema (la mezcla
  no tiene productos configurados) en vez de simular que sigue cargando.
- Cambiar de lote ya no borra las cantidades digitadas: se conservan por
  `producto_id`, y un token descarta la precarga que perdió la carrera.
- `productosParaMostrar` pasa a `useMemo` para no recalcular identidad en cada
  render.
- `presentacion_kg_l` (fertilización) se pide en una sola consulta `in` en vez
  de un `select` por producto, en serie.
- El perfil del responsable se busca por `usuarios.id`, que ES el uid de auth.
  Filtrar por `user_id` — columna que no existe — devolvía 400 en cada apertura
  del formulario y el campo Responsable nunca se autocompletaba.

`src/__tests__/movimientoDiarioProductosGuard.test.ts` fija las tres reglas:
la precarga no depende del lote, "Cargando..." sólo con carga real, y cambiar
de lote no borra lo digitado.

Co-Authored-By: Claude Opus 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_017YQ8kKDmMf7DSD6wZMygiw