### PR TITLE
fix(tests): make requiereDecisionSeccion hermetic so main stops failing on a clean checkout

### DIFF
--- a/src/__tests__/requiereDecisionSeccion.test.tsx
+++ b/src/__tests__/requiereDecisionSeccion.test.tsx
@@ -29,6 +29,27 @@ vi.mock('@/contexts/AuthContext', () => ({
   useAuth: () => authMock(),
 }));
 
+/**
+ * `ConfirmarPendienteDialog` llama a `useGanadoInventario`, y ese hook llama
+ * a `getSupabase()` en el cuerpo -- no dentro de un efecto -- así que se
+ * ejecuta con sólo montar el diálogo, aunque esté cerrado. `getSupabase()`
+ * LANZA si faltan `VITE_SUPABASE_URL` / `VITE_SUPABASE_ANON_KEY`.
+ *
+ * Sin este mock la prueba sólo pasa en una máquina que tenga `.env.local`:
+ * en un checkout limpio (y no hay CI que lo hubiera cantado) los 8 casos de
+ * este archivo fallan con "Missing Supabase environment variables". El
+ * mock lo vuelve hermético -- ninguna prueba de render debería necesitar
+ * credenciales, y ninguna de este archivo toca la red.
+ */
+vi.mock('@/utils/supabase/client', () => ({
+  getSupabase: () => ({
+    from: () => ({
+      select: () => ({ eq: () => ({ order: () => Promise.resolve({ data: [], error: null }) }) }),
+    }),
+    rpc: () => Promise.resolve({ data: null, error: null }),
+  }),
+}));
+
 const { RequiereDecision } = await import('@/components/dashboard/RequiereDecision');
 
 function resultadoBase(overrides: Partial<UseRequiereDecisionResultado> = {}): UseRequiereDecisionResultado {


### PR DESCRIPTION
## Bug
`npm test` en `main` (`8306dbf`) falla: **8 de los 9 casos** de `src/__tests__/requiereDecisionSeccion.test.tsx`, con

```
Error: Missing Supabase environment variables. Please check your .env.local file.
```

Sólo se ve en un entorno **sin `.env.local`** — o sea, en un clon limpio y en cualquier agente. En la máquina del autor pasa, porque Vitest hereda la carga de `.env.local` de Vite y `import.meta.env.VITE_SUPABASE_URL` existe. No hay CI en el repo (`.github/` no existe), así que nada lo cantó.

La corrida de mantenimiento del 2026-08-10 dejó `main@b32585b` verde **en este mismo entorno**, así que la regresión entró con el rediseño del Tablero (#127).

## Root cause
`RequiereDecision.tsx:103` monta **siempre** `ConfirmarPendienteDialog`, incluso con el diálogo cerrado. Ese componente llama a `useGanadoInventario()` (`ConfirmarPendienteDialog.tsx:58`), y el hook llama a `getSupabase()` **en el cuerpo**, no dentro de un efecto (`useGanadoInventario.ts:88`) — así que se ejecuta con el solo render. `getSupabase()` lanza si faltan las variables (`utils/supabase/client.ts:13`).

El autor ya había previsto el problema gemelo y mockeó `@/contexts/AuthContext` (el comentario de cabecera lo explica en detalle), pero se quedó ahí: el cliente de Supabase quedó sin mockear.

## Fix
Se agrega `vi.mock('@/utils/supabase/client')` junto al mock de AuthContext que ya estaba. Es el cambio mínimo y respeta la intención del archivo: sigue renderizando el árbol completo, diálogo incluido.

**No se toca código de producción** — en el navegador las variables sí existen y el comportamiento no cambia.

## Verification
- `npx vitest run src/__tests__/requiereDecisionSeccion.test.tsx`: **9/9 pasan** (antes 1/9).
- `npm test`: **119 archivos / 2.818 pruebas, todo verde** (antes: 1 archivo y 8 pruebas en rojo).
- `npx tsc --noEmit` limpio · `eslint` sin errores.

## Rollback
Revertir el commit.

## Follow-up
No se agrega una guarda estructural que impida reintroducir el patrón (un test de render que alcanza `getSupabase()`). Valdría la pena, pero es un trabajo aparte y no pertenece a este arreglo.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4)_