### PR TITLE
fix(clima): un día capturado incompleto deja de escribirse como 0,00 mm confiable (migración 103)

### DIFF
--- a/src/__tests__/calculosClima.test.ts
+++ b/src/__tests__/calculosClima.test.ts
@@ -445,6 +445,59 @@ describe('construirFranjaLluvia', () => {
     expect(franja[0].mm).toBeNull();
   });
 
+  // -------------------------------------------------------------------------
+  // Migración 103 — día capturado incompleto (corte de luz en la finca)
+  // -------------------------------------------------------------------------
+  // Caso REAL de producción: el 2026-08-19 la estación registró 167 de las 288
+  // lecturas del día (sin captura entre las 11:00 y las 17:00, ni después de
+  // las 21:10, por un corte de luz prolongado) y el rollup nocturno lo escribió
+  // como `lluvia_confianza='ok', lluvia_total_mm=0.00`. Nadie puede afirmar que
+  // no llovió en esas nueve horas — y en Aguadas la tarde es justamente cuando
+  // llueve. Es el espejo del bug que motivó la 068: aquél fabricaba un
+  // DUPLICADO, éste fabrica un CERO.
+  it('un día `cobertura_parcial` es "sin_dato" con su causa — JAMÁS "seco" (migración 103)', () => {
+    const rows = [
+      resumenDia({
+        fecha: '2026-08-19',
+        lluvia_total_mm: 0,
+        lluvia_confianza: 'cobertura_parcial',
+        lecturas_count: 167,
+      }),
+    ];
+    const franja = construirFranjaLluvia(rows, 1, '2026-08-19');
+
+    expect(franja[0].estado).toBe('sin_dato');
+    expect(franja[0].estado).not.toBe('seco');
+    expect(franja[0].mm).toBeNull();
+    expect(franja[0].mm).not.toBe(0);
+    expect(franja[0].causa).toBe('cobertura_parcial');
+  });
+
+  it('la MISMA fila marcada `ok` sí es un cero real — la confianza es lo único que las separa', () => {
+    const fila = { fecha: '2026-08-19', lluvia_total_mm: 0, lecturas_count: 167 };
+
+    const parcial = construirFranjaLluvia(
+      [resumenDia({ ...fila, lluvia_confianza: 'cobertura_parcial' })], 1, '2026-08-19');
+    const okReal = construirFranjaLluvia(
+      [resumenDia({ ...fila, lluvia_confianza: 'ok' })], 1, '2026-08-19');
+
+    expect(parcial[0]).toMatchObject({ estado: 'sin_dato', mm: null, causa: 'cobertura_parcial' });
+    expect(okReal[0]).toMatchObject({ estado: 'seco', mm: 0, causa: null });
+  });
+
+  it('distingue las dos causas de sin_dato en la misma franja: congelado vs cobertura parcial', () => {
+    const rows = [
+      resumenDia({ fecha: '2026-08-17', lluvia_total_mm: 3.2, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-18', lluvia_total_mm: null, lluvia_confianza: 'contador_congelado' }),
+      resumenDia({ fecha: '2026-08-19', lluvia_total_mm: 0, lluvia_confianza: 'cobertura_parcial', lecturas_count: 167 }),
+    ];
+    const franja = construirFranjaLluvia(rows, 3, '2026-08-19');
+
+    expect(franja.map((d) => d.estado)).toEqual(['lluvia', 'sin_dato', 'sin_dato']);
+    expect(franja.map((d) => d.causa)).toEqual([null, 'contador_congelado', 'cobertura_parcial']);
+    expect(franja.filter((d) => d.estado === 'seco')).toHaveLength(0);
+  });
+
   it('respeta el rango exacto de `dias` terminando en `hastaISO`, ordenado ascendente', () => {
     const rows = [
       resumenDia({ fecha: '2026-08-13', lluvia_total_mm: 1, lluvia_confianza: 'ok' }),
@@ -453,5 +506,42 @@ describe('construirFranjaLluvia', () => {
     ];
     const franja = construirFranjaLluvia(rows, 3, '2026-08-15');
     expect(franja.map((d) => d.fecha)).toEqual(['2026-08-13', '2026-08-14', '2026-08-15']);
+  });
+});
+
+// ===========================================================================
+// La puerta por la que TODO consumidor de clima_resumen_diario tiene que pasar
+// ===========================================================================
+// Es la única función que sabe qué valores de `lluvia_confianza` invalidan el
+// total. Leer `lluvia_total_mm` directo resucita el bug que la migración
+// correspondiente detectó — pasó con el reporte semanal en S30/2026.
+describe('lluviaConfiableDeResumen', () => {
+  let lluviaConfiableDeResumen: (
+    fila: { lluvia_total_mm: number | null; lluvia_confianza?: string | null },
+  ) => number | null;
+
+  beforeAll(async () => {
+    const mod = await import('@/utils/calculosClima');
+    lluviaConfiableDeResumen = mod.lluviaConfiableDeResumen;
+  });
+
+  it('devuelve null para los dos estados de desconfianza, y el valor para los demás', () => {
+    const casos: Array<[string | null | undefined, number | null, number | null]> = [
+      // [confianza, lluvia_total_mm, esperado]
+      ['ok', 12.5, 12.5],
+      ['ok', 0, 0],
+      ['sin_time_piezo', 4.2, 4.2],
+      ['contador_congelado', 15.75, null],
+      ['cobertura_parcial', 0, null],
+      ['cobertura_parcial', 18.03, null],
+      [undefined, 7, 7],
+      [null, 7, 7],
+    ];
+
+    for (const [confianza, total, esperado] of casos) {
+      expect(
+        lluviaConfiableDeResumen({ lluvia_total_mm: total, lluvia_confianza: confianza }),
+      ).toBe(esperado);
+    }
   });
 });

--- a/src/__tests__/esco-improvements.test.ts
+++ b/src/__tests__/esco-improvements.test.ts
@@ -327,9 +327,20 @@ describe('Climate data lee el histórico, no la ventana de 24 h', () => {
     expect(chatSource).toContain('dias_sin_lluvia');
   });
 
-  it('aplica la compuerta de confianza de la migración 068', () => {
+  it('aplica la compuerta de confianza de las migraciones 068 y 103', () => {
     expect(chatSource).toContain('function lluviaConfiable');
     expect(chatSource).toContain("lluvia_confianza === 'contador_congelado'");
+    // Migración 103: un día que la estación capturó incompleto (corte de luz)
+    // tampoco tiene total que afirmar. Sin esto Esco lee el 0,00 mm que el
+    // rollup dejó escrito y afirma que no llovió en horas que nadie vio.
+    expect(chatSource).toContain("lluvia_confianza === 'cobertura_parcial'");
+  });
+
+  it('el conteo de "días sin llover" cubre las dos causas de sin dato', () => {
+    // Es el consumidor del incidente del 2026-08-16, donde el modelo terminó
+    // inventando "47 días sin lluvia". Un día parcial que no entre acá vuelve
+    // a convertir un hueco de datos en una afirmación.
+    expect(chatSource).toContain('lluvia_confianza=in.(contador_congelado,cobertura_parcial)');
   });
 
   it('un día con el contador congelado vale sin dato, nunca 0', () => {

--- a/src/components/dashboard/FranjaLluvia.tsx
+++ b/src/components/dashboard/FranjaLluvia.tsx
@@ -38,6 +38,9 @@ function causaTexto(dias: DiaFranjaLluvia[]): string | null {
   if (dias.some((d) => d.causa === 'contador_congelado')) {
     return ' — el contador del pluviómetro no se reinició';
   }
+  if (dias.some((d) => d.causa === 'cobertura_parcial')) {
+    return ' — la estación no registró el día completo';
+  }
   return null;
 }
 
@@ -85,6 +88,7 @@ export function FranjaLluvia({ dias, visibleEnMovil = 7 }: FranjaLluviaProps) {
                   <span className="sr-only">
                     {d.fecha}: sin dato de lluvia
                     {d.causa === 'contador_congelado' ? ' — contador del pluviómetro congelado' : ''}
+                    {d.causa === 'cobertura_parcial' ? ' — la estación no registró el día completo' : ''}
                   </span>
                 </div>
                 <span className="text-[10px] text-brand-brown/40">{etiquetaDia(d.fecha)}</span>

--- a/src/sql/migrations/103_clima_cobertura_parcial.sql
+++ b/src/sql/migrations/103_clima_cobertura_parcial.sql
@@ -1,0 +1,496 @@
+-- =============================================================================
+-- 103_clima_cobertura_parcial.sql
+--
+-- Un dia del que solo se capturo una parte deja de escribirse en la historia
+-- permanente del clima como si fuera un dia completo y confiable.
+--
+-- -----------------------------------------------------------------------------
+-- EL BUG
+-- -----------------------------------------------------------------------------
+-- `fn_clima_rollup_diario` (migracion 068) decide `lluvia_confianza` mirando
+-- UNICAMENTE si el contador de lluvia de Ecowitt se refresco ese dia. Nunca
+-- mira cuanto del dia se alcanzo a capturar. `lecturas_count` se agrega con un
+-- COUNT(*) y se guarda, pero jamas entra a un predicado.
+--
+-- Resultado, verificado vivo en produccion (2026-08-20):
+--
+--   SELECT fecha, lecturas_count, lluvia_total_mm, lluvia_confianza
+--     FROM clima_resumen_diario WHERE fecha = '2026-08-19';
+--   -- 2026-08-19 | 167 | 0.00 | ok
+--
+-- La estacion muestrea cada 5 minutos: 288 lecturas por dia. El 2026-08-19
+-- llegaron 167 (58%). Repartidas por hora de Bogota:
+--
+--   00-09h: 12/hora (completo)   10h: 5    11h-16h: 0 (nada)
+--   17h: 4    18h-20h: 12/hora   21h: 2    22h-23h: 0 (nada)
+--
+-- O sea: no hay captura entre las 11:00 y las 17:00, ni despues de las 21:10.
+-- Casi nueve horas del dia sin registro -- justamente la franja de la tarde en
+-- que llueve en Aguadas. Y aun asi la fila quedo escrita con el sello `ok`
+-- afirmando 0,00 mm. Causa confirmada por Santiago el 2026-08-20: corte de luz
+-- prolongado en la finca.
+--
+-- Es el espejo exacto de la 068. Aquella migracion existe para impedir un
+-- DUPLICADO fabricado; esto fabrica un CERO. Las dos violan la misma regla que
+-- este proyecto sostiene en monitoreo, en hato y en el reporte semanal:
+-- "sin dato" es NULL, jamas 0. "No llovio" y "no sabemos" son cosas distintas.
+--
+-- Y no es un accidente irrepetible: ahora que la causa es un corte de luz, cada
+-- corte que empiece o termine a media jornada produce un dia parcial que el
+-- rollup de esa noche va a sellar como confiable. La restauracion parcial es el
+-- caso mas probable y es justo el peligroso -- si la luz NO vuelve en todo el
+-- dia no se inserta fila y eso si es seguro (no hay fila = sin dato).
+--
+-- Consumidores rio abajo que hoy se comen ese 0 como bueno: el reporte semanal
+-- (`fetchDatosReporteSemanal.ts`, el mismo consumidor del incidente S30/2026 que
+-- motivo la 068), la vista de Clima historicos, la franja de lluvia del tablero
+-- y las respuestas de clima de Esco. Ninguno lee `lecturas_count`.
+--
+-- -----------------------------------------------------------------------------
+-- EL ARREGLO
+-- -----------------------------------------------------------------------------
+-- Un cuarto valor de `lluvia_confianza`: `cobertura_parcial`. Un dia con menos
+-- de 240 lecturas (~83% de las 288 esperadas) guarda `lluvia_total_mm = NULL`,
+-- igual que un contador congelado. El numero crudo no se conserva porque, a
+-- diferencia del backfill de la 068 -- que deja el duplicado intacto para
+-- auditoria en una columna que el frontend ya nulea --, aca el valor no es una
+-- lectura sospechosa sino un total incompleto por construccion: el contador es
+-- acumulado, y si faltan las ultimas horas del dia el maximo disponible es una
+-- cota inferior, no una medicion.
+--
+-- 240 y no 288: la propia estacion tiene dias de 279-289 lecturas por jitter del
+-- cron de 5 minutos. En los 153 dias que lleva la estacion Ecowitt, exactamente
+-- 4 caen por debajo de 240 y los 149 restantes estan en 279+. No hay zona gris.
+--
+-- -----------------------------------------------------------------------------
+-- DESVIACION DELIBERADA #1 -- donde va el check dentro del CASE
+-- -----------------------------------------------------------------------------
+-- La accion propuesta en el hallazgo decia "despues de los checks de frescura".
+-- Va ANTES, y a proposito.
+--
+-- La cobertura es una propiedad de la CAPTURA del dia, anterior e independiente
+-- de cualquier pregunta sobre el contador de lluvia. Si solo vimos el 58% del
+-- dia no podemos afirmar nada sobre el total, se vea como se vea la marca de
+-- frescura del piezo. Puesto al final, la primera rama del CASE de la 068
+-- (`ultima_actualizacion_lluvia IS NULL` -> 'sin_time_piezo', que CONFIA en el
+-- valor crudo) se dispararia primero y un dia parcial sin senal de frescura
+-- seguiria entrando con su numero -- justo el hueco que hay que cerrar.
+--
+-- Ponerlo primero solo puede producir MAS NULLs, nunca menos: no puede volver
+-- confiable ningun dia que la 068 hubiera desconfiado. Lo unico que cambia para
+-- un dia que es parcial Y tiene el contador congelado es la ETIQUETA
+-- ('cobertura_parcial' en vez de 'contador_congelado'); el valor es NULL en los
+-- dos casos, asi que ningun numero se mueve. Si se prefiere la version literal
+-- del hallazgo, es mover una rama del CASE.
+--
+-- -----------------------------------------------------------------------------
+-- DESVIACION DELIBERADA #2 -- el backfill NO puede ser `WHERE lecturas_count < 240`
+-- -----------------------------------------------------------------------------
+-- El hallazgo propuso `UPDATE ... WHERE lecturas_count < 240 AND
+-- lluvia_confianza='ok'` y afirmaba que tocaba 1 fila. Ejecutado como SELECT
+-- contra produccion antes de escribir esto: toca **1.734**.
+--
+-- La razon es que `clima_resumen_diario` tiene DOS poblaciones con semanticas
+-- distintas de `lecturas_count`:
+--
+--   station_id                | filas | fechas                  | lecturas_count
+--   --------------------------+-------+-------------------------+---------------
+--   'wunderground-historico'  | 1.757 | 2020-07-01 .. 2025-11-04| siempre 1
+--   '84:1F:E8:35:D8:73 '      |   153 | 2026-03-18 .. 2026-08-19| 111 .. 289
+--
+-- Las 1.757 filas de `wunderground-historico` son agregados DIARIOS importados:
+-- `lecturas_count = 1` significa "un registro diario importado", no "1 de 288
+-- lecturas". De ellas 1.730 estan en `ok`. El UPDATE propuesto tal cual les
+-- pondria `lluvia_total_mm = NULL` a cinco anios y medio de historia pluvial
+-- legitima -- borraria la unica serie larga de lluvia que tiene la finca.
+--
+-- Por eso el backfill se acota a la estacion de muestreo por 5 minutos, con un
+-- literal explicito y no con una regex (leccion de la 099), y con guardas que
+-- verifican que la exclusion es coherente (toda fila excluida tiene
+-- `lecturas_count = 1`) y que despues del UPDATE la poblacion historica quedo
+-- intacta.
+--
+-- La regla del CASE dentro de la funcion no necesita ese filtro: el rollup solo
+-- lee `clima_lecturas`, que unicamente alimenta el sync de 5 minutos de
+-- `clima.tsx` para esa estacion (verificado: es el unico write path del repo, y
+-- `clima_lecturas` tiene un solo station_id).
+--
+-- Filas afectadas por el backfill: 4 (2026-08-19, 2026-03-30, 2026-03-27,
+-- 2026-03-18), mas cualquier dia parcial nuevo que el cron nocturno haya escrito
+-- entre hoy y el momento en que se corra esto. Ver la guarda 2.
+--
+-- -----------------------------------------------------------------------------
+-- LO QUE ESTA MIGRACION NO ARREGLA (decision de producto pendiente)
+-- -----------------------------------------------------------------------------
+-- Rescata SOLO la lluvia. Temperatura, humedad y radiacion de un dia parcial
+-- siguen consumiendose como fiables aunque el promedio este sesgado por el hueco
+-- horario: la radiacion media del 2026-08-19 quedo en 109,81 W/m2 contra 145-151
+-- de los dias despejados de la ventana (-25%), porque el hueco de 11:00 a 17:00
+-- se comio el pico solar. No se toca aca porque NULLear esos agregados es una
+-- decision de producto de Santiago, no un arreglo mecanico.
+--
+-- -----------------------------------------------------------------------------
+-- Correr el archivo COMPLETO de una sola vez (SQL editor o `apply_migration`),
+-- para que sea UNA transaccion: los `RAISE EXCEPTION` de las guardas dependen de
+-- eso para deshacer todo. Misma convencion que 075/076/077/080/081, que tampoco
+-- escriben BEGIN/COMMIT explicitos.
+-- =============================================================================
+
+
+-- -----------------------------------------------------------------------------
+-- 0. Guardas previas -- estado esperado antes de tocar nada.
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_stations         integer;
+  v_wu_filas         integer;
+  v_wu_lc1           integer;
+  v_wu_ok            integer;
+  v_objetivo         integer;
+  v_objetivo_viejos  integer;
+  v_check_def        text;
+BEGIN
+  -- 0.1 Exactamente dos poblaciones. Si aparece una tercera estacion, la
+  --     semantica de `lecturas_count` deja de estar establecida y el backfill
+  --     de mas abajo deja de ser seguro: hay que revisarlo a mano.
+  SELECT count(DISTINCT station_id) INTO v_stations FROM public.clima_resumen_diario;
+  IF v_stations <> 2 THEN
+    RAISE EXCEPTION 'Migracion 103: se esperaban 2 station_id en clima_resumen_diario y hay %. El backfill asume dos poblaciones conocidas (import diario de Wunderground vs muestreo de 5 min de Ecowitt); con una tercera hay que revisar a mano antes de correr esto.', v_stations;
+  END IF;
+
+  -- 0.2 La poblacion historica esta congelada y es homogenea: 1.757 filas, todas
+  --     con lecturas_count = 1. Es lo que justifica excluirla por station_id.
+  SELECT count(*) INTO v_wu_filas
+    FROM public.clima_resumen_diario WHERE station_id = 'wunderground-historico';
+  SELECT count(*) INTO v_wu_lc1
+    FROM public.clima_resumen_diario WHERE station_id = 'wunderground-historico' AND lecturas_count = 1;
+  SELECT count(*) INTO v_wu_ok
+    FROM public.clima_resumen_diario WHERE station_id = 'wunderground-historico' AND lluvia_confianza = 'ok';
+
+  IF v_wu_filas <> 1757 THEN
+    RAISE EXCEPTION 'Migracion 103: se esperaban 1.757 filas de wunderground-historico y hay %. Esa serie deberia estar cerrada (2020-07-01 .. 2025-11-04); si crecio, revisa a mano.', v_wu_filas;
+  END IF;
+  IF v_wu_lc1 <> v_wu_filas THEN
+    RAISE EXCEPTION 'Migracion 103: % de las % filas de wunderground-historico NO tienen lecturas_count = 1. La exclusion por station_id deja de ser coherente -- ABORTA.', v_wu_filas - v_wu_lc1, v_wu_filas;
+  END IF;
+  IF v_wu_ok <> 1730 THEN
+    RAISE EXCEPTION 'Migracion 103: se esperaban 1.730 filas ok en wunderground-historico y hay %.', v_wu_ok;
+  END IF;
+
+  -- 0.3 El conjunto a corregir. Se permite que haya crecido desde el analisis
+  --     (2026-08-20): el cron nocturno puede haber sellado dias parciales
+  --     nuevos mientras dure el corte de luz, y NULearlos es exactamente el
+  --     objetivo. Lo que NO se permite es que aparezcan filas parciales viejas
+  --     que el analisis no vio -- eso significaria que la poblacion no es la
+  --     que se estudio.
+  SELECT count(*) INTO v_objetivo
+    FROM public.clima_resumen_diario
+   WHERE station_id <> 'wunderground-historico'
+     AND lecturas_count < 240
+     AND lluvia_confianza = 'ok';
+
+  SELECT count(*) INTO v_objetivo_viejos
+    FROM public.clima_resumen_diario
+   WHERE station_id <> 'wunderground-historico'
+     AND lecturas_count < 240
+     AND lluvia_confianza = 'ok'
+     AND fecha <= DATE '2026-08-19'
+     AND fecha NOT IN (DATE '2026-08-19', DATE '2026-03-30', DATE '2026-03-27', DATE '2026-03-18');
+
+  IF v_objetivo < 4 THEN
+    RAISE EXCEPTION 'Migracion 103: se esperaban al menos 4 filas parciales marcadas ok en la estacion Ecowitt y hay %. Puede que la migracion ya se haya corrido.', v_objetivo;
+  END IF;
+  IF v_objetivo_viejos <> 0 THEN
+    RAISE EXCEPTION 'Migracion 103: aparecieron % filas parciales con fecha <= 2026-08-19 que el analisis del 2026-08-20 no identifico. La poblacion cambio -- revisa a mano antes de correr esto.', v_objetivo_viejos;
+  END IF;
+
+  -- 0.4 Los 4 dias conocidos tienen que seguir ahi.
+  IF NOT EXISTS (SELECT 1 FROM public.clima_resumen_diario WHERE fecha = DATE '2026-08-19' AND lecturas_count = 167 AND lluvia_confianza = 'ok' AND lluvia_total_mm = 0.00) THEN
+    RAISE EXCEPTION 'Migracion 103: la fila del 2026-08-19 no esta en el estado documentado (167 lecturas, ok, 0.00 mm). ABORTA.';
+  END IF;
+
+  -- 0.5 El CHECK todavia es el de la 068 (no se corrio esto antes).
+  SELECT pg_get_constraintdef(oid) INTO v_check_def
+    FROM pg_constraint
+   WHERE conrelid = 'public.clima_resumen_diario'::regclass
+     AND conname  = 'clima_resumen_diario_lluvia_confianza_check';
+  IF v_check_def IS NULL THEN
+    RAISE EXCEPTION 'Migracion 103: no existe clima_resumen_diario_lluvia_confianza_check. Estado inesperado -- ABORTA.';
+  END IF;
+  IF v_check_def LIKE '%cobertura_parcial%' THEN
+    RAISE EXCEPTION 'Migracion 103: el CHECK ya incluye cobertura_parcial -- la migracion ya se corrio. ABORTA.';
+  END IF;
+
+  RAISE NOTICE 'Migracion 103: pre-condiciones OK -- 2 estaciones, 1.757 filas historicas intactas, % filas parciales por corregir.', v_objetivo;
+END $$;
+
+
+-- -----------------------------------------------------------------------------
+-- 1. Cuarto valor admitido en lluvia_confianza.
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.clima_resumen_diario
+  DROP CONSTRAINT clima_resumen_diario_lluvia_confianza_check;
+
+ALTER TABLE public.clima_resumen_diario
+  ADD CONSTRAINT clima_resumen_diario_lluvia_confianza_check
+  CHECK (lluvia_confianza IN ('ok', 'contador_congelado', 'sin_time_piezo', 'cobertura_parcial'));
+
+COMMENT ON COLUMN public.clima_resumen_diario.lluvia_confianza IS
+  'ok = contador verificado fresco ese dia. contador_congelado = el contador de Ecowitt no se reinicio (lluvia_total_mm queda NULL, nunca un duplicado). sin_time_piezo = Ecowitt no envio la senal de frescura; se confia en el valor crudo como antes de la migracion 068. cobertura_parcial = el dia se capturo incompleto (menos de 240 de las 288 lecturas de 5 min esperadas, tipicamente por corte de luz en la finca); lluvia_total_mm queda NULL porque el contador es acumulado y un dia truncado solo da una cota inferior, nunca un total -- migracion 103.';
+
+
+-- -----------------------------------------------------------------------------
+-- 2. El rollup nocturno pasa a mirar la cobertura del dia.
+--
+-- Cuerpo de la 068 verbatim salvo por la rama nueva del CASE y el CASE del
+-- INSERT. Se conserva `SET search_path = public, pg_temp` porque la 082 lo
+-- pineo sobre esta funcion y un CREATE OR REPLACE sin el lo perderia
+-- (verificado contra `pg_get_functiondef` en produccion el 2026-08-20: el
+-- cuerpo vivo es identico al fichero de la 068 mas ese pin).
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.fn_clima_rollup_diario(p_fecha date DEFAULT (now() AT TIME ZONE 'America/Bogota')::date - 1)
+RETURNS void
+LANGUAGE plpgsql
+SET search_path = public, pg_temp
+AS $$
+BEGIN
+  WITH agregado AS (
+    SELECT
+      DATE(timestamp AT TIME ZONE 'America/Bogota') AS fecha,
+      station_id,
+      ROUND(MIN(temp_c), 2) AS temp_c_min,
+      ROUND(MAX(temp_c), 2) AS temp_c_max,
+      ROUND(AVG(temp_c), 2) AS temp_c_avg,
+      ROUND(MIN(humedad_pct), 2) AS humedad_pct_min,
+      ROUND(MAX(humedad_pct), 2) AS humedad_pct_max,
+      ROUND(AVG(humedad_pct), 2) AS humedad_pct_avg,
+      ROUND(MAX(lluvia_diaria_mm), 2) AS lluvia_max_dia,
+      ROUND(AVG(viento_kmh), 2) AS viento_kmh_avg,
+      ROUND(MAX(rafaga_kmh), 2) AS rafaga_kmh_max,
+      ROUND(
+        DEGREES(
+          ATAN2(
+            AVG(SIN(RADIANS(viento_dir))),
+            AVG(COS(RADIANS(viento_dir)))
+          )
+        )::numeric % 360, 1
+      ) AS viento_dir_predominante,
+      ROUND(AVG(radiacion_wm2), 2) AS radiacion_wm2_avg,
+      ROUND(MAX(radiacion_wm2), 2) AS radiacion_wm2_max,
+      MAX(uv_index) AS uv_index_max,
+      COUNT(*) AS lecturas_count,
+      -- Freshness of the rain counter: Ecowitt's own "last updated" time for
+      -- the chronologically last reading of the day.
+      (ARRAY_AGG(lluvia_diaria_actualizada_en ORDER BY timestamp DESC))[1] AS ultima_actualizacion_lluvia
+    FROM clima_lecturas
+    WHERE DATE(timestamp AT TIME ZONE 'America/Bogota') = p_fecha
+    GROUP BY 1, 2
+  ),
+  evaluado AS (
+    SELECT
+      a.*,
+      CASE
+        -- Migracion 103. Va PRIMERO: la cobertura del dia es anterior e
+        -- independiente de cualquier pregunta sobre el contador de lluvia. Si
+        -- solo se capturo una parte del dia no hay total que afirmar, se vea
+        -- como se vea la marca de frescura del piezo. Puesto despues, la rama
+        -- 'sin_time_piezo' -- que CONFIA en el valor crudo -- se disparia
+        -- primero y dejaria pasar el numero de un dia truncado.
+        -- 240 de 288 lecturas de 5 min = 83,3%. Los dias sanos de la estacion
+        -- estan en 279-289; los incompletos, en 111-225. No hay zona gris.
+        WHEN a.lecturas_count < 240 THEN 'cobertura_parcial'
+        WHEN a.ultima_actualizacion_lluvia IS NULL THEN 'sin_time_piezo'
+        WHEN DATE(a.ultima_actualizacion_lluvia AT TIME ZONE 'America/Bogota') < a.fecha THEN 'contador_congelado'
+        WHEN a.lluvia_max_dia IS NOT NULL AND a.lluvia_max_dia > 0
+             AND a.lluvia_max_dia IS NOT DISTINCT FROM y.lluvia_total_mm THEN 'contador_congelado'
+        ELSE 'ok'
+      END AS lluvia_confianza
+    FROM agregado a
+    LEFT JOIN clima_resumen_diario y
+      ON y.fecha = a.fecha - 1 AND y.station_id = a.station_id
+  )
+  INSERT INTO clima_resumen_diario (
+    fecha, station_id,
+    temp_c_min, temp_c_max, temp_c_avg,
+    humedad_pct_min, humedad_pct_max, humedad_pct_avg,
+    lluvia_total_mm, lluvia_confianza,
+    viento_kmh_avg, rafaga_kmh_max,
+    viento_dir_predominante,
+    radiacion_wm2_avg, radiacion_wm2_max,
+    uv_index_max,
+    lecturas_count
+  )
+  SELECT
+    fecha, station_id,
+    temp_c_min, temp_c_max, temp_c_avg,
+    humedad_pct_min, humedad_pct_max, humedad_pct_avg,
+    CASE WHEN lluvia_confianza IN ('contador_congelado', 'cobertura_parcial') THEN NULL ELSE lluvia_max_dia END,
+    lluvia_confianza,
+    viento_kmh_avg, rafaga_kmh_max,
+    viento_dir_predominante,
+    radiacion_wm2_avg, radiacion_wm2_max,
+    uv_index_max,
+    lecturas_count
+  FROM evaluado
+  ON CONFLICT (fecha, station_id) DO UPDATE SET
+    temp_c_min      = EXCLUDED.temp_c_min,
+    temp_c_max      = EXCLUDED.temp_c_max,
+    temp_c_avg      = EXCLUDED.temp_c_avg,
+    humedad_pct_min = EXCLUDED.humedad_pct_min,
+    humedad_pct_max = EXCLUDED.humedad_pct_max,
+    humedad_pct_avg = EXCLUDED.humedad_pct_avg,
+    lluvia_total_mm = EXCLUDED.lluvia_total_mm,
+    lluvia_confianza = EXCLUDED.lluvia_confianza,
+    viento_kmh_avg  = EXCLUDED.viento_kmh_avg,
+    rafaga_kmh_max  = EXCLUDED.rafaga_kmh_max,
+    viento_dir_predominante = EXCLUDED.viento_dir_predominante,
+    radiacion_wm2_avg = EXCLUDED.radiacion_wm2_avg,
+    radiacion_wm2_max = EXCLUDED.radiacion_wm2_max,
+    uv_index_max    = EXCLUDED.uv_index_max,
+    lecturas_count  = EXCLUDED.lecturas_count;
+
+  -- Prune old 5-min readings (keep rolling 24h window) -- same as before.
+  DELETE FROM clima_lecturas
+  WHERE timestamp < now() - interval '24 hours';
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_clima_rollup_diario IS
+  'Rollup nocturno de clima_lecturas -> clima_resumen_diario con deteccion de contador de lluvia congelado (migracion 068) y de dia capturado incompleto (migracion 103). p_fecha por defecto: ayer (Bogota).';
+
+
+-- -----------------------------------------------------------------------------
+-- 3. Backfill de los dias parciales ya escritos como confiables.
+--
+-- Acotado a la estacion de muestreo de 5 minutos. Sin ese filtro el UPDATE
+-- alcanza las 1.730 filas historicas de wunderground-historico (agregados
+-- diarios, lecturas_count = 1 por construccion) y borra cinco anios y medio de
+-- lluvia legitima. Ver el encabezado, DESVIACION DELIBERADA #2.
+-- -----------------------------------------------------------------------------
+UPDATE public.clima_resumen_diario
+   SET lluvia_confianza = 'cobertura_parcial',
+       lluvia_total_mm  = NULL
+ WHERE station_id <> 'wunderground-historico'
+   AND lecturas_count < 240
+   AND lluvia_confianza = 'ok';
+
+
+-- -----------------------------------------------------------------------------
+-- 4. Post-condiciones.
+-- -----------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_parciales     integer;
+  v_parciales_nn  integer;
+  v_restantes     integer;
+  v_wu_ok         integer;
+  v_wu_parcial    integer;
+  v_wu_nulos      integer;
+  v_total         integer;
+  v_check_def     text;
+BEGIN
+  -- 4.1 Los dias parciales quedaron marcados, y TODOS con lluvia_total_mm NULL.
+  SELECT count(*) INTO v_parciales
+    FROM public.clima_resumen_diario WHERE lluvia_confianza = 'cobertura_parcial';
+  SELECT count(*) INTO v_parciales_nn
+    FROM public.clima_resumen_diario WHERE lluvia_confianza = 'cobertura_parcial' AND lluvia_total_mm IS NOT NULL;
+
+  IF v_parciales < 4 THEN
+    RAISE EXCEPTION 'Migracion 103: quedaron % filas cobertura_parcial, se esperaban al menos 4.', v_parciales;
+  END IF;
+  IF v_parciales_nn <> 0 THEN
+    RAISE EXCEPTION 'Migracion 103: % filas cobertura_parcial conservan lluvia_total_mm. Un dia incompleto no puede afirmar un total -- ABORTA.', v_parciales_nn;
+  END IF;
+
+  -- 4.2 No queda ni un dia parcial de la estacion Ecowitt marcado ok. Esta es
+  --     la verificacion de que el arreglo cerro, y se recalcula desde cero.
+  SELECT count(*) INTO v_restantes
+    FROM public.clima_resumen_diario
+   WHERE station_id <> 'wunderground-historico'
+     AND lecturas_count < 240
+     AND lluvia_confianza = 'ok';
+  IF v_restantes <> 0 THEN
+    RAISE EXCEPTION 'Migracion 103: todavia quedan % dias parciales marcados ok. La correccion es incompleta.', v_restantes;
+  END IF;
+
+  -- 4.3 La serie historica de Wunderground quedo INTACTA. Es la guarda que
+  --     protege contra el error que el hallazgo original traia incorporado.
+  SELECT count(*) INTO v_wu_ok
+    FROM public.clima_resumen_diario WHERE station_id = 'wunderground-historico' AND lluvia_confianza = 'ok';
+  SELECT count(*) INTO v_wu_parcial
+    FROM public.clima_resumen_diario WHERE station_id = 'wunderground-historico' AND lluvia_confianza = 'cobertura_parcial';
+  SELECT count(*) INTO v_wu_nulos
+    FROM public.clima_resumen_diario WHERE station_id = 'wunderground-historico' AND lluvia_total_mm IS NULL;
+
+  IF v_wu_ok <> 1730 THEN
+    RAISE EXCEPTION 'Migracion 103: wunderground-historico paso de 1.730 a % filas ok. El backfill toco la serie historica -- ABORTA.', v_wu_ok;
+  END IF;
+  IF v_wu_parcial <> 0 THEN
+    RAISE EXCEPTION 'Migracion 103: % filas de wunderground-historico quedaron marcadas cobertura_parcial. ABORTA.', v_wu_parcial;
+  END IF;
+  IF v_wu_nulos <> 54 THEN
+    RAISE EXCEPTION 'Migracion 103: wunderground-historico tiene % filas con lluvia_total_mm NULL, se esperaban 54 (las que ya venian sin dato del import). ABORTA.', v_wu_nulos;
+  END IF;
+
+  -- 4.4 No se creo ni se borro ninguna fila: esto es un UPDATE, no una limpieza.
+  SELECT count(*) INTO v_total FROM public.clima_resumen_diario;
+  IF v_total <> 1910 THEN
+    RAISE EXCEPTION 'Migracion 103: clima_resumen_diario quedo con % filas, se esperaban 1.910. Esta migracion no inserta ni borra filas.', v_total;
+  END IF;
+
+  -- 4.5 El CHECK admite el valor nuevo.
+  SELECT pg_get_constraintdef(oid) INTO v_check_def
+    FROM pg_constraint
+   WHERE conrelid = 'public.clima_resumen_diario'::regclass
+     AND conname  = 'clima_resumen_diario_lluvia_confianza_check';
+  IF v_check_def IS NULL OR v_check_def NOT LIKE '%cobertura_parcial%' THEN
+    RAISE EXCEPTION 'Migracion 103: el CHECK no quedo con cobertura_parcial. ABORTA.';
+  END IF;
+
+  RAISE NOTICE 'Migracion 103: post-condiciones OK -- % dias marcados cobertura_parcial (todos con lluvia_total_mm NULL), 0 dias parciales marcados ok, serie de wunderground-historico intacta (1.730 ok / 1.757 filas), 1.910 filas en total.', v_parciales;
+END $$;
+
+
+-- =============================================================================
+-- ROLLBACK
+-- =============================================================================
+-- No hace falta tabla de respaldo: son 4 filas y los valores previos estan
+-- documentados aca. Si la migracion se corre despues del 2026-08-20 y el cron
+-- alcanzo a sellar dias parciales nuevos, esos NO estan en esta lista -- para
+-- deshacerlos habria que releer sus totales crudos, que el UPDATE de arriba si
+-- descarta (a diferencia del backfill de la 068, que solo marca metadata).
+-- Cotejar contra la salida del RAISE NOTICE del paso 4 antes de revertir.
+--
+-- Estado previo de las 4 filas conocidas (station_id = '84:1F:E8:35:D8:73 '):
+--
+--   fecha        lecturas_count  lluvia_total_mm  lluvia_confianza
+--   2026-08-19   167             0.00             ok
+--   2026-03-30   147             18.03            ok
+--   2026-03-27   225             3.30             ok
+--   2026-03-18   111             1.02             ok
+--
+-- Para revertir por completo, en este orden:
+--
+--   -- (a) devolver las 4 filas a su estado previo
+--   UPDATE public.clima_resumen_diario SET lluvia_confianza = 'ok', lluvia_total_mm = 0.00
+--    WHERE fecha = DATE '2026-08-19' AND station_id = '84:1F:E8:35:D8:73 ';
+--   UPDATE public.clima_resumen_diario SET lluvia_confianza = 'ok', lluvia_total_mm = 18.03
+--    WHERE fecha = DATE '2026-03-30' AND station_id = '84:1F:E8:35:D8:73 ';
+--   UPDATE public.clima_resumen_diario SET lluvia_confianza = 'ok', lluvia_total_mm = 3.30
+--    WHERE fecha = DATE '2026-03-27' AND station_id = '84:1F:E8:35:D8:73 ';
+--   UPDATE public.clima_resumen_diario SET lluvia_confianza = 'ok', lluvia_total_mm = 1.02
+--    WHERE fecha = DATE '2026-03-18' AND station_id = '84:1F:E8:35:D8:73 ';
+--
+--   -- (b) restaurar la funcion de la 068 (correr el paso 3 de
+--   --     068_clima_lluvia_confianza.sql tal cual, y volver a pinear el
+--   --     search_path que agrego la 082):
+--   --     ALTER FUNCTION public.fn_clima_rollup_diario(date) SET search_path = public, pg_temp;
+--
+--   -- (c) restaurar el CHECK original. Requiere que ya no quede ninguna fila
+--   --     en 'cobertura_parcial', o falla:
+--   ALTER TABLE public.clima_resumen_diario
+--     DROP CONSTRAINT clima_resumen_diario_lluvia_confianza_check;
+--   ALTER TABLE public.clima_resumen_diario
+--     ADD CONSTRAINT clima_resumen_diario_lluvia_confianza_check
+--     CHECK (lluvia_confianza IN ('ok', 'contador_congelado', 'sin_time_piezo'));
+-- =============================================================================

--- a/src/supabase/functions/server/chat.tsx
+++ b/src/supabase/functions/server/chat.tsx
@@ -2056,9 +2056,15 @@ interface FilaResumenClima {
  * marcado vale **null (sin dato)**, jamas 0: "no llovio" y "no sabemos" son
  * cosas distintas, y confundirlas es exactamente lo que producia el bug de
  * lluvia duplicada.
+ *
+ * La migracion 103 agrega `cobertura_parcial` por la misma puerta: un dia que
+ * la estacion capturo incompleto (corte de luz en la finca) tampoco tiene un
+ * total que afirmar. Es el mismo error con el signo cambiado -- la 068 impedia
+ * un DUPLICADO fabricado, la 103 impide un CERO fabricado.
  */
 function lluviaConfiable(fila: { lluvia_total_mm: number | null; lluvia_confianza?: string | null }): number | null {
   if (fila.lluvia_confianza === 'contador_congelado') return null;
+  if (fila.lluvia_confianza === 'cobertura_parcial') return null;
   return fila.lluvia_total_mm;
 }
 
@@ -2145,7 +2151,7 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     temp_avg: r.temp_c_avg, temp_max: r.temp_c_max, temp_min: r.temp_c_min,
     humedad_avg: r.humedad_pct_avg, viento_avg: r.viento_kmh_avg,
     lluvia_mm: lluviaConfiable(r),
-    lluvia_sin_dato: r.lluvia_confianza === 'contador_congelado',
+    lluvia_sin_dato: r.lluvia_confianza === 'contador_congelado' || r.lluvia_confianza === 'cobertura_parcial',
     radiacion_avg: r.radiacion_wm2_avg, radiacion_max: r.radiacion_wm2_max,
   }));
 
@@ -2183,12 +2189,14 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
   const ultimaLluviaFecha = lluviaHoy != null && lluviaHoy > 0 ? hoy : ultimaDeResumen?.fecha ?? null;
   const ultimaLluviaMm = lluviaHoy != null && lluviaHoy > 0 ? lluviaHoy : ultimaDeResumen?.lluvia_total_mm ?? null;
 
-  // Dias marcados `contador_congelado` entre la ultima lluvia y hoy: en esos no
-  // se sabe si llovio, asi que el conteo es un maximo, no una certeza.
+  // Dias sin dato de lluvia entre la ultima lluvia y hoy: en esos no se sabe si
+  // llovio, asi que el conteo es un maximo, no una certeza. Cubre el contador
+  // congelado (068) y el dia capturado incompleto (103) -- omitir el segundo
+  // haria que Esco afirmara "N dias sin llover" incluyendo dias que nadie vio.
   let diasSinDatoDesdeEntonces = 0;
   if (ultimaLluviaFecha) {
     const desdeRaw = await supabaseQuery('clima_resumen_diario',
-      `select=fecha&lluvia_confianza=eq.contador_congelado&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
+      `select=fecha&lluvia_confianza=in.(contador_congelado,cobertura_parcial)&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
     ) as Array<{ fecha: string }>;
     diasSinDatoDesdeEntonces = (desdeRaw ?? []).length;
   }

--- a/src/types/clima.ts
+++ b/src/types/clima.ts
@@ -25,7 +25,11 @@ export interface LecturaClima {
 //   viene NULL (sin dato, nunca un duplicado fabricado) — ver migración 068.
 // 'sin_time_piezo' = Ecowitt no envió la señal de frescura; se confía en el
 //   valor crudo (comportamiento previo a la migración 068).
-export type LluviaConfianza = 'ok' | 'contador_congelado' | 'sin_time_piezo';
+// 'cobertura_parcial' = el día se capturó incompleto (menos de 240 de las 288
+//   lecturas de 5 min esperadas, típicamente por corte de luz en la finca);
+//   lluvia_total_mm viene NULL, porque el contador es acumulado y un día
+//   truncado sólo da una cota inferior, nunca un total — ver migración 103.
+export type LluviaConfianza = 'ok' | 'contador_congelado' | 'sin_time_piezo' | 'cobertura_parcial';
 
 export interface ResumenDiario {
   fecha: string;

--- a/src/utils/calculosClima.ts
+++ b/src/utils/calculosClima.ts
@@ -28,10 +28,20 @@ function safeMin(values: number[]): number {
 // consumidor de clima_resumen_diario debe pasar por aqui: sumar
 // lluvia_total_mm directo revive el duplicado que la migracion detecto.
 // "Sin dato" es NULL, nunca 0.
+//
+// Migración 103: `cobertura_parcial` entra por la misma puerta. Un día del que
+// sólo se capturó una parte (corte de luz en la finca) no tiene total que
+// afirmar — el contador de lluvia es acumulado, así que el máximo de las
+// lecturas disponibles es una cota inferior, no una medición. El rollup lo
+// guarda como NULL, y esta puerta lo sostiene también para las filas que el
+// backfill de la 103 marcó. Es el espejo del bug de la 068: aquélla impedía un
+// duplicado fabricado, ésta impide un CERO fabricado.
+const CONFIANZAS_SIN_DATO = new Set(['contador_congelado', 'cobertura_parcial']);
+
 export function lluviaConfiableDeResumen(
   fila: { lluvia_total_mm: number | null; lluvia_confianza?: string | null }
 ): number | null {
-  if (fila.lluvia_confianza === 'contador_congelado') return null;
+  if (fila.lluvia_confianza != null && CONFIANZAS_SIN_DATO.has(fila.lluvia_confianza)) return null;
   return fila.lluvia_total_mm;
 }
 
@@ -48,7 +58,7 @@ export interface DiaFranjaLluvia {
   /** mm confiables — SIEMPRE null cuando estado es 'sin_dato', nunca 0 */
   mm: number | null;
   /** Sólo relevante cuando estado es 'sin_dato' */
-  causa: 'contador_congelado' | 'sin_registro' | null;
+  causa: 'contador_congelado' | 'cobertura_parcial' | 'sin_registro' | null;
 }
 
 // Arma la franja de los últimos `dias` días terminando en `hastaISO`
@@ -80,7 +90,13 @@ export function construirFranjaLluvia(
 
     const mm = lluviaConfiableDeResumen(fila);
     if (mm === null) {
-      const causa = fila.lluvia_confianza === 'contador_congelado' ? 'contador_congelado' : 'sin_registro';
+      // Un día `cobertura_parcial` (migración 103) es 'sin_dato' igual que uno
+      // con el contador congelado, y JAMÁS 'seco': la fila trae 0.00 mm sólo
+      // porque no se capturó la tarde, no porque no haya llovido.
+      const causa: DiaFranjaLluvia['causa'] =
+        fila.lluvia_confianza === 'contador_congelado' ? 'contador_congelado'
+        : fila.lluvia_confianza === 'cobertura_parcial' ? 'cobertura_parcial'
+        : 'sin_registro';
       resultado.push({ fecha: fechaStr, estado: 'sin_dato', mm: null, causa });
     } else if (mm > 0) {
       resultado.push({ fecha: fechaStr, estado: 'lluvia', mm, causa: null });

--- a/supabase/functions/make-server-1ccce916/chat.tsx
+++ b/supabase/functions/make-server-1ccce916/chat.tsx
@@ -2056,9 +2056,15 @@ interface FilaResumenClima {
  * marcado vale **null (sin dato)**, jamas 0: "no llovio" y "no sabemos" son
  * cosas distintas, y confundirlas es exactamente lo que producia el bug de
  * lluvia duplicada.
+ *
+ * La migracion 103 agrega `cobertura_parcial` por la misma puerta: un dia que
+ * la estacion capturo incompleto (corte de luz en la finca) tampoco tiene un
+ * total que afirmar. Es el mismo error con el signo cambiado -- la 068 impedia
+ * un DUPLICADO fabricado, la 103 impide un CERO fabricado.
  */
 function lluviaConfiable(fila: { lluvia_total_mm: number | null; lluvia_confianza?: string | null }): number | null {
   if (fila.lluvia_confianza === 'contador_congelado') return null;
+  if (fila.lluvia_confianza === 'cobertura_parcial') return null;
   return fila.lluvia_total_mm;
 }
 
@@ -2145,7 +2151,7 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     temp_avg: r.temp_c_avg, temp_max: r.temp_c_max, temp_min: r.temp_c_min,
     humedad_avg: r.humedad_pct_avg, viento_avg: r.viento_kmh_avg,
     lluvia_mm: lluviaConfiable(r),
-    lluvia_sin_dato: r.lluvia_confianza === 'contador_congelado',
+    lluvia_sin_dato: r.lluvia_confianza === 'contador_congelado' || r.lluvia_confianza === 'cobertura_parcial',
     radiacion_avg: r.radiacion_wm2_avg, radiacion_max: r.radiacion_wm2_max,
   }));
 
@@ -2183,12 +2189,14 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
   const ultimaLluviaFecha = lluviaHoy != null && lluviaHoy > 0 ? hoy : ultimaDeResumen?.fecha ?? null;
   const ultimaLluviaMm = lluviaHoy != null && lluviaHoy > 0 ? lluviaHoy : ultimaDeResumen?.lluvia_total_mm ?? null;
 
-  // Dias marcados `contador_congelado` entre la ultima lluvia y hoy: en esos no
-  // se sabe si llovio, asi que el conteo es un maximo, no una certeza.
+  // Dias sin dato de lluvia entre la ultima lluvia y hoy: en esos no se sabe si
+  // llovio, asi que el conteo es un maximo, no una certeza. Cubre el contador
+  // congelado (068) y el dia capturado incompleto (103) -- omitir el segundo
+  // haria que Esco afirmara "N dias sin llover" incluyendo dias que nadie vio.
   let diasSinDatoDesdeEntonces = 0;
   if (ultimaLluviaFecha) {
     const desdeRaw = await supabaseQuery('clima_resumen_diario',
-      `select=fecha&lluvia_confianza=eq.contador_congelado&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
+      `select=fecha&lluvia_confianza=in.(contador_congelado,cobertura_parcial)&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
     ) as Array<{ fecha: string }>;
     diasSinDatoDesdeEntonces = (desdeRaw ?? []).length;
   }


### PR DESCRIPTION
Cierra el hallazgo **ESCO-32** (P1) de la corrida de mantenimiento `2026-08-20-jueves`.

> **Este PR no aplica nada a producción — la migración la tiene que correr Santiago.**
> Los cambios de frontend/edge sí viajan con el deploy; el edge function además necesita `npx supabase functions deploy make-server-1ccce916`.

---

## Bug

`fn_clima_rollup_diario` (migración 068) decide `lluvia_confianza` mirando **únicamente** si el contador de lluvia de Ecowitt se refrescó ese día. Nunca mira **cuánto del día se alcanzó a capturar**: `lecturas_count` se agrega con un `COUNT(*)` y se guarda, pero jamás entra a un predicado.

Evidencia viva en producción (`ywhtjwawnkeqlwxbvgup`, SELECT, 2026-08-20):

```
SELECT fecha, lecturas_count, lluvia_total_mm, lluvia_confianza
  FROM clima_resumen_diario WHERE fecha = '2026-08-19';
-- 2026-08-19 | 167 | 0.00 | ok
```

La estación muestrea cada 5 minutos: **288 lecturas/día**. El 08-19 llegaron **167 (58%)**. Por hora de Bogotá:

| franja | lecturas |
|---|---|
| 00–09h | 12/hora (completo) |
| 10h | 5 |
| **11h–16h** | **0 (nada)** |
| 17h | 4 |
| 18h–20h | 12/hora |
| 21h | 2 |
| **22h–23h** | **0 (nada)** |

Casi nueve horas del día sin registro — justo la franja de la tarde en que llueve en Aguadas — y aun así la fila quedó sellada `ok` afirmando **0,00 mm**. La escribió el rollup nocturno (`cron.job_run_details` jobid=2, 05:15:00.254829+00), no el backfill de la 068.

Es el **espejo exacto** de la 068: aquella migración existe para impedir un DUPLICADO fabricado; esto fabrica un **CERO**. Las dos violan la misma regla que el proyecto sostiene en monitoreo, en hato y en el reporte semanal: *"sin dato" es NULL, jamás 0*.

Y no es irrepetible. Causa confirmada por Santiago: **corte de luz prolongado en la finca**. Cada corte que empiece o termine a media jornada produce un día parcial que el rollup de esa noche sella como confiable. Si la luz **no** vuelve en todo el día no se inserta fila, y eso sí es seguro; el caso peligroso es la restauración parcial, que es el más probable.

Consumidores río abajo que hoy se comen ese 0 como bueno: el reporte semanal (`fetchDatosReporteSemanal.ts` — el mismo consumidor del incidente S30/2026 que motivó la 068), Clima históricos, la franja de lluvia del tablero y las respuestas de clima de Esco. Ninguno lee `lecturas_count`.

## Causa raíz

El `CASE` de `lluvia_confianza` en la 068 sólo pregunta por la frescura del contador (`ultima_actualizacion_lluvia`) y por el duplicado exacto contra el día anterior. La **cobertura de la captura** no es una entrada de esa decisión. Verificado con `pg_get_functiondef` contra producción: el cuerpo vivo es idéntico al fichero de la 068, más el `SET search_path` que le pineó la 082.

## Fix

**Migración `103_clima_cobertura_parcial.sql`** (no aplicada):

1. `DROP` + re-`ADD` de `clima_resumen_diario_lluvia_confianza_check` con un cuarto valor: `cobertura_parcial`.
2. `CREATE OR REPLACE FUNCTION fn_clima_rollup_diario` — cuerpo de la 068 **verbatim** (incluido el `SET search_path = public, pg_temp` de la 082, que un `CREATE OR REPLACE` sin él perdería) más una rama: `lecturas_count < 240` ⇒ `cobertura_parcial` y `lluvia_total_mm = NULL`.
3. Backfill de los días parciales ya escritos como confiables.
4. Guardas `RAISE EXCEPTION` pre y post al estilo 080/081, y bloque `ROLLBACK` ejecutable al pie.

**Frontend** — `lluviaConfiableDeResumen()` (`src/utils/calculosClima.ts`) devuelve `null` también para `cobertura_parcial`. Es la puerta única por la que pasan el reporte semanal, la vista de Clima, la franja del tablero y las agregaciones mensual/anual, así que un solo cambio los cubre a todos. `construirFranjaLluvia` nombra la causa nueva, y `FranjaLluvia.tsx` la explica ("la estación no registró el día completo") en el pie y en el texto de lectores de pantalla.

**Esco** (`chat.tsx`, los dos árboles, sincronizados) — la evidencia del hallazgo decía que Esco filtraba con `lluvia_confianza=eq.ok` y estaba a salvo; **no es así**: ese filtro sólo está en la consulta lateral de "última lluvia". La serie principal de `execClimateData` pasa por `lluviaConfiable(r)` sin filtro, así que habría reportado el 0,00 mm como bueno. Corregidos tres sitios: la puerta `lluviaConfiable`, el flag `lluvia_sin_dato` y la consulta de "días sin llover" (`in.(contador_congelado,cobertura_parcial)`) — que es exactamente el consumidor del incidente del 2026-08-16, donde el modelo terminó inventando "47 días sin lluvia".

### Por qué 240

La propia estación tiene días de 279–289 lecturas por jitter del cron de 5 minutos. En los 153 días que lleva, exactamente 4 caen por debajo de 240 y los 149 restantes están en 279+. **No hay zona gris.** 240/288 = 83,3%.

### Desviación deliberada #1 — el check va ANTES de los de frescura, no después

La acción propuesta en el hallazgo decía "después de los checks de frescura". Va antes, a propósito: la cobertura es una propiedad de la **captura** del día, anterior e independiente de cualquier pregunta sobre el contador. Puesto al final, la primera rama del `CASE` de la 068 (`ultima_actualizacion_lluvia IS NULL` → `sin_time_piezo`, que **confía en el valor crudo**) se dispararía primero y un día parcial sin señal de frescura seguiría entrando con su número — justo el hueco a cerrar.

Ponerlo primero sólo puede producir **más** NULLs, nunca menos: no puede volver confiable ningún día que la 068 hubiera desconfiado. Para un día que es parcial *y* tiene el contador congelado cambia sólo la **etiqueta**; el valor es NULL en los dos casos, así que ningún número se mueve. Si se prefiere la versión literal del hallazgo, es mover una rama del `CASE`.

---

## ⚠️ Desviación deliberada #2 — el backfill propuesto habría borrado 5 años y medio de lluvia

El hallazgo proponía `UPDATE ... WHERE lecturas_count < 240 AND lluvia_confianza='ok'` y afirmaba que tocaba **1 fila**. Ejecutado como `SELECT` contra producción antes de escribir nada:

```
SELECT count(*) FROM clima_resumen_diario
 WHERE lecturas_count < 240 AND lluvia_confianza = 'ok';
-- 1734
```

`clima_resumen_diario` tiene **dos poblaciones** con semánticas distintas de `lecturas_count`:

| station_id | filas | fechas | lecturas_count | en `ok` |
|---|---|---|---|---|
| `wunderground-historico` | 1.757 | 2020-07-01 … 2025-11-04 | **siempre 1** | 1.730 |
| `84:1F:E8:35:D8:73 ` (Ecowitt) | 153 | 2026-03-18 … 2026-08-19 | 111 … 289 | 122 |

Las 1.757 filas de `wunderground-historico` son **agregados diarios importados**: `lecturas_count = 1` significa "un registro diario importado", no "1 de 288 lecturas". El UPDATE propuesto tal cual les pondría `lluvia_total_mm = NULL` y borraría la única serie larga de lluvia que tiene la finca.

El backfill de este PR se acota a la estación de muestreo de 5 min, con un literal explícito y no una regex (lección de la 099), y con guardas que verifican que la exclusión es coherente (toda fila excluida tiene `lecturas_count = 1`) y que la serie histórica quedó intacta después.

La regla dentro de la función no necesita ese filtro: el rollup sólo lee `clima_lecturas`, que únicamente alimenta el sync de 5 min de `clima.tsx` (verificado: es el único write path del repo, y la tabla tiene un solo `station_id`).

### Filas que toca el backfill: **4**

```sql
UPDATE public.clima_resumen_diario
   SET lluvia_confianza = 'cobertura_parcial', lluvia_total_mm = NULL
 WHERE station_id <> 'wunderground-historico'
   AND lecturas_count < 240
   AND lluvia_confianza = 'ok';
```

| fecha | lecturas_count | lluvia_total_mm previo | confianza previa |
|---|---|---|---|
| 2026-08-19 | 167 | 0.00 | ok |
| 2026-03-30 | 147 | 18.03 | ok |
| 2026-03-27 | 225 | 3.30 | ok |
| 2026-03-18 | 111 | 1.02 | ok |

Más cualquier día parcial nuevo que el cron nocturno escriba entre hoy y el momento en que se corra (la guarda 0.3 lo permite explícitamente — es el objetivo — pero aborta si aparecen filas parciales **con fecha ≤ 2026-08-19** que el análisis no vio).

**Rollback**: no hace falta tabla de respaldo; son 4 filas y los valores previos están en el bloque `ROLLBACK` al pie del fichero, con los tres pasos (devolver las 4 filas, restaurar la función de la 068 + re-pinear el `search_path` de la 082, restaurar el `CHECK` original).

---

## Verificación

Todo lo de producción fue **SELECT únicamente**. No se ejecutó ni un DDL/DML.

- `pg_get_functiondef('fn_clima_rollup_diario(date)')` → cuerpo vivo idéntico al fichero de la 068 + `SET search_path TO 'public','pg_temp'`. El `CREATE OR REPLACE` de la 103 copia ese cuerpo y **conserva el pin**.
- `pg_get_constraintdef` del CHECK → `('ok','contador_congelado','sin_time_piezo')`, sin `cobertura_parcial` (la migración no se corrió antes).
- Conteos que respaldan cada guarda: 2 `station_id`; wunderground 1.757 filas / 1.757 con `lecturas_count=1` / 1.730 en `ok` / 54 con `lluvia_total_mm` NULL; Ecowitt 153 filas / 122 `ok` / 31 `contador_congelado` / 0 `sin_time_piezo` / 4 por debajo de 240; total 1.910.
- Distribución horaria del 2026-08-19 (la tabla del apartado Bug), desde `clima_lecturas`.
- `clima_lecturas` tiene un solo `station_id` → la regla dentro de la función nunca ve datos de agregado diario.

En el worktree, los tres verdes:

```
npm test         → 120 archivos, 2826/2826 tests pasando
npx tsc --noEmit → limpio (exit 0)
npm run lint     → 0 errores (942 warnings preexistentes; ninguno en los ficheros de este PR)
```

**Tests nuevos** (`src/__tests__/calculosClima.test.ts`, con el caso real del 2026-08-19):
- un día `cobertura_parcial` es `sin_dato` con su causa, **jamás** `seco` — y `mm` es `null`, nunca `0`;
- la **misma** fila marcada `ok` sí es un cero real: la confianza es lo único que las separa;
- las dos causas de `sin_dato` conviven distinguidas en una misma franja;
- tabla de la puerta `lluviaConfiableDeResumen` sobre los cuatro valores de confianza.

**Guarda estática reforzada** (`esco-improvements.test.ts`): ahora exige las dos causas en `chat.tsx` y que la consulta de "días sin llover" cubra ambas. Los dos árboles de edge function quedan byte-idénticos (`diff` limpio).

---

## Follow-up

- **Este arreglo rescata SÓLO la lluvia.** Temperatura, humedad y radiación de un día parcial se siguen consumiendo como fiables aunque el promedio esté sesgado por el hueco horario: la radiación media del 2026-08-19 quedó en 109,81 W/m² contra 145–151 de los días despejados de la ventana (**−25%**), porque el hueco de 11:00 a 17:00 se comió el pico solar. NULLear esos agregados **necesita una decisión de producto de Santiago** — la alternativa es exponer `lecturas_count` en Clima históricos y en el reporte semanal y dejar que el humano juzgue. Deliberadamente fuera de alcance acá.
- **`fn_clima_rollup_diario` no reprocesa días viejos.** Los 4 días quedan corregidos por el backfill, pero su lluvia real sigue siendo irrecuperable desde la base; una corrección de verdad necesitaría re-consultar la API de historia de Ecowitt (`/clima/backfill`), que es un trabajo aparte y deliberado — misma postura que tomó la 068 con sus días congelados.
- **El edge function necesita redeploy** (`npx supabase functions deploy make-server-1ccce916`) para que el arreglo de Esco tome efecto.
- El corte de luz en la finca sigue en curso al momento de escribir esto. Mientras la migración no se aplique, cada restauración a media jornada sella otro día malo; el backfill de la 103 los recoge igual cuando se corra, porque el `WHERE` es por estado, no por fecha.


---
_Generated by [Claude Code](https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4)_