### PR TITLE
fix(clima): reja de frescura — el Tablero deja de rotular "Ahora" una lectura vieja y de desaparecer a las 24 h

### DIFF
--- a/src/__tests__/calculosSaludDatos.test.ts
+++ b/src/__tests__/calculosSaludDatos.test.ts
@@ -12,12 +12,14 @@ import {
   diasDesde,
   clasificarPorCadencia,
   clasificarClima,
+  clasificarFrescuraEstacion,
   construirSenalesSaludDatos,
   UMBRAL_MONITOREO,
   UMBRAL_CHEQUEO,
   UMBRAL_PESAJE,
   UMBRAL_QUINCENA,
 } from '@/utils/calculosSaludDatos';
+import { UMBRAL_FRESCURA_LECTURA } from '@/utils/calculosClima';
 
 describe('diasDesde', () => {
   it('calcula días entre una fecha pasada y hoy', () => {
@@ -73,9 +75,10 @@ describe('construirSenalesSaludDatos', () => {
     ultimaQuincena: { anio: 2026, mes: 7, quincena: 2 as const },
     climaConfiables: 7,
     climaTotal: 10,
+    minutosUltimaLectura: 12,
   };
 
-  it('caso real completo: cinco señales con las edades exactas del plan', () => {
+  it('caso real completo: las señales con las edades exactas del plan', () => {
     const senales = construirSenalesSaludDatos(base);
     const porClave = Object.fromEntries(senales.map((s) => [s.clave, s]));
 
@@ -84,11 +87,19 @@ describe('construirSenalesSaludDatos', () => {
     expect(porClave.pesaje.detalle).toBe('4 d');
     expect(porClave.quincena.detalle).toBe('julio Q2');
     expect(porClave.clima.detalle).toBe('7 de 10 días confiables');
+    expect(porClave.estacion.detalle).toBe('hace 12 min');
   });
 
-  it('el orden es siempre: monitoreo, chequeo, pesaje, quincena, clima', () => {
+  it('el orden es siempre: monitoreo, chequeo, pesaje, quincena, clima, estación', () => {
     const senales = construirSenalesSaludDatos(base);
-    expect(senales.map((s) => s.clave)).toEqual(['monitoreo', 'chequeo', 'pesaje', 'quincena', 'clima']);
+    expect(senales.map((s) => s.clave)).toEqual([
+      'monitoreo',
+      'chequeo',
+      'pesaje',
+      'quincena',
+      'clima',
+      'estacion',
+    ]);
   });
 
   it('clasifica el nivel de cada señal con sus propios umbrales -- caso real, todo fresco salvo el clima', () => {
@@ -99,6 +110,7 @@ describe('construirSenalesSaludDatos', () => {
     expect(porClave.pesaje.nivel).toBe('verde'); // 4 <= 7
     expect(porClave.quincena.nivel).toBe('verde'); // fin de julio Q2 (31-jul) a 16-ago = 16 d <= 20
     expect(porClave.clima.nivel).toBe('ambar'); // 7 de 10 confiables
+    expect(porClave.estacion.nivel).toBe('verde'); // 12 min <= 30
   });
 
   it('chequeo pasado el umbral rojo (75 d, el mismo punto en que el plan lo escala a "Requiere tu decisión")', () => {
@@ -121,7 +133,7 @@ describe('construirSenalesSaludDatos', () => {
 
   it('sin módulo hato_lechero, no aparecen chequeo/pesaje/quincena', () => {
     const senales = construirSenalesSaludDatos({ ...base, hasHato: false });
-    expect(senales.map((s) => s.clave)).toEqual(['monitoreo', 'clima']);
+    expect(senales.map((s) => s.clave)).toEqual(['monitoreo', 'clima', 'estacion']);
   });
 
   it('sin ningún módulo, arreglo vacío', () => {
@@ -137,6 +149,7 @@ describe('construirSenalesSaludDatos', () => {
       ultimaQuincena: null,
       climaConfiables: null,
       climaTotal: null,
+      minutosUltimaLectura: null,
     });
     const porClave = Object.fromEntries(senales.map((s) => [s.clave, s]));
     expect(porClave.monitoreo).toMatchObject({ detalle: 'nunca', nivel: 'gris' });
@@ -144,5 +157,40 @@ describe('construirSenalesSaludDatos', () => {
     expect(porClave.pesaje).toMatchObject({ detalle: 'nunca', nivel: 'gris' });
     expect(porClave.quincena).toMatchObject({ detalle: 'nunca', nivel: 'gris' });
     expect(porClave.clima).toMatchObject({ nivel: 'gris' });
+    expect(porClave.estacion).toMatchObject({ detalle: 'sin lecturas', nivel: 'gris' });
+  });
+
+  // ------------------------------------------------------------------
+  // Señal "Estación" (frescura de clima_lecturas) -- corte de luz del
+  // 2026-08-19/20 en la finca: 14 h sin una sola lectura mientras la señal
+  // "Clima" (confiabilidad de lluvia) seguía diciendo "ok".
+  // ------------------------------------------------------------------
+
+  it('la estación muda no contagia a la señal de clima ni al revés: son dos señales distintas', () => {
+    const senales = construirSenalesSaludDatos({
+      ...base,
+      climaConfiables: 10,
+      climaTotal: 10,
+      minutosUltimaLectura: 14 * 60, // el corte real: 14 h
+    });
+    const porClave = Object.fromEntries(senales.map((s) => [s.clave, s]));
+    expect(porClave.clima.nivel).toBe('verde'); // los días que llegaron son confiables
+    expect(porClave.estacion.nivel).toBe('rojo'); // pero la estación está muda
+    expect(porClave.estacion.detalle).toBe('hace 14 h');
+  });
+});
+
+describe('clasificarFrescuraEstacion', () => {
+  it('usa los MISMOS umbrales que las tarjetas de clima (30 min / 3 h), no unos propios', () => {
+    expect(UMBRAL_FRESCURA_LECTURA).toEqual({ frescaMinutos: 30, demoradaMinutos: 180 });
+    expect(clasificarFrescuraEstacion(5)).toBe('verde');
+    expect(clasificarFrescuraEstacion(30)).toBe('verde');
+    expect(clasificarFrescuraEstacion(31)).toBe('ambar');
+    expect(clasificarFrescuraEstacion(180)).toBe('ambar');
+    expect(clasificarFrescuraEstacion(181)).toBe('rojo');
+  });
+
+  it('sin ninguna lectura, gris ("sin lecturas") -- nunca verde por omisión', () => {
+    expect(clasificarFrescuraEstacion(null)).toBe('gris');
   });
 });

--- a/src/__tests__/climaFrescura.test.tsx
+++ b/src/__tests__/climaFrescura.test.tsx
@@ -1,0 +1,229 @@
+import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import { MemoryRouter } from 'react-router-dom';
+import type { LecturaClima, ResumenDiario } from '@/types/clima';
+import {
+  UMBRAL_FRESCURA_LECTURA,
+  clasificarFrescuraLectura,
+  etiquetaEdadLectura,
+  lecturaEsReciente,
+  minutosDesdeLectura,
+} from '@/utils/calculosClima';
+
+/**
+ * Frescura de la lectura en vivo (ESCO-31). Caso real: el 2026-08-19 a las
+ * 21:05 Bogotá la finca se quedó sin luz; la estación no envió una lectura
+ * más hasta las 11:30 del día siguiente (14 h 25 min de hueco, verificado
+ * contra producción). Durante todo ese rato el Tablero mostró la lectura de
+ * las 21:05 — 19,5 °C / 0 W/m² / 0 km/h — bajo el rótulo "Ahora".
+ *
+ * `useClimaData` hace I/O contra Supabase dentro de un `useEffect`, que SSR
+ * no ejecuta -- por eso se mockea, mismo precedente que
+ * `climaCardFranja.test.tsx`.
+ */
+
+const AHORA = new Date('2026-08-20T11:00:00-05:00');
+
+function haceMinutos(min: number): string {
+  return new Date(AHORA.getTime() - min * 60_000).toISOString();
+}
+
+describe('minutosDesdeLectura', () => {
+  it('mide la edad en minutos sobre el instante de la lectura', () => {
+    expect(minutosDesdeLectura({ timestamp: haceMinutos(0) }, AHORA)).toBe(0);
+    expect(minutosDesdeLectura({ timestamp: haceMinutos(45) }, AHORA)).toBe(45);
+    expect(minutosDesdeLectura({ timestamp: haceMinutos(14 * 60 + 25) }, AHORA)).toBe(865);
+  });
+
+  it('sin lectura, null -- nunca 0, que significaría "recién llegada"', () => {
+    expect(minutosDesdeLectura(null, AHORA)).toBeNull();
+    expect(minutosDesdeLectura(undefined, AHORA)).toBeNull();
+    expect(minutosDesdeLectura({ timestamp: 'no es una fecha' }, AHORA)).toBeNull();
+  });
+
+  it('una lectura con timestamp futuro (reloj de la estación adelantado) da 0, nunca negativo', () => {
+    expect(minutosDesdeLectura({ timestamp: haceMinutos(-10) }, AHORA)).toBe(0);
+  });
+});
+
+describe('lecturaEsReciente', () => {
+  it('la lectura de hace 5 min sirve como condiciones actuales', () => {
+    expect(lecturaEsReciente({ timestamp: haceMinutos(5) }, undefined, AHORA)).toBe(true);
+  });
+
+  it('la del corte de luz (14 h) no', () => {
+    expect(lecturaEsReciente({ timestamp: haceMinutos(14 * 60) }, undefined, AHORA)).toBe(false);
+  });
+
+  it('sin lectura, false -- nunca true por omisión', () => {
+    expect(lecturaEsReciente(null, undefined, AHORA)).toBe(false);
+  });
+
+  it('el umbral es parametrizable, con el default en UMBRAL_FRESCURA_LECTURA', () => {
+    expect(UMBRAL_FRESCURA_LECTURA.frescaMinutos).toBe(30);
+    expect(UMBRAL_FRESCURA_LECTURA.demoradaMinutos).toBe(180);
+    expect(lecturaEsReciente({ timestamp: haceMinutos(45) }, undefined, AHORA)).toBe(false);
+    expect(lecturaEsReciente({ timestamp: haceMinutos(45) }, 60, AHORA)).toBe(true);
+  });
+});
+
+describe('clasificarFrescuraLectura', () => {
+  it('fresca hasta el umbral inclusive, demorada hasta el segundo, obsoleta por encima', () => {
+    expect(clasificarFrescuraLectura({ timestamp: haceMinutos(5) }, AHORA)).toBe('fresca');
+    expect(clasificarFrescuraLectura({ timestamp: haceMinutos(30) }, AHORA)).toBe('fresca');
+    expect(clasificarFrescuraLectura({ timestamp: haceMinutos(31) }, AHORA)).toBe('demorada');
+    expect(clasificarFrescuraLectura({ timestamp: haceMinutos(180) }, AHORA)).toBe('demorada');
+    expect(clasificarFrescuraLectura({ timestamp: haceMinutos(181) }, AHORA)).toBe('obsoleta');
+  });
+
+  it('sin ninguna lectura es obsoleta, no "fresca por defecto" -- tras la poda de 24 h de la migración 036 eso es justamente una estación muda hace más de un día', () => {
+    expect(clasificarFrescuraLectura(null, AHORA)).toBe('obsoleta');
+  });
+});
+
+describe('etiquetaEdadLectura', () => {
+  it('minutos, horas y días, con formato colombiano', () => {
+    expect(etiquetaEdadLectura(0)).toBe('hace instantes');
+    expect(etiquetaEdadLectura(45)).toBe('hace 45 min');
+    expect(etiquetaEdadLectura(59)).toBe('hace 59 min');
+    expect(etiquetaEdadLectura(60)).toBe('hace 1 h');
+    expect(etiquetaEdadLectura(14 * 60 + 25)).toBe('hace 14 h'); // el corte real
+    expect(etiquetaEdadLectura(72 * 60)).toBe('hace 3 d');
+  });
+
+  it('sin lectura, "sin lecturas" -- nunca "hace 0 min"', () => {
+    expect(etiquetaEdadLectura(null)).toBe('sin lecturas');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// ClimaCard: lo que ve el usuario en el Tablero General
+// ---------------------------------------------------------------------------
+
+const resultadoMock = vi.fn();
+
+vi.mock('@/hooks/useClimaData', () => ({
+  useClimaData: () => resultadoMock(),
+}));
+
+const { ClimaCard } = await import('@/components/dashboard/ClimaCard');
+
+function lectura(minutosDeAntiguedad: number): LecturaClima {
+  return {
+    id: 1,
+    timestamp: haceMinutos(minutosDeAntiguedad),
+    station_id: '84:1F:E8:35:D8:73',
+    temp_c: 19.5,
+    humedad_pct: 88,
+    viento_kmh: 0,
+    rafaga_kmh: 0,
+    viento_dir: 90,
+    lluvia_tasa_mm_hr: 0,
+    lluvia_evento_mm: 0,
+    lluvia_diaria_mm: 0,
+    lluvia_diaria_actualizada_en: null,
+    radiacion_wm2: 0,
+    uv_index: 0,
+    created_at: haceMinutos(minutosDeAntiguedad),
+  };
+}
+
+const RESUMENES: ResumenDiario[] = [
+  {
+    fecha: '2026-08-19',
+    station_id: '84:1F:E8:35:D8:73',
+    temp_c_min: 15,
+    temp_c_max: 27,
+    temp_c_avg: 21,
+    humedad_pct_min: 50,
+    humedad_pct_max: 95,
+    humedad_pct_avg: 75,
+    lluvia_total_mm: 0,
+    lluvia_confianza: 'ok',
+    viento_kmh_avg: 5,
+    rafaga_kmh_max: 12,
+    viento_dir_predominante: 90,
+    radiacion_wm2_avg: 200,
+    radiacion_wm2_max: 700,
+    uv_index_max: 6,
+    lecturas_count: 164,
+  },
+];
+
+function renderCard(estado: Record<string, unknown>) {
+  resultadoMock.mockReturnValue({
+    resumenPeriodos: [],
+    resumenesDiarios: RESUMENES,
+    loading: false,
+    estacionConfigurada: true,
+    ...estado,
+  });
+  return renderToStaticMarkup(
+    <MemoryRouter>
+      <ClimaCard />
+    </MemoryRouter>,
+  );
+}
+
+describe('ClimaCard — reja de frescura', () => {
+  const TZ_ORIGINAL = process.env.TZ;
+
+  beforeEach(() => {
+    process.env.TZ = 'America/Bogota';
+    vi.useFakeTimers();
+    vi.setSystemTime(AHORA);
+  });
+
+  afterEach(() => {
+    vi.useRealTimers();
+    process.env.TZ = TZ_ORIGINAL;
+    resultadoMock.mockReset();
+  });
+
+  it('lectura fresca: se rotula "Ahora" y se pinta sin atenuar (comportamiento previo intacto)', () => {
+    const html = renderCard({ lecturaActual: lectura(5) });
+    expect(html).toContain('Ahora');
+    expect(html).toContain('20°C'); // Math.round(19,5)
+    expect(html).not.toContain('opacity-60');
+    expect(html).not.toContain('Sin dato reciente');
+  });
+
+  it('entre 30 min y 3 h: el rótulo deja de decir "Ahora" y los valores se atenúan', () => {
+    const html = renderCard({ lecturaActual: lectura(95) });
+    expect(html).toContain('hace 1 h');
+    expect(html).not.toContain('>Ahora<');
+    expect(html).toContain('opacity-60');
+    expect(html).toContain('20°C'); // el valor sigue visible, sólo calificado
+  });
+
+  it('el caso real del corte de luz (14 h): estado explícito, sin ningún valor presentado como actual', () => {
+    const html = renderCard({ lecturaActual: lectura(14 * 60 + 25) });
+    expect(html).toContain('Sin dato reciente del clima');
+    expect(html).toContain('Última lectura hace 14 h');
+    expect(html).not.toContain('>Ahora<');
+    expect(html).not.toContain('20°C');
+    expect(html).not.toContain('0 W/m²');
+  });
+
+  it('a las ~24 h el cron poda clima_lecturas y no queda ninguna: la tarjeta lo DICE, no desaparece', () => {
+    const html = renderCard({ lecturaActual: null });
+    expect(html).not.toBe('');
+    expect(html).toContain('Sin dato reciente del clima');
+    expect(html).toContain('más de 24 h');
+  });
+
+  it('una lectura sin temperatura tampoco se pinta como actual', () => {
+    const html = renderCard({ lecturaActual: { ...lectura(2), temp_c: null } });
+    expect(html).toContain('Sin dato reciente del clima');
+  });
+
+  it('el estado "sin dato reciente" conserva la historia (franja de lluvia), que sigue siendo válida', () => {
+    const html = renderCard({ lecturaActual: null });
+    expect(html).toContain('data-estado=');
+  });
+
+  it('sin estación en toda la base, la tarjeta sí desaparece: nunca hubo clima que mostrar', () => {
+    const html = renderCard({ lecturaActual: null, resumenesDiarios: [], estacionConfigurada: false });
+    expect(html).toBe('');
+  });
+});

--- a/src/__tests__/climaFrescuraGuard.test.ts
+++ b/src/__tests__/climaFrescuraGuard.test.ts
@@ -1,0 +1,119 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { resolve, relative } from 'path';
+
+/**
+ * Guarda estructural: nadie pinta `lecturaActual` sin pasarla por la reja de
+ * frescura.
+ *
+ * `lecturaActual()` (`calculosClima.ts`) es un `max by timestamp` y nada más:
+ * no sabe si la lectura que devuelve es de hace 5 minutos o de anoche. Una
+ * pantalla que la renderiza sin mirar la edad presenta la lectura vieja como
+ * si fuera actual, y en este proyecto eso no es un detalle de UI — la finca
+ * planea aplicaciones e irrigación contra esos números.
+ *
+ * **Ya ocurrió:** el 2026-08-19 a las 21:05 Bogotá la finca se quedó sin luz.
+ * Durante ~14 h la estación no envió una sola lectura (Ecowitt respondía HTTP
+ * 200 con `{"message":"No data available"}`, así que ni el cron ni el log de
+ * la edge function se pusieron rojos) y el Tablero General siguió mostrando
+ * 19,5 °C / 0 W/m² / 0 km/h bajo el rótulo **"Ahora"**. Peor: a las ~24 h el
+ * cron de la migración 036 poda `clima_lecturas`, `lecturaActual` pasa a
+ * `null` y la tarjeta **desaparecía** del tablero en vez de decir "sin dato"
+ * — lo contrario del contrato "sin dato ≠ 0" del proyecto.
+ *
+ * La causa fue un corte de luz, o sea que **se repite**. Por eso esto es una
+ * prueba y no un comentario.
+ *
+ * Para agregar un archivo a la lista blanca tiene que ser genuinamente un
+ * sitio que no PINTA la lectura (la produce, la tipa, o la pasa hacia abajo).
+ */
+
+const SRC = resolve(__dirname, '..');
+
+/** Funciones que cuentan como "pasó por la reja". */
+const HELPERS_FRESCURA = [
+  'clasificarFrescuraLectura',
+  'lecturaEsReciente',
+  'minutosDesdeLectura',
+];
+
+/** Archivos que mencionan `lecturaActual` pero no la pintan, con el motivo. */
+const LISTA_BLANCA: Record<string, string> = {
+  'utils/calculosClima.ts':
+    'Define lecturaActual() y las propias funciones de frescura.',
+  'hooks/useClimaData.ts':
+    'Produce la lectura y la expone; no renderiza nada. La reja va en cada consumidor, que es quien decide qué decir.',
+  'components/clima/ClimaDashboard.tsx':
+    'Sólo pasa la prop a ClimaKPICards, que sí tiene la reja. No pinta ningún valor de la lectura.',
+};
+
+function archivosFuente(dir: string, acc: string[] = []): string[] {
+  for (const entrada of readdirSync(dir)) {
+    if (entrada === 'node_modules' || entrada === '__tests__') continue;
+    const ruta = resolve(dir, entrada);
+    if (statSync(ruta).isDirectory()) archivosFuente(ruta, acc);
+    else if (/\.tsx?$/.test(entrada)) acc.push(ruta);
+  }
+  return acc;
+}
+
+function mencionanLecturaActual(): { rel: string; contenido: string }[] {
+  return archivosFuente(SRC)
+    .map((f) => ({ rel: relative(SRC, f).split('\\').join('/'), contenido: readFileSync(f, 'utf8') }))
+    .filter(({ contenido }) => contenido.includes('lecturaActual'));
+}
+
+describe('todo consumidor de lecturaActual pasa por la reja de frescura', () => {
+  it('ningún componente nuevo renderiza la lectura sin mirar su edad', () => {
+    const infractores = mencionanLecturaActual()
+      .filter(({ rel }) => !(rel in LISTA_BLANCA))
+      .filter(({ contenido }) => !HELPERS_FRESCURA.some((h) => contenido.includes(h)))
+      .map(({ rel }) => rel);
+
+    expect(infractores).toEqual([]);
+  });
+
+  it('la lista blanca no tiene entradas muertas', () => {
+    const todos = mencionanLecturaActual().map(({ rel }) => rel);
+    const muertas = Object.keys(LISTA_BLANCA).filter((k) => !todos.includes(k));
+    expect(muertas).toEqual([]);
+  });
+
+  it('los dos sitios que hoy la pintan siguen teniendo la reja', () => {
+    // Regresión explícita: si alguien borra la reja de uno de estos dos, la
+    // prueba de arriba lo agarra igual, pero este caso nombra el archivo.
+    for (const rel of [
+      'components/dashboard/ClimaCard.tsx',
+      'components/clima/components/ClimaKPICards.tsx',
+    ]) {
+      const contenido = readFileSync(resolve(SRC, rel), 'utf8');
+      expect(HELPERS_FRESCURA.some((h) => contenido.includes(h))).toBe(true);
+    }
+  });
+
+  it('la tarjeta del Tablero no puede volver a desaparecer por falta de lectura', () => {
+    const card = readFileSync(resolve(SRC, 'components/dashboard/ClimaCard.tsx'), 'utf8');
+    // El único `return null` admisible es el de "la estación nunca existió".
+    const retornosNulos = card.match(/return null;/g) ?? [];
+    expect(retornosNulos.length).toBe(1);
+    expect(card).toContain('if (!estacionConfigurada) {');
+    expect(card).toContain('Sin dato reciente del clima');
+  });
+
+  it('los umbrales viven en UN solo lugar (UMBRAL_FRESCURA_LECTURA)', () => {
+    const clima = readFileSync(resolve(SRC, 'utils/calculosClima.ts'), 'utf8');
+    expect(clima).toContain('export const UMBRAL_FRESCURA_LECTURA');
+
+    // Nadie más define sus propios minutos de frescura: ni las tarjetas ni la
+    // señal "Estación" de Salud de los datos.
+    for (const rel of [
+      'components/dashboard/ClimaCard.tsx',
+      'components/clima/components/ClimaKPICards.tsx',
+      'utils/calculosSaludDatos.ts',
+      'components/dashboard/hooks/useSaludDatos.ts',
+    ]) {
+      const contenido = readFileSync(resolve(SRC, rel), 'utf8');
+      expect(contenido).not.toMatch(/const\s+UMBRAL_FRESCURA/);
+    }
+  });
+});

--- a/src/__tests__/climaTablaCorrectaGuard.test.ts
+++ b/src/__tests__/climaTablaCorrectaGuard.test.ts
@@ -46,8 +46,26 @@ const LISTA_BLANCA: Record<string, string> = {
     'Backfill del reporte semanal: completa los días que el rollup aún no produjo. La serie del reporte sale de clima_resumen_diario (arreglo de 2026-04-16).',
   'supabase/functions/server/chat.tsx':
     'execClimateData: condiciones actuales y el día en curso. La serie histórica sale de clima_resumen_diario (arreglo de 2026-08-16).',
+  'components/dashboard/hooks/useSaludDatos.ts':
+    'Señal "Estación" de Salud de los datos: es un MAX(timestamp) que quiere justamente el instante más reciente, para decir si la estación está reportando AHORA. No lee ninguna serie histórica.',
   'types/database.ts': 'Tipos generados del esquema.',
 };
+
+/**
+ * Quita los comentarios antes de buscar el nombre de la tabla: desde que
+ * `clima_lecturas` tiene también una reja de frescura, varios archivos la
+ * NOMBRAN al explicar por qué no la consultan (p. ej. "el cron de la 036 poda
+ * clima_lecturas a 24 h"). Contar esas menciones como consultas convertía la
+ * guarda en un impuesto sobre documentar bien. Se descartan los comentarios de
+ * bloque (incluidos los de JSX) y las líneas que empiezan con `//` o `*`.
+ */
+function sinComentarios(contenido: string): string {
+  return contenido
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .split('\n')
+    .filter((linea) => !/^\s*(\/\/|\*)/.test(linea))
+    .join('\n');
+}
 
 function archivosFuente(dir: string, acc: string[] = []): string[] {
   for (const entrada of readdirSync(dir)) {
@@ -61,7 +79,7 @@ function archivosFuente(dir: string, acc: string[] = []): string[] {
 
 describe('clima_lecturas solo se lee donde la ventana de 24 h es lo que se quiere', () => {
   const infractores = archivosFuente(SRC)
-    .filter((f) => readFileSync(f, 'utf8').includes('clima_lecturas'))
+    .filter((f) => sinComentarios(readFileSync(f, 'utf8')).includes('clima_lecturas'))
     .map((f) => relative(SRC, f).split('\\').join('/'))
     .filter((rel) => !(rel in LISTA_BLANCA));
 
@@ -71,7 +89,7 @@ describe('clima_lecturas solo se lee donde la ventana de 24 h es lo que se quier
 
   it('la lista blanca no tiene entradas muertas', () => {
     const todos = archivosFuente(SRC)
-      .filter((f) => readFileSync(f, 'utf8').includes('clima_lecturas'))
+      .filter((f) => sinComentarios(readFileSync(f, 'utf8')).includes('clima_lecturas'))
       .map((f) => relative(SRC, f).split('\\').join('/'));
     const muertas = Object.keys(LISTA_BLANCA).filter((k) => !todos.includes(k));
     expect(muertas).toEqual([]);

--- a/src/components/clima/components/ClimaKPICards.tsx
+++ b/src/components/clima/components/ClimaKPICards.tsx
@@ -1,7 +1,12 @@
 import { useMemo } from 'react';
-import { Thermometer, CloudRain, Wind, Droplets, Sun, Zap } from 'lucide-react';
+import { Thermometer, CloudRain, Wind, Droplets, Sun, Zap, CloudOff } from 'lucide-react';
 import { LecturaClima } from '@/types/clima';
-import { calcularResumen24h } from '@/utils/calculosClima';
+import {
+  calcularResumen24h,
+  clasificarFrescuraLectura,
+  etiquetaEdadLectura,
+  minutosDesdeLectura,
+} from '@/utils/calculosClima';
 import { estimateSunHoursToday, getRadiationStatus } from '@/utils/calculosRadiacion';
 import { WindDirectionArrow } from './WindDirectionArrow';
 import { Skeleton } from '@/components/ui/skeleton';
@@ -22,6 +27,14 @@ export function ClimaKPICards({ lecturaActual, todasLecturas, loading }: ClimaKP
   }, [todasLecturas]);
 
   const sunStatus = todaySunEstimate ? getRadiationStatus(todaySunEstimate.sunHoursSoFar) : null;
+
+  // Misma reja de frescura que la tarjeta del Tablero: `lecturaActual` es un
+  // `max by timestamp` sin noción de edad, así que sin esto la última lectura
+  // de anoche se pinta bajo el título "Condiciones Actuales" como si fuera de
+  // hace 5 minutos. Umbrales: UMBRAL_FRESCURA_LECTURA en calculosClima.ts.
+  const minutosLectura = minutosDesdeLectura(lecturaActual);
+  const frescura = clasificarFrescuraLectura(lecturaActual);
+  const mostrarAvisoFrescura = !loading && frescura !== 'fresca';
 
   const getUVDescriptor = (uv: number | null) => {
     if (uv === null) return '--';
@@ -76,7 +89,24 @@ export function ClimaKPICards({ lecturaActual, todasLecturas, loading }: ClimaKP
   );
 
   return (
-    <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4">
+    <div className="space-y-3">
+      {mostrarAvisoFrescura && (
+        <div className="flex items-start gap-2 rounded-lg border border-amber-200 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+          <CloudOff className="w-4 h-4 shrink-0 mt-0.5" aria-hidden="true" />
+          <span>
+            {minutosLectura === null
+              ? 'La estación no envía lecturas desde hace más de 24 h.'
+              : `Última lectura ${etiquetaEdadLectura(minutosLectura)}.`}{' '}
+            Los valores de abajo no son las condiciones actuales.
+          </span>
+        </div>
+      )}
+
+      <div
+        className={`grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-4 ${
+          frescura === 'obsoleta' && !loading ? 'opacity-60' : ''
+        }`}
+      >
       {/* Temperatura */}
       <KPICard
         icon={<Thermometer className="w-6 h-6" />}
@@ -179,6 +209,7 @@ export function ClimaKPICards({ lecturaActual, todasLecturas, loading }: ClimaKP
         unit={`(${getUVDescriptor(lecturaActual?.uv_index ?? null)})`}
         color="from-purple-400 to-pink-500"
       />
+      </div>
     </div>
   );
 }

--- a/src/components/dashboard/ClimaCard.tsx
+++ b/src/components/dashboard/ClimaCard.tsx
@@ -1,14 +1,20 @@
 import { useEffect, useMemo, useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { Cloud, Droplets, Wind, CloudRain, Sun } from 'lucide-react';
+import { Cloud, Droplets, Wind, CloudRain, Sun, CloudOff } from 'lucide-react';
 import { useClimaData } from '@/hooks/useClimaData';
 import { getSupabase } from '@/utils/supabase/client';
 import { projectId } from '@/utils/supabase/info.tsx';
 import { aggregateRadiation } from '@/utils/calculosRadiacion';
 import { fechaAISODate, obtenerFechaHoy } from '@/utils/fechas';
 import { formatNumber } from '@/utils/format';
-import { construirFranjaLluvia } from '@/utils/calculosClima';
+import {
+  construirFranjaLluvia,
+  clasificarFrescuraLectura,
+  etiquetaEdadLectura,
+  minutosDesdeLectura,
+} from '@/utils/calculosClima';
 import { FranjaLluvia } from './FranjaLluvia';
+import type { ResumenClima } from '@/types/clima';
 
 interface DiaPronostico {
   date: string;
@@ -83,11 +89,55 @@ export function ClimaCard() {
     return <div className="h-20 bg-gray-100 rounded-2xl animate-pulse" />;
   }
 
-  if (!estacionConfigurada || !lecturaActual || lecturaActual.temp_c === null) {
+  // Única razón para no pintar nada: la estación nunca existió (ni una
+  // lectura ni un resumen en toda la base). Que DEJE de reportar no es eso —
+  // eso se dice, no se esconde. Antes esta guarda también cubría
+  // `!lecturaActual`, y como el cron de la migración 036 poda
+  // `clima_lecturas` a 24 h, una estación muda un día entero hacía
+  // desaparecer la tarjeta del Tablero en silencio.
+  if (!estacionConfigurada) {
     return null;
   }
 
   const resumenSemana = resumenPeriodos.find((p) => p.label === 'Semana')?.resumen ?? null;
+
+  // Reja de frescura: `lecturaActual` es un `max by timestamp` sin noción de
+  // edad, así que la última lectura de anoche llegaba acá indistinguible de
+  // una de hace 5 minutos y se rotulaba "Ahora" (2026-08-19/20: 14 h de corte
+  // de luz en la finca mostrando 19,5°C / 0 W/m² / 0 km/h como actuales).
+  // Umbrales: UMBRAL_FRESCURA_LECTURA en calculosClima.ts.
+  const minutosLectura = minutosDesdeLectura(lecturaActual);
+  const frescura = clasificarFrescuraLectura(lecturaActual);
+  if (frescura === 'obsoleta' || !lecturaActual || lecturaActual.temp_c === null) {
+    return (
+      <div
+        onClick={() => navigate('/clima')}
+        className="bg-white rounded-2xl p-4 border border-gray-200 hover:border-primary/40 transition-all cursor-pointer space-y-3"
+      >
+        <div className="flex items-start gap-3">
+          <CloudOff className="w-6 h-6 text-brand-brown/40 shrink-0" aria-hidden="true" />
+          <div className="min-w-0">
+            <p className="text-sm font-medium text-foreground">Sin dato reciente del clima</p>
+            <p className="text-xs text-brand-brown/60">
+              {minutosLectura === null
+                ? 'La estación no envía lecturas desde hace más de 24 h.'
+                : `Última lectura ${etiquetaEdadLectura(minutosLectura)}.`}{' '}
+              Los datos de abajo son historia, no condiciones actuales.
+            </p>
+          </div>
+        </div>
+
+        {resumenSemana && <ResumenSemana resumen={resumenSemana} sunHoursSemana={sunHoursSemana} />}
+
+        <FranjaLluvia dias={franjaLluvia10Dias} visibleEnMovil={7} />
+      </div>
+    );
+  }
+
+  // A partir de acá la lectura existe, tiene temperatura y es 'fresca' o
+  // 'demorada'. En 'demorada' los valores se atenúan y el rótulo deja de
+  // decir "Ahora".
+  const atenuado = frescura === 'demorada' ? 'opacity-60' : '';
 
   return (
     <div
@@ -95,14 +145,16 @@ export function ClimaCard() {
       className="bg-white rounded-2xl p-4 border border-gray-200 hover:border-primary/40 transition-all cursor-pointer space-y-3"
     >
       <div className="flex items-center gap-4 flex-wrap">
-        <span className="text-[10px] uppercase text-brand-brown/40 tracking-wide">Ahora</span>
+        <span className="text-[10px] uppercase text-brand-brown/40 tracking-wide">
+          {frescura === 'fresca' ? 'Ahora' : etiquetaEdadLectura(minutosLectura)}
+        </span>
 
-        <div className="flex items-center gap-2">
+        <div className={`flex items-center gap-2 ${atenuado}`}>
           <Cloud className="w-8 h-8 text-primary/70" />
           <span className="text-2xl font-semibold text-foreground">{Math.round(lecturaActual.temp_c)}°C</span>
         </div>
 
-        <div className="flex items-center gap-3 text-xs text-brand-brown/60 flex-wrap">
+        <div className={`flex items-center gap-3 text-xs text-brand-brown/60 flex-wrap ${atenuado}`}>
           {lecturaActual.humedad_pct !== null && (
             <span className="flex items-center gap-1">
               <Droplets className="w-3.5 h-3.5" /> {Math.round(lecturaActual.humedad_pct)}%
@@ -142,34 +194,7 @@ export function ClimaCard() {
         )}
       </div>
 
-      {resumenSemana && (
-        <div className="pt-3 border-t border-gray-100 flex items-center gap-4 flex-wrap text-xs text-brand-brown/70">
-          <span className="text-[10px] uppercase text-brand-brown/40 tracking-wide">Esta semana</span>
-          {resumenSemana.lluvia_total_mm !== null && (
-            <span className="flex items-center gap-1">
-              <CloudRain className="w-3.5 h-3.5 text-blue-400" /> {formatMm(resumenSemana.lluvia_total_mm)} acumulados
-            </span>
-          )}
-          {resumenSemana.temp_promedio_c !== null && (
-            <span>
-              Prom. {resumenSemana.temp_promedio_c.toFixed(1)}°C
-              {resumenSemana.temp_max_c !== null && resumenSemana.temp_min_c !== null && (
-                <span className="text-brand-brown/50"> ({resumenSemana.temp_min_c.toFixed(0)}°–{resumenSemana.temp_max_c.toFixed(0)}°)</span>
-              )}
-            </span>
-          )}
-          {resumenSemana.rafaga_max_kmh !== null && (
-            <span className="flex items-center gap-1">
-              <Wind className="w-3.5 h-3.5" /> ráfaga máx. {Math.round(resumenSemana.rafaga_max_kmh)} km/h
-            </span>
-          )}
-          {sunHoursSemana !== null && (
-            <span className="flex items-center gap-1">
-              <Sun className="w-3.5 h-3.5 text-amber-500" /> {sunHoursSemana.toFixed(1)} h-sol/día
-            </span>
-          )}
-        </div>
-      )}
+      {resumenSemana && <ResumenSemana resumen={resumenSemana} sunHoursSemana={sunHoursSemana} />}
 
       <FranjaLluvia dias={franjaLluvia10Dias} visibleEnMovil={7} />
     </div>
@@ -178,4 +203,45 @@ export function ClimaCard() {
 
 function formatMm(mm: number): string {
   return `${formatNumber(mm, mm < 10 ? 1 : 0)} mm`;
+}
+
+// El resumen semanal y la franja de lluvia salen de `clima_resumen_diario`,
+// no de la lectura en vivo: siguen siendo válidos (son historia) cuando la
+// estación está muda, así que el estado "sin dato reciente" los conserva en
+// vez de dejar la tarjeta hueca.
+function ResumenSemana({
+  resumen,
+  sunHoursSemana,
+}: {
+  resumen: ResumenClima;
+  sunHoursSemana: number | null;
+}) {
+  return (
+    <div className="pt-3 border-t border-gray-100 flex items-center gap-4 flex-wrap text-xs text-brand-brown/70">
+      <span className="text-[10px] uppercase text-brand-brown/40 tracking-wide">Esta semana</span>
+      {resumen.lluvia_total_mm !== null && (
+        <span className="flex items-center gap-1">
+          <CloudRain className="w-3.5 h-3.5 text-blue-400" /> {formatMm(resumen.lluvia_total_mm)} acumulados
+        </span>
+      )}
+      {resumen.temp_promedio_c !== null && (
+        <span>
+          Prom. {resumen.temp_promedio_c.toFixed(1)}°C
+          {resumen.temp_max_c !== null && resumen.temp_min_c !== null && (
+            <span className="text-brand-brown/50"> ({resumen.temp_min_c.toFixed(0)}°–{resumen.temp_max_c.toFixed(0)}°)</span>
+          )}
+        </span>
+      )}
+      {resumen.rafaga_max_kmh !== null && (
+        <span className="flex items-center gap-1">
+          <Wind className="w-3.5 h-3.5" /> ráfaga máx. {Math.round(resumen.rafaga_max_kmh)} km/h
+        </span>
+      )}
+      {sunHoursSemana !== null && (
+        <span className="flex items-center gap-1">
+          <Sun className="w-3.5 h-3.5 text-amber-500" /> {sunHoursSemana.toFixed(1)} h-sol/día
+        </span>
+      )}
+    </div>
+  );
 }

--- a/src/components/dashboard/hooks/useSaludDatos.ts
+++ b/src/components/dashboard/hooks/useSaludDatos.ts
@@ -11,11 +11,20 @@
 // "Hoy en la finca" (`construirFranjaLluvia`, `calculosClima.ts`) -- nunca
 // se relee `lluvia_total_mm` a mano aquí, esa es exactamente la trampa que
 // `lluviaConfiableDeResumen()` existe para cerrar (CLAUDE.md, migración 068).
+//
+// La señal "Estación" es una consulta APARTE, contra `clima_lecturas`, y mide
+// otra cosa: si la estación está reportando ahora. La de "Clima" mide la
+// confiabilidad del contador de lluvia de los días que sí llegaron, así que
+// decía "ok" el 2026-08-20 con la estación muda desde las 21:05 de la noche
+// anterior (14 h de corte de luz en la finca). Ninguna de las dos reemplaza a
+// la otra. Ésta es la única lectura de `clima_lecturas` fuera del tablero en
+// vivo, y es legítima justamente porque quiere el instante más reciente y
+// nada más -- ver `climaTablaCorrectaGuard.test.ts`.
 
 import { useEffect, useState } from 'react';
 import { getSupabase } from '@/utils/supabase/client';
 import { obtenerFechaHoy } from '@/utils/fechas';
-import { construirFranjaLluvia } from '@/utils/calculosClima';
+import { construirFranjaLluvia, minutosDesdeLectura } from '@/utils/calculosClima';
 import { construirSenalesSaludDatos, type SenalSaludDatos } from '@/utils/calculosSaludDatos';
 import type { QuincenaResuelta } from '@/utils/calculosDinero';
 import type { ResumenDiario } from '@/types/clima';
@@ -58,7 +67,7 @@ export function useSaludDatos(params: UseSaludDatosParams): { estado: EstadoSalu
       const supabaseSinTipos = supabase as any; // eslint-disable-line @typescript-eslint/no-explicit-any
 
       try {
-        const [monitoreoRes, climaRes, chequeoRes, pesajeRes, quincenaRes] = await Promise.all([
+        const [monitoreoRes, climaRes, estacionRes, chequeoRes, pesajeRes, quincenaRes] = await Promise.all([
           hasAguacate
             ? supabase
                 .from('monitoreos')
@@ -72,6 +81,13 @@ export function useSaludDatos(params: UseSaludDatosParams): { estado: EstadoSalu
                 .select('fecha, lluvia_total_mm, lluvia_confianza')
                 .order('fecha', { ascending: false })
                 .limit(LIMITE_FETCH_CLIMA)
+            : Promise.resolve({ data: null, error: null }),
+          hasAguacate
+            ? supabaseSinTipos
+                .from('clima_lecturas')
+                .select('timestamp')
+                .order('timestamp', { ascending: false })
+                .limit(1)
             : Promise.resolve({ data: null, error: null }),
           hasHato
             ? supabaseSinTipos.from('hato_chequeos').select('fecha').order('fecha', { ascending: false }).limit(1)
@@ -102,6 +118,12 @@ export function useSaludDatos(params: UseSaludDatosParams): { estado: EstadoSalu
           climaConfiables = franja.filter((d) => d.estado !== 'sin_dato').length;
         }
 
+        // `null` cuando la tabla vino vacía: tras la poda de 24 h de la
+        // migración 036 eso es "la estación no reporta desde hace más de un
+        // día", que la señal muestra como "sin lecturas" -- nunca como 0 min.
+        const filaEstacion = estacionRes.data?.[0] as { timestamp: string } | undefined;
+        const minutosUltimaLectura = hasAguacate ? minutosDesdeLectura(filaEstacion ?? null) : null;
+
         const fechaUltimoChequeo: string | null =
           (chequeoRes.data?.[0] as { fecha: string } | undefined)?.fecha?.slice(0, 10) ?? null;
         const fechaUltimoPesaje: string | null =
@@ -126,6 +148,7 @@ export function useSaludDatos(params: UseSaludDatosParams): { estado: EstadoSalu
             ultimaQuincena,
             climaConfiables,
             climaTotal,
+            minutosUltimaLectura,
           }),
         );
         setEstado('listo');

--- a/src/utils/calculosClima.ts
+++ b/src/utils/calculosClima.ts
@@ -1,5 +1,6 @@
 import type { LecturaClima, ResumenClima, ResumenDiario, LecturaClimaAgregada, DatoAnualOverlay, SerieAnual } from '@/types/clima';
 import { fechaAISODate } from '@/utils/fechas';
+import { formatNumber } from '@/utils/format';
 
 function round2(n: number): number {
   return Math.round(n * 100) / 100;
@@ -107,6 +108,87 @@ export function lecturaActual(rows: LecturaClima[]): LecturaClima | null {
   return rows.reduce((latest, row) =>
     new Date(row.timestamp) > new Date(latest.timestamp) ? row : latest
   );
+}
+
+// ============================================================================
+// Frescura de la lectura en vivo (corte de luz en la finca, ESCO-31)
+// ============================================================================
+
+/**
+ * UMBRALES DE FRESCURA — ÚNICO LUGAR DONDE SE TOCAN.
+ *
+ * La estación envía una lectura cada 5 minutos, así que cualquier hueco de
+ * más de media hora ya no es jitter de la sincronización: es la estación
+ * callada (corte de luz en la finca, internet caído, Ecowitt respondiendo
+ * `{"message":"No data available"}` con HTTP 200 — que es exactamente lo que
+ * pasó el 2026-08-19/20, 14 h sin una sola lectura).
+ *
+ * Los dos números gobiernan a la vez la tarjeta del Tablero, la de `/clima`
+ * y la señal "Estación" de Salud de los datos: cambiarlos acá los cambia en
+ * los tres sitios. Son criterio de FRESCURA de captura, no una regla
+ * agronómica — mismo estatus que los umbrales de `calculosSaludDatos.ts`.
+ */
+export const UMBRAL_FRESCURA_LECTURA = {
+  /** Hasta acá la lectura se presenta como "Ahora", sin atenuar. */
+  frescaMinutos: 30,
+  /** Entre `frescaMinutos` y acá se muestra atenuada y rotulada "hace N h".
+   *  Por encima no se muestra ningún valor: estado explícito "sin dato
+   *  reciente" — un número viejo presentado como actual es peor que ninguno,
+   *  porque contra él se planean aplicaciones e irrigación. */
+  demoradaMinutos: 180,
+} as const;
+
+/** `obsoleta` incluye el caso "no hay ninguna lectura": el cron de la
+ *  migración 036 poda `clima_lecturas` a 24 h, así que una estación muda
+ *  desde hace más de un día deja la tabla vacía. Eso NO es "todo bien", y
+ *  nunca puede volver a hacer desaparecer la tarjeta en silencio. */
+export type FrescuraLectura = 'fresca' | 'demorada' | 'obsoleta';
+
+/** Edad de la lectura en minutos (redondeada hacia abajo). `null` cuando no
+ *  hay lectura o su `timestamp` no es parseable — nunca 0, que significaría
+ *  "recién llegada". Aritmética de instantes sobre `timestamptz`: no hay
+ *  trampa de huso horario acá (a diferencia de las fechas `YYYY-MM-DD`). */
+export function minutosDesdeLectura(
+  lectura: { timestamp: string } | null | undefined,
+  ahora: Date = new Date(),
+): number | null {
+  if (!lectura?.timestamp) return null;
+  const ms = new Date(lectura.timestamp).getTime();
+  if (Number.isNaN(ms)) return null;
+  return Math.max(0, Math.floor((ahora.getTime() - ms) / 60000));
+}
+
+/** ¿La lectura sirve para presentarse como condiciones actuales? Sin lectura
+ *  la respuesta es `false`, nunca `true` por omisión. */
+export function lecturaEsReciente(
+  lectura: { timestamp: string } | null | undefined,
+  maxMinutos: number = UMBRAL_FRESCURA_LECTURA.frescaMinutos,
+  ahora: Date = new Date(),
+): boolean {
+  const minutos = minutosDesdeLectura(lectura, ahora);
+  return minutos !== null && minutos <= maxMinutos;
+}
+
+export function clasificarFrescuraLectura(
+  lectura: { timestamp: string } | null | undefined,
+  ahora: Date = new Date(),
+): FrescuraLectura {
+  const minutos = minutosDesdeLectura(lectura, ahora);
+  if (minutos === null) return 'obsoleta';
+  if (minutos <= UMBRAL_FRESCURA_LECTURA.frescaMinutos) return 'fresca';
+  if (minutos <= UMBRAL_FRESCURA_LECTURA.demoradaMinutos) return 'demorada';
+  return 'obsoleta';
+}
+
+/** "hace 45 min" · "hace 14 h" · "hace 3 d" · "sin lecturas" (null). Nunca
+ *  "hace 0 min": por debajo del minuto se dice "hace instantes". */
+export function etiquetaEdadLectura(minutos: number | null): string {
+  if (minutos === null) return 'sin lecturas';
+  if (minutos < 1) return 'hace instantes';
+  if (minutos < 60) return `hace ${formatNumber(minutos, 0)} min`;
+  const horas = Math.floor(minutos / 60);
+  if (horas < 48) return `hace ${formatNumber(horas, 0)} h`;
+  return `hace ${formatNumber(Math.floor(horas / 24), 0)} d`;
 }
 
 // ============================================================================

--- a/src/utils/calculosSaludDatos.ts
+++ b/src/utils/calculosSaludDatos.ts
@@ -14,6 +14,7 @@
 // dueño los ajuste sin desplegar, es candidato a Ola 3 (ver plan §6).
 
 import { diferenciaEnDias } from '@/utils/fechas';
+import { UMBRAL_FRESCURA_LECTURA, etiquetaEdadLectura } from '@/utils/calculosClima';
 import { etiquetaQuincena, type QuincenaResuelta } from '@/utils/calculosDinero';
 import { rangoQuincena } from '@/utils/calculosHato';
 
@@ -77,12 +78,28 @@ export function clasificarClima(confiables: number, total: number): NivelSaludDa
   return 'rojo';
 }
 
+// Frescura de la ESTACIÓN (`clima_lecturas`), que es otra cosa que la señal
+// "Clima" de arriba: esa mide la CONFIABILIDAD del contador de lluvia sobre
+// los días que sí llegaron (migración 068), y por eso decía "ok" el
+// 2026-08-20 con la estación muda desde las 21:05 de la noche anterior. Ésta
+// mide si la estación está reportando AHORA. Se quedan las dos, separadas.
+//
+// Los umbrales NO se redefinen acá: son los mismos `UMBRAL_FRESCURA_LECTURA`
+// que gobiernan la tarjeta del Tablero y la de `/clima`, para que la señal no
+// pueda decir "al día" mientras la tarjeta dice "sin dato reciente".
+export function clasificarFrescuraEstacion(minutos: number | null): NivelSaludDato {
+  if (minutos === null) return 'gris';
+  if (minutos <= UMBRAL_FRESCURA_LECTURA.frescaMinutos) return 'verde';
+  if (minutos <= UMBRAL_FRESCURA_LECTURA.demoradaMinutos) return 'ambar';
+  return 'rojo';
+}
+
 // ---------------------------------------------------------------------------
-// Ensamblado de las cinco señales, en el orden fijo del diseño
+// Ensamblado de las seis señales, en el orden fijo del diseño
 // ---------------------------------------------------------------------------
 
 export interface SenalSaludDatos {
-  clave: 'monitoreo' | 'chequeo' | 'pesaje' | 'quincena' | 'clima';
+  clave: 'monitoreo' | 'chequeo' | 'pesaje' | 'quincena' | 'clima' | 'estacion';
   etiqueta: string;
   /** "13 d" · "julio Q2" · "7 de 10 días confiables" · "nunca" */
   detalle: string;
@@ -104,13 +121,18 @@ export interface InputSaludDatos {
    *  de `0`, que sí sería "se consultó y no hay ninguna lectura". */
   climaConfiables: number | null;
   climaTotal: number | null;
+  /** Edad en minutos de la última fila de `clima_lecturas`. `null` = no se
+   *  consultó (sin módulo aguacate) o la tabla no tiene ninguna fila -- que
+   *  después de la poda de 24 h de la migración 036 significa "la estación
+   *  no reporta desde hace más de un día", nunca "todo bien". */
+  minutosUltimaLectura: number | null;
 }
 
 /**
  * Arma las señales visibles del bloque "Salud de los datos", ya filtradas
  * por módulo (plan §8: "filtra sus filas por módulo -- sólo las señales de
  * sus módulos") y en el orden fijo del diseño: monitoreo, chequeo, pesaje,
- * quincena, clima. Sin ningún módulo habilitado, arreglo vacío -- el
+ * quincena, clima, estación. Sin ningún módulo habilitado, arreglo vacío -- el
  * componente decide qué hacer con eso (colapsar la sección entera, mismo
  * criterio que el resto del tablero).
  */
@@ -165,6 +187,13 @@ export function construirSenalesSaludDatos(input: InputSaludDatos): SenalSaludDa
       etiqueta: 'Clima',
       detalle: total === 0 ? 'sin datos recientes' : `${confiables} de ${total} días confiables`,
       nivel: clasificarClima(confiables, total),
+    });
+
+    senales.push({
+      clave: 'estacion',
+      etiqueta: 'Estación',
+      detalle: etiquetaEdadLectura(input.minutosUltimaLectura),
+      nivel: clasificarFrescuraEstacion(input.minutosUltimaLectura),
     });
   }
 


### PR DESCRIPTION
Cierra el hallazgo **ESCO-31** (P1) de la corrida `2026-08-20-jueves`.

## Bug

El **2026-08-19 a las 21:05 Bogotá la finca se quedó sin luz**. Santiago confirmó la causa: la estación **no está dañada y no hay nada que reparar en hardware** — volvió sola a las 11:30 de hoy, cuando volvió la energía (verificado contra producción: `clima_lecturas` tiene 164 filas del 19-ago hasta las 21:05 y luego nada hasta las 11:30 del 20-ago; 14 h 25 min de hueco).

**Eso no reduce el defecto: lo vuelve recurrente.** Cada corte de luz futuro produce exactamente esta pantalla. Durante esas 14 h:

- El Tablero General mostró **19,5 °C / 0 W/m² / 0 km/h rotulados "Ahora"** — la lectura de las 21:05 de la noche anterior — a los cinco usuarios, que planean aplicaciones e irrigación contra esos números.
- El bloque "Salud de los datos" decía **ok**, porque su señal de clima mide otra cosa (confiabilidad del contador de lluvia, migración 068) y no consultaba `clima_lecturas` en absoluto.
- Ninguna capa automática lo detectó: `pg_cron` `succeeded`, HTTP 200, log de la edge function limpio — Ecowitt responde 200 con `{"message":"No data available"}`.
- **A las ~24 h empeoraba en silencio**: el cron de la migración 036 poda `clima_lecturas` a una ventana rodante de 24 h, `lecturaActual` pasa a `null` y la tarjeta **desaparecía** del Tablero en vez de decir "sin dato" — el inverso exacto del contrato "sin dato ≠ 0" del proyecto. Si el corte se hubiera prolongado dos horas más, pasaba hoy.

## Causa raíz

`lecturaActual()` (`calculosClima.ts:105`) es un `max by timestamp` y nada más: no sabe si lo que devuelve es de hace 5 minutos o de anoche. `useClimaData` no filtra por edad y su `ultimaActualizacion` es la hora del *fetch*, no la de la lectura, así que tampoco sirve de reloj. `ClimaCard.tsx` solo se rendía con `lecturaActual == null` (`return null`, tarjeta invisible) y pintaba el rótulo "Ahora" incondicionalmente.

## Fix

Sin cambios de esquema ni de datos. Solo lectura y presentación.

1. **`src/utils/calculosClima.ts`** — sección nueva de frescura (dos hunks: una línea de import y un bloque completo después de `lecturaActual`; **cero contacto con las funciones de lluvia/cobertura**, para no chocar con el PR paralelo):
   - `UMBRAL_FRESCURA_LECTURA` — los dos umbrales, en un solo lugar.
   - `minutosDesdeLectura(lectura, ahora?)` — edad en minutos; `null` sin lectura, nunca `0`.
   - `lecturaEsReciente(lectura, maxMinutos?, ahora?)` — `false` sin lectura, nunca `true` por omisión.
   - `clasificarFrescuraLectura(...)` → `'fresca' | 'demorada' | 'obsoleta'`; **sin lectura es `obsoleta`**, porque después de la poda de 24 h eso significa "muda hace más de un día".
   - `etiquetaEdadLectura(minutos)` → `"hace 45 min"` · `"hace 14 h"` · `"sin lecturas"` (números por `formatNumber`, nunca inline).
2. **`ClimaCard.tsx`** (Tablero): entre 30 min y 3 h los valores se atenúan (`opacity-60`) y el rótulo "Ahora" se reemplaza por "hace N h"; por encima, estado explícito **"Sin dato reciente del clima — última lectura hace N h"** (o "La estación no envía lecturas desde hace más de 24 h" cuando no queda ninguna fila). **El `return null` de la línea 86 desapareció**: el único que queda es `if (!estacionConfigurada)`, o sea "la estación nunca existió en toda la base", que es distinto de "dejó de reportar". El resumen semanal y la franja de lluvia se conservan en el estado degradado — salen de `clima_resumen_diario`, son historia y siguen siendo válidos.
3. **`ClimaKPICards.tsx`** (`/clima`): la misma lectura vieja se pintaba bajo el título "Condiciones Actuales" en la pantalla de detalle. Mismo aviso, misma función pura. Es el mismo defecto, no código adyacente.
4. **`useSaludDatos.ts` + `calculosSaludDatos.ts`**: señal nueva **"Estación"** (`MAX(timestamp)` de `clima_lecturas`, `limit 1`), **junto a** la de confiabilidad de lluvia, no en su lugar — miden cosas distintas y hay una prueba que fija que una puede estar verde con la otra roja. Sin lecturas muestra "sin lecturas" en gris, nunca "0 min".
5. **Guarda estática `src/__tests__/climaFrescuraGuard.test.ts`** (patrón de `climaTablaCorrectaGuard.test.ts`): ningún archivo puede renderizar `lecturaActual` sin mencionar una de las funciones de frescura; lista blanca con motivo para los tres sitios que la producen/tipan/reenvían sin pintarla; y dos cláusulas extra — que `ClimaCard` conserve un solo `return null`, y que nadie defina umbrales de frescura propios fuera de `UMBRAL_FRESCURA_LECTURA`.

## Dónde viven los umbrales (para ajustarlos)

**`src/utils/calculosClima.ts` → `UMBRAL_FRESCURA_LECTURA`.** Un solo objeto, dos números:

```ts
export const UMBRAL_FRESCURA_LECTURA = {
  frescaMinutos: 30,    // hasta acá se dice "Ahora"
  demoradaMinutos: 180, // hasta acá se atenúa y se dice "hace N h"; por encima, "sin dato reciente"
} as const;
```

**30 min / 3 h son una propuesta, no una decisión.** Gobiernan a la vez la tarjeta del Tablero, la de `/clima` y la señal "Estación" de Salud de los datos: cambiar esos dos números los cambia en los tres sitios, sin tocar nada más. La guarda estática impide que alguien vuelva a definir umbrales propios en otro archivo. Criterio para elegirlos: la estación envía cada 5 minutos, así que 30 min ya son 6 lecturas perdidas.

## Verificación

- `npx tsc --noEmit` — limpio.
- `npm run lint` — **0 errores** (942 warnings preexistentes; verifiqué archivo por archivo que `ClimaKPICards.tsx` tiene los mismos 4 warnings de React Compiler que en `main`, ninguno nuevo).
- `npm test` — **122 archivos / 2.847 pruebas, todas verdes**, incluidas 23 nuevas.
- Casos cubiertos con el corte real como fixture (`climaFrescura.test.tsx`): fresca → "Ahora" sin atenuar (comportamiento previo intacto); 95 min → "hace 1 h" + atenuado, valor todavía visible; 14 h 25 min → estado explícito y **ningún valor** presentado como actual; `lecturaActual: null` → la tarjeta **dice** que no hay dato en vez de desaparecer; estación inexistente → sigue devolviendo `''`.
- Producción, solo `SELECT`: confirmado el hueco 19-ago 21:05 → 20-ago 11:30 y que la estación volvió (última lectura hace 1 min al momento de escribir).

Nota sobre `climaTablaCorrectaGuard.test.ts`: se le agregó `useSaludDatos.ts` a la lista blanca (es un `MAX(timestamp)` que quiere justamente el instante más reciente) y ahora **descarta los comentarios** antes de buscar el nombre de la tabla — varios archivos la *nombran* al explicar por qué no la consultan, y contar esas menciones como consultas convertía la guarda en un impuesto sobre documentar bien.

## Rollback

`git revert` del merge commit. No hay migración, no se escribió ni un dato, y el comportamiento previo se restaura entero. Si solo molesta la atenuación intermedia, subir `frescaMinutos` a `180` deja únicamente el estado explícito.

## Follow-up (fuera de alcance acá)

- **Detección**, que sigue sin existir: nada avisa cuando la estación se calla; la única vía es que un humano abra el Tablero. Candidato natural: extender el tick de alertas (`hato/alertas/tick`) o el cron de clima para notificar por Telegram tras N horas mudo.
- **`lluvia_diaria_mm` ("mm hoy")** en el estado `demorada` sigue mostrándose atenuado: es el contador acumulado de Ecowitt y entre las 00:00 y la primera lectura del día podría arrastrar el total de ayer — misma clase de bug que cerró la migración 068. El rótulo "hace N h" lo califica, pero merece su propia compuerta.
- `useClimaData.ultimaActualizacion` sigue siendo la hora del *fetch*. No se tocó (lo consumen otras pantallas); la frescura real ahora se deriva del `timestamp` de la lectura.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4)_