### PR TITLE
fix(clima): paginate clima_resumen_diario so period cards stop losing 910 days

### DIFF
--- a/src/__tests__/climaResumenDiarioPaginadoGuard.test.ts
+++ b/src/__tests__/climaResumenDiarioPaginadoGuard.test.ts
@@ -1,0 +1,70 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { fetchAll } from '@/utils/supabase/fetchAll';
+
+/**
+ * Guarda del fetch de `clima_resumen_diario` en `useClimaData`.
+ *
+ * **El defecto.** `clima_resumen_diario` guarda UNA FILA POR DÍA desde
+ * 2020-07-01. Verificado contra producción el 2026-08-20: **1.910 filas**.
+ * El hook las pedía con `.select('*').order('fecha', { ascending: true })`
+ * y sin paginar, así que PostgREST cortaba en 1.000 filas SIN AVISAR y el
+ * navegador se quedaba con los 1.000 días más viejos:
+ *
+ *   fila 1000 → 2023-07-11   ·   fila 1001 → 2023-07-12   ·   perdidas: 910
+ *
+ * O sea: todo lo posterior al 2023-07-11 nunca llegaba. Y `resumenesDiarios`
+ * alimenta las tarjetas de período (Semana/Mes/Trimestre/Año a la fecha/
+ * Último año), las series históricas de 7d–365d, la vista mensual de >365d,
+ * la superposición por año y `ContextoSolar`. Como todos filtran por una
+ * fecha de corte reciente, se quedaban con CERO filas y
+ * `buildResumenFromDaily([])` devuelve todo `null` → la tabla "Resumen
+ * Acumulado" mostraba `—` en todo menos en "Día" (que se calcula aparte,
+ * desde `clima_lecturas`).
+ *
+ * `clima_lecturas` NO necesita paginarse: la 036 la poda a una ventana
+ * rodante de 24 h (~288 filas), muy por debajo del tope.
+ *
+ * Las dos reglas que fija esta prueba:
+ *  1. `clima_resumen_diario` se pide por `fetchAll` con `.range(...)`.
+ *  2. Nunca vuelve a existir un `select` de esa tabla sin paginación.
+ */
+
+const HOOK = resolve(__dirname, '../hooks/useClimaData.ts');
+const fuente = readFileSync(HOOK, 'utf-8');
+
+describe('useClimaData — clima_resumen_diario', () => {
+  it('pide los resúmenes diarios por fetchAll, con range', () => {
+    expect(fuente).toContain("import { fetchAll } from '@/utils/supabase/fetchAll';");
+    expect(fuente).toMatch(
+      /fetchAll<ResumenDiario>\(\(desde, hasta\) =>[\s\S]*?\.from\('clima_resumen_diario' as any\)[\s\S]*?\.range\(desde, hasta\)/,
+    );
+  });
+
+  it('no queda ninguna lectura sin paginar de clima_resumen_diario', () => {
+    // El bloque `.from('clima_resumen_diario')...` tiene que terminar en
+    // `.range(`. Se recorta cada aparición hasta el primer `)` de cierre de
+    // la cadena para no arrastrar el resto del archivo.
+    const apariciones = [...fuente.matchAll(/\.from\('clima_resumen_diario'[\s\S]{0,300}/g)];
+    expect(apariciones.length).toBeGreaterThan(0);
+    for (const [bloque] of apariciones) {
+      expect(bloque).toContain('.range(');
+    }
+  });
+
+  it('fetchAll recupera las 1.910 filas reales, no las primeras 1.000', async () => {
+    // Reproducción del corte: un backend que nunca devuelve más de 1.000
+    // filas por llamada, como PostgREST.
+    const TOTAL = 1910;
+    const todas = Array.from({ length: TOTAL }, (_, i) => ({ fecha: i }));
+    const { filas, truncado } = await fetchAll<{ fecha: number }>((desde, hasta) =>
+      Promise.resolve({ data: todas.slice(desde, Math.min(hasta + 1, desde + 1000)), error: null }),
+    );
+    expect(truncado).toBe(false);
+    expect(filas).toHaveLength(TOTAL);
+    // La consulta vieja se habría quedado acá — el último día entregado era
+    // 2023-07-11, la fila 1.000.
+    expect(filas[filas.length - 1].fecha).toBe(TOTAL - 1);
+  });
+});

--- a/src/hooks/useClimaData.ts
+++ b/src/hooks/useClimaData.ts
@@ -1,5 +1,6 @@
 import { useState, useEffect, useMemo, useCallback } from 'react';
 import { getSupabase } from '@/utils/supabase/client';
+import { fetchAll } from '@/utils/supabase/fetchAll';
 import type { LecturaClima, ResumenDiario, PeriodoResumen, LecturaClimaAgregada, SerieAnual } from '@/types/clima';
 import {
   lecturaActual as getLecturaActual,
@@ -64,31 +65,37 @@ export function useClimaData(): UseClimaDataReturn {
 
       const supabase = getSupabase();
 
-      // Fetch both tables in parallel
+      // Fetch both tables in parallel.
+      //
+      // `clima_resumen_diario` tiene UNA FILA POR DÍA desde 2020-07-01 y hoy
+      // ya pasa de 1.900: por encima del tope de 1.000 filas que PostgREST
+      // aplica en silencio. Sin paginar, y ordenando `fecha` ascendente, el
+      // navegador recibía los 1.000 días MÁS VIEJOS (2020-07-01 → 2023-07-11)
+      // y perdía los 910 más recientes — es decir, todo lo que las tarjetas
+      // de período y los históricos necesitan de verdad. Por eso va por
+      // `fetchAll`, igual que las consultas de reportes.
       const [liveRes, dailyRes] = await Promise.all([
         // Live readings: all rows in clima_lecturas (rolling 24h window after migration)
         (supabase
           .from('clima_lecturas' as any)
           .select('*')
           .order('timestamp', { ascending: true }) as any),
-        // Daily summaries: all rows (one per day, stays small forever)
-        (supabase
-          .from('clima_resumen_diario' as any)
-          .select('*')
-          .order('fecha', { ascending: true }) as any),
+        fetchAll<ResumenDiario>((desde, hasta) =>
+          (supabase
+            .from('clima_resumen_diario' as any)
+            .select('*')
+            .order('fecha', { ascending: true })
+            .range(desde, hasta) as any),
+        ),
       ]);
 
       if (liveRes.error) {
         setError(liveRes.error.message);
         return;
       }
-      if (dailyRes.error) {
-        setError(dailyRes.error.message);
-        return;
-      }
 
       setLiveLecturas((liveRes.data as LecturaClima[]) ?? []);
-      setResumenesDiarios((dailyRes.data as ResumenDiario[]) ?? []);
+      setResumenesDiarios(dailyRes.filas);
       setUltimaActualizacion(new Date());
     } catch (err) {
       setError(err instanceof Error ? err.message : 'Error desconocido');


### PR DESCRIPTION
## Bug
En `/clima`, la tabla **"Resumen Acumulado"** muestra `—` en Semana, Mes, Trimestre, Año a la fecha y Último año — sólo "Día" trae datos — y los históricos de 7d–365d salen vacíos. Afecta a todo usuario con el módulo Aguacate, desde que `clima_resumen_diario` pasó las 1.000 filas (es decir, desde que la migración 035 la sembró con la historia completa).

## Root cause
`src/hooks/useClimaData.ts:76-79` pedía la tabla entera con `.select('*').order('fecha', { ascending: true })` **y sin paginar**.

`clima_resumen_diario` es una fila por día desde 2020-07-01. Verificado contra producción el 2026-08-20:

```sql
SELECT count(*), min(fecha), max(fecha) FROM clima_resumen_diario;
-- 1910 | 2020-07-01 | 2026-08-19

WITH o AS (SELECT fecha, row_number() OVER (ORDER BY fecha ASC) rn FROM clima_resumen_diario)
SELECT (SELECT fecha FROM o WHERE rn=1000), (SELECT fecha FROM o WHERE rn=1001), (SELECT count(*) FROM o WHERE rn>1000);
-- 2023-07-11 | 2023-07-12 | 910
```

PostgREST corta en 1.000 filas **sin avisar**, y como el orden es ascendente lo que llega al navegador son los **1.000 días más viejos**: `2020-07-01 → 2023-07-11`. Los **910 días restantes** — todo lo posterior al 2023-07-11 — nunca llegan.

`resumenesDiarios` alimenta las tarjetas de período, `serieHistorica` (7d–365d y >365d), `serieAnual` y `ContextoSolar`. Todos filtran por una fecha de corte reciente, así que se quedaban con **cero filas**, y `buildResumenFromDaily([])` devuelve todo `null` → `—` en pantalla.

Nota: el síntoma es *dato faltante*, no un número inventado — el contrato "sin dato ≠ 0" se respeta. Pero la pantalla queda sin su contenido principal.

## Fix
La consulta pasa por `fetchAll` (`src/utils/supabase/fetchAll.ts`), que es el remedio que el proyecto ya usa para este tope exacto en los reportes de finanzas (`CLAUDE.md`: *"All report queries must go through `fetchAll`"*).

Cambio mínimo: misma tabla, mismo orden, mismas columnas, sólo paginado.

`clima_lecturas` se deja **como está a propósito** — la migración 036 la poda a una ventana rodante de 24 h (~288 filas) y nunca se acerca al tope.

## Verification
- `src/__tests__/climaResumenDiarioPaginadoGuard.test.ts` (nuevo): **falla en `8306dbf`** (2 de 3 casos) y pasa con el arreglo. Incluye una reproducción del corte con un backend que nunca devuelve más de 1.000 filas por llamada.
- `npx tsc --noEmit` limpio · `eslint` 0 errores sobre los archivos tocados.
- `npm test`: 120 archivos / 2.821 pruebas. La única falla es `requiereDecisionSeccion.test.tsx`, **anterior a este cambio** y presente igual en `8306dbf`; la arregla el PR companion #130.

## Rollback
Revertir el commit.

## Follow-up
Fuera de alcance a propósito: la estación Ecowitt **lleva sin reportar desde el 2026-08-20 02:05 UTC** y "Condiciones Actuales" pinta la última lectura sin decir de cuándo es. Va como hallazgo aparte — el umbral de "viejo" es una decisión de producto.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4)_