### PR TITLE
fix(finanzas): pagina el tablero de gastos — se perdían $1.436M al tope de 1.000 filas de PostgREST

### DIFF
--- a/src/__tests__/finanzasDashboardPaginadoGuard.test.tsx
+++ b/src/__tests__/finanzasDashboardPaginadoGuard.test.tsx
@@ -1,0 +1,287 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import React from 'react';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Guarda del tope de 1.000 filas en el tablero de Finanzas
+ * (`src/components/finanzas/hooks/useDashboardData.ts`).
+ *
+ * **El defecto.** `getGastosPorTrimestreMultiSerie` pedía DOS AÑOS de
+ * `fin_gastos` con `.select(...)` a secas: sin `.range()`, sin `fetchAll`,
+ * sin `.limit()`. PostgREST corta en 1.000 filas y NO avisa. Verificado
+ * contra producción el 2026-08-20:
+ *
+ *   filas reales 2025-01-01 → 2026-12-31 (Confirmado): 1.760
+ *   suma real:                                          $3.264.382.075,87
+ *   suma entregada con el tope:                         $1.828.104.228,00
+ *   faltante:                                           $1.436.277.847,87 (44,0%)
+ *
+ * Y como la consulta tampoco pedía un orden, el corte lo decidía el orden
+ * físico del heap: las filas perdidas se repartían entre 2025 y 2026 sin
+ * dejar ningún hueco visible, y podían cambiar entre una carga y otra. La
+ * gráfica se veía perfectamente normal y estaba mal en $1.444M.
+ *
+ * El mismo defecto tenía `sumGastos`, que alimenta los KPIs: un año completo
+ * ya pasa del tope (1.356 filas en 2024, 1.156 en 2025), así que "Total 2024"
+ * y "Total 2025" salían cortos.
+ *
+ * **Por qué esta prueba no se limita a comprobar que se llama a `fetchAll`.**
+ * Esa aserción demuestra que la implementación cambió, no que el error
+ * existía ni que quedó corregido. Los casos de abajo montan un backend que
+ * se comporta como PostgREST — nunca devuelve más de 1.000 filas por
+ * llamada, respeta `.range()` — y verifican la CIFRA.
+ */
+
+const HOOK = resolve(__dirname, '../components/finanzas/hooks/useDashboardData.ts');
+const fuente = readFileSync(HOOK, 'utf-8');
+
+// --- Cifras reales de producción (2026-08-20), usadas como fixture ---
+const FILAS_2A = 1760;
+const TOTAL_2A = 3264382075.87;
+const TOTAL_CON_TOPE = 1828104228;
+const FILAS_2025 = 1156;
+const TOTAL_2025 = 2071350517;
+
+const TOPE_POSTGREST = 1000;
+
+interface Fila {
+  id: string;
+  fecha: string;
+  valor: number;
+  negocio_id: string;
+  fin_negocios: { nombre: string };
+  estado: string;
+}
+
+/**
+ * Reparte `total` entre `n` filas repartidas por los cuatro trimestres de
+ * cada año, de forma que la suma dé exactamente `total`.
+ */
+function generarGastos(n: number, total: number, anios: number[]): Fila[] {
+  const centavos = Math.round(total * 100);
+  const base = Math.floor(centavos / n);
+  const resto = centavos - base * n;
+  return Array.from({ length: n }, (_, i) => {
+    const anio = anios[i % anios.length];
+    const mes = String((i % 12) + 1).padStart(2, '0');
+    const dia = String((i % 28) + 1).padStart(2, '0');
+    return {
+      id: `g-${String(i).padStart(6, '0')}`,
+      fecha: `${anio}-${mes}-${dia}`,
+      valor: (base + (i < resto ? 1 : 0)) / 100,
+      negocio_id: 'neg-1',
+      fin_negocios: { nombre: 'Aguacate Hass' },
+      estado: 'Confirmado',
+    };
+  });
+}
+
+/**
+ * Backend falso con el comportamiento exacto que produjo el error: si el
+ * llamante no pide `.range(...)`, devuelve las primeras 1.000 filas y calla.
+ */
+function crearSupabaseFalso(filas: Fila[]) {
+  const llamadas: { rango: [number, number] | null; orden: string[] }[] = [];
+
+  function builder(fuenteFilas: Fila[]) {
+    let datos = fuenteFilas;
+    let rango: [number, number] | null = null;
+    const orden: string[] = [];
+
+    const api: any = {
+      select: () => api,
+      eq: (col: string, val: unknown) => {
+        datos = datos.filter((f) => (f as any)[col] === val);
+        return api;
+      },
+      in: () => api,
+      not: () => api,
+      gte: (col: string, val: string) => {
+        datos = datos.filter((f) => (f as any)[col] >= val);
+        return api;
+      },
+      lte: (col: string, val: string) => {
+        datos = datos.filter((f) => (f as any)[col] <= val);
+        return api;
+      },
+      order: (col: string, opts?: { ascending?: boolean }) => {
+        orden.push(`${col}:${opts?.ascending === false ? 'desc' : 'asc'}`);
+        return api;
+      },
+      range: (desde: number, hasta: number) => {
+        rango = [desde, hasta];
+        return api;
+      },
+      then: (resolver: (r: { data: Fila[] | null; error: null }) => unknown) => {
+        // Orden total, igual que en Postgres con ORDER BY fecha, id.
+        const ordenadas = [...datos].sort((a, b) => {
+          const desc = orden[0]?.endsWith(':desc');
+          const cmp = a.fecha === b.fecha ? a.id.localeCompare(b.id) : a.fecha < b.fecha ? -1 : 1;
+          return desc ? -cmp : cmp;
+        });
+        llamadas.push({ rango, orden: [...orden] });
+        const desde = rango ? rango[0] : 0;
+        const hastaPedido = rango ? rango[1] - rango[0] + 1 : Infinity;
+        const cuantas = Math.min(hastaPedido, TOPE_POSTGREST);
+        return Promise.resolve(resolver({ data: ordenadas.slice(desde, desde + cuantas), error: null }));
+      },
+    };
+    return api;
+  }
+
+  return {
+    cliente: { from: (_tabla: string) => builder(filas) },
+    llamadas,
+  };
+}
+
+const filasMock = vi.fn<() => Fila[]>(() => []);
+
+vi.mock('@/utils/supabase/client', () => ({
+  getSupabase: () => crearSupabaseFalso(filasMock()).cliente,
+}));
+
+const { useDashboardData } = await import('@/components/finanzas/hooks/useDashboardData');
+
+/**
+ * `useDashboardData` usa `useState`, así que hay que montarlo. Mismo
+ * precedente que `climaCardFranja.test.tsx`: SSR con `renderToStaticMarkup`
+ * para capturar la API del hook, sin añadir dependencias de testing.
+ */
+function apiDelHook() {
+  let api: ReturnType<typeof useDashboardData> | null = null;
+  function Sonda() {
+    api = useDashboardData();
+    return null;
+  }
+  renderToStaticMarkup(React.createElement(Sonda));
+  return api!;
+}
+
+function sumarSeries(data: Record<string, number | string>[]): number {
+  return data.reduce((total, fila) => {
+    return (
+      total +
+      Object.entries(fila).reduce(
+        (s, [k, v]) => (k === 'trimestre' ? s : s + (typeof v === 'number' ? v : 0)),
+        0,
+      )
+    );
+  }, 0);
+}
+
+describe('useDashboardData — tope de 1.000 filas de PostgREST', () => {
+  beforeEach(() => {
+    vi.useRealTimers();
+    filasMock.mockReset();
+  });
+
+  // ---------------------------------------------------------------- comporta.
+  it('la gráfica de gastos por trimestre suma los $3.264M reales, no los $1.828M que entrega el tope', async () => {
+    // El hook consulta `${año-1}-01-01` .. `${año}-12-31`. Fijamos el reloj
+    // en 2026 para reproducir exactamente la ventana de dos años del defecto.
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-20T12:00:00-05:00'));
+
+    const filas = generarGastos(FILAS_2A, TOTAL_2A, [2025, 2026]);
+    filasMock.mockReturnValue(filas);
+
+    const { getGastosPorTrimestreMultiSerie } = apiDelHook();
+    const { data } = await getGastosPorTrimestreMultiSerie({} as any);
+    vi.useRealTimers();
+
+    const total = sumarSeries(data as Record<string, number | string>[]);
+
+    expect(total).toBeCloseTo(TOTAL_2A, 2);
+    // La cifra que veía Gerencia. Si vuelve a aparecer, el tope volvió.
+    expect(total).not.toBeCloseTo(TOTAL_CON_TOPE, 2);
+    expect(TOTAL_2A - TOTAL_CON_TOPE).toBeGreaterThan(1_400_000_000);
+  });
+
+  it('sin paginar, ese mismo backend entrega exactamente 1.000 filas — el defecto es real, no hipotético', async () => {
+    const filas = generarGastos(FILAS_2A, TOTAL_2A, [2025, 2026]);
+    const { cliente } = crearSupabaseFalso(filas);
+    // La consulta tal cual estaba antes del arreglo: sin `.range()`.
+    const { data } = await (cliente
+      .from('fin_gastos')
+      .select('fecha, valor')
+      .eq('estado', 'Confirmado')
+      .gte('fecha', '2025-01-01')
+      .lte('fecha', '2026-12-31') as any);
+    expect(data).toHaveLength(TOPE_POSTGREST);
+    expect(filas).toHaveLength(FILAS_2A);
+  });
+
+  it('los KPIs de gastos suman el año completo (1.156 filas de 2025), no las primeras 1.000', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-20T12:00:00-05:00'));
+
+    const filas = generarGastos(FILAS_2025, TOTAL_2025, [2025]);
+    filasMock.mockReturnValue(filas);
+
+    const { getKPIsGastosGeneral } = apiDelHook();
+    const kpis = await getKPIsGastosGeneral({} as any);
+    vi.useRealTimers();
+
+    // `totalAnterior` = Total 2025 completo.
+    expect(kpis.totalAnterior.valor).toBeCloseTo(TOTAL_2025, 2);
+  });
+
+  it('no duplica ni pierde filas al cruzar la frontera de página', async () => {
+    vi.useFakeTimers();
+    vi.setSystemTime(new Date('2026-08-20T12:00:00-05:00'));
+
+    // 2.500 filas de $1 cada una: cualquier duplicado o salto en el borde de
+    // las páginas 1.000 / 2.000 se ve en el total al peso.
+    const filas = generarGastos(2500, 2500, [2025, 2026]);
+    filasMock.mockReturnValue(filas);
+
+    const { getGastosPorTrimestreMultiSerie } = apiDelHook();
+    const { data } = await getGastosPorTrimestreMultiSerie({} as any);
+    vi.useRealTimers();
+
+    expect(sumarSeries(data as Record<string, number | string>[])).toBeCloseTo(2500, 2);
+  });
+
+  // ---------------------------------------------------------------- estático.
+  it('ninguna lectura de fin_gastos/fin_ingresos queda sin paginar', () => {
+    expect(fuente).toContain("import { fetchAll } from '@/utils/supabase/fetchAll';");
+
+    // Cada `.from('fin_gastos'|'fin_ingresos')` tiene que estar dentro de un
+    // callback de `fetchAll` y terminar en `.range(rangoDesde, rangoHasta)`.
+    const lecturas = [...fuente.matchAll(/\.from\('fin_(?:gastos|ingresos)'\)/g)];
+    expect(lecturas.length).toBeGreaterThanOrEqual(12);
+    for (const lectura of lecturas) {
+      const i = lectura.index!;
+      const antes = fuente.slice(Math.max(0, i - 600), i);
+      const despues = fuente.slice(i, i + 1200);
+      expect(antes, `sin fetchAll: ...${despues.slice(0, 80)}`).toContain('fetchAll<');
+      expect(despues, `sin range: ...${despues.slice(0, 80)}`).toContain('.range(rangoDesde, rangoHasta)');
+    }
+  });
+
+  it('toda consulta paginada lleva orden total (fecha + id), porque range() es un OFFSET', () => {
+    // Un OFFSET sobre un resultado sin orden total no es reproducible entre
+    // páginas: dos filas con la misma `fecha` pueden salir en distinto orden
+    // en la página 1 y en la 2, y entonces una se duplica y otra se pierde.
+    expect(fuente).toMatch(/function ordenarDeterminista[\s\S]*?\.order\('fecha'[\s\S]*?\.order\('id'/);
+
+    const usos = [...fuente.matchAll(/\.range\(rangoDesde, rangoHasta\)/g)];
+    const ordenados = [...fuente.matchAll(/ordenarDeterminista\(/g)];
+    // Una definición + un uso por cada consulta paginada.
+    expect(ordenados.length).toBe(usos.length + 1);
+  });
+
+  it('las consultas paginadas piden id y fecha, que es lo que el orden necesita', () => {
+    const selects = [...fuente.matchAll(/\.select\('([^']*)'\)/g)]
+      .map((m) => m[1])
+      .filter((s) => s.includes('valor'));
+    expect(selects.length).toBeGreaterThanOrEqual(12);
+    for (const sel of selects) {
+      expect(sel).toMatch(/\bid\b/);
+      expect(sel).toMatch(/\bfecha\b/);
+    }
+  });
+});

--- a/src/components/finanzas/hooks/useDashboardData.ts
+++ b/src/components/finanzas/hooks/useDashboardData.ts
@@ -1,5 +1,6 @@
 import { useState } from 'react';
 import { getSupabase } from '@/utils/supabase/client';
+import { fetchAll } from '@/utils/supabase/fetchAll';
 import { calcularRangoFechasPorPeriodo } from '@/utils/fechas';
 import type {
   FiltrosFinanzas,
@@ -44,6 +45,22 @@ function resolveFechas(filtros: FiltrosFinanzas) {
   return { fecha_desde: filtros.fecha_desde || '', fecha_hasta: filtros.fecha_hasta || '' };
 }
 
+/**
+ * Orden total y determinista para paginar.
+ *
+ * `fetchAll` pagina por `.range(desde, hasta)`, o sea por OFFSET. Un offset
+ * sobre un resultado sin orden total no es reproducible entre páginas: dos
+ * filas con la misma `fecha` pueden salir en distinto orden en la página 1 y
+ * en la 2, y entonces una fila se duplica y otra se pierde. Por eso todas las
+ * consultas paginadas de este hook ordenan por `fecha` y desempatan por `id`,
+ * que es la PK.
+ */
+function ordenarDeterminista(query: any, ascendente = true) {
+  return query
+    .order('fecha', { ascending: ascendente })
+    .order('id', { ascending: ascendente });
+}
+
 export function useDashboardData() {
   const [loading, setLoading] = useState(false);
   const supabase = getSupabase();
@@ -70,18 +87,25 @@ export function useDashboardData() {
     return query;
   };
 
+  // Un año completo de gastos ya pasa del tope: 1.356 filas en 2024 y 1.156
+  // en 2025 (producción, 2026-08-20). Sin paginar, `Total 2024` mostraba un
+  // -25,0% y `Total 2025` un -11,7% frente a la cifra real.
   async function sumGastos(desde: string, hasta: string, negocioId?: string) {
-    let q: any = supabase.from('fin_gastos').select('valor').eq('estado', 'Confirmado').gte('fecha', desde).lte('fecha', hasta);
-    if (negocioId) q = q.eq('negocio_id', negocioId);
-    const { data } = await q;
-    return (data as any[])?.reduce((s: number, r: any) => s + (r.valor || 0), 0) || 0;
+    const { filas } = await fetchAll<{ valor: number | null }>((rangoDesde, rangoHasta) => {
+      let q: any = supabase.from('fin_gastos').select('id, fecha, valor').eq('estado', 'Confirmado').gte('fecha', desde).lte('fecha', hasta);
+      if (negocioId) q = q.eq('negocio_id', negocioId);
+      return ordenarDeterminista(q).range(rangoDesde, rangoHasta);
+    });
+    return filas.reduce((s: number, r) => s + (r.valor || 0), 0);
   }
 
   async function sumIngresos(desde: string, hasta: string, negocioId?: string) {
-    let q: any = supabase.from('fin_ingresos').select('valor').gte('fecha', desde).lte('fecha', hasta);
-    if (negocioId) q = q.eq('negocio_id', negocioId);
-    const { data } = await q;
-    return (data as any[])?.reduce((s: number, r: any) => s + (r.valor || 0), 0) || 0;
+    const { filas } = await fetchAll<{ valor: number | null }>((rangoDesde, rangoHasta) => {
+      let q: any = supabase.from('fin_ingresos').select('id, fecha, valor').gte('fecha', desde).lte('fecha', hasta);
+      if (negocioId) q = q.eq('negocio_id', negocioId);
+      return ordenarDeterminista(q).range(rangoDesde, rangoHasta);
+    });
+    return filas.reduce((s: number, r) => s + (r.valor || 0), 0);
   }
 
   function variacion(actual: number, anterior: number) {
@@ -140,14 +164,17 @@ export function useDashboardData() {
             sumGastos(fullPrev2.desde, fullPrev2.hasta, neg.id),
           ]);
 
-          // Get categories and conceptos for this negocio
-          const { data: catData } = await (supabase
-            .from('fin_gastos')
-            .select('categoria_id, concepto_id, valor, fecha, fin_categorias_gastos(nombre), fin_conceptos_gastos(nombre)')
-            .eq('estado', 'Confirmado')
-            .eq('negocio_id', neg.id)
-            .gte('fecha', fullPrev2.desde)
-            .lte('fecha', ytdCurrent.hasta) as any);
+          // Get categories and conceptos for this negocio.
+          // Tres años por negocio: el mayor va en 984 filas (producción,
+          // 2026-08-20), a 16 del tope. Latente, no teórico.
+          const { filas: catData } = await fetchAll<any>((rangoDesde, rangoHasta) =>
+            (ordenarDeterminista(supabase
+              .from('fin_gastos')
+              .select('id, categoria_id, concepto_id, valor, fecha, fin_categorias_gastos(nombre), fin_conceptos_gastos(nombre)')
+              .eq('estado', 'Confirmado')
+              .eq('negocio_id', neg.id)
+              .gte('fecha', fullPrev2.desde)
+              .lte('fecha', ytdCurrent.hasta)).range(rangoDesde, rangoHasta) as any));
 
           const catMap = new Map<string, {
             nombre: string;
@@ -155,7 +182,7 @@ export function useDashboardData() {
             conceptos: Map<string, { nombre: string; ytd_actual: number; ytd_anterior: number; total_anterior: number; total_n2: number }>;
           }>();
 
-          catData?.forEach((g: any) => {
+          catData.forEach((g: any) => {
             const catId = g.categoria_id || 'sin_cat';
             const catNombre = g.fin_categorias_gastos?.nombre || 'Sin categoria';
             if (!catMap.has(catId)) {
@@ -221,19 +248,25 @@ export function useDashboardData() {
     setLoading(true);
     try {
       const year = new Date().getFullYear();
-      const { data: gastos } = await (supabase
-        .from('fin_gastos')
-        .select('fecha, valor, negocio_id, fin_negocios(nombre)')
-        .eq('estado', 'Confirmado')
-        .gte('fecha', `${year - 1}-01-01`)
-        .lte('fecha', `${year}-12-31`) as any);
+      // La gráfica del tablero por defecto. Dos años de gastos son 1.760
+      // filas (producción, 2026-08-20): PostgREST devolvía las primeras 1.000
+      // y se perdían $1.436M de $3.264M (44,0%). Como no había orden, el
+      // corte lo decidía el heap y se repartía por todos los trimestres sin
+      // dejar hueco visible.
+      const { filas: gastos } = await fetchAll<any>((rangoDesde, rangoHasta) =>
+        (ordenarDeterminista(supabase
+          .from('fin_gastos')
+          .select('id, fecha, valor, negocio_id, fin_negocios(nombre)')
+          .eq('estado', 'Confirmado')
+          .gte('fecha', `${year - 1}-01-01`)
+          .lte('fecha', `${year}-12-31`)).range(rangoDesde, rangoHasta) as any));
 
-      if (!gastos || gastos.length === 0) return { data: [], negocios: [] };
+      if (gastos.length === 0) return { data: [], negocios: [] };
 
       const negocioNames = new Set<string>();
       const quarterMap = new Map<string, Record<string, number>>();
 
-      (gastos as any[]).forEach((g: any) => {
+      gastos.forEach((g: any) => {
         const qLabel = getQuarterLabel(g.fecha);
         const negNombre = g.fin_negocios?.nombre || 'Otro';
         negocioNames.add(negNombre);
@@ -257,15 +290,16 @@ export function useDashboardData() {
     setLoading(true);
     try {
       const { fecha_desde, fecha_hasta } = resolveFechas(_filtros);
-      let q: any = supabase
-        .from('fin_gastos')
-        .select('valor, fin_categorias_gastos(nombre), fin_negocios(nombre)')
-        .eq('estado', 'Confirmado');
-      if (fecha_desde) q = q.gte('fecha', fecha_desde);
-      if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
-
-      const { data: gastos } = await q;
-      if (!gastos || gastos.length === 0) return { data: [], negocios: [] };
+      const { filas: gastos } = await fetchAll<any>((rangoDesde, rangoHasta) => {
+        let q: any = supabase
+          .from('fin_gastos')
+          .select('id, fecha, valor, fin_categorias_gastos(nombre), fin_negocios(nombre)')
+          .eq('estado', 'Confirmado');
+        if (fecha_desde) q = q.gte('fecha', fecha_desde);
+        if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
+        return ordenarDeterminista(q).range(rangoDesde, rangoHasta);
+      });
+      if (gastos.length === 0) return { data: [], negocios: [] };
 
       const negocioNames = new Set<string>();
       const catMap = new Map<string, Record<string, number>>();
@@ -341,17 +375,16 @@ export function useDashboardData() {
     setLoading(true);
     try {
       const year = new Date().getFullYear();
-      const { data: ingresos } = await (supabase
-        .from('fin_ingresos')
-        .select('fecha, valor')
-        .eq('negocio_id', negocioId)
-        .gte('fecha', `${year - 1}-01-01`)
-        .lte('fecha', `${year}-12-31`) as any);
-
-      if (!ingresos) return [];
+      const { filas: ingresos } = await fetchAll<any>((rangoDesde, rangoHasta) =>
+        (ordenarDeterminista(supabase
+          .from('fin_ingresos')
+          .select('id, fecha, valor')
+          .eq('negocio_id', negocioId)
+          .gte('fecha', `${year - 1}-01-01`)
+          .lte('fecha', `${year}-12-31`)).range(rangoDesde, rangoHasta) as any));
 
       const qMap = new Map<string, number>();
-      (ingresos as any[]).forEach((i: any) => {
+      ingresos.forEach((i: any) => {
         const q = getQuarterLabel(i.fecha);
         qMap.set(q, (qMap.get(q) || 0) + (i.valor || 0));
       });
@@ -369,20 +402,20 @@ export function useDashboardData() {
     try {
       const year = new Date().getFullYear();
       const regionId = typeof _filtros.region_id === 'string' ? _filtros.region_id : undefined;
-      let q: any = supabase
-        .from('fin_gastos')
-        .select('fecha, valor')
-        .eq('estado', 'Confirmado')
-        .eq('negocio_id', negocioId)
-        .gte('fecha', `${year - 1}-01-01`)
-        .lte('fecha', `${year}-12-31`);
-      if (regionId) q = q.eq('region_id', regionId);
-      const { data: gastos } = await q;
-
-      if (!gastos) return [];
+      const { filas: gastos } = await fetchAll<any>((rangoDesde, rangoHasta) => {
+        let q: any = supabase
+          .from('fin_gastos')
+          .select('id, fecha, valor')
+          .eq('estado', 'Confirmado')
+          .eq('negocio_id', negocioId)
+          .gte('fecha', `${year - 1}-01-01`)
+          .lte('fecha', `${year}-12-31`);
+        if (regionId) q = q.eq('region_id', regionId);
+        return ordenarDeterminista(q).range(rangoDesde, rangoHasta);
+      });
 
       const qMap = new Map<string, number>();
-      (gastos as any[]).forEach((g: any) => {
+      gastos.forEach((g: any) => {
         const q = getQuarterLabel(g.fecha);
         qMap.set(q, (qMap.get(q) || 0) + (g.valor || 0));
       });
@@ -399,16 +432,16 @@ export function useDashboardData() {
     setLoading(true);
     try {
       const { fecha_desde, fecha_hasta } = resolveFechas(_filtros);
-      let q: any = supabase
-        .from('fin_ingresos')
-        .select('fecha, nombre, valor, cantidad, precio_unitario, cosecha, alianza, cliente, finca, fin_categorias_ingresos(nombre), fin_compradores(nombre)')
-        .eq('negocio_id', negocioId)
-        .order('fecha', { ascending: false });
-      if (fecha_desde) q = q.gte('fecha', fecha_desde);
-      if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
-
-      const { data } = await q;
-      return (data || []).map((d: any) => ({
+      const { filas: data } = await fetchAll<any>((rangoDesde, rangoHasta) => {
+        let q: any = supabase
+          .from('fin_ingresos')
+          .select('id, fecha, nombre, valor, cantidad, precio_unitario, cosecha, alianza, cliente, finca, fin_categorias_ingresos(nombre), fin_compradores(nombre)')
+          .eq('negocio_id', negocioId);
+        if (fecha_desde) q = q.gte('fecha', fecha_desde);
+        if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
+        return ordenarDeterminista(q, false).range(rangoDesde, rangoHasta);
+      });
+      return data.map((d: any) => ({
         fecha: d.fecha,
         tipo_ingreso: d.fin_categorias_ingresos?.nombre || d.nombre,
         cantidad: d.cantidad,
@@ -433,15 +466,16 @@ export function useDashboardData() {
     try {
       const year = new Date().getFullYear();
       const ytd = getYTDRange(year);
-      const { data } = await (supabase
-        .from('fin_ingresos')
-        .select('valor, cantidad, fin_categorias_ingresos(nombre)')
-        .eq('negocio_id', negocioId)
-        .not('cantidad', 'is', null)
-        .gte('fecha', ytd.desde)
-        .lte('fecha', ytd.hasta) as any);
+      const { filas: data } = await fetchAll<any>((rangoDesde, rangoHasta) =>
+        (ordenarDeterminista(supabase
+          .from('fin_ingresos')
+          .select('id, fecha, valor, cantidad, fin_categorias_ingresos(nombre)')
+          .eq('negocio_id', negocioId)
+          .not('cantidad', 'is', null)
+          .gte('fecha', ytd.desde)
+          .lte('fecha', ytd.hasta)).range(rangoDesde, rangoHasta) as any));
 
-      const rows = ((data || []) as any[]).filter((r: any) =>
+      const rows = data.filter((r: any) =>
         !categoriaFiltro ||
         (r.fin_categorias_ingresos?.nombre || '').toLowerCase().includes(categoriaFiltro.toLowerCase())
       );
@@ -461,18 +495,18 @@ export function useDashboardData() {
     try {
       const { fecha_desde, fecha_hasta } = resolveFechas(_filtros);
       const regionId = typeof _filtros.region_id === 'string' ? _filtros.region_id : undefined;
-      let q: any = supabase
-        .from('fin_gastos')
-        .select('fecha, nombre, valor, fin_categorias_gastos(nombre), fin_conceptos_gastos(nombre)')
-        .eq('estado', 'Confirmado')
-        .eq('negocio_id', negocioId)
-        .order('fecha', { ascending: false });
-      if (regionId) q = q.eq('region_id', regionId);
-      if (fecha_desde) q = q.gte('fecha', fecha_desde);
-      if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
-
-      const { data } = await q;
-      return (data || []).map((d: any) => ({
+      const { filas: data } = await fetchAll<any>((rangoDesde, rangoHasta) => {
+        let q: any = supabase
+          .from('fin_gastos')
+          .select('id, fecha, nombre, valor, fin_categorias_gastos(nombre), fin_conceptos_gastos(nombre)')
+          .eq('estado', 'Confirmado')
+          .eq('negocio_id', negocioId);
+        if (regionId) q = q.eq('region_id', regionId);
+        if (fecha_desde) q = q.gte('fecha', fecha_desde);
+        if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
+        return ordenarDeterminista(q, false).range(rangoDesde, rangoHasta);
+      });
+      return data.map((d: any) => ({
         fecha: d.fecha,
         categoria: d.fin_categorias_gastos?.nombre || '',
         concepto: d.fin_conceptos_gastos?.nombre || d.nombre,
@@ -487,18 +521,19 @@ export function useDashboardData() {
     setLoading(true);
     try {
       const { fecha_desde, fecha_hasta } = resolveFechas(_filtros);
-      let q: any = supabase
-        .from('fin_ingresos')
-        .select('valor, fin_categorias_ingresos(nombre)')
-        .eq('negocio_id', negocioId);
-      if (fecha_desde) q = q.gte('fecha', fecha_desde);
-      if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
-
-      const { data } = await q;
-      if (!data || data.length === 0) return [];
+      const { filas: data } = await fetchAll<any>((rangoDesde, rangoHasta) => {
+        let q: any = supabase
+          .from('fin_ingresos')
+          .select('id, fecha, valor, fin_categorias_ingresos(nombre)')
+          .eq('negocio_id', negocioId);
+        if (fecha_desde) q = q.gte('fecha', fecha_desde);
+        if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
+        return ordenarDeterminista(q).range(rangoDesde, rangoHasta);
+      });
+      if (data.length === 0) return [];
 
       const catMap = new Map<string, number>();
-      (data as any[]).forEach((d: any) => {
+      data.forEach((d: any) => {
         const name = d.fin_categorias_ingresos?.nombre || 'Sin categoria';
         catMap.set(name, (catMap.get(name) || 0) + (d.valor || 0));
       });
@@ -517,20 +552,21 @@ export function useDashboardData() {
     try {
       const { fecha_desde, fecha_hasta } = resolveFechas(_filtros);
       const regionId = typeof _filtros.region_id === 'string' ? _filtros.region_id : undefined;
-      let q: any = supabase
-        .from('fin_gastos')
-        .select('valor, fin_categorias_gastos(nombre)')
-        .eq('estado', 'Confirmado')
-        .eq('negocio_id', negocioId);
-      if (regionId) q = q.eq('region_id', regionId);
-      if (fecha_desde) q = q.gte('fecha', fecha_desde);
-      if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
-
-      const { data } = await q;
-      if (!data || data.length === 0) return [];
+      const { filas: data } = await fetchAll<any>((rangoDesde, rangoHasta) => {
+        let q: any = supabase
+          .from('fin_gastos')
+          .select('id, fecha, valor, fin_categorias_gastos(nombre)')
+          .eq('estado', 'Confirmado')
+          .eq('negocio_id', negocioId);
+        if (regionId) q = q.eq('region_id', regionId);
+        if (fecha_desde) q = q.gte('fecha', fecha_desde);
+        if (fecha_hasta) q = q.lte('fecha', fecha_hasta);
+        return ordenarDeterminista(q).range(rangoDesde, rangoHasta);
+      });
+      if (data.length === 0) return [];
 
       const catMap = new Map<string, number>();
-      (data as any[]).forEach((d: any) => {
+      data.forEach((d: any) => {
         const name = d.fin_categorias_gastos?.nombre || 'Sin categoria';
         catMap.set(name, (catMap.get(name) || 0) + (d.valor || 0));
       });


### PR DESCRIPTION
Notion: [ESCO-2 — P1](https://app.notion.com/3b167755ed68818d9438e86878b7d494)

## Bug

La gráfica de gastos del tablero de Finanzas (`/finanzas`, vista por defecto) mostraba **$1.828M** donde la verdad son **$3.264M**: se perdían **$1.436M (44,0%)** sin señal alguna.

Los KPIs de la misma pantalla tenían el mismo defecto en su propia escala: `Total 2024` salía **−25,0%** y `Total 2025` **−11,7%** frente a la cifra real.

Esto es plata mal mostrada a Gerencia.

## Root cause

`getGastosPorTrimestreMultiSerie` (`useDashboardData.ts`) pedía **dos años** de `fin_gastos` con `.select(...)` a secas: sin `.range()`, sin `fetchAll`, sin `.limit()`. PostgREST corta en 1.000 filas y **no avisa** — no hay error, no hay bandera, la respuesta se ve normal.

Dos agravantes:

1. **Sin `.order()`**, el corte lo decidía el orden físico del heap. Las 760 filas perdidas se repartían entre 2025 y 2026 sin dejar ningún trimestre vacío, así que no había hueco que notar — y podían cambiar entre una carga y otra.
2. **No era una sola consulta.** Las 12 lecturas de `fin_gastos`/`fin_ingresos` del hook estaban igual. `sumGastos`/`sumIngresos` alimentan los KPIs y un año completo ya pasa del tope (1.356 filas en 2024, 1.156 en 2025). Y la consulta de categorías del pivot va hoy en **984 filas — a 16 del tope**: no era teórica, era cuestión de semanas.

`/finanzas/reportes` nunca tuvo el problema porque ya usa `fetchAll` (`useReportesFinancierosData.ts:133-157`), que es exactamente lo que el `CLAUDE.md` manda: *"All report queries must go through `fetchAll`"*.

## Fix

Mismo remedio que el PR #131 (`useClimaData`, 910 días perdidos): las 12 lecturas pasan por `fetchAll`.

Además, **todas ordenan por `fecha` + `id`**. `fetchAll` pagina con `.range()`, que es un OFFSET: sobre un resultado sin orden **total** el offset no es reproducible entre páginas — dos filas con la misma `fecha` pueden salir en distinto orden en la página 1 y en la 2, y entonces una se duplica y otra se pierde. `fecha` sola no alcanza; `id` es la PK y cierra el orden. Va en un helper (`ordenarDeterminista`) para que no se olvide en la próxima consulta.

**No se toca ninguna regla contable.** Los filtros de `estado='Confirmado'`, negocio, región y rango de fechas quedan iguales carácter por carácter; sólo cambia cómo se traen las filas. Único cambio de comportamiento colateral: `fetchAll` lanza ante un error de red donde antes se tragaba el error y devolvía 0. Los tres consumidores (`DashboardGeneral`, `DashboardNegocio`, `DashboardGanado`) ya envuelven en `try/catch`, así que el modo de falla pasa de *"muestra $0 en silencio"* a *"no muestra nada"* — mejor para una pantalla de plata, y sin caída.

## Verification

**Verdad de terreno (producción `ywhtjwawnkeqlwxbvgup`, SELECT, 2026-08-20):**

```sql
select count(*) as filas, sum(valor) as total
from fin_gastos
where estado = 'Confirmado'
  and fecha between '2025-01-01' and '2026-12-31';
-- filas = 1760   total = 3264382075.87
```

```sql
-- lo que PostgREST entregaba sin paginar
select sum(valor) from (
  select valor from fin_gastos
  where estado = 'Confirmado'
    and fecha between '2025-01-01' and '2026-12-31'
  limit 1000
) t;
-- 1828104228.00
```

| | Filas | Total |
|---|---:|---:|
| **Antes** (tope de 1.000) | 1.000 | **$1.828.104.228** |
| **Después** (`fetchAll`) | 1.760 | **$3.264.382.075,87** |
| Faltante | 760 | **$1.436.277.847,87 (44,0%)** |

> El hallazgo citaba **$3.238.535.771,87** al 2026-08-10. La diferencia son **10 gastos capturados desde entonces** (594 → 604 filas en 2026): es la misma cifra, medida hoy. La prueba de aceptación se cumple — el total ya no es el truncado de $1.828M sino la suma completa.

**Guarda de regresión**: `src/__tests__/finanzasDashboardPaginadoGuard.test.tsx` (7 casos).

Cuatro son **de comportamiento**, no de implementación: montan un backend falso que se porta como PostgREST (nunca devuelve más de 1.000 filas por llamada, respeta `.range()`), lo cargan con las 1.760 filas y los $3.264M reales, y verifican **la cifra**.

- la gráfica suma $3.264.382.075,87 y **no** $1.828.104.228
- ese mismo backend, consultado como estaba el código antes, entrega exactamente 1.000 filas — el defecto se reproduce, no se supone
- los KPIs suman las 1.156 filas de 2025 completas
- 2.500 filas de $1 cruzan dos fronteras de página sin duplicar ni perder ni un peso

Los otros tres son estáticos (toda lectura dentro de `fetchAll` + `.range()`, orden total, `select` con `id` y `fecha`).

**Contraprueba** — con el `useDashboardData.ts` de `origin/main`, **6 de los 7 fallan**. (El séptimo pasa porque es el que demuestra que el tope existe; no toca el hook.)

**En el worktree:**
- `npx tsc --noEmit` → limpio
- `npm run lint` → **0 errores** (942 → 952 warnings, las 10 son `no-explicit-any` en el estilo que ya tenía el archivo)
- `npm test` → **2.828 pruebas, 121 archivos, todo verde**

## Rollback

`git revert 936451c`. Un solo archivo de producción y un archivo de prueba nuevo; sin migraciones, sin cambios de esquema, sin despliegue de edge functions. Revertir devuelve la cifra truncada.

## Follow-up

**Ninguna otra consulta trunca hoy** — lo verifiqué contra producción, no de vista. El máximo por negocio-año es **451 filas** (Aguacate Hass 2023) y `fin_transacciones_ganado` tiene **94 filas en total**. Quedan fuera de este PR a propósito: son componentes distintos y el arreglo aquí ya es el que estaba mal mostrando plata.

Por orden de riesgo real:

1. **`src/components/finanzas/components/GastosList.tsx:172`** — el único con riesgo vivo. El historial de gastos no pagina; por defecto filtra `ytd` (604 filas hoy, seguro), pero con `rango_personalizado` el rango lo pone el usuario y **el histórico completo son 4.474 filas**. Un rango amplio trunca hoy mismo. `IngresosList.tsx:164` es su gemelo pero `fin_ingresos` tiene 232 filas en total, así que no corre peligro todavía.
2. **`src/components/finanzas/hooks/useGanadoData.ts:100`** y **`src/components/finanzas/dashboard/components/GastosDetalleDialog.tsx:71`** — misma pantalla, mismo defecto de forma, pero acotados por negocio (Ganado: máx. 163 filas/año) o por negocio+categoría (máx. 200). Latentes.
3. **`src/components/finanzas/hooks/usePresupuestoData.ts:252`**, **`src/components/produccion/hooks/useCostoKg.ts:215`** — un negocio por año, máx. 451. Latentes.

Aparte: `applyFilters` (línea 68) es código muerto desde antes de este PR — no lo llama nadie. No lo toqué para no mezclar.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4)_