### PR TITLE
Rediseño del módulo Aplicaciones + 7 defectos de producción

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -513,6 +513,15 @@ Tailwind 4.3 **compiles on every `vite dev` / `vite build`** (`@tailwindcss/vite
 |---|---|
 | `src/index.css` | The CSS entry point — three lines: `@import "tailwindcss";`, `@import "tw-animate-css";`, `@import "./styles/globals.css";`. The **only** stylesheet `main.tsx` imports. Never hand-edit |
 | `src/styles/globals.css` | Source of truth for tokens (`:root`, `@theme inline`), `@font-face`, base typography, and the project's own CSS rules |
+
+> **`--input` dejó de ser `transparent` (2026-08-20).** `input.tsx` pinta `border-input` sobre
+> `bg-input-background` (#ffffff), así que con el token en `transparent` **todo `Input` de la app era
+> una caja blanca con borde invisible**: se leía como campo sobre el fondo off-white de la página
+> (`#F8FAF5`) y desaparecía dentro de una `Card` blanca — que es donde viven casi todos los
+> formularios. En la misma pantalla, `DateInput` sí trae su propio borde (`border-primary/20`), así
+> que dos campos vecinos se veían distintos sin ningún motivo. Ahora es el olivo de marca con algo
+> más de peso que `--border`, que está calibrado para separadores y no para bordes de campo.
+> **Lo consumen 54 archivos**: cualquier cambio a este token se ve en todos los módulos a la vez.
 | `src/components/finanzas/dashboard/components/dashboardTables.css` | Plain CSS imported directly by 4 finance table components. No Tailwind directives, so it does not depend on the import chain |
 
 **The import chain is load-bearing.** `globals.css` must enter through `index.css`, never through a JavaScript `import`. Tailwind only reads `@theme`, `@custom-variant` and `@layer base` from files reachable via the `@import "tailwindcss"` chain — import `globals.css` from `main.tsx` instead and the build still passes, CSS is still emitted, and every token silently stops existing.
@@ -585,11 +594,12 @@ See `BUG_REPORT.md` for current tracked bugs. As of the last update, the Reporte
 
 Start with [`docs/README.md`](docs/README.md) for the living-document index. Completed plans, resolved incidents and one-time setup guides live under [`docs/archive/`](docs/archive/README.md).
 
-Two module contracts live as **nested `CLAUDE.md` files** rather than in this one — they load automatically only when Claude works with files under their directory, which keeps them out of unrelated sessions. Read them directly when working on those modules.
+Three module contracts live as **nested `CLAUDE.md` files** rather than in this one — they load automatically only when Claude works with files under their directory, which keeps them out of unrelated sessions. Read them directly when working on those modules.
 
 | Document | Location | Purpose |
 |----------|----------|---------|
 | Hato Lechero contract | `src/components/hato/CLAUDE.md` | Full module contract (auto-loads under that dir) |
+| Aplicaciones contract | `src/components/aplicaciones/CLAUDE.md` | Dónde vive el plan real, qué comparaciones son legítimas, guardas del módulo (auto-loads under that dir) |
 | PO maintenance operation | `escociaos-po/CLAUDE.md` | Scheduled audit operation: agent roster, run protocol, memory layer |
 | Finanzas view contracts | `src/components/finanzas/CLAUDE.md` | Gastos/Ingresos historial, ganado merge, table CSS (auto-loads under that dir) |
 | Database schema | `docs/supabase_tablas.md` | Schema reference; validate against migrations |

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -175,10 +175,16 @@ The applications module has two distinct tracking layers — **do not confuse th
 
 | Layer | Tables | Purpose |
 |---|---|---|
-| **Planned** | `aplicaciones_lotes_planificado`, `aplicaciones_productos`, `aplicaciones_mezclas` | What was planned before execution (lot targets, product dosis, mixes) |
+| **Planned** | `aplicaciones_calculos`, `aplicaciones_productos`, `aplicaciones_mezclas` (`aplicaciones_lotes_planificado` está vacía — ver la nota debajo) | What was planned before execution (lot targets, product dosis, mixes) |
 | **Real** | `movimientos_diarios`, `movimientos_diarios_productos` | What actually happened per day (canecas, bultos, products used) |
 
-`aplicaciones_lotes_planificado` is the canonical source for planned tree counts and lot assignments. `movimientos_diarios` is the canonical source for real execution data. Never substitute one for the other.
+`movimientos_diarios` is the canonical source for real execution data. Never substitute it for a planned-layer table.
+
+> **Corregido 2026-08-20 contra producción. `aplicaciones_lotes_planificado` está VACÍA — 0 filas, las 20 aplicaciones — y nunca se escribió.** Esta línea la llamaba "the canonical source for planned tree counts and lot assignments"; no lo es, y la migración 023 la marcó "KEEP - actively used" con el mismo error. **Leerla no falla: devuelve vacío**, que es la trampa — el consumidor cae a su fallback y nadie se entera.
+>
+> **El mapeo mezcla→lote real vive en `aplicaciones_calculos.mezcla_id`** (59 de 67 filas, 16 de 20 aplicaciones). Ese es el que hay que leer. Ya costó un defecto: `CalculadoraAplicaciones.tsx` rehidrata las mezclas sin `lotes_asignados` — la tabla `aplicaciones_mezclas` no tiene esa columna — así que reabrir una aplicación guardada muestra "0 lotes" y volver a guardar escribe el vacío encima de un mapeo que el usuario no ve que todavía tenía.
+>
+> **La tabla NO se borró a propósito.** `src/hooks/useReporteAplicacion.ts` la lee en 8 sitios (la prefiere para conteo de árboles y cae a `aplicaciones_lotes`) y `chat.tsx` de Esco una vez. Borrarla rompe el Reporte. Eliminarla exige primero sacar esos lectores, y es un cambio aparte — no un rediseño.
 
 > **Removed tables** (migration 022): `aplicaciones_lotes_real`, `aplicaciones_productos_real`, `aplicaciones_productos_planificado`, `aplicaciones_mezclas_productos` — these were ghost tables from an abandoned design; they were never populated or queried.
 

--- a/src/__tests__/aplicacionesFixedInsetGuard.test.ts
+++ b/src/__tests__/aplicacionesFixedInsetGuard.test.ts
@@ -12,16 +12,19 @@ import { join, relative } from 'path';
  * de pantalla como diálogo.
  *
  * `dialogScrollContract.test.ts` ya vigila el contrato de scroll de `DialogContent`, pero
- * solo mira `DialogContent` — no puede ver estos cinco modales hechos a mano porque no usan
- * ese componente en absoluto.
+ * solo mira `DialogContent` — no puede ver los modales hechos a mano porque no usan ese
+ * componente en absoluto.
  *
- * HOY el módulo tiene exactamente 5 de estos (ver ALLOWLIST): son la Fase 0 encontrándolos,
- * no la Fase 0 introduciéndolos. La decisión 1 del contrato ya migra uno de los cinco
- * (CierreAplicacion.tsx, que hoy es una página completa disfrazada de modal) a página real con
- * `AplicacionShell` — las fases siguientes hacen lo mismo con los otros cuatro. Por eso este
- * guard está en verde hoy mismo (los 5 están en la allowlist) pero no puede admitir un sexto:
- * cualquier archivo nuevo bajo este módulo que use `fixed inset-0` hace fallar el test, con los
- * nombres de archivo listados en el mensaje de fallo.
+ * El módulo arrancó con exactamente 5 de estos (ver ALLOWLIST original en el historial de
+ * git): son la Fase 0 encontrándolos, no la Fase 0 introduciéndolos. W00 (Lista/Detalle/Iniciar
+ * Ejecución), W03 (Cierre) y W01 (Calculadora — este cambio) ya migraron los 5 a
+ * `Dialog`/`AlertDialog` reales o a `AplicacionShell` (Cierre, página completa en vez de modal
+ * falso). La confirmación de "¿Cancelar aplicación?" de `CalculadoraAplicaciones.tsx` era el
+ * último: pasó de un `<div className="fixed inset-0 ...">` a mano a `ConfirmDialog` (`AlertDialog`
+ * de Radix, regla 6 del contrato — es una acción destructiva/irreversible). La ALLOWLIST queda
+ * vacía — no es un permiso permanente, así que el guard no admite ningún archivo nuevo: cualquiera
+ * bajo este módulo que use `fixed inset-0` hace fallar el test, con los nombres de archivo
+ * listados en el mensaje de fallo.
  *
  * Busca solo dentro de valores de `className` (atributo JSX, string u objeto de plantilla),
  * nunca en texto plano del archivo — así un comentario que *mencione* "fixed inset-0" (como
@@ -31,24 +34,13 @@ import { join, relative } from 'path';
 const APLICACIONES_DIR = join(__dirname, '..', 'components', 'aplicaciones');
 
 /**
- * Los 5 modales hechos a mano que existen HOY. Cada entrada debe borrarse de esta lista
- * cuando su workflow se migra a `Dialog`/`AlertDialog` (acciones destructivas, regla 6) o a
- * `AplicacionShell` (páginas completas, como Cierre). La allowlist debe llegar a [] — no es
- * un permiso permanente.
+ * Los 5 modales hechos a mano que existían al arrancar Fase 0/1 ya migraron todos —
+ * `CalculadoraAplicaciones.tsx` era el último (ver docstring de arriba). Esta lista queda
+ * vacía a propósito: no es un permiso permanente, y la tercera prueba de este archivo
+ * (`la allowlist no contiene ningún archivo que ya haya migrado`) falla si alguien agrega
+ * una entrada que ya no tiene `fixed inset-0`.
  */
-const ALLOWLIST = new Set([
-  // Confirmación de cancelar el wizard — debería ser AlertDialog (acción destructiva/irreversible).
-  'CalculadoraAplicaciones.tsx',
-  // Confirmación de eliminar una aplicación — debería ser AlertDialog.
-  'AplicacionesList.tsx',
-  // Modal de detalle de una aplicación — debería ser Dialog + DialogContent size + DialogBody.
-  'DetalleAplicacion.tsx',
-  // Modal de iniciar ejecución — debería ser Dialog + DialogContent size + DialogBody.
-  'IniciarEjecucionModal.tsx',
-  // Hoy es la PANTALLA COMPLETA de Cierre disfrazada de modal (decisión 1 del contrato):
-  // pasa a página real en /aplicaciones/:id/cierre con AplicacionShell + AplicacionStepper.
-  'CierreAplicacion.tsx',
-]);
+const ALLOWLIST = new Set<string>([]);
 
 function collectTsx(dir: string, out: string[] = []): string[] {
   for (const entry of readdirSync(dir)) {

--- a/src/__tests__/aplicacionesFixedInsetGuard.test.ts
+++ b/src/__tests__/aplicacionesFixedInsetGuard.test.ts
@@ -1,0 +1,143 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync, readdirSync, statSync } from 'fs';
+import { join, relative } from 'path';
+
+/**
+ * Guard: prohíbe `fixed inset-0` a mano bajo `src/components/aplicaciones/`.
+ *
+ * Regla 4 del contrato de Fase 0 (`CONTRATO_FASE0.md`): los diálogos del proyecto van con
+ * `Dialog` + `DialogContent size` + `DialogBody` (Radix, accesible por defecto — foco
+ * atrapado, Escape, backdrop). Un `<div className="fixed inset-0 ...">` a mano reimplementa
+ * un modal sin nada de eso: sin trap de foco, sin cierre con Escape, invisible para lectores
+ * de pantalla como diálogo.
+ *
+ * `dialogScrollContract.test.ts` ya vigila el contrato de scroll de `DialogContent`, pero
+ * solo mira `DialogContent` — no puede ver estos cinco modales hechos a mano porque no usan
+ * ese componente en absoluto.
+ *
+ * HOY el módulo tiene exactamente 5 de estos (ver ALLOWLIST): son la Fase 0 encontrándolos,
+ * no la Fase 0 introduciéndolos. La decisión 1 del contrato ya migra uno de los cinco
+ * (CierreAplicacion.tsx, que hoy es una página completa disfrazada de modal) a página real con
+ * `AplicacionShell` — las fases siguientes hacen lo mismo con los otros cuatro. Por eso este
+ * guard está en verde hoy mismo (los 5 están en la allowlist) pero no puede admitir un sexto:
+ * cualquier archivo nuevo bajo este módulo que use `fixed inset-0` hace fallar el test, con los
+ * nombres de archivo listados en el mensaje de fallo.
+ *
+ * Busca solo dentro de valores de `className` (atributo JSX, string u objeto de plantilla),
+ * nunca en texto plano del archivo — así un comentario que *mencione* "fixed inset-0" (como
+ * este mismo, o el de AplicacionShell.tsx explicando la migración) no cuenta como violación.
+ */
+
+const APLICACIONES_DIR = join(__dirname, '..', 'components', 'aplicaciones');
+
+/**
+ * Los 5 modales hechos a mano que existen HOY. Cada entrada debe borrarse de esta lista
+ * cuando su workflow se migra a `Dialog`/`AlertDialog` (acciones destructivas, regla 6) o a
+ * `AplicacionShell` (páginas completas, como Cierre). La allowlist debe llegar a [] — no es
+ * un permiso permanente.
+ */
+const ALLOWLIST = new Set([
+  // Confirmación de cancelar el wizard — debería ser AlertDialog (acción destructiva/irreversible).
+  'CalculadoraAplicaciones.tsx',
+  // Confirmación de eliminar una aplicación — debería ser AlertDialog.
+  'AplicacionesList.tsx',
+  // Modal de detalle de una aplicación — debería ser Dialog + DialogContent size + DialogBody.
+  'DetalleAplicacion.tsx',
+  // Modal de iniciar ejecución — debería ser Dialog + DialogContent size + DialogBody.
+  'IniciarEjecucionModal.tsx',
+  // Hoy es la PANTALLA COMPLETA de Cierre disfrazada de modal (decisión 1 del contrato):
+  // pasa a página real en /aplicaciones/:id/cierre con AplicacionShell + AplicacionStepper.
+  'CierreAplicacion.tsx',
+]);
+
+function collectTsx(dir: string, out: string[] = []): string[] {
+  for (const entry of readdirSync(dir)) {
+    const full = join(dir, entry);
+    if (statSync(full).isDirectory()) {
+      collectTsx(full, out);
+    } else if (entry.endsWith('.tsx')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+/** `true` si algún `className="..."`, `className={'...'}` o `className={\`...\`}` del archivo
+ * contiene literalmente "fixed inset-0". No mira comentarios ni el resto del código fuente. */
+function usaFixedInsetAMano(source: string): boolean {
+  const classNameRe = /className\s*=\s*(?:"([^"]*)"|'([^']*)'|\{`([^`]*)`\})/g;
+  let m: RegExpExecArray | null;
+  while ((m = classNameRe.exec(source)) !== null) {
+    const valor = m[1] ?? m[2] ?? m[3] ?? '';
+    if (valor.includes('fixed inset-0')) {
+      return true;
+    }
+  }
+  return false;
+}
+
+describe('guard: fixed inset-0 a mano en src/components/aplicaciones/', () => {
+  const files = collectTsx(APLICACIONES_DIR);
+
+  it('encuentra archivos del módulo para auditar', () => {
+    expect(files.length).toBeGreaterThan(10);
+  });
+
+  it('ningún archivo fuera de la allowlist usa "fixed inset-0" a mano', () => {
+    const offenders: string[] = [];
+
+    for (const file of files) {
+      const rel = relative(APLICACIONES_DIR, file).replace(/\\/g, '/');
+      if (ALLOWLIST.has(rel)) continue;
+
+      if (usaFixedInsetAMano(readFileSync(file, 'utf-8'))) {
+        offenders.push(rel);
+      }
+    }
+
+    expect(
+      offenders,
+      `Estos archivos usan "fixed inset-0" a mano en vez de Dialog/AlertDialog ` +
+        `(regla 4 y 6 de CONTRATO_FASE0.md). Reemplázalos por Dialog + DialogContent size + ` +
+        `DialogBody, o por AlertDialog si la acción es destructiva/irreversible:\n  ` +
+        offenders.join('\n  '),
+    ).toEqual([]);
+  });
+
+  it('la allowlist no contiene ningún archivo que ya haya migrado', () => {
+    const offenders: string[] = [];
+
+    for (const rel of ALLOWLIST) {
+      const full = join(APLICACIONES_DIR, rel);
+      let source: string;
+      try {
+        source = readFileSync(full, 'utf-8');
+      } catch {
+        // El archivo ya no existe — probablemente se migró y se borró; hay que quitarlo de la
+        // allowlist en el mismo cambio.
+        offenders.push(`${rel} (no existe — quítalo de ALLOWLIST)`);
+        continue;
+      }
+      if (!usaFixedInsetAMano(source)) {
+        offenders.push(`${rel} (ya no usa "fixed inset-0" — quítalo de ALLOWLIST)`);
+      }
+    }
+
+    expect(offenders).toEqual([]);
+  });
+
+  it('detecta el patrón real: className string literal', () => {
+    const injected = '<div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">';
+    expect(usaFixedInsetAMano(injected)).toBe(true);
+  });
+
+  it('NO marca un comentario que solo menciona la frase "fixed inset-0"', () => {
+    const injected = '// migración pendiente: hoy es un modal fixed inset-0 hecho a mano';
+    expect(usaFixedInsetAMano(injected)).toBe(false);
+  });
+
+  it('NO marca un DialogContent real (Radix) aunque el archivo hable de modales', () => {
+    const injected = '<DialogContent size="md" className="p-0"><DialogBody>x</DialogBody></DialogContent>';
+    expect(usaFixedInsetAMano(injected)).toBe(false);
+  });
+});

--- a/src/__tests__/calculadoraAplicacionesHelpers.test.ts
+++ b/src/__tests__/calculadoraAplicacionesHelpers.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect } from 'vitest';
+import {
+  sugerirNombreAplicacion,
+  sugerirFechaFin,
+} from '../utils/calculadoraAplicacionesHelpers';
+
+describe('sugerirNombreAplicacion', () => {
+  it('arma "Tipo · N lotes · mes año" para fertilización con 4 lotes', () => {
+    expect(sugerirNombreAplicacion('fertilizacion', 4, '2026-08-18')).toBe(
+      'Fertilización · 4 lotes · ago 2026',
+    );
+  });
+
+  it('usa singular "lote" cuando hay exactamente 1', () => {
+    expect(sugerirNombreAplicacion('fumigacion', 1, '2026-01-05')).toBe(
+      'Fumigación · 1 lote · ene 2026',
+    );
+  });
+
+  it('capitaliza Drench igual que los otros tipos', () => {
+    expect(sugerirNombreAplicacion('drench', 2, '2026-12-01')).toBe(
+      'Drench · 2 lotes · dic 2026',
+    );
+  });
+
+  it('sin tipo aún elegido, omite el segmento de tipo', () => {
+    expect(sugerirNombreAplicacion(undefined, 3, '2026-08-18')).toBe('3 lotes · ago 2026');
+  });
+
+  it('sin lotes seleccionados, omite el segmento de lotes', () => {
+    expect(sugerirNombreAplicacion('fertilizacion', 0, '2026-08-18')).toBe(
+      'Fertilización · ago 2026',
+    );
+  });
+
+  it('sin fecha de inicio, omite el segmento de mes/año', () => {
+    expect(sugerirNombreAplicacion('fertilizacion', 4, '')).toBe('Fertilización · 4 lotes');
+  });
+
+  it('sin ningún dato, produce string vacío', () => {
+    expect(sugerirNombreAplicacion(undefined, 0, '')).toBe('');
+  });
+});
+
+describe('sugerirFechaFin', () => {
+  it('suma un mes calendario a una fecha ISO local (18/08 -> 18/09)', () => {
+    expect(sugerirFechaFin('2026-08-18')).toBe('2026-09-18');
+  });
+
+  it('cruza el fin de año correctamente (dic -> ene del siguiente año)', () => {
+    expect(sugerirFechaFin('2026-12-15')).toBe('2027-01-15');
+  });
+
+  it('cae al último día del mes destino cuando el día de origen no existe (31 ene -> 28/29 feb)', () => {
+    // 2026 no es bisiesto
+    expect(sugerirFechaFin('2026-01-31')).toBe('2026-02-28');
+  });
+
+  it('respeta años bisiestos', () => {
+    expect(sugerirFechaFin('2028-01-31')).toBe('2028-02-29');
+  });
+
+  it('string vacío devuelve string vacío', () => {
+    expect(sugerirFechaFin('')).toBe('');
+  });
+});

--- a/src/__tests__/calculosCierreAplicacion.test.ts
+++ b/src/__tests__/calculosCierreAplicacion.test.ts
@@ -1,0 +1,192 @@
+import { describe, it, expect } from 'vitest';
+import {
+  calcularDesviacionInsumo,
+  calcularInsumosConDesviacion,
+  calcularExcepcionesCierre,
+  derivarFechasEjecucionReal,
+  agruparRegistrosPorLote,
+  calcularKPIsLabores,
+  formatearListaConY,
+} from '@/utils/calculosCierreAplicacion';
+import type { RegistroTrabajoCierre } from '@/types/aplicaciones';
+
+function registro(overrides: Partial<RegistroTrabajoCierre>): RegistroTrabajoCierre {
+  return {
+    tarea_id: 't1',
+    trabajador_nombre: 'Juan Pérez',
+    trabajador_tipo: 'empleado',
+    lote_id: 'l1',
+    lote_nombre: 'Lote 1',
+    fecha_trabajo: '2026-08-05',
+    fraccion_jornal: 1,
+    costo_jornal: 100000,
+    empleado_id: 'e1',
+    ...overrides,
+  };
+}
+
+describe('calcularDesviacionInsumo', () => {
+  it('planeado 0 nunca es crítico, sin importar el aplicado (regla histórica del módulo)', () => {
+    const r = calcularDesviacionInsumo({ planeado: 0, aplicado: 5 });
+    expect(r.esCritico).toBe(false);
+    expect(r.diferencia).toBe(5);
+  });
+
+  it('desviación dentro del 15% no es crítica', () => {
+    const r = calcularDesviacionInsumo({ planeado: 100, aplicado: 110 });
+    expect(r.esCritico).toBe(false);
+    expect(r.diferencia).toBe(10);
+  });
+
+  it('desviación por encima del 15% (sobre-aplicación) es crítica', () => {
+    const r = calcularDesviacionInsumo({ planeado: 100, aplicado: 120 });
+    expect(r.esCritico).toBe(true);
+    expect(r.diferencia).toBe(20);
+  });
+
+  it('desviación por encima del 15% (sub-aplicación) también es crítica', () => {
+    const r = calcularDesviacionInsumo({ planeado: 100, aplicado: 80 });
+    expect(r.esCritico).toBe(true);
+    expect(r.diferencia).toBe(-20);
+  });
+});
+
+describe('calcularInsumosConDesviacion', () => {
+  it('anota diferencia y esCritico por cada insumo, preservando el resto de campos', () => {
+    const resultado = calcularInsumosConDesviacion([
+      { nombre: 'Magister', unidad: 'Litros', planeado: 9.13, aplicado: 9.12 },
+      { nombre: 'Citroemulsion', unidad: 'Litros', planeado: 45.5, aplicado: 60 },
+    ]);
+    expect(resultado[0]).toMatchObject({ nombre: 'Magister', esCritico: false });
+    expect(resultado[1]).toMatchObject({ nombre: 'Citroemulsion', esCritico: true });
+  });
+});
+
+describe('derivarFechasEjecucionReal', () => {
+  it('sin registros ni movimientos → fuente "ninguna", fechas null', () => {
+    const r = derivarFechasEjecucionReal([], []);
+    expect(r).toEqual({ fechaInicio: null, fechaFin: null, fuente: 'ninguna' });
+  });
+
+  it('solo registros de labor → fuente "registros", min/max de esas fechas', () => {
+    const r = derivarFechasEjecucionReal(['2026-08-05', '2026-08-02', '2026-08-09'], []);
+    expect(r).toEqual({ fechaInicio: '2026-08-02', fechaFin: '2026-08-09', fuente: 'registros' });
+  });
+
+  it('solo movimientos diarios → fuente "movimientos", min/max de esas fechas', () => {
+    const r = derivarFechasEjecucionReal([], ['2026-08-04', '2026-08-19']);
+    expect(r).toEqual({ fechaInicio: '2026-08-04', fechaFin: '2026-08-19', fuente: 'movimientos' });
+  });
+
+  it('ambas fuentes → fuente "combinado", unión de rango (nunca angosta lo ya capturado)', () => {
+    const r = derivarFechasEjecucionReal(
+      ['2026-08-05', '2026-08-10'],
+      ['2026-08-04', '2026-08-19'],
+    );
+    expect(r).toEqual({ fechaInicio: '2026-08-04', fechaFin: '2026-08-19', fuente: 'combinado' });
+  });
+
+  it('ignora strings vacíos/undefined mezclados en los arreglos', () => {
+    const r = derivarFechasEjecucionReal(['2026-08-05', '', '2026-08-02'], []);
+    expect(r).toEqual({ fechaInicio: '2026-08-02', fechaFin: '2026-08-05', fuente: 'registros' });
+  });
+});
+
+describe('agruparRegistrosPorLote', () => {
+  it('agrupa solo los registros activos (no eliminados) por lote_id, con _index estable', () => {
+    const registros: RegistroTrabajoCierre[] = [
+      registro({ id: 'r1', lote_id: 'l1', lote_nombre: 'Piedra Paula' }),
+      registro({ id: 'r2', lote_id: 'l2', lote_nombre: 'La Vega' }),
+      registro({ id: 'r3', lote_id: 'l1', lote_nombre: 'Piedra Paula', _deleted: true }),
+    ];
+    const porLote = agruparRegistrosPorLote(registros);
+    expect(porLote.size).toBe(2);
+    expect(porLote.get('l1')?.registros).toHaveLength(1);
+    expect(porLote.get('l1')?.registros[0]._index).toBe(0);
+    expect(porLote.get('l2')?.lote_nombre).toBe('La Vega');
+  });
+});
+
+describe('calcularKPIsLabores', () => {
+  it('suma jornales/costo y cuenta trabajadores y días únicos', () => {
+    const registros: RegistroTrabajoCierre[] = [
+      registro({ empleado_id: 'e1', fecha_trabajo: '2026-08-04', fraccion_jornal: 2, costo_jornal: 174000 }),
+      registro({ empleado_id: 'e1', fecha_trabajo: '2026-08-05', fraccion_jornal: 2, costo_jornal: 174000 }),
+      registro({ empleado_id: undefined, contratista_id: 'c1', fecha_trabajo: '2026-08-05', fraccion_jornal: 1.5, costo_jornal: 142500 }),
+    ];
+    const kpis = calcularKPIsLabores(registros);
+    expect(kpis.totalJornales).toBe(5.5);
+    expect(kpis.costoManoObra).toBe(490500);
+    expect(kpis.trabajadoresUnicos).toBe(2);
+    expect(kpis.diasTrabajados).toBe(2);
+  });
+});
+
+describe('formatearListaConY', () => {
+  it('lista vacía → cadena vacía', () => {
+    expect(formatearListaConY([])).toBe('');
+  });
+
+  it('un solo elemento → tal cual, sin "y"', () => {
+    expect(formatearListaConY(['Magister (9,12 Litros)'])).toBe('Magister (9,12 Litros)');
+  });
+
+  it('dos elementos → unidos por "y", sin coma', () => {
+    expect(formatearListaConY(['A', 'B'])).toBe('A y B');
+  });
+
+  it('tres o más elementos → coma entre todos salvo el último, que lleva "y"', () => {
+    expect(formatearListaConY(['A', 'B', 'C', 'D'])).toBe('A, B, C y D');
+  });
+});
+
+describe('calcularExcepcionesCierre', () => {
+  const lotes = [
+    { lote_id: 'l1', nombre: 'Piedra Paula' },
+    { lote_id: 'l2', nombre: 'La Vega' },
+    { lote_id: 'l3', nombre: 'Australia' },
+  ];
+
+  it('sin novedades: 4 insumos ok, todos los lotes con jornales, ningún costo en $0 → todo vacío', () => {
+    const insumos = [{ nombre: 'Magister', unidad: 'Litros', planeado: 9.13, aplicado: 9.12 }];
+    const registros = [
+      registro({ lote_id: 'l1', costo_jornal: 100000 }),
+      registro({ lote_id: 'l2', costo_jornal: 100000 }),
+      registro({ lote_id: 'l3', costo_jornal: 100000 }),
+    ];
+    const r = calcularExcepcionesCierre(insumos, registros, lotes, true);
+    expect(r).toEqual({ insumosCriticos: [], registrosSinTarifa: [], lotesSinLabor: [] });
+  });
+
+  it('detecta un insumo con desviación crítica', () => {
+    const insumos = [{ nombre: 'Citroemulsion', unidad: 'Litros', planeado: 45.5, aplicado: 60 }];
+    const r = calcularExcepcionesCierre(insumos, [], lotes, true);
+    expect(r.insumosCriticos).toEqual([{ nombre: 'Citroemulsion', diferencia: 14.5, unidad: 'Litros' }]);
+  });
+
+  it('detecta registros con costo_jornal en 0', () => {
+    const registros = [
+      registro({ lote_id: 'l1', costo_jornal: 0, trabajador_nombre: 'Piedra Paula' }),
+      registro({ lote_id: 'l2', costo_jornal: 100000 }),
+    ];
+    const r = calcularExcepcionesCierre([], registros, lotes, true);
+    expect(r.registrosSinTarifa).toHaveLength(1);
+    expect(r.registrosSinTarifa[0]).toMatchObject({ lote_id: 'l1', trabajador_nombre: 'Piedra Paula' });
+  });
+
+  it('detecta un lote de la aplicación sin ningún jornal registrado', () => {
+    const registros = [registro({ lote_id: 'l1' }), registro({ lote_id: 'l2' })];
+    const r = calcularExcepcionesCierre([], registros, lotes, true);
+    expect(r.lotesSinLabor).toEqual([{ lote_id: 'l3', nombre: 'Australia' }]);
+  });
+
+  it('NO marca lotes sin labor cuando la aplicación no tiene tarea vinculada (ya hay otro aviso para eso)', () => {
+    const r = calcularExcepcionesCierre([], [], lotes, false);
+    expect(r.lotesSinLabor).toEqual([]);
+  });
+
+  it('NO marca lotes sin labor cuando el fetch de lotes llegó vacío (evita falso positivo masivo)', () => {
+    const r = calcularExcepcionesCierre([], [registro({ lote_id: 'l1' })], [], true);
+    expect(r.lotesSinLabor).toEqual([]);
+  });
+});

--- a/src/__tests__/estadoAplicacionEtiquetas.test.ts
+++ b/src/__tests__/estadoAplicacionEtiquetas.test.ts
@@ -1,0 +1,67 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+/**
+ * Guarda: el estado que se guarda NO es el que se muestra.
+ *
+ * `aplicaciones.estado` guarda `Calculada`, pero la UI viene diciendo **"Planificada"** desde
+ * siempre — `AplicacionesList.tsx` lo traduce con su `ESTADO_LABELS`, el `<select>` de filtro usa
+ * esa etiqueta y el KPI dice "Planificadas". La primera versión de `EstadoAplicacionBadge`
+ * renderizaba `{estado}` crudo; al cablearla a las 5 pantallas habría cambiado esa palabra en
+ * silencio, sin migración, sin error de tipos y sin que ningún test existente lo notara.
+ *
+ * Esta guarda es estática a propósito: el defecto no es de comportamiento (el componente
+ * "funciona" igual), es de contrato con la usuaria, y solo se ve leyendo qué texto sale a pantalla.
+ */
+
+const RAIZ = join(__dirname, '..');
+const BADGE = join(RAIZ, 'components/aplicaciones/shared/EstadoAplicacionBadge.tsx');
+const LISTA = join(RAIZ, 'components/aplicaciones/AplicacionesList.tsx');
+
+/** Único par estado-guardado → etiqueta-visible que puede divergir. El resto es identidad. */
+const TRADUCCION_OBLIGATORIA = { guardado: 'Calculada', visible: 'Planificada' } as const;
+
+describe('EstadoAplicacionBadge — etiquetas visibles', () => {
+  const badge = readFileSync(BADGE, 'utf8');
+
+  it('traduce el estado guardado a la etiqueta que ve la usuaria, no lo imprime crudo', () => {
+    expect(
+      badge.includes(`'${TRADUCCION_OBLIGATORIA.visible}'`),
+      `EstadoAplicacionBadge debe mostrar "${TRADUCCION_OBLIGATORIA.visible}" cuando el estado ` +
+        `guardado es "${TRADUCCION_OBLIGATORIA.guardado}". Si imprime el valor crudo, la pantalla ` +
+        `empieza a decir una palabra distinta a la que la gente lleva meses leyendo.`,
+    ).toBe(true);
+  });
+
+  it('no renderiza {estado} directamente dentro del Badge', () => {
+    const renderizaCrudo = /<Badge[^>]*>\s*\{\s*estado\s*\}/s.test(badge);
+    expect(
+      renderizaCrudo,
+      'El Badge debe renderizar la etiqueta traducida, no `{estado}`.',
+    ).toBe(false);
+  });
+
+  it('sigue mostrando — cuando no hay estado, nunca un estado inventado', () => {
+    expect(badge).toMatch(/if\s*\(!estado\)/);
+    expect(badge).toContain('—');
+  });
+
+  it('la traducción del componente coincide con la que ya usa AplicacionesList', () => {
+    const lista = readFileSync(LISTA, 'utf8');
+    // AplicacionesList es la fuente histórica de la etiqueta: si alguien la cambia allá,
+    // este test obliga a cambiarla también en el componente compartido (o al revés).
+    const listaTraduce = new RegExp(
+      `['"]${TRADUCCION_OBLIGATORIA.guardado}['"]\\s*:\\s*['"]${TRADUCCION_OBLIGATORIA.visible}['"]`,
+    ).test(lista);
+    const badgeTraduce = new RegExp(
+      `${TRADUCCION_OBLIGATORIA.guardado}\\s*:\\s*['"]${TRADUCCION_OBLIGATORIA.visible}['"]`,
+    ).test(badge);
+
+    expect(
+      listaTraduce && badgeTraduce,
+      'AplicacionesList y EstadoAplicacionBadge deben coincidir en la etiqueta visible. ' +
+        `Lista traduce: ${listaTraduce}. Badge traduce: ${badgeTraduce}.`,
+    ).toBe(true);
+  });
+});

--- a/src/__tests__/estadoAplicacionEtiquetas.test.ts
+++ b/src/__tests__/estadoAplicacionEtiquetas.test.ts
@@ -6,10 +6,18 @@ import { join } from 'path';
  * Guarda: el estado que se guarda NO es el que se muestra.
  *
  * `aplicaciones.estado` guarda `Calculada`, pero la UI viene diciendo **"Planificada"** desde
- * siempre — `AplicacionesList.tsx` lo traduce con su `ESTADO_LABELS`, el `<select>` de filtro usa
- * esa etiqueta y el KPI dice "Planificadas". La primera versión de `EstadoAplicacionBadge`
- * renderizaba `{estado}` crudo; al cablearla a las 5 pantallas habría cambiado esa palabra en
- * silencio, sin migración, sin error de tipos y sin que ningún test existente lo notara.
+ * siempre. Antes de W00, `AplicacionesList.tsx` traducía con su propio `ESTADO_LABELS`; la
+ * primera versión de `EstadoAplicacionBadge` renderizaba `{estado}` crudo, y cablearla a las 5
+ * pantallas habría cambiado esa palabra en silencio, sin migración, sin error de tipos y sin que
+ * ningún test existente lo notara.
+ *
+ * W00 (implementación) eliminó el `ESTADO_LABELS` local de `AplicacionesList.tsx` — la Lista ya
+ * no tiene su propio mapa, delega el badge por completo en `EstadoAplicacionBadge`. Con eso
+ * dejó de haber DOS mapas que puedan desincronizarse; solo queda uno, y ese es el que las otras
+ * tres pruebas de este archivo ya vigilan. Lo único que `AplicacionesList.tsx` sigue necesitando
+ * decidir por su cuenta es el texto visible de su `ToggleGroup` de filtro (no puede importar la
+ * etiqueta del Badge porque el filtro también tiene una opción "Todos" que el Badge no conoce) —
+ * eso es lo que las dos pruebas de abajo verifican, en vez de exigir un segundo mapa idéntico.
  *
  * Esta guarda es estática a propósito: el defecto no es de comportamiento (el componente
  * "funciona" igual), es de contrato con la usuaria, y solo se ve leyendo qué texto sale a pantalla.
@@ -47,21 +55,27 @@ describe('EstadoAplicacionBadge — etiquetas visibles', () => {
     expect(badge).toContain('—');
   });
 
-  it('la traducción del componente coincide con la que ya usa AplicacionesList', () => {
+  it('AplicacionesList delega el badge de estado en el componente compartido, no en un mapa propio', () => {
     const lista = readFileSync(LISTA, 'utf8');
-    // AplicacionesList es la fuente histórica de la etiqueta: si alguien la cambia allá,
-    // este test obliga a cambiarla también en el componente compartido (o al revés).
-    const listaTraduce = new RegExp(
-      `['"]${TRADUCCION_OBLIGATORIA.guardado}['"]\\s*:\\s*['"]${TRADUCCION_OBLIGATORIA.visible}['"]`,
-    ).test(lista);
-    const badgeTraduce = new RegExp(
-      `${TRADUCCION_OBLIGATORIA.guardado}\\s*:\\s*['"]${TRADUCCION_OBLIGATORIA.visible}['"]`,
-    ).test(badge);
+    expect(
+      lista.includes('EstadoAplicacionBadge'),
+      'AplicacionesList.tsx debe importar y usar <EstadoAplicacionBadge> en vez de reimplementar ' +
+        'su propio mapa estado→etiqueta (eso es exactamente lo que este módulo tenía antes y lo ' +
+        'que causaba que las pantallas se desincronizaran).',
+    ).toBe(true);
+  });
+
+  it('el ToggleGroup de filtro de AplicacionesList sigue mostrando la misma etiqueta visible ("Planificada")', () => {
+    const lista = readFileSync(LISTA, 'utf8');
+    // El filtro no puede delegar la etiqueta en el Badge (tiene una opción "Todos" que el Badge
+    // no modela), así que la sigue escribiendo literal como texto de un <ToggleGroupItem> — esta
+    // prueba es la que impide que ese texto se quede diciendo el valor crudo "Calculada".
+    const filtroDiceLaEtiquetaVisible = new RegExp(`>\\s*${TRADUCCION_OBLIGATORIA.visible}\\s*<`).test(lista);
 
     expect(
-      listaTraduce && badgeTraduce,
-      'AplicacionesList y EstadoAplicacionBadge deben coincidir en la etiqueta visible. ' +
-        `Lista traduce: ${listaTraduce}. Badge traduce: ${badgeTraduce}.`,
+      filtroDiceLaEtiquetaVisible,
+      `El filtro de estado en AplicacionesList.tsx debe mostrar "${TRADUCCION_OBLIGATORIA.visible}" ` +
+        `como opción visible para el estado guardado "${TRADUCCION_OBLIGATORIA.guardado}".`,
     ).toBe(true);
   });
 });

--- a/src/__tests__/tableCrudoTrinquete.test.ts
+++ b/src/__tests__/tableCrudoTrinquete.test.ts
@@ -94,12 +94,6 @@ const UI_TABLE_REL = 'components/ui/table.tsx';
  * borrar su entrada en el mismo cambio.
  */
 const DEUDA_TABLA_CRUDA: readonly string[] = [
-  'components/aplicaciones/CierreAplicacion.tsx',
-  'components/aplicaciones/DetalleAplicacion.tsx',
-  'components/aplicaciones/PasoListaCompras.tsx',
-  'components/aplicaciones/report/EconomicSection.tsx',
-  'components/aplicaciones/report/ProductComparisonTable.tsx',
-  'components/aplicaciones/report/TechnicalSection.tsx',
   'components/configuracion/TelegramConfig.tsx',
   'components/configuracion/UsuariosConfig.tsx',
   'components/finanzas/components/GastosBatchTable.tsx',
@@ -274,8 +268,8 @@ describe('trinquete: <table> crudo solo se permite si está declarado en DEUDA_T
       expect(realSources.has(UI_TABLE_REL)).toBe(false);
     });
 
-    it('el conteo de deuda real de hoy es 41 (visible en el diff si alguien lo cambia sin querer)', () => {
-      expect(DEUDA_TABLA_CRUDA.length).toBe(41);
+    it('el conteo de deuda real de hoy es 35 (visible en el diff si alguien lo cambia sin querer)', () => {
+      expect(DEUDA_TABLA_CRUDA.length).toBe(35);
     });
 
     it('regla 1 — ningún archivo con <table> crudo fuera de la lista declarada', () => {

--- a/src/components/aplicaciones/AplicacionesList.tsx
+++ b/src/components/aplicaciones/AplicacionesList.tsx
@@ -615,6 +615,7 @@ export function AplicacionesList() {
                             });
                           }}
                           className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
+                          aria-label="Más opciones"
                         >
                           <MoreVertical className="w-5 h-5 text-brand-brown/70" />
                         </button>

--- a/src/components/aplicaciones/AplicacionesList.tsx
+++ b/src/components/aplicaciones/AplicacionesList.tsx
@@ -4,6 +4,7 @@ import {
   Plus,
   Search,
   Filter,
+  ChevronDown,
   Droplet,
   Leaf,
   Calendar,
@@ -12,10 +13,9 @@ import {
   Play,
   CheckCircle2,
   Clock,
-  Loader2,
   Edit2,
   Trash2,
-  X,
+  AlertCircle,
   ClipboardList,
   FileText,
 } from 'lucide-react';
@@ -31,29 +31,23 @@ import {
   DropdownMenuSeparator,
   DropdownMenuTrigger,
 } from '../ui/dropdown-menu';
+import { Button } from '@/components/ui/button';
+import { Input } from '@/components/ui/input';
+import { Card } from '@/components/ui/card';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription, EmptyContent } from '@/components/ui/empty';
+import { Skeleton } from '@/components/ui/skeleton';
+import { ConfirmDialog } from '../ui/confirm-dialog';
+import { KPICard } from './shared/KPICard';
+import { EstadoAplicacionBadge } from './shared/EstadoAplicacionBadge';
+import { formatearNumero, formatShortDate } from '@/utils/format';
+import { cn } from '@/components/ui/utils';
 
 const TIPOS_LABELS: Record<TipoAplicacion, string> = {
   'Fumigación': 'Fumigación',
   'Fertilización': 'Fertilización',
   'Drench': 'Drench',
-};
-
-const ESTADO_LABELS: Record<EstadoAplicacion, string> = {
-  'Calculada': 'Planificada',
-  'En ejecución': 'En Ejecución',
-  'Cerrada': 'Cerrada',
-};
-
-const ESTADO_COLORS: Record<EstadoAplicacion, string> = {
-  'Calculada': 'bg-blue-100 text-blue-700 border-blue-200',
-  'En ejecución': 'bg-green-100 text-green-700 border-green-200',
-  'Cerrada': 'bg-gray-100 text-gray-700 border-gray-200',
-};
-
-const ESTADO_ICONS: Record<EstadoAplicacion, typeof Clock> = {
-  'Calculada': Clock,
-  'En ejecución': Play,
-  'Cerrada': CheckCircle2,
 };
 
 export function AplicacionesList() {
@@ -62,33 +56,23 @@ export function AplicacionesList() {
 
   const [aplicaciones, setAplicaciones] = useState<Aplicacion[]>([]);
   const [isLoading, setIsLoading] = useState(true);
+  const [loadError, setLoadError] = useState(false);
   const [searchQuery, setSearchQuery] = useState('');
   const [filtroTipo, setFiltroTipo] = useState<TipoAplicacion | 'todos'>('todos');
   const [filtroEstado, setFiltroEstado] = useState<EstadoAplicacion | 'todos'>('todos');
-  const [menuAbiertoId, setMenuAbiertoId] = useState<string | null>(null);
-  const [menuPosition, setMenuPosition] = useState<{ top: number; left: number } | null>(null);
+  const [filtrosAbiertos, setFiltrosAbiertos] = useState(false);
   const [eliminando, setEliminando] = useState<string | null>(null);
   const [iniciarEjecucionId, setIniciarEjecucionId] = useState<string | null>(null);
   const [aplicacionDetalle, setAplicacionDetalle] = useState<Aplicacion | null>(null);
+
   useEffect(() => {
     loadAplicaciones();
   }, []);
 
-  // Cerrar menú al hacer clic fuera
-  useEffect(() => {
-    const handleClickOutside = () => {
-      if (menuAbiertoId) {
-        setMenuAbiertoId(null);
-      }
-    };
-
-    document.addEventListener('click', handleClickOutside);
-    return () => document.removeEventListener('click', handleClickOutside);
-  }, [menuAbiertoId]);
-
   const loadAplicaciones = async () => {
     try {
       setIsLoading(true);
+      setLoadError(false);
 
       const { data, error } = await supabase
         .from('aplicaciones')
@@ -122,10 +106,9 @@ export function AplicacionesList() {
         throw error;
       }
 
-
       // Mapear datos de BD al formato de la interfaz
       const aplicacionesMapeadas: Aplicacion[] = [];
-      
+
       (data || []).forEach((row: any) => {
         try {
           // Extraer lotes seleccionados
@@ -204,6 +187,7 @@ export function AplicacionesList() {
       setAplicaciones(aplicacionesMapeadas);
     } catch (err) {
       console.error('Failed to load aplicaciones list:', err);
+      setLoadError(true);
     } finally {
       setIsLoading(false);
     }
@@ -222,6 +206,8 @@ export function AplicacionesList() {
     return matchSearch && matchTipo && matchEstado;
   });
 
+  const hayFiltrosActivos = searchQuery !== '' || filtroTipo !== 'todos' || filtroEstado !== 'todos';
+
   // Estadísticas
   const stats = {
     total: aplicaciones.length,
@@ -230,12 +216,13 @@ export function AplicacionesList() {
     cerradas: aplicaciones.filter((a) => a.estado === 'Cerrada').length,
   };
 
+  const aplicacionAEliminar = aplicaciones.find((a) => a.id === eliminando) ?? null;
+
   /**
    * ELIMINAR APLICACIÓN
    */
   const handleEliminar = async (aplicacionId: string) => {
     try {
-
       // 1. Verificar y eliminar movimientos de inventario primero
       const { data: movimientos, error: errorCheckMovimientos } = await supabase
         .from('movimientos_inventario')
@@ -247,7 +234,6 @@ export function AplicacionesList() {
       }
 
       if (movimientos && movimientos.length > 0) {
-        
         const { error: errorDeleteMovimientos } = await supabase
           .from('movimientos_inventario')
           .delete()
@@ -256,7 +242,6 @@ export function AplicacionesList() {
         if (errorDeleteMovimientos) {
           throw errorDeleteMovimientos;
         }
-        
       } else {
         /* no inventory movements to delete — proceed */
       }
@@ -271,7 +256,6 @@ export function AplicacionesList() {
         throw errorLotes;
       }
 
-
       // 3. Obtener IDs de mezclas
       const { data: mezclas, error: errorMezclas } = await supabase
         .from('aplicaciones_mezclas')
@@ -281,7 +265,6 @@ export function AplicacionesList() {
       if (errorMezclas) {
         throw errorMezclas;
       }
-
 
       // 4. Eliminar productos de las mezclas
       if (mezclas && mezclas.length > 0) {
@@ -296,7 +279,6 @@ export function AplicacionesList() {
           throw errorProductosMezcla;
         }
 
-
         // 5. Eliminar mezclas
         const { error: errorDeleteMezclas } = await supabase
           .from('aplicaciones_mezclas')
@@ -306,7 +288,6 @@ export function AplicacionesList() {
         if (errorDeleteMezclas) {
           throw errorDeleteMezclas;
         }
-
       }
 
       // 6. Eliminar cálculos
@@ -319,7 +300,6 @@ export function AplicacionesList() {
         throw errorCalculos;
       }
 
-
       // 7. Eliminar lista de compras
       const { error: errorCompras } = await supabase
         .from('aplicaciones_compras')
@@ -329,7 +309,6 @@ export function AplicacionesList() {
       if (errorCompras) {
         throw errorCompras;
       }
-
 
       // 8. Finalmente, eliminar la aplicación
       const { error: errorAplicacion } = await supabase
@@ -341,11 +320,10 @@ export function AplicacionesList() {
         throw errorAplicacion;
       }
 
-
       // Actualizar lista local
       setAplicaciones(aplicaciones.filter(a => a.id !== aplicacionId));
       setEliminando(null);
-      
+
       toast.success('Aplicación eliminada exitosamente');
     } catch (error) {
       toast.error('Error al eliminar la aplicación. Por favor intenta nuevamente.');
@@ -363,323 +341,342 @@ export function AplicacionesList() {
           </p>
         </div>
 
-        <button
-          onClick={() => navigate('/aplicaciones/calculadora')}
-          className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:from-primary-dark hover:to-secondary-dark transition-all shadow-sm"
-        >
-          <Plus className="w-5 h-5" />
-          <span>Nueva Aplicación</span>
-        </button>
+        <Button onClick={() => navigate('/aplicaciones/calculadora')} className="w-full sm:w-auto">
+          <Plus className="size-4" aria-hidden="true" />
+          Nueva Aplicación
+        </Button>
       </div>
 
-      {/* Estadísticas */}
-      <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-        <div className="bg-white rounded-xl border border-gray-200 p-4">
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-sm text-brand-brown/70">Total</p>
-            <div className="w-10 h-10 bg-gradient-to-br from-primary/10 to-secondary/10 rounded-lg flex items-center justify-center">
-              <Calendar className="w-5 h-5 text-primary" />
-            </div>
-          </div>
-          <p className="text-2xl text-foreground">{stats.total}</p>
-        </div>
-
-        <div className="bg-white rounded-xl border border-gray-200 p-4">
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-sm text-brand-brown/70">Planificadas</p>
-            <div className="w-10 h-10 bg-blue-100 rounded-lg flex items-center justify-center">
-              <Clock className="w-5 h-5 text-blue-600" />
-            </div>
-          </div>
-          <p className="text-2xl text-foreground">{stats.planificadas}</p>
-        </div>
-
-        <div className="bg-white rounded-xl border border-gray-200 p-4">
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-sm text-brand-brown/70">En Ejecución</p>
-            <div className="w-10 h-10 bg-green-100 rounded-lg flex items-center justify-center">
-              <Play className="w-5 h-5 text-green-600" />
-            </div>
-          </div>
-          <p className="text-2xl text-foreground">{stats.en_ejecucion}</p>
-        </div>
-
-        <div className="bg-white rounded-xl border border-gray-200 p-4">
-          <div className="flex items-center justify-between mb-2">
-            <p className="text-sm text-brand-brown/70">Cerradas</p>
-            <div className="w-10 h-10 bg-gray-100 rounded-lg flex items-center justify-center">
-              <CheckCircle2 className="w-5 h-5 text-gray-600" />
-            </div>
-          </div>
-          <p className="text-2xl text-foreground">{stats.cerradas}</p>
-        </div>
+      {/* Estadísticas — solo "En Ejecución" lleva el acento olivo: es el único
+          estado que pide acción hoy (misma jerarquía que EstadoAplicacionBadge). */}
+      <div className="grid grid-cols-2 lg:grid-cols-4 gap-4">
+        <KPICard
+          titulo="Total"
+          valor={formatearNumero(stats.total, 0)}
+          icon={Calendar}
+          tono="neutro"
+          comparaciones={[]}
+        />
+        <KPICard
+          titulo="Planificadas"
+          valor={formatearNumero(stats.planificadas, 0)}
+          icon={Clock}
+          tono="neutro"
+          comparaciones={[]}
+        />
+        <KPICard
+          titulo="En Ejecución"
+          valor={formatearNumero(stats.en_ejecucion, 0)}
+          icon={Play}
+          tono="primary"
+          comparaciones={[]}
+        />
+        <KPICard
+          titulo="Cerradas"
+          valor={formatearNumero(stats.cerradas, 0)}
+          icon={CheckCircle2}
+          tono="neutro"
+          comparaciones={[]}
+        />
       </div>
 
       {/* Filtros y búsqueda */}
-      <div className="bg-white rounded-xl border border-gray-200 p-4">
-        <div className="flex flex-col sm:flex-row gap-4">
+      <Card className="p-4 shadow-sm">
+        <div className="flex flex-col sm:flex-row gap-3">
           {/* Búsqueda */}
-          <div className="flex-1 relative">
-            <Search className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-brand-brown/40" />
-            <input
+          <div className="relative flex-1 min-w-0 sm:min-w-[220px]">
+            <Search className="absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" aria-hidden="true" />
+            <Input
               type="text"
               placeholder="Buscar aplicación..."
               value={searchQuery}
               onChange={(e) => setSearchQuery(e.target.value)}
-              className="w-full pl-10 pr-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+              className="pl-9"
             />
           </div>
 
-          {/* Filtro por tipo */}
-          <select
-            value={filtroTipo}
-            onChange={(e) => setFiltroTipo(e.target.value as TipoAplicacion | 'todos')}
-            className="px-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          {/* Toggle de filtros — solo móvil: los filtros de abajo se colapsan detrás de
+              este botón para no competir por ancho con el buscador. */}
+          <Button
+            type="button"
+            variant="outline"
+            onClick={() => setFiltrosAbiertos((prev) => !prev)}
+            className="sm:hidden justify-between"
+            aria-expanded={filtrosAbiertos}
           >
-            <option value="todos">Todos los tipos</option>
-            <option value="fumigacion">Fumigación</option>
-            <option value="fertilizacion">Fertilización</option>
-            <option value="drench">Drench</option>
-          </select>
+            <span className="flex items-center gap-2">
+              <Filter className="size-4" aria-hidden="true" />
+              Filtros
+            </span>
+            <ChevronDown
+              className={cn('size-4 transition-transform', filtrosAbiertos && 'rotate-180')}
+              aria-hidden="true"
+            />
+          </Button>
 
-          {/* Filtro por estado */}
-          <select
-            value={filtroEstado}
-            onChange={(e) => setFiltroEstado(e.target.value as EstadoAplicacion | 'todos')}
-            className="px-4 py-2 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary"
+          <div
+            className={cn(
+              'flex flex-col gap-3 sm:flex sm:flex-row',
+              !filtrosAbiertos && 'hidden sm:flex',
+            )}
           >
-            <option value="todos">Todos los estados</option>
-            <option value="Calculada">Planificada</option>
-            <option value="En ejecución">En Ejecución</option>
-            <option value="Cerrada">Cerrada</option>
-          </select>
+            <ToggleGroup
+              type="single"
+              variant="outline"
+              value={filtroEstado}
+              onValueChange={(value) => {
+                if (value) setFiltroEstado(value as EstadoAplicacion | 'todos');
+              }}
+              aria-label="Filtrar por estado"
+              className="w-full sm:w-auto"
+            >
+              {/* px-3 + sm:flex-none: ToggleGroupItem trae `min-w-0 flex-1` con `px-2` en el
+                  primitivo, así que en escritorio los 4 se reparten el ancho por igual y
+                  "En Ejecución" (el más largo) se desborda de su caja y se pega visualmente al
+                  vecino. En móvil el grupo sí es de ancho completo y el reparto igual es correcto,
+                  por eso el override solo aplica desde sm. */}
+              <ToggleGroupItem value="todos" className="px-3 sm:flex-none">Todos</ToggleGroupItem>
+              <ToggleGroupItem value="Calculada" className="px-3 sm:flex-none">Planificada</ToggleGroupItem>
+              <ToggleGroupItem value="En ejecución" className="px-3 sm:flex-none">En Ejecución</ToggleGroupItem>
+              <ToggleGroupItem value="Cerrada" className="px-3 sm:flex-none">Cerrada</ToggleGroupItem>
+            </ToggleGroup>
+
+            <Select
+              value={filtroTipo}
+              onValueChange={(value) => setFiltroTipo(value as TipoAplicacion | 'todos')}
+            >
+              <SelectTrigger className="w-full sm:w-[180px]">
+                <SelectValue />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="todos">Todos los tipos</SelectItem>
+                <SelectItem value="Fumigación">Fumigación</SelectItem>
+                <SelectItem value="Fertilización">Fertilización</SelectItem>
+                <SelectItem value="Drench">Drench</SelectItem>
+              </SelectContent>
+            </Select>
+          </div>
         </div>
-      </div>
+      </Card>
 
       {/* Lista de aplicaciones */}
-      <div className="bg-white rounded-xl border border-gray-200 overflow-hidden">
+      <Card className="overflow-hidden shadow-sm">
         {isLoading ? (
-          <div className="flex items-center justify-center py-12">
-            <Loader2 className="w-8 h-8 text-primary animate-spin" />
+          <div className="divide-y divide-border">
+            {[0, 1, 2].map((i) => (
+              <div key={i} className="flex items-center gap-4 p-4">
+                <Skeleton className="size-11 shrink-0 rounded-xl" />
+                <div className="flex-1 space-y-2">
+                  <Skeleton className="h-3.5 w-3/5" />
+                  <Skeleton className="h-3 w-2/5" />
+                </div>
+              </div>
+            ))}
           </div>
+        ) : loadError ? (
+          <Empty className="border-none">
+            <EmptyHeader>
+              <EmptyMedia variant="icon" className="bg-destructive/10 text-destructive">
+                <AlertCircle aria-hidden="true" />
+              </EmptyMedia>
+              <EmptyTitle>No se pudieron cargar las aplicaciones</EmptyTitle>
+              <EmptyDescription>
+                Revisa tu conexión e intenta de nuevo. Si el problema persiste, contacta a soporte.
+              </EmptyDescription>
+            </EmptyHeader>
+            <EmptyContent>
+              <Button variant="outline" onClick={loadAplicaciones}>
+                Reintentar
+              </Button>
+            </EmptyContent>
+          </Empty>
         ) : aplicacionesFiltradas.length === 0 ? (
-          <div className="text-center py-12">
-            <div className="w-16 h-16 bg-gradient-to-br from-primary/10 to-secondary/10 rounded-2xl mx-auto mb-4 flex items-center justify-center">
-              <Droplet className="w-8 h-8 text-primary" />
-            </div>
-            <h3 className="text-lg text-foreground mb-2">
-              {searchQuery || filtroTipo !== 'todos' || filtroEstado !== 'todos'
-                ? 'No se encontraron aplicaciones'
-                : 'No hay aplicaciones registradas'}
-            </h3>
-            <p className="text-sm text-brand-brown/70 mb-6">
-              {searchQuery || filtroTipo !== 'todos' || filtroEstado !== 'todos'
-                ? 'Intenta ajustar los filtros de búsqueda'
-                : 'Comienza creando tu primera aplicación'}
-            </p>
-            {!searchQuery && filtroTipo === 'todos' && filtroEstado === 'todos' && (
-              <button
-                onClick={() => navigate('/aplicaciones/calculadora')}
-                className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:from-primary-dark hover:to-secondary-dark transition-all"
-              >
-                <Plus className="w-5 h-5" />
-                <span>Nueva Aplicación</span>
-              </button>
+          <Empty className="border-none">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                {hayFiltrosActivos ? <Search aria-hidden="true" /> : <Droplet aria-hidden="true" />}
+              </EmptyMedia>
+              <EmptyTitle>
+                {hayFiltrosActivos ? 'No se encontraron aplicaciones' : 'No hay aplicaciones registradas'}
+              </EmptyTitle>
+              <EmptyDescription>
+                {hayFiltrosActivos
+                  ? 'Intenta ajustar los filtros de búsqueda'
+                  : 'Comienza creando tu primera aplicación'}
+              </EmptyDescription>
+            </EmptyHeader>
+            {!hayFiltrosActivos && (
+              <EmptyContent>
+                <Button onClick={() => navigate('/aplicaciones/calculadora')}>
+                  <Plus className="size-4" aria-hidden="true" />
+                  Nueva Aplicación
+                </Button>
+              </EmptyContent>
             )}
-          </div>
+          </Empty>
         ) : (
-          <div className="divide-y divide-gray-200">
+          <div className="divide-y divide-border">
             {aplicacionesFiltradas.map((aplicacion) => {
-              const EstadoIcon = ESTADO_ICONS[(aplicacion.estado ?? 'Calculada') as EstadoAplicacion];
               const TipoIcon = aplicacion.tipo_aplicacion === 'Fumigación' ? Droplet : Leaf;
+              const nombre = aplicacion.nombre_aplicacion ?? 'Sin nombre';
+              const fechaMostrar =
+                aplicacion.fecha_inicio ?? aplicacion.fecha_inicio_planeada ?? aplicacion.created_at ?? null;
 
               return (
                 <div
                   key={aplicacion.id}
-                  className="p-4 hover:bg-gray-50 transition-colors cursor-pointer"
+                  className="p-4 hover:bg-muted/40 transition-colors cursor-pointer"
                   onClick={() => setAplicacionDetalle(aplicacion)}
                 >
                   <div className="flex items-start justify-between gap-4">
-                    <div className="flex items-start gap-4 flex-1">
+                    <div className="flex items-start gap-4 flex-1 min-w-0">
                       {/* Icono */}
-                      <div className="w-12 h-12 bg-gradient-to-br from-primary/10 to-secondary/10 rounded-xl flex items-center justify-center flex-shrink-0">
-                        <TipoIcon className="w-6 h-6 text-primary" />
+                      <div className="flex size-11 shrink-0 items-center justify-center rounded-xl bg-primary/10 text-primary">
+                        <TipoIcon className="size-5" aria-hidden="true" />
                       </div>
 
                       {/* Información */}
                       <div className="flex-1 min-w-0">
-                        {/* `flex-1 min-w-0` on the <h3> alone was not enough: on mobile the
-                            "Acciones" column (main button + menú ⋮) never hides, so it keeps
-                            eating into this row's width regardless of how far the name
-                            shrinks — the badge (flex-shrink-0) has nowhere left to go and
-                            gets clipped by the list's `overflow-hidden` card. Verified this
-                            was estado-independent (the shortest label "Cerrada" was cut too),
-                            so it isn't about badge width, it's about the shared line running
-                            out of room. Below `lg` the badge drops to its own line, under the
-                            name — same "identidad arriba, resto abajo" shape Patrón A already
-                            uses (`TareaMobileCard.tsx`), so its width no longer competes with
-                            the name's and both render in full regardless of label length. */}
-                        <div className="flex flex-col gap-1 mb-1 lg:flex-row lg:items-center lg:gap-2">
-                          <h3 className="text-foreground truncate text-sm lg:text-base lg:flex-1 lg:min-w-0">
-                            {aplicacion.nombre_aplicacion}
-                          </h3>
-                          <span
-                            className={`self-start px-2 py-0.5 text-xs rounded-lg border whitespace-nowrap flex-shrink-0 lg:self-auto ${
-                              ESTADO_COLORS[(aplicacion.estado ?? 'Calculada') as EstadoAplicacion]
-                            }`}
-                          >
-                            {ESTADO_LABELS[(aplicacion.estado ?? 'Calculada') as EstadoAplicacion]}
-                          </span>
+                        {/* Trunca a 1 línea en escritorio; envuelve a 2 en móvil (mismo patrón
+                            que `.gasto-nombre` en Gastos/Ingresos: `truncate` + `max-sm:*`). */}
+                        <h3
+                          title={nombre}
+                          className="text-foreground text-sm sm:text-base font-medium mb-1.5 truncate max-sm:whitespace-normal max-sm:line-clamp-2"
+                        >
+                          {nombre}
+                        </h3>
+
+                        {/* Badge de estado — solo en móvil, bajo el título. En escritorio
+                            vive en el cluster de acciones (ver fix 1 del mockup: badge +
+                            botón + ⋮ comparten un solo ancla vertical). */}
+                        <div className="sm:hidden mb-1.5">
+                          <EstadoAplicacionBadge estado={aplicacion.estado} />
                         </div>
 
-                        <div className="flex flex-wrap items-center gap-2 lg:gap-4 text-sm text-brand-brown/70">
-                          <span className="flex items-center gap-1">
-                            <TipoIcon className="w-4 h-4" />
+                        <div className="flex flex-wrap items-center gap-x-4 gap-y-1 text-sm text-brand-brown/70">
+                          <span className="flex items-center gap-1.5">
+                            <TipoIcon className="size-3.5" aria-hidden="true" />
                             {TIPOS_LABELS[aplicacion.tipo_aplicacion]}
                           </span>
-                          <span className="flex items-center gap-1">
-                            <Calendar className="w-4 h-4" />
-                            {new Date(aplicacion.fecha_inicio ?? aplicacion.fecha_inicio_planeada ?? '').toLocaleDateString('es-CO')}
+                          <span className="flex items-center gap-1.5">
+                            <Calendar className="size-3.5" aria-hidden="true" />
+                            {fechaMostrar ? formatShortDate(fechaMostrar) : '—'}
                           </span>
-                          <span className="flex items-center gap-1">
-                            <MapPin className="w-4 h-4" />
+                          <span className="flex items-center gap-1.5">
+                            <MapPin className="size-3.5" aria-hidden="true" />
                             {aplicacion.configuracion?.lotes_seleccionados?.length ?? 0} lotes
                           </span>
                         </div>
 
                         {aplicacion.proposito && (
-                          <p className="text-sm text-brand-brown/70 mt-2 line-clamp-1">
+                          <p className="text-sm text-brand-brown/70 mt-1.5 truncate">
                             {aplicacion.proposito}
                           </p>
                         )}
                       </div>
                     </div>
 
-                    {/* Acciones — escritorio (≥640px): botón principal por estado + menú
-                        ⋮ con Editar/Eliminar. Sin cambios de comportamiento; solo se
-                        ocultó por completo debajo de 640px (ver bloque `sm:hidden` más
-                        abajo) — en esa columna es donde vivía el problema de fondo. */}
-                    <div className="hidden sm:flex items-center gap-2">
-                      {/* Botón principal según estado */}
+                    {/* Cluster de acciones — escritorio (≥640px): badge + botón principal + ⋮,
+                        un solo grupo flex (align-items:center, self-center sobre la fila) para
+                        que se centre igual sin importar cuántas líneas ocupe el título ni si
+                        hay descripción. */}
+                    <div className="hidden sm:flex items-center gap-3 self-center flex-shrink-0">
+                      <EstadoAplicacionBadge estado={aplicacion.estado} />
+
                       {aplicacion.estado === 'Calculada' && (
-                        <button
+                        <Button
+                          size="sm"
+                          variant="outline"
+                          className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary"
                           onClick={(e) => {
                             e.stopPropagation();
                             setIniciarEjecucionId(aplicacion.id);
                           }}
-                          className="px-3 lg:px-4 py-2 bg-gradient-to-r from-green-600 to-green-500 text-white rounded-lg hover:from-green-700 hover:to-green-600 transition-all flex items-center gap-2"
                         >
-                          <Play className="w-4 h-4" />
+                          <Play className="size-4" aria-hidden="true" />
                           <span className="hidden lg:inline">Iniciar Ejecución</span>
-                        </button>
+                        </Button>
                       )}
 
                       {aplicacion.estado === 'En ejecución' && (
-                        <button
+                        <Button
+                          size="sm"
                           onClick={(e) => {
                             e.stopPropagation();
                             navigate(`/aplicaciones/${aplicacion.id}/movimientos`);
                           }}
-                          className="px-3 lg:px-4 py-2 bg-gradient-to-r from-brand-brown to-brand-brown/80 text-white rounded-lg hover:from-brand-brown hover:to-brand-brown/80 transition-all flex items-center gap-2"
                         >
-                          <ClipboardList className="w-4 h-4" />
+                          <ClipboardList className="size-4" aria-hidden="true" />
                           <span className="hidden lg:inline">Registrar Movimientos</span>
-                        </button>
+                        </Button>
                       )}
 
                       {aplicacion.estado === 'Cerrada' && (
-                        <button
+                        <Button
+                          size="sm"
+                          variant="outline"
                           onClick={(e) => {
                             e.stopPropagation();
                             navigate(`/aplicaciones/${aplicacion.id}/reporte`);
                           }}
-                          className="px-3 lg:px-4 py-2 bg-gradient-to-r from-primary to-secondary text-white rounded-lg hover:from-primary-dark hover:to-secondary-dark transition-all flex items-center gap-2"
                         >
-                          <FileText className="w-4 h-4" />
+                          <FileText className="size-4" aria-hidden="true" />
                           <span className="hidden lg:inline">Ver Reporte</span>
-                        </button>
+                        </Button>
                       )}
 
-                      {/* Menú de 3 puntos - solo Editar y Eliminar */}
-                      <div className="relative">
-                        <button
-                          onClick={(e) => {
-                            e.stopPropagation();
-                            const rect = e.currentTarget.getBoundingClientRect();
-                            setMenuAbiertoId(
-                              menuAbiertoId === aplicacion.id ? null : aplicacion.id
-                            );
-                            setMenuPosition({
-                              top: rect.bottom + window.scrollY,
-                              left: rect.left + window.scrollX - 192 + rect.width,
-                            });
-                          }}
-                          className="p-2 hover:bg-gray-200 rounded-lg transition-colors"
-                          aria-label="Más opciones"
-                        >
-                          <MoreVertical className="w-5 h-5 text-brand-brown/70" />
-                        </button>
-
-                        {/* Dropdown menu - solo Editar y Eliminar */}
-                        {menuAbiertoId === aplicacion.id && menuPosition && (
-                          <div
-                            className="fixed w-48 bg-white rounded-lg shadow-xl border border-gray-200 py-1 z-[9999]"
-                            style={{
-                              top: `${menuPosition.top}px`,
-                              left: `${menuPosition.left}px`,
-                            }}
-                          >
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                navigate(`/aplicaciones/calculadora/${aplicacion.id}`);
-                                setMenuAbiertoId(null);
-                              }}
-                              className="w-full px-4 py-2 text-left text-sm text-foreground hover:bg-gray-50 flex items-center gap-2 transition-colors"
+                      {/* Menú de 3 puntos (Radix) — solo Editar y Eliminar; la acción
+                          principal ya vive fuera, como botón visible en escritorio. */}
+                      <div onClick={(e) => e.stopPropagation()}>
+                        <DropdownMenu>
+                          <DropdownMenuTrigger asChild>
+                            <Button
+                              variant="ghost"
+                              size="icon"
+                              className="border-none text-muted-foreground hover:bg-muted hover:text-foreground data-[state=open]:bg-muted data-[state=open]:text-foreground"
+                              aria-label={`Más acciones para "${nombre}"`}
                             >
-                              <Edit2 className="w-4 h-4 text-gray-500" />
+                              <MoreVertical className="size-5" aria-hidden="true" />
+                            </Button>
+                          </DropdownMenuTrigger>
+                          <DropdownMenuContent align="end">
+                            <DropdownMenuItem
+                              onClick={() => navigate(`/aplicaciones/calculadora/${aplicacion.id}`)}
+                            >
+                              <Edit2 className="size-4" aria-hidden="true" />
                               Editar
-                            </button>
-                            
-                            <button
-                              onClick={(e) => {
-                                e.stopPropagation();
-                                setEliminando(aplicacion.id);
-                                setMenuAbiertoId(null);
-                              }}
-                              className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-red-50 flex items-center gap-2 transition-colors"
-                            >
-                              <Trash2 className="w-4 h-4" />
+                            </DropdownMenuItem>
+                            <DropdownMenuSeparator />
+                            <DropdownMenuItem variant="destructive" onClick={() => setEliminando(aplicacion.id)}>
+                              <Trash2 className="size-4" aria-hidden="true" />
                               Eliminar
-                            </button>
-                          </div>
-                        )}
+                            </DropdownMenuItem>
+                          </DropdownMenuContent>
+                        </DropdownMenu>
                       </div>
                     </div>
 
                     {/* Acciones — móvil (<640px): decisión del dueño tras la tercera
-                        vuelta, "esconde todas las acciones detrás de los 3 puntos".
-                        La causa de fondo (medida en las dos vueltas anteriores) era que
-                        esta columna nunca se ocultaba y le robaba ancho real a la fila
-                        sin importar cuánto encogiera el nombre — cada botón que se
-                        agregaba volvía a cortar la descripción y los badges. Un único
-                        ⋮ de 44px reemplaza tanto el botón principal como el menú
+                        vuelta, "esconde todas las acciones detrás de los 3 puntos". Un
+                        único ⋮ de 44px reemplaza tanto el botón principal como el menú
                         Editar/Eliminar; la condición por estado se conserva idéntica,
-                        solo cambia dónde se muestra cada acción. Rótulos de texto
-                        (no solo ícono) porque dentro de un menú un ▶ suelto no se
-                        entiende por contexto. */}
+                        solo cambia dónde se muestra cada acción. */}
                     <div className="sm:hidden flex-shrink-0" onClick={(e) => e.stopPropagation()}>
                       <DropdownMenu>
-                        <DropdownMenuTrigger
-                          className="touch-target inline-flex items-center justify-center rounded-lg hover:bg-gray-200 transition-colors"
-                          aria-label={`Más acciones para "${aplicacion.nombre_aplicacion}"`}
-                        >
-                          <MoreVertical className="w-5 h-5 text-brand-brown/70" />
+                        <DropdownMenuTrigger asChild>
+                          <Button
+                            variant="ghost"
+                            size="icon"
+                            className="border-none text-muted-foreground hover:bg-muted hover:text-foreground data-[state=open]:bg-muted data-[state=open]:text-foreground"
+                            aria-label={`Más acciones para "${nombre}"`}
+                          >
+                            <MoreVertical className="size-5" aria-hidden="true" />
+                          </Button>
                         </DropdownMenuTrigger>
                         <DropdownMenuContent align="end">
                           {aplicacion.estado === 'Calculada' && (
                             <DropdownMenuItem onClick={() => setIniciarEjecucionId(aplicacion.id)}>
-                              <Play className="w-4 h-4" />
+                              <Play className="size-4" aria-hidden="true" />
                               Iniciar Ejecución
                             </DropdownMenuItem>
                           )}
@@ -688,14 +685,14 @@ export function AplicacionesList() {
                             <DropdownMenuItem
                               onClick={() => navigate(`/aplicaciones/${aplicacion.id}/movimientos`)}
                             >
-                              <ClipboardList className="w-4 h-4" />
+                              <ClipboardList className="size-4" aria-hidden="true" />
                               Registrar Movimientos
                             </DropdownMenuItem>
                           )}
 
                           {aplicacion.estado === 'Cerrada' && (
                             <DropdownMenuItem onClick={() => navigate(`/aplicaciones/${aplicacion.id}/reporte`)}>
-                              <FileText className="w-4 h-4" />
+                              <FileText className="size-4" aria-hidden="true" />
                               Ver Reporte
                             </DropdownMenuItem>
                           )}
@@ -705,12 +702,12 @@ export function AplicacionesList() {
                           <DropdownMenuItem
                             onClick={() => navigate(`/aplicaciones/calculadora/${aplicacion.id}`)}
                           >
-                            <Edit2 className="w-4 h-4 text-gray-500" />
+                            <Edit2 className="size-4" aria-hidden="true" />
                             Editar
                           </DropdownMenuItem>
 
                           <DropdownMenuItem variant="destructive" onClick={() => setEliminando(aplicacion.id)}>
-                            <Trash2 className="w-4 h-4" />
+                            <Trash2 className="size-4" aria-hidden="true" />
                             Eliminar
                           </DropdownMenuItem>
                         </DropdownMenuContent>
@@ -722,44 +719,23 @@ export function AplicacionesList() {
             })}
           </div>
         )}
-      </div>
+      </Card>
 
-      {/* Modal de confirmación de eliminación */}
-      {eliminando && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-          <div className="bg-white rounded-xl max-w-md w-full p-6">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-12 h-12 bg-red-100 rounded-full flex items-center justify-center">
-                <Trash2 className="w-6 h-6 text-red-600" />
-              </div>
-              <div>
-                <h3 className="text-lg text-foreground">Eliminar Aplicación</h3>
-                <p className="text-sm text-brand-brown/70">Esta acción no se puede deshacer</p>
-              </div>
-            </div>
-
-            <p className="text-sm text-brand-brown/70 mb-6">
-              ¿Estás seguro de que deseas eliminar esta aplicación? Se eliminarán todos los
-              datos asociados incluyendo mezclas, cálculos y relaciones con lotes.
-            </p>
-
-            <div className="flex gap-3">
-              <button
-                onClick={() => setEliminando(null)}
-                className="flex-1 px-4 py-2 border border-gray-300 text-brand-brown rounded-lg hover:bg-gray-50 transition-all"
-              >
-                Cancelar
-              </button>
-              <button
-                onClick={() => handleEliminar(eliminando)}
-                className="flex-1 px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-all"
-              >
-                Eliminar
-              </button>
-            </div>
-          </div>
-        </div>
-      )}
+      {/* Confirmación de eliminación — AlertDialog (ConfirmDialog ya lo envuelve), nunca un
+          <div fixed inset-0> a mano: foco atrapado, cierre con Escape, accesible por defecto. */}
+      <ConfirmDialog
+        open={!!eliminando}
+        onOpenChange={(open) => {
+          if (!open) setEliminando(null);
+        }}
+        title="Eliminar Aplicación"
+        description={`¿Deseas eliminar «${aplicacionAEliminar?.nombre_aplicacion ?? 'esta aplicación'}»? Se eliminarán todos los datos asociados: mezclas, cálculos y relaciones con lotes. Esta acción no se puede deshacer.`}
+        confirmLabel="Eliminar"
+        onConfirm={() => {
+          if (eliminando) handleEliminar(eliminando);
+        }}
+        destructive
+      />
 
       {/* Modal de iniciar ejecución */}
       {iniciarEjecucionId && (

--- a/src/components/aplicaciones/AtencionRequeridaPanel.tsx
+++ b/src/components/aplicaciones/AtencionRequeridaPanel.tsx
@@ -1,0 +1,95 @@
+import { AlertTriangle } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+import { formatearMoneda, formatearNumero } from '@/utils/format';
+import type {
+  ExcepcionesCierre,
+  InsumoCriticoExcepcion,
+  LoteSinLaborExcepcion,
+  RegistroSinTarifaExcepcion,
+} from '@/utils/calculosCierreAplicacion';
+
+interface AtencionRequeridaPanelProps {
+  excepciones: ExcepcionesCierre;
+  className?: string;
+}
+
+/**
+ * Panel agregado de excepciones (`W03-cierre-v2.md` §1.1/§2) — junta 3 señales que el sistema ya
+ * calculaba pero dejaba enterradas fila por fila dentro de lotes colapsados.
+ *
+ * **No hay versión vacía a propósito.** Cuando no hay ninguna excepción real (el caso normal, ver
+ * el `.md` §6 "Estados nuevos") este componente no renderiza nada — ni un banner "todo bien" ni un
+ * `null` disfrazado de tarjeta vacía. Un panel que siempre está ahí, con o sin novedades, es un
+ * panel que el usuario aprende a ignorar.
+ */
+export function AtencionRequeridaPanel({ excepciones, className }: AtencionRequeridaPanelProps) {
+  const { insumosCriticos, registrosSinTarifa, lotesSinLabor } = excepciones;
+  const total = insumosCriticos.length + registrosSinTarifa.length + lotesSinLabor.length;
+
+  if (total === 0) return null;
+
+  return (
+    <div
+      className={cn(
+        'rounded-lg border-[1.5px] border-dashed border-warning/40 bg-warning/5 p-4',
+        className,
+      )}
+      role="region"
+      aria-label="Atención requerida antes de cerrar"
+    >
+      <div className="mb-2.5 flex items-center gap-2">
+        <AlertTriangle className="size-5 text-warning-foreground" aria-hidden="true" />
+        <h4 className="text-sm font-semibold text-warning-foreground">Atención requerida</h4>
+      </div>
+      <ul className="flex flex-col gap-2">
+        {lotesSinLabor.map((item) => (
+          <ItemLoteSinLabor key={`lote-${item.lote_id}`} item={item} />
+        ))}
+        {insumosCriticos.map((item) => (
+          <ItemInsumoCritico key={`insumo-${item.nombre}`} item={item} />
+        ))}
+        {registrosSinTarifa.length > 0 && <ItemRegistrosSinTarifa items={registrosSinTarifa} />}
+      </ul>
+    </div>
+  );
+}
+
+function ItemLoteSinLabor({ item }: { item: LoteSinLaborExcepcion }) {
+  return (
+    <li className="flex gap-2 text-xs leading-relaxed text-foreground">
+      <AlertTriangle className="mt-0.5 size-3 shrink-0 text-warning-foreground" aria-hidden="true" />
+      <span>
+        <b className="font-semibold">Lote {item.nombre}:</b> 0 jornales registrados — revisa si
+        falta capturar el trabajo o el lote no tuvo labor esta vez.
+      </span>
+    </li>
+  );
+}
+
+function ItemInsumoCritico({ item }: { item: InsumoCriticoExcepcion }) {
+  const signo = item.diferencia > 0 ? '+' : '';
+  return (
+    <li className="flex gap-2 text-xs leading-relaxed text-foreground">
+      <AlertTriangle className="mt-0.5 size-3 shrink-0 text-warning-foreground" aria-hidden="true" />
+      <span>
+        <b className="font-semibold">{item.nombre}:</b> desviación de {signo}
+        {formatearNumero(item.diferencia, 2)} {item.unidad} respecto al plan — más del 15%.
+      </span>
+    </li>
+  );
+}
+
+function ItemRegistrosSinTarifa({ items }: { items: RegistroSinTarifaExcepcion[] }) {
+  return (
+    <li className="flex gap-2 text-xs leading-relaxed text-foreground">
+      <AlertTriangle className="mt-0.5 size-3 shrink-0 text-warning-foreground" aria-hidden="true" />
+      <span>
+        <b className="font-semibold">
+          {items.length} {items.length === 1 ? 'registro' : 'registros'} con costo{' '}
+          {formatearMoneda(0)}:
+        </b>{' '}
+        falta tarifa asignada a ese trabajador.
+      </span>
+    </li>
+  );
+}

--- a/src/components/aplicaciones/CLAUDE.md
+++ b/src/components/aplicaciones/CLAUDE.md
@@ -1,0 +1,96 @@
+# CLAUDE.md — Módulo Aplicaciones
+
+Contrato del módulo tras el rediseño de 2026-08-20. Acá va lo que **no** se deduce leyendo el
+código: de dónde sale cada dato, qué comparación es legítima y cuál es un error de categoría, y qué
+guardas te van a frenar. Lo obvio (qué archivo renderiza qué) se ve mejor con `ls` y `grep`.
+
+## Los 5 workflows
+
+Es una máquina de estados, no un conjunto de páginas. `aplicaciones.estado` decide qué pantalla es
+alcanzable: `Calculada` → `En ejecución` → `Cerrada`.
+
+| | Ruta | Archivos |
+|---|---|---|
+| Lista (hub) | `/aplicaciones` | `AplicacionesList` · `DetalleAplicacion` · `IniciarEjecucionModal` |
+| Calculadora | `/aplicaciones/calculadora/:id?` | `CalculadoraAplicaciones` · `PasoConfiguracion` · `PasoMezcla` · `PasoListaCompras` |
+| Movimientos | `/aplicaciones/:id/movimientos` | `DailyMovementsDashboard` · `DailyMovementForm` · `…Wrapper` |
+| Cierre | `/aplicaciones/:id/cierre` | `CierreAplicacion` (orquestador) · `SeccionInsumosCierre` · `SeccionLaboresCierre` · `SeccionConfirmarCierre` · `AtencionRequeridaPanel` |
+| Reporte | `/aplicaciones/:id/reporte` | `report/*` + `src/hooks/useReporteAplicacion.ts` |
+
+Compartidos en `shared/`: `AplicacionShell`, `AplicacionStepper`, `EstadoAplicacionBadge`, `KPICard`.
+Lógica pura y testeada: `src/utils/calculosCierreAplicacion.ts`, `calculadoraAplicacionesHelpers.ts`.
+
+## El estado que se guarda NO es el que se muestra
+
+`estado` guarda `Calculada`; la UI dice **"Planificada"**, y lo viene diciendo desde siempre.
+`EstadoAplicacionBadge` hace la traducción; el filtro de la Lista escribe la etiqueta literal
+(no puede delegarla porque tiene una opción "Todos" que el Badge no modela).
+`src/__tests__/estadoAplicacionEtiquetas.test.ts` lo vigila. **No "corrijas" Planificada a Calculada**
+— ya pasó dos veces en el rediseño, y ninguna herramienta lo detecta: no hay migración, no hay error
+de tipos, solo cambia en silencio una palabra que la gente lleva meses leyendo.
+
+## De dónde sale el PLAN — y de dónde no
+
+**`aplicaciones_lotes_planificado` está vacía. 0 filas, siempre.** El plan real vive en
+**`aplicaciones_calculos`** (67 filas, 16 de 20 aplicaciones): `numero_canecas`, `litros_mezcla`,
+`kilos_totales`, `numero_bultos`, y el mapeo mezcla↔lote en `mezcla_id`. Los insumos planificados
+están en `aplicaciones_productos.cantidad_total_necesaria`, que es un total **por mezcla** — si una
+mezcla abarca varios lotes hay que repartirlo, no sumarlo en cada uno.
+
+Este error ya se cometió tres veces en tres lugares distintos: la Calculadora perdiendo el mapeo
+mezcla→lote al recargar (D6), el Reporte perdiendo la columna Plan entera, y `useReporteAplicacion`
+trayendo `aplicaciones_calculos(*)` en el query y no usándolo. **Leer la tabla vacía no falla:
+devuelve 0 y el consumidor cae a su respaldo sin que nadie se entere.** Es la trampa.
+
+## Comparaciones legítimas y una que no lo es
+
+- **Usa `calcularCambio()`, no `calcularDesviacion()`.** La segunda devuelve literalmente `100`
+  cuando el planeado es 0 (`calculosReporteAplicacion.ts:15`) — no es un bug tipográfico, es su
+  diseño. Con el plan estructuralmente en 0, eso pintaba `+100,0%` en las 4 tarjetas de TODAS las
+  aplicaciones cerradas. `calcularCambio` devuelve `undefined` sin base, y `KPICard` omite el badge.
+- **`costo_total` y `costo_por_arbol` NO llevan plan, a propósito.** El real es insumos + mano de
+  obra; el único plan que existe es el de insumos. No hay plan de jornales guardado en ninguna parte.
+  Compararlos daba "+138,1%" en una aplicación cuyos insumos se desviaron +0,4%. `costo_productos` sí
+  conserva su plan: ahí sí se comparan insumos con insumos.
+- **Jornales es la excepción**: su plan se *calcula* (`tareas.jornales_estimados` prorrateado, con
+  respaldo `árboles/500`), no se guarda. Por eso nunca le faltó la columna cuando a las otras sí.
+
+## Reglas de pantalla que ya costaron un defecto
+
+- **Nunca un "100%" pelado cuando lo aplicado excede lo planeado.** 76,0 sobre 75,8 canecas redondea
+  a 100% y esconde el exceso. Se muestra `Excedido +0,2` con el delta real, y por debajo del límite
+  el porcentaje va con un decimal (99,7%), nunca redondeado a entero.
+- **Los operandos y el resultado llevan los mismos decimales.** "76,0 − 75,8 = +0,17" no cierra y
+  hace dudar del número; son 76,00 − 75,83.
+- **Ausencia no es cero.** Sin dato → `—`. Nunca 0, nunca un porcentaje inventado, nunca una serie de
+  gráfico dibujada en cero (se omite entera, leyenda incluida).
+- **Un solo acento olivo.** La jerarquía la carga la intensidad, no el tono: `En ejecución` sólido,
+  `Calculada` tinte, `Cerrada` contorno neutro. El módulo tenía cuatro paletas distintas peleando
+  (badges, botones de fila, gradientes de `HeroKPICards`, azul/morado en `EconomicSection`).
+
+## Guardas que te van a frenar
+
+- `aplicacionesFixedInsetGuard.test.ts` — falla si aparece `fixed inset-0` en un `className` bajo
+  este directorio. Los 5 modales a mano ya migraron y **la lista de excepciones está vacía**: si
+  agregás una, estás yendo para atrás. Usá `Dialog`/`Sheet`/`Drawer`/`AlertDialog`.
+- `dialogScrollContract.test.ts` — el scroll va en `DialogBody`, nunca en `DialogContent`.
+- `tableCrudoTrinquete.test.ts` — trinquete de `<table>` crudas. Cuando migrás un archivo a `Table`,
+  **hay que sacarlo de `DEUDA_TABLA_CRUDA` y ajustar el conteo**, o el test falla por deuda saldada.
+- `estadoAplicacionEtiquetas.test.ts` — ver arriba.
+
+## Datos que se capturan y no se veían
+
+- **La cuadrilla vive en `movimientos_diarios_trabajadores`** (926 filas, ~6 por movimiento), con su
+  lote, fracción de jornal y costo. `movimientos_diarios.responsable` es **texto libre** con el
+  nombre del responsable — no es la cuadrilla, y está sucio ("Felipe García" / "Felipe Garcia").
+  `movimientos_diarios.personal` es una columna muerta, NULL en todas las filas.
+- **`sublotes_ids` ya no se escribe** (`aplicaciones_lotes`). Las 87 filas existentes guardan
+  exactamente TODOS los sublotes de su lote — cero subconjuntos parciales — así que es derivable de
+  `lote_id` y nadie lo lee. La columna se conserva; el campo opcional sigue en el tipo TS.
+
+## Riesgo que no se tocó
+
+**`cerrarAplicacion()` son 6+ escrituras a Supabase sin transacción** (`registros_trabajo` ×3 →
+`aplicaciones_cierre` → `aplicaciones` → `tareas` → `productos` → `movimientos_inventario`). Si falla
+a la mitad, el cierre queda partido. El rediseño preservó el orden exacto y deliberadamente no lo
+tocó: envolverlo en un RPC es su propio trabajo, con su propia verificación.

--- a/src/components/aplicaciones/CalculadoraAplicaciones.tsx
+++ b/src/components/aplicaciones/CalculadoraAplicaciones.tsx
@@ -776,7 +776,10 @@ export function CalculadoraAplicaciones() {
         onDiscard={clearFormData}
       />
 
-      <div className="bg-card rounded-2xl shadow-sm border border-border p-6 sm:p-8">
+      {/* Antes esto era una tercera tarjeta con sombra y borde propios: encabezado + stepper +
+          contenido, tres bloques apilados antes del primer campo. El stepper es orientación, no
+          contenido — va como banda ligera, sin competir con la tarjeta del formulario. */}
+      <div className="py-2">
         <AplicacionStepper pasos={PASOS} pasoActual={state.paso_actual} />
       </div>
 

--- a/src/components/aplicaciones/CalculadoraAplicaciones.tsx
+++ b/src/components/aplicaciones/CalculadoraAplicaciones.tsx
@@ -1,22 +1,18 @@
 import { useState, useEffect } from 'react';
 import { useNavigate, useParams } from 'react-router-dom';
-import {
-  Settings,
-  Beaker,
-  ShoppingCart,
-  Check,
-  ChevronLeft,
-  ChevronRight,
-  X,
-  AlertTriangle,
-  FileDown,
-  Loader2,
-} from 'lucide-react';
+import { ChevronLeft, ChevronRight, X, AlertTriangle, Check } from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
-import { generarPDFListaCompras } from '../../utils/generarPDFListaCompras';
 import { useFormPersistence } from '../../hooks/useFormPersistence';
 import { FormDraftBanner } from '../shared/FormDraftBanner';
+import { AplicacionShell } from './shared/AplicacionShell';
+import { AplicacionStepper, type PasoStepper } from './shared/AplicacionStepper';
+import { Button } from '../ui/button';
+import { ButtonGroup } from '../ui/button-group';
+import { Spinner } from '../ui/spinner';
+import { Alert, AlertTitle, AlertDescription } from '../ui/alert';
+import { ConfirmDialog } from '../ui/confirm-dialog';
 import type {
+  EstadoAplicacion,
   EstadoCalculadora,
   ConfiguracionAplicacion,
   Mezcla,
@@ -26,33 +22,20 @@ import type {
 
 // Importar componentes de pasos
 import { PasoConfiguracion } from './PasoConfiguracion';
-import { PasoMezcla } from './PasoMezcla';
+import type { EstadoAsignacionMezcla } from './PasoMezcla';
 import { PasoListaCompras } from './PasoListaCompras';
 import { obtenerFechaHoy } from '@/utils/fechas';
 
 // ============================================================================
-// CONFIGURACIÓN DE PASOS
+// CONFIGURACIÓN DE PASOS — 2, no 3 (W01-calculadora-v2.md). "Configuración" y "Mezcla"
+// se fusionan en "Plan": son la misma cadena causal de decisión (qué se va a hacer y
+// dónde), mientras que "Lista de Compras" es una fase distinta de verdad (procurar, no
+// decidir) y se mantiene aparte.
 // ============================================================================
 
-const PASOS = [
-  {
-    numero: 1,
-    titulo: 'Configuración',
-    descripcion: 'Selecciona lotes y tipo de aplicación',
-    icono: Settings,
-  },
-  {
-    numero: 2,
-    titulo: 'Mezcla',
-    descripcion: 'Define productos y dosis',
-    icono: Beaker,
-  },
-  {
-    numero: 3,
-    titulo: 'Lista de Compras',
-    descripcion: 'Revisa inventario y necesidades',
-    icono: ShoppingCart,
-  },
+const PASOS: PasoStepper[] = [
+  { id: 'plan', titulo: 'Plan', descripcion: 'Lotes, mezclas y dosis' },
+  { id: 'compras', titulo: 'Lista de Compras', descripcion: 'Inventario y costos' },
 ];
 
 // ============================================================================
@@ -83,15 +66,20 @@ export function CalculadoraAplicaciones() {
 
   // Use form persistence for NEW applications only (not in edit mode)
   const [state, setState, clearFormData] = useFormPersistence<EstadoCalculadora>({
-    key: modoEdicion ? `calculadora-edit-${id}` : 'calculadora-new-v1',
+    key: modoEdicion ? `calculadora-edit-${id}` : 'calculadora-new-v2',
     initialState: INITIAL_STATE,
     debounceMs: 1500, // Longer debounce for complex form
-    enabled: !modoEdicion // Only enable for new applications
+    enabled: !modoEdicion, // Only enable for new applications
   });
 
   const [showCancelDialog, setShowCancelDialog] = useState(false);
   const [validationError, setValidationError] = useState('');
   const [cargandoDatos, setCargandoDatos] = useState(false);
+  const [estadoAplicacionActual, setEstadoAplicacionActual] = useState<EstadoAplicacion | null>(null);
+
+  // D6 — estado de asignación mezcla↔lotes por mezcla.id, solo relevante con 2+ mezclas
+  // (con 1 sola mezcla la asignación se hereda estructuralmente, ver PasoMezcla.tsx).
+  const [estadosAsignacion, setEstadosAsignacion] = useState<Record<string, EstadoAsignacionMezcla>>({});
 
   // ==========================================================================
   // CARGAR DATOS EN MODO EDICIÓN
@@ -101,6 +89,7 @@ export function CalculadoraAplicaciones() {
     if (modoEdicion && id) {
       cargarAplicacion();
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [id, modoEdicion]);
 
   const cargarAplicacion = async () => {
@@ -114,62 +103,48 @@ export function CalculadoraAplicaciones() {
         .eq('id', id!)
         .single();
 
-      if (errorAplicacion) {
-        throw errorAplicacion;
-      }
+      if (errorAplicacion) throw errorAplicacion;
+      if (!aplicacion) throw new Error('Aplicación no encontrada');
 
-      if (!aplicacion) {
-        throw new Error('Aplicación no encontrada');
-      }
-
+      setEstadoAplicacionActual((aplicacion.estado as EstadoAplicacion | null) ?? null);
 
       // 2. Obtener lotes con conteo de árboles
       const { data: lotesData, error: errorLotes } = await supabase
         .from('aplicaciones_lotes')
-        .select(`
+        .select(
+          `
           *,
-          lotes (
-            id,
-            nombre,
-            area_hectareas
-          )
-        `)
+          lotes ( id, nombre, area_hectareas )
+        `,
+        )
         .eq('aplicacion_id', id!);
 
-      if (errorLotes) {
-        throw errorLotes;
-      }
-
+      if (errorLotes) throw errorLotes;
 
       // 3. Obtener mezclas
-      const { data: mezclas, error: errorMezclas } = await supabase
+      const { data: mezclasRaw, error: errorMezclas } = await supabase
         .from('aplicaciones_mezclas')
         .select('*')
         .eq('aplicacion_id', id!)
         .order('numero_mezcla');
 
-      if (errorMezclas) {
-        throw errorMezclas;
-      }
-
+      if (errorMezclas) throw errorMezclas;
 
       // 4. Obtener productos de cada mezcla
-      const mezclasConProductos = await Promise.all(
-        (mezclas || []).map(async (mezcla) => {
+      let mezclasConProductos = await Promise.all(
+        (mezclasRaw || []).map(async (mezcla) => {
           const { data: productos, error: errorProductos } = await supabase
             .from('aplicaciones_productos')
             .select('*')
             .eq('mezcla_id', mezcla.id);
 
-          if (errorProductos) {
-            throw errorProductos;
-          }
+          if (errorProductos) throw errorProductos;
 
           return {
             id: mezcla.id,
             numero_orden: mezcla.numero_mezcla,
             nombre: mezcla.nombre_mezcla || `Mezcla ${mezcla.numero_mezcla}`,
-            productos: (productos || []).map(p => ({
+            productos: (productos || []).map((p) => ({
               producto_id: p.producto_id,
               producto_nombre: p.producto_nombre,
               producto_categoria: p.producto_categoria,
@@ -181,66 +156,79 @@ export function CalculadoraAplicaciones() {
               dosis_pequenos: p.dosis_pequenos || undefined,
               dosis_clonales: p.dosis_clonales || undefined,
               cantidad_total_necesaria: p.cantidad_total_necesaria || 0,
-            }))
+            })),
+            lotes_asignados: [] as string[],
           };
-        })
+        }),
       );
 
-
-      // 5. Obtener cálculos
+      // 5. Obtener cálculos — es también la fuente del mapeo mezcla↔lote real
+      // (`aplicaciones_calculos.mezcla_id`, contrato de Fase 0).
       const { data: calculos, error: errorCalculos } = await supabase
         .from('aplicaciones_calculos')
         .select('*')
         .eq('aplicacion_id', id!);
 
-      if (errorCalculos) {
-        throw errorCalculos;
-      }
+      if (errorCalculos) throw errorCalculos;
 
+      // 5b. D6 — rehidratar `lotes_asignados` por mezcla en vez de dejarlo vacío (el bug
+      // original: cargarAplicacion() nunca lo poblaba). Con una sola mezcla no hace falta
+      // leer nada: se hereda de los lotes de la aplicación, estructuralmente sin ambigüedad
+      // (W01-calculadora-v2.md §5). Con 2+ mezclas se lee `aplicaciones_calculos.mezcla_id`
+      // y se distinguen 3 estados — nunca se confunde "0 lotes" con "no se pudo leer".
+      const idsLotesAplicacion = (lotesData || []).map((l) => l.lote_id);
+      const nuevosEstadosAsignacion: Record<string, EstadoAsignacionMezcla> = {};
+
+      if (mezclasConProductos.length === 1) {
+        mezclasConProductos = [{ ...mezclasConProductos[0], lotes_asignados: idsLotesAplicacion }];
+      } else if (mezclasConProductos.length > 1) {
+        const algunCalculoTraeMezclaId = (calculos || []).some((c) => !!c.mezcla_id);
+        mezclasConProductos = mezclasConProductos.map((m) => {
+          const lotesDeEstaMezcla = Array.from(
+            new Set((calculos || []).filter((c) => c.mezcla_id === m.id).map((c) => c.lote_id as string)),
+          );
+          if (!algunCalculoTraeMezclaId) {
+            // Ningún cálculo de TODA la aplicación trae mezcla_id: no es "0 lotes", es que
+            // no se puede leer el mapeo — falla de carga, no una decisión deliberada.
+            nuevosEstadosAsignacion[m.id] = 'error';
+          } else if (lotesDeEstaMezcla.length === 0) {
+            nuevosEstadosAsignacion[m.id] = 'sin_asignar';
+          } else {
+            nuevosEstadosAsignacion[m.id] = 'ok';
+          }
+          return { ...m, lotes_asignados: lotesDeEstaMezcla };
+        });
+      }
+      setEstadosAsignacion(nuevosEstadosAsignacion);
 
       // 6. Obtener lista de compras
       const { data: compras, error: errorCompras } = await supabase
         .from('aplicaciones_compras')
-        .select(`
-          id,
-          aplicacion_id,
-          producto_id,
-          producto_nombre,
-          producto_categoria,
-          unidad,
-          inventario_actual,
-          cantidad_necesaria,
-          cantidad_faltante,
-          presentacion_comercial,
-          unidades_a_comprar,
-          precio_unitario,
-          costo_estimado,
-          alerta,
-          created_at
-        `)
+        .select(
+          `
+          id, aplicacion_id, producto_id, producto_nombre, producto_categoria, unidad,
+          inventario_actual, cantidad_necesaria, cantidad_faltante, presentacion_comercial,
+          unidades_a_comprar, precio_unitario, costo_estimado, alerta, created_at
+        `,
+        )
         .eq('aplicacion_id', id!);
 
-      if (errorCompras) {
-        throw errorCompras;
-      }
-
+      if (errorCompras) throw errorCompras;
 
       // 7. Mapear datos a la configuración
-      const tipoAplicacion = aplicacion.tipo_aplicacion === 'Fumigación' 
-        ? 'fumigacion' 
-        : aplicacion.tipo_aplicacion === 'Fertilización'
-        ? 'fertilizacion'
-        : 'drench';
+      const tipoAplicacion =
+        aplicacion.tipo_aplicacion === 'Fumigación'
+          ? 'fumigacion'
+          : aplicacion.tipo_aplicacion === 'Fertilización'
+            ? 'fertilizacion'
+            : 'drench';
 
-      // Parsear blanco_biologico
       let blancoBiologico: string[] = [];
       if (aplicacion.blanco_biologico) {
         try {
-          blancoBiologico = JSON.parse(aplicacion.blanco_biologico);
-          if (!Array.isArray(blancoBiologico)) {
-            blancoBiologico = [];
-          }
-        } catch (e) {
+          const parsed = JSON.parse(aplicacion.blanco_biologico);
+          if (Array.isArray(parsed)) blancoBiologico = parsed;
+        } catch {
           blancoBiologico = [];
         }
       }
@@ -253,8 +241,8 @@ export function CalculadoraAplicaciones() {
         fecha_recomendacion: aplicacion.fecha_recomendacion || undefined,
         proposito: aplicacion.proposito || undefined,
         agronomo_responsable: aplicacion.agronomo_responsable || undefined,
-        blanco_biologico: blancoBiologico.length > 0 ? blancoBiologico : [],
-        lotes_seleccionados: (lotesData || []).map(lote => ({
+        blanco_biologico: blancoBiologico,
+        lotes_seleccionados: (lotesData || []).map((lote) => ({
           lote_id: lote.lote_id,
           nombre: lote.lotes?.nombre || 'Sin nombre',
           sublotes_ids: lote.sublotes_ids || [],
@@ -268,10 +256,10 @@ export function CalculadoraAplicaciones() {
           },
           calibracion_litros_arbol: lote.calibracion_litros_arbol || undefined,
           tamano_caneca: (lote.tamano_caneca || undefined) as 20 | 200 | 500 | 1000 | undefined,
-        }))
+        })),
       };
 
-      const calculosData = (calculos || []).map(calc => ({
+      const calculosData = (calculos || []).map((calc) => ({
         lote_id: calc.lote_id,
         lote_nombre: calc.lote_nombre,
         total_arboles: calc.total_arboles,
@@ -286,25 +274,28 @@ export function CalculadoraAplicaciones() {
         productos: [],
       })) as CalculosPorLote[];
 
-      const listaCompras: ListaCompras | null = compras && compras.length > 0 ? {
-        items: compras.map(item => ({
-          producto_id: item.producto_id,
-          producto_nombre: item.producto_nombre,
-          producto_categoria: item.producto_categoria ?? '',
-          unidad: item.unidad,
-          inventario_actual: item.inventario_actual,
-          cantidad_necesaria: item.cantidad_necesaria,
-          cantidad_faltante: item.cantidad_faltante,
-          presentacion_comercial: item.presentacion_comercial || '',
-          unidades_a_comprar: item.unidades_a_comprar,
-          ultimo_precio_unitario: item.precio_unitario || undefined,
-          costo_estimado: item.costo_estimado || undefined,
-          alerta: (item.alerta ?? 'normal') as 'normal' | 'sin_precio' | 'sin_stock',
-        })),
-        costo_total_estimado: compras.reduce((sum, item) => sum + (item.costo_estimado || 0), 0),
-        productos_sin_precio: compras.filter(item => !item.precio_unitario).length,
-        productos_sin_stock: compras.filter(item => item.cantidad_faltante > 0).length,
-      } : null;
+      const listaCompras: ListaCompras | null =
+        compras && compras.length > 0
+          ? {
+              items: compras.map((item) => ({
+                producto_id: item.producto_id,
+                producto_nombre: item.producto_nombre,
+                producto_categoria: item.producto_categoria ?? '',
+                unidad: item.unidad,
+                inventario_actual: item.inventario_actual,
+                cantidad_necesaria: item.cantidad_necesaria,
+                cantidad_faltante: item.cantidad_faltante,
+                presentacion_comercial: item.presentacion_comercial || '',
+                unidades_a_comprar: item.unidades_a_comprar,
+                ultimo_precio_unitario: item.precio_unitario || undefined,
+                costo_estimado: item.costo_estimado || undefined,
+                alerta: (item.alerta ?? 'normal') as 'normal' | 'sin_precio' | 'sin_stock',
+              })),
+              costo_total_estimado: compras.reduce((sum, item) => sum + (item.costo_estimado || 0), 0),
+              productos_sin_precio: compras.filter((item) => !item.precio_unitario).length,
+              productos_sin_stock: compras.filter((item) => item.cantidad_faltante > 0).length,
+            }
+          : null;
 
       // 8. Actualizar estado
       setState({
@@ -316,12 +307,10 @@ export function CalculadoraAplicaciones() {
         guardando: false,
         error: null,
       });
-
-
     } catch (error) {
-      setState(prev => ({
+      setState((prev) => ({
         ...prev,
-        error: error instanceof Error ? error.message : 'Error cargando la aplicación'
+        error: error instanceof Error ? error.message : 'Error cargando la aplicación',
       }));
     } finally {
       setCargandoDatos(false);
@@ -329,10 +318,12 @@ export function CalculadoraAplicaciones() {
   };
 
   // ==========================================================================
-  // VALIDACIONES POR PASO
+  // VALIDACIÓN DEL PASO "PLAN" — fusión de las viejas validarPaso1 + validarPaso2: ya no
+  // hay una pantalla intermedia donde detenerse, así que se valida todo junto antes de
+  // pasar a Lista de Compras.
   // ==========================================================================
 
-  const validarPaso1 = (): boolean => {
+  const validarPasoPlan = (): boolean => {
     if (!state.configuracion) {
       setValidationError('Debes completar la configuración');
       return false;
@@ -344,74 +335,70 @@ export function CalculadoraAplicaciones() {
       setValidationError('Debes ingresar un nombre para la aplicación');
       return false;
     }
-
     if (!tipo) {
       setValidationError('Debes seleccionar un tipo de aplicación');
       return false;
     }
-
     if (!fecha_inicio_planeada) {
       setValidationError('Debes seleccionar una fecha de inicio');
       return false;
     }
-
     if (lotes_seleccionados.length === 0) {
       setValidationError('Debes seleccionar al menos un lote');
       return false;
     }
 
-    // Validar calibración para fumigaciones
-    if (tipo === 'fumigacion') {
+    if (tipo === 'fumigacion' || tipo === 'drench') {
       const lotesSinCalibracion = lotes_seleccionados.filter(
-        l => !l.calibracion_litros_arbol || 
-             l.calibracion_litros_arbol <= 0 || 
-             !l.tamano_caneca
+        (l) => !l.calibracion_litros_arbol || l.calibracion_litros_arbol <= 0 || !l.tamano_caneca,
       );
-      
       if (lotesSinCalibracion.length > 0) {
-        const nombres = lotesSinCalibracion
-          .map(l => l.nombre)
-          .join(', ');
         setValidationError(
-          `Los siguientes lotes necesitan calibración completa (L/árbol y tamaño de caneca): ${nombres}`
+          `Los siguientes lotes necesitan calibración completa (L/árbol y tamaño de caneca): ${lotesSinCalibracion
+            .map((l) => l.nombre)
+            .join(', ')}`,
         );
         return false;
       }
     }
 
-    setValidationError('');
-    return true;
-  };
-
-  const validarPaso2 = (): boolean => {
     if (state.mezclas.length === 0) {
       setValidationError('Debes crear al menos una mezcla');
       return false;
     }
 
-    // Validar que todas las mezclas tengan productos
     const mezclasSinProductos = state.mezclas.filter((m) => m.productos.length === 0);
-
     if (mezclasSinProductos.length > 0) {
       setValidationError('Todas las mezclas deben tener al menos un producto');
       return false;
     }
 
-    // Validar que todos los productos tengan dosis configuradas
-    const productosSinDosis = state.mezclas.flatMap((m) => m.productos).filter((p) => {
-      if (state.configuracion?.tipo === 'fumigacion' || state.configuracion?.tipo === 'drench') {
-        // Fumigación y Drench usan dosis por caneca
-        return !p.dosis_por_caneca || p.dosis_por_caneca <= 0;
-      } else {
-        // Fertilización: al menos una dosis debe ser > 0
+    // Con 2+ mezclas la asignación de lotes vuelve a ser una decisión real (antes la
+    // gateaba el diálogo "Confirmar Mezcla"; al volverse edición directa, esta es la
+    // única puerta que queda para no guardar una mezcla sin lotes).
+    if (state.mezclas.length > 1) {
+      const mezclasSinLotes = state.mezclas.filter((m) => !m.lotes_asignados || m.lotes_asignados.length === 0);
+      if (mezclasSinLotes.length > 0) {
+        setValidationError(
+          `Estas mezclas todavía no tienen lotes asignados: ${mezclasSinLotes.map((m) => m.nombre).join(', ')}`,
+        );
+        return false;
+      }
+    }
+
+    const productosSinDosis = state.mezclas
+      .flatMap((m) => m.productos)
+      .filter((p) => {
+        if (tipo === 'fumigacion' || tipo === 'drench') {
+          return !p.dosis_por_caneca || p.dosis_por_caneca <= 0;
+        }
         return (
           (p.dosis_grandes || 0) === 0 &&
           (p.dosis_medianos || 0) === 0 &&
           (p.dosis_pequenos || 0) === 0 &&
           (p.dosis_clonales || 0) === 0
         );
-      }
-    });
+      });
 
     if (productosSinDosis.length > 0) {
       setValidationError('Todos los productos deben tener dosis configuradas');
@@ -422,62 +409,35 @@ export function CalculadoraAplicaciones() {
     return true;
   };
 
-  const validarPaso3 = (): boolean => {
-    // Paso 3 siempre puede avanzar (aunque falten productos)
-    setValidationError('');
-    return true;
-  };
-
   // ==========================================================================
-  // NAVEGACIÓN
+  // NAVEGACIÓN — 2 pasos
   // ==========================================================================
 
   const handleSiguiente = () => {
-    // Validar paso actual antes de avanzar
-    let esValido = false;
+    if (state.paso_actual === 1 && !validarPasoPlan()) return;
 
-    if (state.paso_actual === 1) {
-      esValido = validarPaso1();
-    } else if (state.paso_actual === 2) {
-      esValido = validarPaso2();
-    } else if (state.paso_actual === 3) {
-      esValido = validarPaso3();
-    }
-
-    if (!esValido) return;
-
-    // Avanzar al siguiente paso
-    if (state.paso_actual < 3) {
-      setState((prev) => ({
-        ...prev,
-        paso_actual: (prev.paso_actual + 1) as 1 | 2 | 3,
-      }));
+    if (state.paso_actual < 2) {
+      setState((prev) => ({ ...prev, paso_actual: (prev.paso_actual + 1) as 1 | 2 }));
       setValidationError('');
     }
   };
 
   const handleAnterior = () => {
     if (state.paso_actual > 1) {
-      setState((prev) => ({
-        ...prev,
-        paso_actual: (prev.paso_actual - 1) as 1 | 2 | 3,
-      }));
+      setState((prev) => ({ ...prev, paso_actual: (prev.paso_actual - 1) as 1 | 2 }));
       setValidationError('');
     }
   };
 
-  const handleCancelar = () => {
-    setShowCancelDialog(true);
-  };
+  const handleCancelar = () => setShowCancelDialog(true);
 
   const confirmarCancelar = () => {
-    clearFormData(); // Clear saved form data
+    setShowCancelDialog(false);
+    clearFormData();
     navigate('/aplicaciones');
   };
 
   const handleGuardarYFinalizar = async () => {
-    if (!validarPaso3()) return;
-
     if (!state.configuracion || state.mezclas.length === 0) {
       setState((prev) => ({ ...prev, error: 'Datos incompletos' }));
       return;
@@ -486,8 +446,9 @@ export function CalculadoraAplicaciones() {
     try {
       setState((prev) => ({ ...prev, guardando: true, error: null }));
 
-      // Obtener usuario actual
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
       if (!user) throw new Error('Usuario no autenticado');
 
       let aplicacionId: string;
@@ -497,9 +458,7 @@ export function CalculadoraAplicaciones() {
         // =============================================================
         // MODO EDICIÓN: ACTUALIZAR APLICACIÓN EXISTENTE
         // =============================================================
-        
 
-        // Obtener código existente
         const { data: aplicacionExistente } = await supabase
           .from('aplicaciones')
           .select('codigo_aplicacion')
@@ -508,14 +467,13 @@ export function CalculadoraAplicaciones() {
 
         codigoAplicacion = aplicacionExistente?.codigo_aplicacion || '';
 
-        // Actualizar aplicación base
         const aplicacionData = {
           nombre_aplicacion: state.configuracion.nombre,
           tipo_aplicacion: (state.configuracion.tipo === 'fumigacion'
             ? 'Fumigación'
             : state.configuracion.tipo === 'fertilizacion'
-            ? 'Fertilización'
-            : 'Drench') as 'Fumigación' | 'Fertilización' | 'Drench',
+              ? 'Fertilización'
+              : 'Drench') as 'Fumigación' | 'Fertilización' | 'Drench',
           proposito: state.configuracion.proposito || null,
           blanco_biologico: state.configuracion.blanco_biologico
             ? JSON.stringify(state.configuracion.blanco_biologico)
@@ -527,70 +485,37 @@ export function CalculadoraAplicaciones() {
           updated_at: new Date().toISOString(),
         };
 
-        const { error: errorAplicacion } = await supabase
-          .from('aplicaciones')
-          .update(aplicacionData)
-          .eq('id', id);
-
-        if (errorAplicacion) {
-          throw errorAplicacion;
-        }
-
+        const { error: errorAplicacion } = await supabase.from('aplicaciones').update(aplicacionData).eq('id', id);
+        if (errorAplicacion) throw errorAplicacion;
 
         // Eliminar relaciones existentes
+        await supabase.from('aplicaciones_lotes').delete().eq('aplicacion_id', id!);
 
-        // Eliminar lotes
-        await supabase
-          .from('aplicaciones_lotes')
-          .delete()
-          .eq('aplicacion_id', id!);
-
-        // Eliminar productos de mezclas
         const { data: mezclasExistentes } = await supabase
           .from('aplicaciones_mezclas')
           .select('id')
           .eq('aplicacion_id', id!);
 
         if (mezclasExistentes && mezclasExistentes.length > 0) {
-          const mezclaIds = mezclasExistentes.map(m => m.id);
-          
-          await supabase
-            .from('aplicaciones_productos')
-            .delete()
-            .in('mezcla_id', mezclaIds);
+          const mezclaIds = mezclasExistentes.map((m) => m.id);
+          await supabase.from('aplicaciones_productos').delete().in('mezcla_id', mezclaIds);
         }
 
-        // Eliminar mezclas
-        await supabase
-          .from('aplicaciones_mezclas')
-          .delete()
-          .eq('aplicacion_id', id!);
-
-        // Eliminar cálculos
-        await supabase
-          .from('aplicaciones_calculos')
-          .delete()
-          .eq('aplicacion_id', id!);
-
-        // Eliminar lista de compras
-        await supabase
-          .from('aplicaciones_compras')
-          .delete()
-          .eq('aplicacion_id', id!);
-
+        await supabase.from('aplicaciones_mezclas').delete().eq('aplicacion_id', id!);
+        await supabase.from('aplicaciones_calculos').delete().eq('aplicacion_id', id!);
+        await supabase.from('aplicaciones_compras').delete().eq('aplicacion_id', id!);
 
         aplicacionId = id;
-
       } else {
         // =============================================================
         // MODO CREACIÓN: INSERTAR NUEVA APLICACIÓN
         // =============================================================
-        
-        // Generar código único (formato: APL-YYYYMMDD-XXX)
+
         const fecha = new Date();
-        const codigoBase = `APL-${fecha.getFullYear()}${String(fecha.getMonth() + 1).padStart(2, '0')}${String(fecha.getDate()).padStart(2, '0')}`;
-        
-        // Buscar último código del día
+        const codigoBase = `APL-${fecha.getFullYear()}${String(fecha.getMonth() + 1).padStart(2, '0')}${String(
+          fecha.getDate(),
+        ).padStart(2, '0')}`;
+
         const { data: ultimaAplicacion } = await supabase
           .from('aplicaciones')
           .select('codigo_aplicacion')
@@ -611,10 +536,10 @@ export function CalculadoraAplicaciones() {
           tipo_aplicacion: (state.configuracion.tipo === 'fumigacion'
             ? 'Fumigación'
             : state.configuracion.tipo === 'fertilizacion'
-            ? 'Fertilización'
-            : 'Drench') as 'Fumigación' | 'Fertilización' | 'Drench',
+              ? 'Fertilización'
+              : 'Drench') as 'Fumigación' | 'Fertilización' | 'Drench',
           proposito: state.configuracion.proposito || null,
-          blanco_biologico: state.configuracion.blanco_biologico 
+          blanco_biologico: state.configuracion.blanco_biologico
             ? JSON.stringify(state.configuracion.blanco_biologico)
             : null,
           fecha_inicio_planeada: state.configuracion.fecha_inicio_planeada,
@@ -626,70 +551,56 @@ export function CalculadoraAplicaciones() {
           fecha_fin_ejecucion: null,
         };
 
-
-        const { data, error: errorAplicacion } = await supabase
-          .from('aplicaciones')
-          .insert([aplicacionData])
-          .select();
-
-        if (errorAplicacion) {
-          throw errorAplicacion;
-        }
+        const { data, error: errorAplicacion } = await supabase.from('aplicaciones').insert([aplicacionData]).select();
+        if (errorAplicacion) throw errorAplicacion;
 
         const aplicacion = data?.[0];
-        if (!aplicacion) {
-          throw new Error('No se pudo crear la aplicación');
-        }
+        if (!aplicacion) throw new Error('No se pudo crear la aplicación');
 
         aplicacionId = aplicacion.id;
       }
 
       // =============================================================
-      // PASO 2: INSERTAR LOTES (común para creación y edición)
+      // INSERTAR LOTES
+      // W01-calculadora-v2.md campo #13 / CLAUDE.md: `sublotes_ids` deja de escribirse.
+      // Es siempre `lote.sublotes.map(s => s.id)` (todos los sublotes del lote, verificado
+      // contra las 87 filas de producción) — no hay un lector real y la columna nullable
+      // simplemente queda NULL en filas nuevas; las 87 existentes no se tocan.
       // =============================================================
-      
+
       const lotesData = state.configuracion.lotes_seleccionados.map((lote) => ({
         aplicacion_id: aplicacionId,
         lote_id: lote.lote_id,
-        sublotes_ids: lote.sublotes_ids || null,
         arboles_grandes: lote.conteo_arboles.grandes,
         arboles_medianos: lote.conteo_arboles.medianos,
         arboles_pequenos: lote.conteo_arboles.pequenos,
         arboles_clonales: lote.conteo_arboles.clonales,
         total_arboles: lote.conteo_arboles.total,
-        calibracion_litros_arbol: ((state.configuracion as any)?.tipo === 'fumigacion' || (state.configuracion as any)?.tipo === 'drench')
-          ? lote.calibracion_litros_arbol
-          : null,
-        tamano_caneca: ((state.configuracion as any)?.tipo === 'fumigacion' || (state.configuracion as any)?.tipo === 'drench')
-          ? lote.tamano_caneca
-          : null,
+        calibracion_litros_arbol:
+          state.configuracion?.tipo === 'fumigacion' || state.configuracion?.tipo === 'drench'
+            ? lote.calibracion_litros_arbol
+            : null,
+        tamano_caneca:
+          state.configuracion?.tipo === 'fumigacion' || state.configuracion?.tipo === 'drench'
+            ? lote.tamano_caneca
+            : null,
       }));
 
-
-      const { error: errorLotes } = await supabase
-        .from('aplicaciones_lotes')
-        .insert(lotesData);
-
-      if (errorLotes) {
-        throw errorLotes;
-      }
-
+      const { error: errorLotes } = await supabase.from('aplicaciones_lotes').insert(lotesData);
+      if (errorLotes) throw errorLotes;
 
       // =============================================================
-      // PASO 3: INSERTAR MEZCLAS Y PRODUCTOS
+      // INSERTAR MEZCLAS Y PRODUCTOS
       // =============================================================
 
-      // Map to store lote_id → mezcla_id relationship
       const loteToMezclaMap: Record<string, string> = {};
 
       for (const mezcla of state.mezclas) {
-        // Insertar mezcla
         const mezclaData = {
           aplicacion_id: aplicacionId,
           numero_mezcla: mezcla.numero_orden,
           nombre_mezcla: mezcla.nombre,
         };
-
 
         const { data: mezclaInsertada, error: errorMezcla } = await supabase
           .from('aplicaciones_mezclas')
@@ -697,65 +608,51 @@ export function CalculadoraAplicaciones() {
           .select()
           .single();
 
-        if (errorMezcla) {
-          throw errorMezcla;
-        }
+        if (errorMezcla) throw errorMezcla;
 
-        // Store lote → mezcla mapping for each assigned lote
-        if (mezcla.lotes_asignados) {
-          mezcla.lotes_asignados.forEach((loteId: string) => {
-            loteToMezclaMap[loteId] = mezclaInsertada.id;
-          });
-        }
+        // Con una sola mezcla, `lotes_asignados` es la misma lista que
+        // `configuracion.lotes_seleccionados` (heredada, ver PasoMezcla.tsx) — el mapeo se
+        // escribe igual que antes.
+        const lotesEfectivos =
+          state.mezclas.length === 1
+            ? state.configuracion.lotes_seleccionados.map((l) => l.lote_id)
+            : mezcla.lotes_asignados || [];
 
-        // Insertar productos de la mezcla
+        lotesEfectivos.forEach((loteId) => {
+          loteToMezclaMap[loteId] = mezclaInsertada.id;
+        });
+
         const productosData = mezcla.productos.map((producto) => ({
           mezcla_id: mezclaInsertada.id,
           producto_id: producto.producto_id,
-          dosis_por_caneca: state.configuracion?.tipo === 'fumigacion'
-            ? producto.dosis_por_caneca
-            : null,
-          unidad_dosis: state.configuracion?.tipo === 'fumigacion'
-            ? producto.unidad_dosis
-            : null,
-          dosis_grandes: state.configuracion?.tipo === 'fertilizacion'
-            ? producto.dosis_grandes
-            : null,
-          dosis_medianos: state.configuracion?.tipo === 'fertilizacion'
-            ? producto.dosis_medianos
-            : null,
-          dosis_pequenos: state.configuracion?.tipo === 'fertilizacion'
-            ? producto.dosis_pequenos
-            : null,
-          dosis_clonales: state.configuracion?.tipo === 'fertilizacion'
-            ? producto.dosis_clonales
-            : null,
+          dosis_por_caneca:
+            state.configuracion?.tipo === 'fumigacion' || state.configuracion?.tipo === 'drench'
+              ? producto.dosis_por_caneca
+              : null,
+          unidad_dosis:
+            state.configuracion?.tipo === 'fumigacion' || state.configuracion?.tipo === 'drench'
+              ? producto.unidad_dosis
+              : null,
+          dosis_grandes: state.configuracion?.tipo === 'fertilizacion' ? producto.dosis_grandes : null,
+          dosis_medianos: state.configuracion?.tipo === 'fertilizacion' ? producto.dosis_medianos : null,
+          dosis_pequenos: state.configuracion?.tipo === 'fertilizacion' ? producto.dosis_pequenos : null,
+          dosis_clonales: state.configuracion?.tipo === 'fertilizacion' ? producto.dosis_clonales : null,
           cantidad_total_necesaria: producto.cantidad_total_necesaria,
           producto_nombre: producto.producto_nombre,
           producto_categoria: producto.producto_categoria,
           producto_unidad: producto.producto_unidad,
         }));
 
-
-        const { error: errorProductos } = await supabase
-          .from('aplicaciones_productos')
-          .insert(productosData);
-
-        if (errorProductos) {
-          throw errorProductos;
-        }
-
+        const { error: errorProductos } = await supabase.from('aplicaciones_productos').insert(productosData);
+        if (errorProductos) throw errorProductos;
       }
 
       // =============================================================
-      // PASO 4: INSERTAR CÁLCULOS POR LOTE
+      // INSERTAR CÁLCULOS POR LOTE
       // =============================================================
-      
+
       const calculosData = state.calculos.map((calculo) => {
-        // Buscar datos del lote
-        const loteConfig = state.configuracion!.lotes_seleccionados.find(
-          (l) => l.lote_id === calculo.lote_id
-        );
+        const loteConfig = state.configuracion!.lotes_seleccionados.find((l) => l.lote_id === calculo.lote_id);
 
         return {
           aplicacion_id: aplicacionId,
@@ -763,51 +660,31 @@ export function CalculadoraAplicaciones() {
           lote_nombre: calculo.lote_nombre,
           area_hectareas: loteConfig?.area_hectareas || null,
           total_arboles: calculo.total_arboles,
-          // Link to mezcla
           mezcla_id: loteToMezclaMap[calculo.lote_id] || null,
-          // Fumigación y Drench
-          litros_mezcla: ((state.configuracion as any)?.tipo === 'fumigacion' || (state.configuracion as any)?.tipo === 'drench')
-            ? calculo.litros_mezcla
-            : null,
-          numero_canecas: ((state.configuracion as any)?.tipo === 'fumigacion' || (state.configuracion as any)?.tipo === 'drench')
-            ? calculo.numero_canecas
-            : null,
-          // Fertilización
-          kilos_totales: state.configuracion?.tipo === 'fertilizacion'
-            ? calculo.kilos_totales
-            : null,
-          numero_bultos: state.configuracion?.tipo === 'fertilizacion'
-            ? calculo.numero_bultos
-            : null,
-          kilos_grandes: state.configuracion?.tipo === 'fertilizacion'
-            ? calculo.kilos_grandes
-            : null,
-          kilos_medianos: state.configuracion?.tipo === 'fertilizacion'
-            ? calculo.kilos_medianos
-            : null,
-          kilos_pequenos: state.configuracion?.tipo === 'fertilizacion'
-            ? calculo.kilos_pequenos
-            : null,
-          kilos_clonales: state.configuracion?.tipo === 'fertilizacion'
-            ? calculo.kilos_clonales
-            : null,
+          litros_mezcla:
+            state.configuracion?.tipo === 'fumigacion' || state.configuracion?.tipo === 'drench'
+              ? calculo.litros_mezcla
+              : null,
+          numero_canecas:
+            state.configuracion?.tipo === 'fumigacion' || state.configuracion?.tipo === 'drench'
+              ? calculo.numero_canecas
+              : null,
+          kilos_totales: state.configuracion?.tipo === 'fertilizacion' ? calculo.kilos_totales : null,
+          numero_bultos: state.configuracion?.tipo === 'fertilizacion' ? calculo.numero_bultos : null,
+          kilos_grandes: state.configuracion?.tipo === 'fertilizacion' ? calculo.kilos_grandes : null,
+          kilos_medianos: state.configuracion?.tipo === 'fertilizacion' ? calculo.kilos_medianos : null,
+          kilos_pequenos: state.configuracion?.tipo === 'fertilizacion' ? calculo.kilos_pequenos : null,
+          kilos_clonales: state.configuracion?.tipo === 'fertilizacion' ? calculo.kilos_clonales : null,
         };
       });
 
-
-      const { error: errorCalculos } = await supabase
-        .from('aplicaciones_calculos')
-        .insert(calculosData);
-
-      if (errorCalculos) {
-        throw errorCalculos;
-      }
-
+      const { error: errorCalculos } = await supabase.from('aplicaciones_calculos').insert(calculosData);
+      if (errorCalculos) throw errorCalculos;
 
       // =============================================================
-      // PASO 5: INSERTAR LISTA DE COMPRAS
+      // INSERTAR LISTA DE COMPRAS
       // =============================================================
-      
+
       if (state.lista_compras && state.lista_compras.items.length > 0) {
         const comprasData = state.lista_compras.items.map((item) => ({
           aplicacion_id: aplicacionId,
@@ -823,38 +700,26 @@ export function CalculadoraAplicaciones() {
           precio_unitario: item.ultimo_precio_unitario || null,
           costo_estimado: item.costo_estimado || null,
           alerta: item.alerta || 'normal',
-          // NO incluir 'estado' - ese campo pertenece a la tabla productos, no a aplicaciones_compras
         }));
 
-
-        const { error: errorCompras } = await supabase
-          .from('aplicaciones_compras')
-          .insert(comprasData);
-
-        if (errorCompras) {
-          throw errorCompras;
-        }
-
+        const { error: errorCompras } = await supabase.from('aplicaciones_compras').insert(comprasData);
+        if (errorCompras) throw errorCompras;
       }
 
       // =============================================================
       // ÉXITO - REDIRIGIR
       // =============================================================
 
-
-      // Clear saved form data since we successfully saved
       clearFormData();
 
-      // Redirigir al listado con mensaje de éxito
       navigate('/aplicaciones', {
         state: {
           success: true,
           mensaje: modoEdicion
             ? `Aplicación ${codigoAplicacion} actualizada exitosamente`
-            : `Aplicación ${codigoAplicacion} guardada exitosamente`
-        }
+            : `Aplicación ${codigoAplicacion} guardada exitosamente`,
+        },
       });
-      
     } catch (error) {
       setState((prev) => ({
         ...prev,
@@ -870,313 +735,141 @@ export function CalculadoraAplicaciones() {
   // ==========================================================================
 
   const updateConfiguracion = (configuracion: ConfiguracionAplicacion) => {
-    setState((prev) => ({
-      ...prev,
-      configuracion,
-    }));
+    setState((prev) => ({ ...prev, configuracion }));
   };
 
   const updateMezclas = (mezclas: Mezcla[], calculos: CalculosPorLote[]) => {
-    setState((prev) => ({
-      ...prev,
-      mezclas,
-      calculos,
-    }));
+    setState((prev) => ({ ...prev, mezclas, calculos }));
   };
 
   const updateListaCompras = (lista_compras: ListaCompras) => {
-    setState((prev) => ({
-      ...prev,
-      lista_compras,
-    }));
+    setState((prev) => ({ ...prev, lista_compras }));
   };
 
   // ==========================================================================
   // RENDER
   // ==========================================================================
 
-  // Mostrar loading mientras se cargan datos en modo edición
   if (cargandoDatos) {
     return (
       <div className="min-h-screen bg-background flex items-center justify-center">
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-12 text-center max-w-md">
-          <Loader2 className="w-12 h-12 text-primary animate-spin mx-auto mb-4" />
+        <div className="bg-card rounded-2xl shadow-sm border border-border p-12 text-center max-w-md">
+          <Spinner className="size-10 text-primary mx-auto mb-4" />
           <h2 className="text-xl text-foreground mb-2">Cargando aplicación...</h2>
-          <p className="text-sm text-brand-brown/70">
-            Estamos recuperando los datos de la aplicación
-          </p>
+          <p className="text-sm text-muted-foreground">Estamos recuperando los datos de la aplicación</p>
         </div>
       </div>
     );
   }
 
+  const nombreVisible = state.configuracion?.nombre?.trim() || (modoEdicion ? 'Editar Aplicación' : 'Nueva Aplicación');
+
   return (
-    <div className="min-h-screen bg-background py-8 px-4 sm:px-6 lg:px-8">
-      <div className="max-w-[1200px] mx-auto">
-        {/* Header con Stepper */}
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 mb-8">
-          {/* Título */}
-          <div className="mb-8">
-            <h1 className="text-foreground mb-2">
-              {modoEdicion ? 'Editar Aplicación' : 'Nueva Aplicación'}
-            </h1>
-            <p className="text-brand-brown/70">
-              Calcula productos, dosis y genera lista de compras automáticamente
-            </p>
-          </div>
+    <AplicacionShell
+      titulo={nombreVisible}
+      subtitulo={modoEdicion ? undefined : 'Calcula productos, dosis y genera la lista de compras automáticamente'}
+      estado={modoEdicion ? estadoAplicacionActual : undefined}
+    >
+      <FormDraftBanner
+        variant="restored"
+        show={state.paso_actual > 1 && !modoEdicion}
+        onDiscard={clearFormData}
+      />
 
-          <FormDraftBanner
-            variant="restored"
-            show={state.paso_actual > 1 && !modoEdicion}
-            onDiscard={clearFormData}
-          />
-
-          {/* Stepper */}
-          <div className="relative">
-            {/* Desktop Stepper */}
-            <div className="hidden md:block">
-              <div className="flex items-center justify-between">
-                {PASOS.map((paso, index) => {
-                  const Icon = paso.icono;
-                  const isActive = state.paso_actual === paso.numero;
-                  const isCompleted = state.paso_actual > paso.numero;
-                  const isLast = index === PASOS.length - 1;
-
-                  return (
-                    <div key={paso.numero} className="flex items-center flex-1">
-                      {/* Paso */}
-                      <div className="flex flex-col items-center">
-                        {/* Círculo con icono */}
-                        <div
-                          className={`
-                            w-16 h-16 rounded-2xl flex items-center justify-center mb-3 transition-all duration-300
-                            ${
-                              isActive
-                                ? 'bg-gradient-to-br from-primary to-secondary text-white shadow-lg scale-110'
-                                : isCompleted
-                                ? 'bg-primary text-white'
-                                : 'bg-gray-100 text-gray-400'
-                            }
-                          `}
-                        >
-                          {isCompleted ? (
-                            <Check className="w-8 h-8" />
-                          ) : (
-                            <Icon className="w-8 h-8" />
-                          )}
-                        </div>
-
-                        {/* Texto */}
-                        <div className="text-center">
-                          <p
-                            className={`text-sm mb-1 transition-colors ${
-                              isActive || isCompleted
-                                ? 'text-foreground'
-                                : 'text-gray-400'
-                            }`}
-                          >
-                            {paso.titulo}
-                          </p>
-                          <p className="text-xs text-brand-brown/50 max-w-[140px]">
-                            {paso.descripcion}
-                          </p>
-                        </div>
-                      </div>
-
-                      {/* Línea conectora */}
-                      {!isLast && (
-                        <div className="flex-1 h-1 mx-4 -mt-12">
-                          <div
-                            className={`h-full rounded-full transition-all duration-300 ${
-                              isCompleted ? 'bg-primary' : 'bg-gray-200'
-                            }`}
-                          />
-                        </div>
-                      )}
-                    </div>
-                  );
-                })}
-              </div>
-            </div>
-
-            {/* Mobile Breadcrumbs */}
-            <div className="md:hidden">
-              <div className="flex items-center justify-center gap-2 mb-6">
-                {PASOS.map((paso) => {
-                  const isActive = state.paso_actual === paso.numero;
-                  const isCompleted = state.paso_actual > paso.numero;
-
-                  return (
-                    <div
-                      key={paso.numero}
-                      className={`
-                        h-2 flex-1 rounded-full transition-all duration-300
-                        ${
-                          isActive || isCompleted
-                            ? 'bg-primary'
-                            : 'bg-gray-200'
-                        }
-                      `}
-                    />
-                  );
-                })}
-              </div>
-
-              {/* Paso actual en móvil */}
-              <div className="text-center">
-                <p className="text-lg text-foreground mb-1">
-                  {PASOS[state.paso_actual - 1].titulo}
-                </p>
-                <p className="text-sm text-brand-brown/70">
-                  Paso {state.paso_actual} de {PASOS.length}
-                </p>
-              </div>
-            </div>
-          </div>
-        </div>
-
-        {/* Mensaje de error de validación */}
-        {validationError && (
-          <div className="mb-6 bg-red-50 border border-red-200 rounded-xl p-4 flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-            <div>
-              <h4 className="text-red-800 mb-1">Error de validación</h4>
-              <p className="text-red-700 text-sm">{validationError}</p>
-            </div>
-          </div>
-        )}
-
-        {/* Error general */}
-        {state.error && (
-          <div className="mb-6 bg-red-50 border border-red-200 rounded-xl p-4 flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-            <div>
-              <h4 className="text-red-800 mb-1">Error</h4>
-              <p className="text-red-700 text-sm">{state.error}</p>
-            </div>
-          </div>
-        )}
-
-        {/* Contenido del paso actual */}
-        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-8 mb-8">
-          {state.paso_actual === 1 && (
-            <PasoConfiguracion
-              configuracion={state.configuracion}
-              onUpdate={updateConfiguracion}
-            />
-          )}
-
-          {state.paso_actual === 2 && state.configuracion && (
-            <PasoMezcla
-              configuracion={state.configuracion}
-              mezclas={state.mezclas}
-              calculos={state.calculos}
-              onUpdate={updateMezclas}
-            />
-          )}
-
-          {state.paso_actual === 3 && state.configuracion && (
-            <PasoListaCompras
-              configuracion={state.configuracion}
-              mezclas={state.mezclas}
-              calculos={state.calculos}
-              lista_compras={state.lista_compras}
-              onUpdate={updateListaCompras}
-            />
-          )}
-        </div>
-
-        {/* Navegación */}
-        <div className="flex items-center justify-between gap-4">
-          {/* Botón Cancelar */}
-          <button
-            onClick={handleCancelar}
-            disabled={state.guardando}
-            className="px-6 py-3 text-brand-brown hover:bg-gray-100 rounded-xl transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <X className="w-5 h-5" />
-            <span className="hidden sm:inline">Cancelar</span>
-          </button>
-
-          <div className="flex items-center gap-4">
-            {/* Botón Anterior */}
-            <button
-              onClick={handleAnterior}
-              disabled={state.paso_actual === 1 || state.guardando}
-              className="px-6 py-3 bg-gray-100 text-foreground rounded-xl hover:bg-gray-200 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center gap-2"
-            >
-              <ChevronLeft className="w-5 h-5" />
-              <span className="hidden sm:inline">Anterior</span>
-            </button>
-
-            {/* Botón Siguiente o Finalizar */}
-            {state.paso_actual < 3 ? (
-              <button
-                onClick={handleSiguiente}
-                disabled={state.guardando}
-                className="px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:from-primary-dark hover:to-secondary-dark transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <span>Siguiente</span>
-                <ChevronRight className="w-5 h-5" />
-              </button>
-            ) : (
-              <button
-                onClick={handleGuardarYFinalizar}
-                disabled={state.guardando}
-                className="px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:from-primary-dark hover:to-secondary-dark transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                {state.guardando ? (
-                  <>
-                    <div className="w-5 h-5 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                    <span>Guardando...</span>
-                  </>
-                ) : (
-                  <>
-                    <Check className="w-5 h-5" />
-                    <span>Guardar y Finalizar</span>
-                  </>
-                )}
-              </button>
-            )}
-          </div>
-        </div>
+      <div className="bg-card rounded-2xl shadow-sm border border-border p-6 sm:p-8">
+        <AplicacionStepper pasos={PASOS} pasoActual={state.paso_actual} />
       </div>
 
-      {/* Dialog de cancelación */}
-      {showCancelDialog && (
-        <div className="fixed inset-0 bg-black/50 flex items-center justify-center p-4 z-50">
-          <div className="bg-white rounded-2xl p-6 max-w-md w-full">
-            <div className="flex items-start gap-4 mb-6">
-              <div className="w-12 h-12 bg-red-100 rounded-xl flex items-center justify-center flex-shrink-0">
-                <AlertTriangle className="w-6 h-6 text-red-600" />
-              </div>
-              <div>
-                <h3 className="text-lg text-foreground mb-2">
-                  ¿Cancelar aplicación?
-                </h3>
-                <p className="text-sm text-brand-brown/70">
-                  Se perderán todos los datos ingresados. Esta acción no se puede deshacer.
-                </p>
-              </div>
-            </div>
-
-            <div className="flex items-center gap-3 justify-end">
-              <button
-                onClick={() => setShowCancelDialog(false)}
-                className="px-4 py-2 text-brand-brown hover:bg-gray-100 rounded-lg transition-all"
-              >
-                Continuar editando
-              </button>
-              <button
-                onClick={confirmarCancelar}
-                className="px-4 py-2 bg-red-600 text-white rounded-lg hover:bg-red-700 transition-all"
-              >
-                Sí, cancelar
-              </button>
-            </div>
-          </div>
-        </div>
+      {validationError && (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <AlertTitle>Error de validación</AlertTitle>
+          <AlertDescription>{validationError}</AlertDescription>
+        </Alert>
       )}
-    </div>
+
+      {state.error && (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <AlertTitle>Error</AlertTitle>
+          <AlertDescription>{state.error}</AlertDescription>
+        </Alert>
+      )}
+
+      <div className="bg-card rounded-2xl shadow-sm border border-border p-6 sm:p-8">
+        {state.paso_actual === 1 && (
+          <PasoConfiguracion
+            configuracion={state.configuracion}
+            onUpdate={updateConfiguracion}
+            mezclas={state.mezclas}
+            onUpdateMezclas={updateMezclas}
+            estadosAsignacion={estadosAsignacion}
+            onReintentarAsignacion={modoEdicion ? cargarAplicacion : undefined}
+          />
+        )}
+
+        {state.paso_actual === 2 && state.configuracion && (
+          <PasoListaCompras
+            configuracion={state.configuracion}
+            mezclas={state.mezclas}
+            calculos={state.calculos}
+            lista_compras={state.lista_compras}
+            onUpdate={updateListaCompras}
+          />
+        )}
+      </div>
+
+      {/* Navegación */}
+      <div className="flex items-center justify-between gap-4 flex-wrap">
+        <Button type="button" variant="ghost" onClick={handleCancelar} disabled={state.guardando}>
+          <X className="w-4 h-4" />
+          <span className="hidden sm:inline">Cancelar</span>
+        </Button>
+
+        <ButtonGroup>
+          <Button
+            type="button"
+            variant="outline"
+            onClick={handleAnterior}
+            disabled={state.paso_actual === 1 || state.guardando}
+          >
+            <ChevronLeft className="w-4 h-4" />
+            <span className="hidden sm:inline">Anterior</span>
+          </Button>
+
+          {state.paso_actual < 2 ? (
+            <Button type="button" onClick={handleSiguiente} disabled={state.guardando}>
+              <span>Siguiente</span>
+              <ChevronRight className="w-4 h-4" />
+            </Button>
+          ) : (
+            <Button type="button" onClick={handleGuardarYFinalizar} disabled={state.guardando}>
+              {state.guardando ? (
+                <>
+                  <Spinner />
+                  <span>Guardando…</span>
+                </>
+              ) : (
+                <>
+                  <Check className="w-4 h-4" />
+                  <span>Guardar y Finalizar</span>
+                </>
+              )}
+            </Button>
+          )}
+        </ButtonGroup>
+      </div>
+
+      <ConfirmDialog
+        open={showCancelDialog}
+        onOpenChange={setShowCancelDialog}
+        title="¿Cancelar aplicación?"
+        description="Se perderán todos los datos ingresados. Esta acción no se puede deshacer."
+        confirmLabel="Sí, cancelar"
+        cancelLabel="Continuar editando"
+        onConfirm={confirmarCancelar}
+        destructive
+      />
+    </AplicacionShell>
   );
 }

--- a/src/components/aplicaciones/CierreAplicacion.tsx
+++ b/src/components/aplicaciones/CierreAplicacion.tsx
@@ -4,6 +4,7 @@ import { getSupabase } from '../../utils/supabase/client';
 import { formatearFecha, obtenerFechaHoy } from '../../utils/fechas';
 import { fetchRegistrosTrabajoParaCierre, recalcularCostoJornal } from '../../utils/laborCosts';
 import { generarPDFReporteCierre } from '../../utils/generarPDFReporteCierre';
+import { formatearNumero } from '../../utils/format';
 import type { Aplicacion, RegistroTrabajoCierre, ResumenLaboresCierre } from '../../types/aplicaciones';
 
 interface CierreAplicacionProps {
@@ -690,6 +691,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
           <button
             onClick={onClose}
             className="p-2 hover:bg-white/20 rounded-lg transition-colors"
+            aria-label="Cerrar"
           >
             <X className="w-5 h-5" />
           </button>
@@ -762,7 +764,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                         </div>
                         <div>
                           <p className="text-xs text-brand-brown/70 mb-1">Total Árboles</p>
-                          <p className="text-sm text-foreground font-medium">{totalArboles.toLocaleString()}</p>
+                          <p className="text-sm text-foreground font-medium">{formatearNumero(totalArboles, 0)}</p>
                         </div>
                         <div>
                           <p className="text-xs text-brand-brown/70 mb-1">Propósito</p>
@@ -804,15 +806,15 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                                       {insumo.nombre}
                                     </td>
                                     <td className="px-4 py-3 text-sm text-brand-brown/70 text-right">
-                                      {insumo.planeado.toFixed(2)} {insumo.unidad}
+                                      {formatearNumero(insumo.planeado, 2)} {insumo.unidad}
                                     </td>
                                     <td className="px-4 py-3 text-sm text-foreground font-medium text-right">
-                                      {insumo.aplicado.toFixed(2)} {insumo.unidad}
+                                      {formatearNumero(insumo.aplicado, 2)} {insumo.unidad}
                                     </td>
                                     <td className={`px-4 py-3 text-sm text-right ${
                                       diferencia > 0 ? 'text-orange-600' : diferencia < 0 ? 'text-blue-600' : 'text-gray-600'
                                     }`}>
-                                      {diferencia > 0 ? '+' : ''}{diferencia.toFixed(2)} {insumo.unidad}
+                                      {diferencia > 0 ? '+' : ''}{formatearNumero(diferencia, 2)} {insumo.unidad}
                                     </td>
                                     <td className="px-4 py-3 text-center">
                                       <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs ${
@@ -842,11 +844,11 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                           <div className="grid grid-cols-3 gap-4">
                             <div className="text-center">
                               <p className="text-xs text-brand-brown/70 mb-1">Planeadas</p>
-                              <p className="text-2xl text-foreground font-semibold">{canecasPlaneadas}</p>
+                              <p className="text-2xl text-foreground font-semibold">{formatearNumero(canecasPlaneadas, 1)}</p>
                             </div>
                             <div className="text-center">
                               <p className="text-xs text-brand-brown/70 mb-1">Aplicadas</p>
-                              <p className="text-2xl text-primary font-semibold">{canecasAplicadas}</p>
+                              <p className="text-2xl text-primary font-semibold">{formatearNumero(canecasAplicadas, 1)}</p>
                             </div>
                             <div className="text-center">
                               <p className="text-xs text-brand-brown/70 mb-1">Diferencia</p>
@@ -855,7 +857,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                                 canecasAplicadas - canecasPlaneadas < 0 ? 'text-blue-600' : 'text-gray-600'
                               }`}>
                                 {canecasAplicadas - canecasPlaneadas > 0 ? '+' : ''}
-                                {canecasAplicadas - canecasPlaneadas}
+                                {formatearNumero(canecasAplicadas - canecasPlaneadas, 1)}
                               </p>
                             </div>
                           </div>
@@ -881,7 +883,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                     <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
                       <div className="bg-primary/5 border border-primary/20 rounded-xl p-4 text-center">
                         <Users className="w-5 h-5 text-primary mx-auto mb-1" />
-                        <p className="text-2xl text-foreground font-bold">{totalJornales.toFixed(1)}</p>
+                        <p className="text-2xl text-foreground font-bold">{formatearNumero(totalJornales, 1)}</p>
                         <p className="text-xs text-brand-brown/70">Jornales</p>
                       </div>
                       <div className="bg-primary/5 border border-primary/20 rounded-xl p-4 text-center">
@@ -957,11 +959,11 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                                   <ChevronDown className={`w-4 h-4 text-gray-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
                                   <span className="text-sm text-foreground font-medium">{lote_nombre}</span>
                                   <span className="text-xs text-brand-brown/60">
-                                    {lotes.find(l => l.lote_id === loteId)?.arboles.toLocaleString()} árboles
+                                    {formatearNumero(lotes.find(l => l.lote_id === loteId)?.arboles ?? 0, 0)} árboles
                                   </span>
                                 </div>
                                 <div className="flex items-center gap-4">
-                                  <span className="text-sm text-foreground font-medium">{totalLote.toFixed(1)} jornales</span>
+                                  <span className="text-sm text-foreground font-medium">{formatearNumero(totalLote, 1)} jornales</span>
                                   <span className="text-sm text-primary font-semibold">{formatearMoneda(costoLote)}</span>
                                 </div>
                               </button>
@@ -1035,6 +1037,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                                                   onClick={() => setEditandoRegistro(regKey)}
                                                   className="p-1 text-gray-400 hover:text-primary transition-colors"
                                                   title="Editar fracción"
+                                                  aria-label="Editar fracción de jornal"
                                                 >
                                                   <Edit3 className="w-3.5 h-3.5" />
                                                 </button>
@@ -1042,6 +1045,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                                                   onClick={() => eliminarRegistro(reg._index)}
                                                   className="p-1 text-gray-400 hover:text-red-500 transition-colors"
                                                   title="Eliminar"
+                                                  aria-label="Eliminar registro de jornal"
                                                 >
                                                   <Trash2 className="w-3.5 h-3.5" />
                                                 </button>
@@ -1274,7 +1278,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                           </div>
                           <div className="flex justify-between">
                             <span className="text-brand-brown/70">Árboles:</span>
-                            <span className="text-foreground">{totalArboles.toLocaleString()}</span>
+                            <span className="text-foreground">{formatearNumero(totalArboles, 0)}</span>
                           </div>
                         </div>
                       </div>
@@ -1293,7 +1297,7 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
                           </div>
                           <div className="flex justify-between">
                             <span className="text-brand-brown/70">Jornales registrados:</span>
-                            <span className="text-foreground font-medium">{totalJornales.toFixed(1)}</span>
+                            <span className="text-foreground font-medium">{formatearNumero(totalJornales, 1)}</span>
                           </div>
                           <div className="flex justify-between">
                             <span className="text-brand-brown/70">Trabajadores:</span>

--- a/src/components/aplicaciones/CierreAplicacion.tsx
+++ b/src/components/aplicaciones/CierreAplicacion.tsx
@@ -1,16 +1,43 @@
-import { useState, useEffect } from 'react';
-import { X, ChevronRight, Check, Users, Calendar, Trash2, Edit3, Plus, AlertTriangle, ChevronDown, Download } from 'lucide-react';
+import { useState, useEffect, useCallback, useMemo } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { AlertTriangle, Check, RefreshCw } from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
-import { formatearFecha, obtenerFechaHoy } from '../../utils/fechas';
+import { obtenerFechaHoy } from '../../utils/fechas';
 import { fetchRegistrosTrabajoParaCierre, recalcularCostoJornal } from '../../utils/laborCosts';
 import { generarPDFReporteCierre } from '../../utils/generarPDFReporteCierre';
-import { formatearNumero } from '../../utils/format';
+import { formatearMoneda, formatearNumero } from '../../utils/format';
+import {
+  calcularExcepcionesCierre,
+  derivarFechasEjecucionReal,
+  agruparRegistrosPorLote,
+  calcularKPIsLabores,
+  formatearListaConY,
+} from '../../utils/calculosCierreAplicacion';
+import { useFormDraft } from '@/hooks/useFormDraft';
+import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
+import { AplicacionShell } from './shared/AplicacionShell';
+import { SeccionInsumosCierre } from './SeccionInsumosCierre';
+import { SeccionLaboresCierre } from './SeccionLaboresCierre';
+import type { NuevoRegistroForm, TrabajadorDisponible } from './SeccionLaboresCierre';
+import { SeccionConfirmarCierre } from './SeccionConfirmarCierre';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { Skeleton } from '@/components/ui/skeleton';
+import { Empty, EmptyContent, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import {
+  AlertDialog,
+  AlertDialogContent,
+  AlertDialogHeader,
+  AlertDialogTitle,
+  AlertDialogDescription,
+  AlertDialogFooter,
+  AlertDialogCancel,
+  AlertDialogAction,
+} from '@/components/ui/alert-dialog';
 import type { Aplicacion, RegistroTrabajoCierre, ResumenLaboresCierre } from '../../types/aplicaciones';
 
 interface CierreAplicacionProps {
   aplicacion: Aplicacion;
-  onClose: () => void;
-  onCerrado: () => void;
 }
 
 interface Movimiento {
@@ -41,17 +68,25 @@ interface DatosFinales {
   observaciones: string;
 }
 
-// Fraction options for inline editing
-const FRACCION_OPTIONS = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0];
-
-type Paso = 'revision' | 'datos-finales' | 'confirmacion';
-
-export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplicacionProps) {
+/**
+ * Cierre de Aplicación — W03 v2 (`docs/…/W03-cierre-v2.md`). PÁGINA de revisión, no un wizard
+ * gateado: ①Insumos ②Labores ③Confirmar son secciones de una sola página con scroll continuo,
+ * cada una en su propio archivo (`SeccionInsumosCierre`, `SeccionLaboresCierre`,
+ * `SeccionConfirmarCierre`) para que este archivo orqueste datos y NO JSX de 1.500 líneas.
+ *
+ * Este archivo sigue siendo el único dueño de:
+ * - `cargarDatos()` y `cerrarAplicacion()` — la secuencia de escrituras a Supabase no se tocó
+ *   (ni el orden ni el manejo de errores), por diseño explícito de este rediseño.
+ * - Todo el estado editable de Labores (`registrosEditados`, `datosFinales`, el formulario
+ *   "Nuevo Registro") — las secciones son presentacionales, reciben props y callbacks.
+ */
+export function CierreAplicacion({ aplicacion }: CierreAplicacionProps) {
   const supabase = getSupabase();
-  const [paso, setPaso] = useState<Paso>('revision');
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
   const [procesando, setProcesando] = useState(false);
+  const [confirmDialogOpen, setConfirmDialogOpen] = useState(false);
 
   // Datos cargados - insumos
   const [movimientos, setMovimientos] = useState<Movimiento[]>([]);
@@ -59,26 +94,27 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
   const [canecasPlaneadas, setCanecasPlaneadas] = useState(0);
   const [canecasAplicadas, setCanecasAplicadas] = useState(0);
   const [lotes, setLotes] = useState<LoteConArboles[]>([]);
-  const [blancoBiologico, setBlancoBiologico] = useState<string>('');
 
   // Datos de labores (desde registros_trabajo)
   const [resumenLabores, setResumenLabores] = useState<ResumenLaboresCierre | null>(null);
   const [registrosEditados, setRegistrosEditados] = useState<RegistroTrabajoCierre[]>([]);
   const [tieneTarea, setTieneTarea] = useState(false);
 
+  // De dónde salieron fechaInicioReal/fechaFinReal la primera vez que se cargaron los datos —
+  // solo para la leyenda "Detectado de…"; el campo sigue siendo 100% editable después.
+  const [fuenteFechas, setFuenteFechas] = useState<'registros' | 'movimientos' | 'combinado' | 'ninguna'>(
+    'ninguna',
+  );
+
   // UI state for labor editing
   const [editandoRegistro, setEditandoRegistro] = useState<string | null>(null);
-  const [loteExpandido, setLoteExpandido] = useState<string | null>(null);
   const [mostrarAgregarRegistro, setMostrarAgregarRegistro] = useState(false);
-  const [trabajadoresDisponibles, setTrabajadoresDisponibles] = useState<Array<{
-    id: string; nombre: string; tipo: 'empleado' | 'contratista';
-    salario?: number; prestaciones?: number; auxilios?: number; horas_semanales?: number; tarifa_jornal?: number;
-  }>>([]);
+  const [trabajadoresDisponibles, setTrabajadoresDisponibles] = useState<TrabajadorDisponible[]>([]);
 
   // Nuevo registro temporal
-  const [nuevoRegistro, setNuevoRegistro] = useState({
+  const [nuevoRegistro, setNuevoRegistro] = useState<NuevoRegistroForm>({
     trabajador_id: '',
-    trabajador_tipo: 'empleado' as 'empleado' | 'contratista',
+    trabajador_tipo: 'empleado',
     lote_id: '',
     fecha_trabajo: obtenerFechaHoy(),
     fraccion_jornal: 1.0,
@@ -91,19 +127,15 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
     observaciones: '',
   });
 
-  useEffect(() => {
-    cargarDatos();
-  }, [aplicacion.id]);
-
-  const cargarDatos = async () => {
+  const cargarDatos = useCallback(async () => {
     setLoading(true);
     setError(null);
     try {
-
       // 1. Cargar aplicación completa con lotes
       const { data: appData } = await supabase
         .from('aplicaciones')
-        .select(`
+        .select(
+          `
           *,
           aplicaciones_lotes (
             lote_id,
@@ -118,39 +150,20 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
             )
           ),
           aplicaciones_calculos (id)
-        `)
+        `,
+        )
         .eq('id', aplicacion.id)
         .single();
 
-
       // Extraer lotes con árboles
-      const lotesData: LoteConArboles[] = appData?.aplicaciones_lotes?.map((al: any) => ({
-        lote_id: al.lotes?.id || '',
-        nombre: al.lotes?.nombre || 'Sin nombre',
-        arboles: al.lotes?.total_arboles || 0,
-      })) || [];
+      const lotesData: LoteConArboles[] =
+        appData?.aplicaciones_lotes?.map((al: any) => ({
+          lote_id: al.lotes?.id || '',
+          nombre: al.lotes?.nombre || 'Sin nombre',
+          arboles: al.lotes?.total_arboles || 0,
+        })) || [];
 
       setLotes(lotesData);
-
-      // Extraer blanco biológico
-      if (appData?.blanco_biologico) {
-        try {
-          const bb = JSON.parse(appData.blanco_biologico);
-          if (Array.isArray(bb) && bb.length > 0) {
-            const { data: plagas } = await supabase
-              .from('plagas_enfermedades_catalogo')
-              .select('nombre')
-              .in('id', bb);
-            setBlancoBiologico(plagas?.map((p) => p.nombre).join(', ') || 'No especificado');
-          } else {
-            setBlancoBiologico('No especificado');
-          }
-        } catch {
-          setBlancoBiologico('No especificado');
-        }
-      } else {
-        setBlancoBiologico('No especificado');
-      }
 
       // 2. Cargar canecas planeadas
       const { data: calculos } = await supabase
@@ -173,20 +186,16 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
         throw new Error(`Error cargando movimientos: ${errorMovimientos.message}`);
       }
 
-
-      // Variable para almacenar movimientos consolidados
       const movimientosConsolidados: Movimiento[] = [];
 
       if (movimientosDiarios && movimientosDiarios.length > 0) {
-        // Calcular canecas aplicadas
         const totalCanecasAplicadas = movimientosDiarios.reduce(
           (sum, mov) => sum + (mov.numero_canecas || 0),
-          0
+          0,
         );
         setCanecasAplicadas(totalCanecasAplicadas);
 
-        // Cargar productos de los movimientos diarios
-        const movimientosIds = movimientosDiarios.map(m => m.id);
+        const movimientosIds = movimientosDiarios.map((m) => m.id);
 
         const { data: productosMovimientos, error: errorProductosMovimientos } = await supabase
           .from('movimientos_diarios_productos')
@@ -197,21 +206,17 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
           throw new Error(`Error cargando productos de movimientos: ${errorProductosMovimientos.message}`);
         }
 
-
         if (productosMovimientos && productosMovimientos.length > 0) {
-          // Obtener IDs únicos de productos
           const productosIds = [...new Set(productosMovimientos.map((p) => p.producto_id))];
 
-          // Cargar precios de productos
           const { data: productos, error: errorProductos } = await supabase
             .from('productos')
             .select('id, precio_unitario')
             .in('id', productosIds);
 
-
           if (errorProductos) {
             setError(
-              `No se pudieron cargar los precios: ${errorProductos.message}. Verifica tus permisos o contacta al administrador.`
+              `No se pudieron cargar los precios: ${errorProductos.message}. Verifica tus permisos o contacta al administrador.`,
             );
             setMovimientos([]);
             setLoading(false);
@@ -225,30 +230,22 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
             return;
           }
 
-          // Verificar que los precios no sean nulos
-          const productosSinPrecio = productos.filter(
-            (p) => !p.precio_unitario || p.precio_unitario === 0
-          );
+          const productosSinPrecio = productos.filter((p) => !p.precio_unitario || p.precio_unitario === 0);
           if (productosSinPrecio.length > 0) {
             setError(
-              `${productosSinPrecio.length} producto(s) no tienen precio asignado. Por favor actualiza los precios en el módulo de Inventario antes de cerrar.`
+              `${productosSinPrecio.length} producto(s) no tienen precio asignado. Por favor actualiza los precios en el módulo de Inventario antes de cerrar.`,
             );
             setMovimientos([]);
             setLoading(false);
             return;
           }
 
-          // Crear mapa de costos
           const costosMap = new Map(productos.map((p) => [p.id, p.precio_unitario || 0]));
 
-          // Consolidar productos por movimiento
-          movimientosDiarios.forEach(mov => {
-            const productosDeMov = productosMovimientos.filter(
-              p => p.movimiento_diario_id === mov.id
-            );
+          movimientosDiarios.forEach((mov) => {
+            const productosDeMov = productosMovimientos.filter((p) => p.movimiento_diario_id === mov.id);
 
-            productosDeMov.forEach(prod => {
-              // Convertir unidades a unidad base si es necesario
+            productosDeMov.forEach((prod) => {
               let cantidadEnUnidadBase = prod.cantidad_utilizada;
               if ((prod.unidad as string) === 'cc') {
                 cantidadEnUnidadBase = prod.cantidad_utilizada / 1000;
@@ -288,12 +285,13 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
 
         const result = await supabase
           .from('aplicaciones_productos')
-          .select('producto_id, producto_nombre, producto_unidad, cantidad_total_necesaria, mezcla_id, dosis_grandes, dosis_medianos, dosis_pequenos, dosis_clonales')
+          .select(
+            'producto_id, producto_nombre, producto_unidad, cantidad_total_necesaria, mezcla_id, dosis_grandes, dosis_medianos, dosis_pequenos, dosis_clonales',
+          )
           .in('mezcla_id', mezclasIds);
 
         productosPlaneados = result.data;
 
-        // When aplicaciones_calculos is empty, recompute per-product planned quantities
         const hasCalcData = appData?.aplicaciones_calculos && appData.aplicaciones_calculos.length > 0;
         if (!hasCalcData && productosPlaneados && productosPlaneados.length > 0) {
           const appLotes = appData?.aplicaciones_lotes || [];
@@ -302,21 +300,19 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
             for (const al of appLotes) {
               const lote = (al as any).lotes;
               if (!lote) continue;
-              totalKg += (lote.arboles_grandes || 0) * (Number(prod.dosis_grandes) || 0) / 1000;
-              totalKg += (lote.arboles_medianos || 0) * (Number(prod.dosis_medianos) || 0) / 1000;
-              totalKg += (lote.arboles_pequenos || 0) * (Number(prod.dosis_pequenos) || 0) / 1000;
-              totalKg += (lote.arboles_clonales || 0) * (Number(prod.dosis_clonales) || 0) / 1000;
+              totalKg += ((lote.arboles_grandes || 0) * (Number(prod.dosis_grandes) || 0)) / 1000;
+              totalKg += ((lote.arboles_medianos || 0) * (Number(prod.dosis_medianos) || 0)) / 1000;
+              totalKg += ((lote.arboles_pequenos || 0) * (Number(prod.dosis_pequenos) || 0)) / 1000;
+              totalKg += ((lote.arboles_clonales || 0) * (Number(prod.dosis_clonales) || 0)) / 1000;
             }
             return { ...prod, cantidad_total_necesaria: Math.round(totalKg * 100) / 100 };
           });
         }
       }
 
-
       // 5. Consolidar insumos
       const insumosMap = new Map<string, ResumenInsumo>();
 
-      // Agregar planeados
       productosPlaneados?.forEach((prod) => {
         const key = prod.producto_id;
         if (!insumosMap.has(key)) {
@@ -331,7 +327,6 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
         insumo.planeado += prod.cantidad_total_necesaria || 0;
       });
 
-      // Agregar aplicados
       movimientosConsolidados.forEach((mov) => {
         const key = mov.producto_id;
         if (!insumosMap.has(key)) {
@@ -349,22 +344,14 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
       setResumenInsumos(Array.from(insumosMap.values()));
 
       // 6. Cargar registros de trabajo desde la tarea vinculada
+      let fechasRegistros: string[] = [];
       if (appData?.tarea_id) {
         setTieneTarea(true);
         try {
           const resumen = await fetchRegistrosTrabajoParaCierre(supabase, appData.tarea_id);
           setResumenLabores(resumen);
-          setRegistrosEditados(resumen.registros.map(r => ({ ...r })));
-
-          // Auto-derive dates from registros if available
-          if (resumen.registros.length > 0) {
-            const fechas = resumen.registros.map(r => r.fecha_trabajo).sort();
-            setDatosFinales(prev => ({
-              ...prev,
-              fechaInicioReal: prev.fechaInicioReal || fechas[0],
-              fechaFinReal: fechas[fechas.length - 1] || prev.fechaFinReal,
-            }));
-          }
+          setRegistrosEditados(resumen.registros.map((r) => ({ ...r })));
+          fechasRegistros = resumen.registros.map((r) => r.fecha_trabajo);
         } catch (err: any) {
           console.error('Error cargando registros de trabajo:', err);
           // Non-blocking: labor data is optional
@@ -373,12 +360,52 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
         setTieneTarea(false);
       }
 
+      // Derivar Fecha Inicio/Fin Real de forma robusta y simétrica (W03-cierre-v2.md §1/§5):
+      // unión de fechas de labor y de movimientos diarios, en vez de la lógica ad hoc anterior
+      // (Fin caía en obtenerFechaHoy(), Inicio solo se corregía si venía vacío).
+      const fechasMovimientos = movimientosConsolidados.map((m) => m.fecha);
+      const derivadas = derivarFechasEjecucionReal(fechasRegistros, fechasMovimientos);
+      setFuenteFechas(derivadas.fuente);
+      if (derivadas.fuente !== 'ninguna') {
+        setDatosFinales((prev) => ({
+          ...prev,
+          fechaInicioReal: derivadas.fechaInicio!,
+          fechaFinReal: derivadas.fechaFin!,
+        }));
+      }
     } catch (err: any) {
       setError('Error al cargar los datos: ' + err.message);
     } finally {
       setLoading(false);
     }
-  };
+  }, [aplicacion.id, supabase]);
+
+  useEffect(() => {
+    cargarDatos();
+  }, [cargarDatos]);
+
+  // ---------------------------------------------------------------------------------------------
+  // Borrador — useFormDraft + FormDraftBanner (decisión del dueño, W03-cierre-v2.md §6/§8.6).
+  // Solo se observa registrosEditados + datosFinales: NO trabajadoresDisponibles (viene de una
+  // query, no de captura del usuario) y NO el formulario "Nuevo Registro" a medio llenar (queda
+  // como sub-estado de UI que se pierde en un refresh real, igual que cuál lote está expandido —
+  // pregunta explícitamente sin resolver en el documento de diseño, resuelta acá del lado de
+  // "menor riesgo": no reabrir un formulario a medias con datos que el usuario no confirmó).
+  // `enabled: !loading` evita que la propia carga inicial (que también cambia estas dos
+  // variables) se guarde como si fuera una edición del usuario.
+  // ---------------------------------------------------------------------------------------------
+  const draft = useFormDraft(
+    `cierre-aplicacion-${aplicacion.id}-v1`,
+    { registrosEditados, datosFinales },
+    { enabled: !loading, debounceMs: 1500 },
+  );
+
+  const handleRestoreDraft = useCallback(() => {
+    if (!draft.draftData) return;
+    setRegistrosEditados(draft.draftData.registrosEditados);
+    setDatosFinales(draft.draftData.datosFinales);
+    draft.acceptDraft();
+  }, [draft]);
 
   /**
    * Cargar trabajadores disponibles para agregar registros
@@ -386,32 +413,50 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
   const cargarTrabajadores = async () => {
     if (trabajadoresDisponibles.length > 0) return;
     const [empRes, contRes] = await Promise.all([
-      supabase.from('empleados').select('id, nombre, salario, prestaciones_sociales, auxilios_no_salariales, horas_semanales').eq('activo', true),
+      supabase
+        .from('empleados')
+        .select('id, nombre, salario, prestaciones_sociales, auxilios_no_salariales, horas_semanales')
+        .eq('activo', true),
       supabase.from('contratistas').select('id, nombre, tarifa_jornal').eq('activo', true),
     ]);
-    const trabajadores: typeof trabajadoresDisponibles = [];
-    (empRes.data || []).forEach((e: any) => trabajadores.push({
-      id: e.id, nombre: e.nombre, tipo: 'empleado',
-      salario: e.salario, prestaciones: e.prestaciones_sociales,
-      auxilios: e.auxilios_no_salariales, horas_semanales: e.horas_semanales,
-    }));
-    (contRes.data || []).forEach((c: any) => trabajadores.push({
-      id: c.id, nombre: c.nombre, tipo: 'contratista', tarifa_jornal: c.tarifa_jornal,
-    }));
+    const trabajadores: TrabajadorDisponible[] = [];
+    (empRes.data || []).forEach((e: any) =>
+      trabajadores.push({
+        id: e.id,
+        nombre: e.nombre,
+        tipo: 'empleado',
+        salario: e.salario,
+        prestaciones: e.prestaciones_sociales,
+        auxilios: e.auxilios_no_salariales,
+        horas_semanales: e.horas_semanales,
+      }),
+    );
+    (contRes.data || []).forEach((c: any) =>
+      trabajadores.push({ id: c.id, nombre: c.nombre, tipo: 'contratista', tarifa_jornal: c.tarifa_jornal }),
+    );
     setTrabajadoresDisponibles(trabajadores);
+  };
+
+  const handleAbrirAgregarRegistro = () => {
+    setNuevoRegistro((prev) => ({ ...prev, fecha_trabajo: datosFinales.fechaFinReal || obtenerFechaHoy() }));
+    setMostrarAgregarRegistro(true);
+    cargarTrabajadores();
   };
 
   /**
    * Editar fracción de un registro
    */
   const editarFraccion = (registroId: string, nuevaFraccion: number) => {
-    setRegistrosEditados(prev => prev.map(r => {
-      if ((r.id || r._isNew) && (r.id === registroId || `new-${registrosEditados.indexOf(r)}` === registroId)) {
-        const nuevoCosto = recalcularCostoJornal(r, nuevaFraccion);
-        return { ...r, fraccion_jornal: nuevaFraccion, costo_jornal: nuevoCosto, _modified: true };
-      }
-      return r;
-    }));
+    setRegistrosEditados((prev) =>
+      prev.map((r, i) => {
+        const key = r.id || `new-${i}`;
+        if (key === registroId) {
+          const nuevoCosto = recalcularCostoJornal(r, nuevaFraccion);
+          return { ...r, fraccion_jornal: nuevaFraccion, costo_jornal: nuevoCosto, _modified: true };
+        }
+        return r;
+      }),
+    );
     setEditandoRegistro(null);
   };
 
@@ -419,19 +464,17 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
    * Marcar registro para eliminar
    */
   const eliminarRegistro = (index: number) => {
-    setRegistrosEditados(prev => prev.map((r, i) =>
-      i === index ? { ...r, _deleted: true } : r
-    ));
+    setRegistrosEditados((prev) => prev.map((r, i) => (i === index ? { ...r, _deleted: true } : r)));
   };
 
   /**
    * Agregar nuevo registro de trabajo
    */
   const agregarRegistro = () => {
-    const trabajador = trabajadoresDisponibles.find(t => t.id === nuevoRegistro.trabajador_id);
+    const trabajador = trabajadoresDisponibles.find((t) => t.id === nuevoRegistro.trabajador_id);
     if (!trabajador || !nuevoRegistro.lote_id) return;
 
-    const lote = lotes.find(l => l.lote_id === nuevoRegistro.lote_id);
+    const lote = lotes.find((l) => l.lote_id === nuevoRegistro.lote_id);
 
     const nuevoReg: RegistroTrabajoCierre = {
       tarea_id: resumenLabores?.tarea_id || aplicacion.tarea_id || '',
@@ -458,41 +501,43 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
 
     nuevoReg.costo_jornal = recalcularCostoJornal(nuevoReg, nuevoRegistro.fraccion_jornal);
 
-    setRegistrosEditados(prev => [...prev, nuevoReg]);
+    setRegistrosEditados((prev) => [...prev, nuevoReg]);
     setMostrarAgregarRegistro(false);
-    setNuevoRegistro({ trabajador_id: '', trabajador_tipo: 'empleado', lote_id: '', fecha_trabajo: obtenerFechaHoy(), fraccion_jornal: 1.0 });
+    setNuevoRegistro({
+      trabajador_id: '',
+      trabajador_tipo: 'empleado',
+      lote_id: '',
+      fecha_trabajo: datosFinales.fechaFinReal || obtenerFechaHoy(),
+      fraccion_jornal: 1.0,
+    });
   };
 
   /**
-   * CERRAR APLICACIÓN
+   * CERRAR APLICACIÓN — secuencia de escrituras sin transacción SQL real. No se toca el orden
+   * ni el manejo de errores (fuera de alcance de W03 v2, ver el `.md` §9 riesgo #1).
    */
   const cerrarAplicacion = async () => {
     try {
       setProcesando(true);
 
-      const registrosActivos = registrosEditados.filter(r => !r._deleted);
+      const registrosActivos = registrosEditados.filter((r) => !r._deleted);
 
-      // Calcular costos desde registros de trabajo
       const totalJornalesLabor = registrosActivos.reduce((s, r) => s + r.fraccion_jornal, 0);
       const costoManoObraReal = registrosActivos.reduce((s, r) => s + r.costo_jornal, 0);
       const valorJornalPromedio = totalJornalesLabor > 0 ? costoManoObraReal / totalJornalesLabor : 0;
 
-      // Calcular costos de insumos
       const totalArbolesCalc = lotes.reduce((sum, lote) => sum + lote.arboles, 0);
-      const costoInsumosCalc = movimientos.reduce(
-        (sum, mov) => sum + mov.cantidad_utilizada * mov.costo_unitario,
-        0
-      );
+      const costoInsumosCalc = movimientos.reduce((sum, mov) => sum + mov.cantidad_utilizada * mov.costo_unitario, 0);
       const costoTotalCalc = costoInsumosCalc + costoManoObraReal;
       const costoPorArbolCalc = totalArbolesCalc > 0 ? costoTotalCalc / totalArbolesCalc : 0;
 
-      // Calcular días de aplicación
       const fechaInicio = new Date(datosFinales.fechaInicioReal);
       const fechaFin = new Date(datosFinales.fechaFinReal);
       const diasAplicacion = Math.ceil((fechaFin.getTime() - fechaInicio.getTime()) / (1000 * 60 * 60 * 24)) + 1;
 
-      // Obtener usuario actual
-      const { data: { user } } = await supabase.auth.getUser();
+      const {
+        data: { user },
+      } = await supabase.auth.getUser();
 
       // 0. Persistir ediciones de registros_trabajo
       for (const reg of registrosEditados) {
@@ -507,14 +552,18 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
             fecha_trabajo: reg.fecha_trabajo,
             fraccion_jornal: reg.fraccion_jornal.toString(),
             costo_jornal: reg.costo_jornal,
-            valor_jornal_empleado: reg.tarifa_jornal || (reg.salario ? Math.round((reg.salario + (reg.prestaciones || 0) + (reg.auxilios || 0)) / ((reg.horas_semanales || 48) * 4.33) * 8) : 0),
+            valor_jornal_empleado:
+              reg.tarifa_jornal ||
+              (reg.salario
+                ? Math.round(((reg.salario + (reg.prestaciones || 0) + (reg.auxilios || 0)) / ((reg.horas_semanales || 48) * 4.33)) * 8)
+                : 0),
             observaciones: reg.observaciones || null,
           } as any);
         } else if (reg._modified && reg.id && !reg._deleted) {
-          await supabase.from('registros_trabajo').update({
-            fraccion_jornal: reg.fraccion_jornal.toString() as any,
-            costo_jornal: reg.costo_jornal,
-          }).eq('id', reg.id);
+          await supabase
+            .from('registros_trabajo')
+            .update({ fraccion_jornal: reg.fraccion_jornal.toString() as any, costo_jornal: reg.costo_jornal })
+            .eq('id', reg.id);
         }
       }
 
@@ -570,26 +619,17 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
 
       // 4. CONSOLIDAR INVENTARIO DE PRODUCTOS APLICADOS
       if (movimientos.length > 0) {
-
-        // Agrupar movimientos por producto
         const consolidado = new Map<string, { nombre: string; cantidad: number }>();
 
         movimientos.forEach((mov) => {
           if (!consolidado.has(mov.producto_id)) {
-            consolidado.set(mov.producto_id, {
-              nombre: mov.producto_nombre,
-              cantidad: 0,
-            });
+            consolidado.set(mov.producto_id, { nombre: mov.producto_nombre, cantidad: 0 });
           }
-
           const item = consolidado.get(mov.producto_id)!;
           item.cantidad += mov.cantidad_utilizada;
         });
 
-
-        // Para cada producto: actualizar inventario y crear movimiento
         for (const [productoId, { nombre, cantidad }] of consolidado.entries()) {
-          // a) Obtener datos actuales del producto
           const { data: producto, error: errorProd } = await supabase
             .from('productos')
             .select('cantidad_actual, unidad_medida, precio_unitario')
@@ -603,7 +643,6 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
           const saldoAnterior = producto.cantidad_actual || 0;
           const saldoNuevo = saldoAnterior - cantidad;
 
-          // b) Actualizar inventario
           const { error: errorUpdateInv } = await supabase
             .from('productos')
             .update({ cantidad_actual: saldoNuevo })
@@ -613,892 +652,313 @@ export function CierreAplicacion({ aplicacion, onClose, onCerrado }: CierreAplic
             throw new Error(`Error actualizando inventario de ${nombre}`);
           }
 
-          // c) Crear movimiento de salida
-          const { error: errorMov } = await supabase
-            .from('movimientos_inventario')
-            .insert({
-              fecha_movimiento: datosFinales.fechaFinReal,
-              producto_id: productoId,
-              tipo_movimiento: 'Salida por Aplicación',
-              cantidad: cantidad,
-              unidad: producto.unidad_medida,
-              lote_aplicacion: lotes.map(l => l.nombre).join(', '),
-              aplicacion_id: aplicacion.id,
-              saldo_anterior: saldoAnterior,
-              saldo_nuevo: saldoNuevo,
-              valor_movimiento: cantidad * (producto.precio_unitario || 0),
-              responsable: user?.email,
-              observaciones: `Cierre de aplicación: ${aplicacion.nombre_aplicacion}`,
-              provisional: false
-            });
+          const { error: errorMov } = await supabase.from('movimientos_inventario').insert({
+            fecha_movimiento: datosFinales.fechaFinReal,
+            producto_id: productoId,
+            tipo_movimiento: 'Salida por Aplicación',
+            cantidad: cantidad,
+            unidad: producto.unidad_medida,
+            lote_aplicacion: lotes.map((l) => l.nombre).join(', '),
+            aplicacion_id: aplicacion.id,
+            saldo_anterior: saldoAnterior,
+            saldo_nuevo: saldoNuevo,
+            valor_movimiento: cantidad * (producto.precio_unitario || 0),
+            responsable: user?.email,
+            observaciones: `Cierre de aplicación: ${aplicacion.nombre_aplicacion}`,
+            provisional: false,
+          });
 
           if (errorMov) {
             throw new Error(`Error registrando movimiento de ${nombre}`);
           }
-
         }
-
       }
 
-      onCerrado();
+      draft.clearDraft();
+      setConfirmDialogOpen(false);
+      navigate('/aplicaciones');
     } catch (err: any) {
       setError('Error al cerrar la aplicación: ' + err.message);
+      setConfirmDialogOpen(false);
     } finally {
       setProcesando(false);
     }
   };
 
-  const formatearMoneda = (valor: number) => {
-    return new Intl.NumberFormat('es-CO', {
-      style: 'currency',
-      currency: 'COP',
-      minimumFractionDigits: 0,
-    }).format(valor);
+  const handleDescargarPDF = async () => {
+    const fechaInicio = new Date(datosFinales.fechaInicioReal);
+    const fechaFin = new Date(datosFinales.fechaFinReal);
+    const diasCalc = Math.ceil((fechaFin.getTime() - fechaInicio.getTime()) / (1000 * 60 * 60 * 24)) + 1;
+    const valorJornalProm = totalJornales > 0 ? costoManoObra / totalJornales : 0;
+    const arbolesJornal = totalJornales > 0 ? totalArboles / totalJornales : 0;
+
+    await generarPDFReporteCierre({
+      nombre: aplicacion.nombre_aplicacion || '',
+      tipo_aplicacion: aplicacion.tipo_aplicacion || '',
+      proposito: aplicacion.proposito ?? undefined,
+      fecha_inicio_planeada: aplicacion.fecha_inicio_planeada ?? undefined,
+      fecha_inicio_ejecucion: datosFinales.fechaInicioReal,
+      fecha_cierre: datosFinales.fechaFinReal,
+      dias_aplicacion: diasCalc,
+      lotes: lotes.map((l) => ({ nombre: l.nombre, arboles: l.arboles })),
+      total_arboles: totalArboles,
+      costo_total_insumos: costoInsumos,
+      costo_total_mano_obra: costoManoObra,
+      costo_total: costoTotal,
+      costo_por_arbol: costoPorArbol,
+      jornales_utilizados: totalJornales,
+      valor_jornal: Math.round(valorJornalProm),
+      arboles_por_jornal: arbolesJornal,
+      comparacion_productos: resumenInsumos.map((i) => {
+        const diferencia = i.aplicado - i.planeado;
+        const porcentajeDesviacion = i.planeado > 0 ? (diferencia / i.planeado) * 100 : 0;
+        let costoProducto = 0;
+        movimientos.forEach((mov) => {
+          if (mov.producto_nombre === i.nombre) {
+            costoProducto += mov.cantidad_utilizada * mov.costo_unitario;
+          }
+        });
+        return {
+          producto_nombre: i.nombre,
+          producto_unidad: i.unidad,
+          cantidad_planeada: i.planeado,
+          cantidad_real: i.aplicado,
+          diferencia,
+          porcentaje_desviacion: porcentajeDesviacion,
+          costo_total: costoProducto,
+        };
+      }),
+      observaciones_cierre: datosFinales.observaciones || undefined,
+    });
   };
 
   // Cálculos derivados
   const totalArboles = lotes.reduce((sum, lote) => sum + lote.arboles, 0);
-  const costoInsumos = movimientos.reduce(
-    (sum, mov) => sum + mov.cantidad_utilizada * mov.costo_unitario,
-    0
-  );
-  const registrosActivos = registrosEditados.filter(r => !r._deleted);
-  const totalJornales = registrosActivos.reduce((s, r) => s + r.fraccion_jornal, 0);
-  const costoManoObra = registrosActivos.reduce((s, r) => s + r.costo_jornal, 0);
+  const costoInsumos = movimientos.reduce((sum, mov) => sum + mov.cantidad_utilizada * mov.costo_unitario, 0);
+  const registrosActivos = useMemo(() => registrosEditados.filter((r) => !r._deleted), [registrosEditados]);
+  const kpis = useMemo(() => calcularKPIsLabores(registrosActivos), [registrosActivos]);
+  const { totalJornales, costoManoObra } = kpis;
   const costoTotal = costoInsumos + costoManoObra;
   const costoPorArbol = totalArboles > 0 ? costoTotal / totalArboles : 0;
 
-  // Agrupar registros activos por lote para display
-  const registrosPorLote = new Map<string, { lote_nombre: string; registros: (RegistroTrabajoCierre & { _index: number })[] }>();
-  registrosEditados.forEach((r, index) => {
-    if (r._deleted) return;
-    const key = r.lote_id;
-    if (!registrosPorLote.has(key)) {
-      registrosPorLote.set(key, { lote_nombre: r.lote_nombre, registros: [] });
-    }
-    registrosPorLote.get(key)!.registros.push({ ...r, _index: index });
-  });
+  const registrosPorLote = useMemo(() => agruparRegistrosPorLote(registrosEditados), [registrosEditados]);
+
+  const excepciones = useMemo(
+    () => calcularExcepcionesCierre(resumenInsumos, registrosActivos, lotes, tieneTarea),
+    [resumenInsumos, registrosActivos, lotes, tieneTarea],
+  );
+
+  const insumosParaDialogo = formatearListaConY(
+    resumenInsumos.map((i) => `${i.nombre} (${formatearNumero(i.aplicado, 2)} ${i.unidad})`),
+  );
+
+  if (loading) {
+    return (
+      <AplicacionShell titulo="Cerrar Aplicación" subtitulo={aplicacion.nombre_aplicacion ?? undefined} estado={aplicacion.estado}>
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+          <Spinner className="size-8 text-primary" />
+          <p className="text-sm text-muted-foreground">Cargando datos de la aplicación…</p>
+        </div>
+        <div className="space-y-4">
+          <Skeleton className="h-40 w-full rounded-2xl" />
+          <Skeleton className="h-64 w-full rounded-2xl" />
+          <Skeleton className="h-40 w-full rounded-2xl" />
+        </div>
+      </AplicacionShell>
+    );
+  }
+
+  if (error) {
+    return (
+      <AplicacionShell titulo="Cerrar Aplicación" subtitulo={aplicacion.nombre_aplicacion ?? undefined} estado={aplicacion.estado}>
+        <Empty>
+          <EmptyMedia variant="icon" className="bg-destructive/10 text-destructive">
+            <AlertTriangle />
+          </EmptyMedia>
+          <EmptyTitle>No pudimos preparar el cierre</EmptyTitle>
+          <EmptyDescription>{error}</EmptyDescription>
+          <EmptyContent>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Button onClick={cargarDatos}>
+                <RefreshCw className="size-4" />
+                Reintentar
+              </Button>
+              <Button variant="outline" onClick={() => navigate('/aplicaciones')}>
+                Volver a Aplicaciones
+              </Button>
+            </div>
+          </EmptyContent>
+        </Empty>
+      </AplicacionShell>
+    );
+  }
 
   return (
-    <div className="fixed inset-0 bg-black/60 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-6xl w-full max-h-[90vh] overflow-hidden flex flex-col">
-        {/* HEADER */}
-        <div className="bg-gradient-to-r from-primary to-secondary px-6 py-4 text-white flex items-center justify-between">
-          <div>
-            <h2 className="text-xl">Cerrar Aplicación</h2>
-            <p className="text-sm text-white/90 mt-1">{aplicacion.nombre_aplicacion}</p>
-          </div>
-          <button
-            onClick={onClose}
-            className="p-2 hover:bg-white/20 rounded-lg transition-colors"
-            aria-label="Cerrar"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
+    <AplicacionShell
+      titulo="Cerrar Aplicación"
+      subtitulo={aplicacion.nombre_aplicacion ?? undefined}
+      estado={aplicacion.estado}
+    >
+      <div className="space-y-6 pb-6">
+        <FormDraftBanner
+          variant="available"
+          show={draft.hasDraft}
+          onRestore={handleRestoreDraft}
+          onDiscard={draft.discardDraft}
+        />
 
-        {/* STEPPER */}
-        <div className="bg-gray-50 px-6 py-3 border-b border-gray-200">
-          <div className="flex items-center justify-center gap-2">
-            <div className={`flex items-center gap-2 ${paso === 'revision' ? 'text-primary' : 'text-gray-400'}`}>
-              <div className={`w-8 h-8 rounded-full flex items-center justify-center ${paso === 'revision' ? 'bg-primary text-white' : 'bg-gray-200'}`}>
-                1
-              </div>
-              <span className="text-sm hidden sm:inline">Insumos</span>
-            </div>
+        <SeccionInsumosCierre
+          tipoAplicacion={aplicacion.tipo_aplicacion}
+          totalLotes={lotes.length}
+          totalArboles={totalArboles}
+          proposito={aplicacion.proposito}
+          resumenInsumos={resumenInsumos}
+          canecasPlaneadas={canecasPlaneadas}
+          canecasAplicadas={canecasAplicadas}
+        />
 
-            <ChevronRight className="w-4 h-4 text-gray-400" />
+        <SeccionLaboresCierre
+          lotes={lotes}
+          tieneTarea={tieneTarea}
+          registrosPorLote={registrosPorLote}
+          kpis={kpis}
+          excepciones={excepciones}
+          editandoRegistro={editandoRegistro}
+          onIniciarEdicion={setEditandoRegistro}
+          onCancelarEdicion={() => setEditandoRegistro(null)}
+          onEditarFraccion={editarFraccion}
+          onEliminarRegistro={eliminarRegistro}
+          mostrarAgregarRegistro={mostrarAgregarRegistro}
+          onAbrirAgregarRegistro={handleAbrirAgregarRegistro}
+          onCancelarAgregarRegistro={() => setMostrarAgregarRegistro(false)}
+          nuevoRegistro={nuevoRegistro}
+          onCambiarNuevoRegistro={(patch) => setNuevoRegistro((prev) => ({ ...prev, ...patch }))}
+          onConfirmarAgregarRegistro={agregarRegistro}
+          trabajadoresDisponibles={trabajadoresDisponibles}
+          fechaInicioReal={datosFinales.fechaInicioReal}
+          fechaFinReal={datosFinales.fechaFinReal}
+          fuenteFechas={fuenteFechas}
+          onCambiarFechaInicio={(v) => setDatosFinales((prev) => ({ ...prev, fechaInicioReal: v }))}
+          onCambiarFechaFin={(v) => setDatosFinales((prev) => ({ ...prev, fechaFinReal: v }))}
+          observaciones={datosFinales.observaciones}
+          onCambiarObservaciones={(v) => setDatosFinales((prev) => ({ ...prev, observaciones: v }))}
+        />
 
-            <div className={`flex items-center gap-2 ${paso === 'datos-finales' ? 'text-primary' : 'text-gray-400'}`}>
-              <div className={`w-8 h-8 rounded-full flex items-center justify-center ${paso === 'datos-finales' ? 'bg-primary text-white' : 'bg-gray-200'}`}>
-                2
-              </div>
-              <span className="text-sm hidden sm:inline">Labores</span>
-            </div>
-
-            <ChevronRight className="w-4 h-4 text-gray-400" />
-
-            <div className={`flex items-center gap-2 ${paso === 'confirmacion' ? 'text-primary' : 'text-gray-400'}`}>
-              <div className={`w-8 h-8 rounded-full flex items-center justify-center ${paso === 'confirmacion' ? 'bg-primary text-white' : 'bg-gray-200'}`}>
-                3
-              </div>
-              <span className="text-sm hidden sm:inline">Confirmación</span>
-            </div>
-          </div>
-        </div>
-
-        {/* CONTENIDO */}
-        <div className="flex-1 overflow-y-auto p-6">
-          {loading ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="w-12 h-12 border-4 border-primary/30 border-t-primary rounded-full animate-spin" />
-            </div>
-          ) : error ? (
-            <div className="bg-red-50 border-2 border-red-200 text-red-700 px-6 py-4 rounded-xl">
-              <p className="font-medium">Error</p>
-              <p className="text-sm mt-1">{error}</p>
-            </div>
-          ) : (
-            <>
-              {/* ========================================= */}
-              {/* PASO 1: REVISIÓN DE INSUMOS */}
-              {/* ========================================= */}
-              {paso === 'revision' && (
-                <div className="space-y-6">
-                  <div>
-                    <h3 className="text-lg text-foreground mb-4">Resumen de la Aplicación</h3>
-
-                    {/* Información General */}
-                    <div className="bg-gradient-to-br from-primary/5 to-secondary/5 border border-primary/20 rounded-xl p-5 mb-4">
-                      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Tipo</p>
-                          <p className="text-sm text-foreground font-medium">
-                            {aplicacion.tipo_aplicacion === 'Fumigación' ? 'Fumigación' :
-                             aplicacion.tipo_aplicacion === 'Fertilización' ? 'Fertilización' : 'Drench'}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Lotes</p>
-                          <p className="text-sm text-foreground font-medium">{lotes.length} lotes</p>
-                        </div>
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Total Árboles</p>
-                          <p className="text-sm text-foreground font-medium">{formatearNumero(totalArboles, 0)}</p>
-                        </div>
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Propósito</p>
-                          <p className="text-sm text-foreground font-medium truncate">{aplicacion.proposito || 'No especificado'}</p>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Tabla de Insumos */}
-                    <div className="bg-white border border-gray-200 rounded-xl overflow-hidden">
-                      <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
-                        <h4 className="text-sm text-foreground font-medium">Insumos Utilizados</h4>
-                      </div>
-
-                      {resumenInsumos.length === 0 ? (
-                        <div className="p-8 text-center">
-                          <p className="text-sm text-brand-brown/70">No hay insumos registrados</p>
-                        </div>
-                      ) : (
-                        <div className="overflow-x-auto">
-                          <table className="w-full">
-                            <thead className="bg-gray-50">
-                              <tr>
-                                <th className="px-4 py-3 text-left text-xs text-brand-brown/70">Producto</th>
-                                <th className="px-4 py-3 text-right text-xs text-brand-brown/70">Planeado</th>
-                                <th className="px-4 py-3 text-right text-xs text-brand-brown/70">Aplicado</th>
-                                <th className="px-4 py-3 text-right text-xs text-brand-brown/70">Diferencia</th>
-                                <th className="px-4 py-3 text-center text-xs text-brand-brown/70">Estado</th>
-                              </tr>
-                            </thead>
-                            <tbody className="divide-y divide-gray-100">
-                              {resumenInsumos.map((insumo, index) => {
-                                const diferencia = insumo.aplicado - insumo.planeado;
-                                const esCritico = insumo.planeado > 0 && Math.abs(diferencia / insumo.planeado) > 0.15;
-
-                                return (
-                                  <tr key={index} className="hover:bg-gray-50 transition-colors">
-                                    <td className="px-4 py-3 text-sm text-foreground">
-                                      {insumo.nombre}
-                                    </td>
-                                    <td className="px-4 py-3 text-sm text-brand-brown/70 text-right">
-                                      {formatearNumero(insumo.planeado, 2)} {insumo.unidad}
-                                    </td>
-                                    <td className="px-4 py-3 text-sm text-foreground font-medium text-right">
-                                      {formatearNumero(insumo.aplicado, 2)} {insumo.unidad}
-                                    </td>
-                                    <td className={`px-4 py-3 text-sm text-right ${
-                                      diferencia > 0 ? 'text-orange-600' : diferencia < 0 ? 'text-blue-600' : 'text-gray-600'
-                                    }`}>
-                                      {diferencia > 0 ? '+' : ''}{formatearNumero(diferencia, 2)} {insumo.unidad}
-                                    </td>
-                                    <td className="px-4 py-3 text-center">
-                                      <span className={`inline-flex items-center px-2.5 py-1 rounded-full text-xs ${
-                                        esCritico
-                                          ? 'bg-red-100 text-red-700'
-                                          : 'bg-green-100 text-green-700'
-                                      }`}>
-                                        {esCritico ? 'Desviado' : 'OK'}
-                                      </span>
-                                    </td>
-                                  </tr>
-                                );
-                              })}
-                            </tbody>
-                          </table>
-                        </div>
-                      )}
-                    </div>
-
-                    {/* Tabla de Canecas (solo para fumigación) */}
-                    {aplicacion.tipo_aplicacion === 'Fumigación' && (
-                      <div className="bg-white border border-gray-200 rounded-xl overflow-hidden mt-4">
-                        <div className="bg-gray-50 px-4 py-3 border-b border-gray-200">
-                          <h4 className="text-sm text-foreground font-medium">Control de Canecas</h4>
-                        </div>
-                        <div className="p-4">
-                          <div className="grid grid-cols-3 gap-4">
-                            <div className="text-center">
-                              <p className="text-xs text-brand-brown/70 mb-1">Planeadas</p>
-                              <p className="text-2xl text-foreground font-semibold">{formatearNumero(canecasPlaneadas, 1)}</p>
-                            </div>
-                            <div className="text-center">
-                              <p className="text-xs text-brand-brown/70 mb-1">Aplicadas</p>
-                              <p className="text-2xl text-primary font-semibold">{formatearNumero(canecasAplicadas, 1)}</p>
-                            </div>
-                            <div className="text-center">
-                              <p className="text-xs text-brand-brown/70 mb-1">Diferencia</p>
-                              <p className={`text-2xl font-semibold ${
-                                canecasAplicadas - canecasPlaneadas > 0 ? 'text-orange-600' :
-                                canecasAplicadas - canecasPlaneadas < 0 ? 'text-blue-600' : 'text-gray-600'
-                              }`}>
-                                {canecasAplicadas - canecasPlaneadas > 0 ? '+' : ''}
-                                {formatearNumero(canecasAplicadas - canecasPlaneadas, 1)}
-                              </p>
-                            </div>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-                  </div>
-                </div>
-              )}
-
-              {/* ========================================= */}
-              {/* PASO 2: REVISIÓN DE LABORES */}
-              {/* ========================================= */}
-              {paso === 'datos-finales' && (
-                <div className="space-y-6">
-                  <div>
-                    <h3 className="text-lg text-foreground mb-2">Revisión de Labores</h3>
-                    <p className="text-sm text-brand-brown/70 mb-4">
-                      Revisa los jornales registrados durante la ejecución. Puedes editar o agregar registros faltantes.
-                    </p>
-
-                    {/* Tarjetas resumen */}
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-3 mb-6">
-                      <div className="bg-primary/5 border border-primary/20 rounded-xl p-4 text-center">
-                        <Users className="w-5 h-5 text-primary mx-auto mb-1" />
-                        <p className="text-2xl text-foreground font-bold">{formatearNumero(totalJornales, 1)}</p>
-                        <p className="text-xs text-brand-brown/70">Jornales</p>
-                      </div>
-                      <div className="bg-primary/5 border border-primary/20 rounded-xl p-4 text-center">
-                        <p className="text-2xl text-foreground font-bold">{formatearMoneda(costoManoObra)}</p>
-                        <p className="text-xs text-brand-brown/70">Costo Mano de Obra</p>
-                      </div>
-                      <div className="bg-primary/5 border border-primary/20 rounded-xl p-4 text-center">
-                        <p className="text-2xl text-foreground font-bold">
-                          {new Set(registrosActivos.map(r => r.empleado_id || r.contratista_id)).size}
-                        </p>
-                        <p className="text-xs text-brand-brown/70">Trabajadores</p>
-                      </div>
-                      <div className="bg-primary/5 border border-primary/20 rounded-xl p-4 text-center">
-                        <Calendar className="w-5 h-5 text-primary mx-auto mb-1" />
-                        <p className="text-2xl text-foreground font-bold">
-                          {new Set(registrosActivos.map(r => r.fecha_trabajo)).size}
-                        </p>
-                        <p className="text-xs text-brand-brown/70">Días trabajados</p>
-                      </div>
-                    </div>
-
-                    {/* Warning si no hay tarea vinculada */}
-                    {!tieneTarea && (
-                      <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4 mb-4">
-                        <div className="flex items-start gap-3">
-                          <AlertTriangle className="w-5 h-5 text-yellow-600 mt-0.5" />
-                          <div>
-                            <p className="text-sm text-yellow-800 font-medium">
-                              Esta aplicación no tiene tarea de labor vinculada
-                            </p>
-                            <p className="text-xs text-yellow-700 mt-1">
-                              Los jornales se registraron antes de implementar la vinculación automática.
-                              Puedes agregar registros manualmente usando el botón de abajo.
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Warning si no hay registros */}
-                    {tieneTarea && registrosActivos.length === 0 && (
-                      <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4 mb-4">
-                        <div className="flex items-start gap-3">
-                          <AlertTriangle className="w-5 h-5 text-yellow-600 mt-0.5" />
-                          <div>
-                            <p className="text-sm text-yellow-800 font-medium">
-                              No hay jornales registrados para esta aplicación
-                            </p>
-                            <p className="text-xs text-yellow-700 mt-1">
-                              Puedes agregar registros de trabajo manualmente o volver al módulo de Labores para registrarlos antes de cerrar.
-                            </p>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Tabla de registros por lote */}
-                    {registrosPorLote.size > 0 && (
-                      <div className="space-y-3 mb-6">
-                        {Array.from(registrosPorLote.entries()).map(([loteId, { lote_nombre, registros: regsLote }]) => {
-                          const totalLote = regsLote.reduce((s, r) => s + r.fraccion_jornal, 0);
-                          const costoLote = regsLote.reduce((s, r) => s + r.costo_jornal, 0);
-                          const isExpanded = loteExpandido === loteId || registrosPorLote.size === 1;
-
-                          return (
-                            <div key={loteId} className="bg-white border border-gray-200 rounded-xl overflow-hidden">
-                              {/* Lote header */}
-                              <button
-                                onClick={() => setLoteExpandido(isExpanded && registrosPorLote.size > 1 ? null : loteId)}
-                                className="w-full px-4 py-3 bg-gray-50 border-b border-gray-200 flex items-center justify-between hover:bg-gray-100 transition-colors"
-                              >
-                                <div className="flex items-center gap-3">
-                                  <ChevronDown className={`w-4 h-4 text-gray-500 transition-transform ${isExpanded ? 'rotate-180' : ''}`} />
-                                  <span className="text-sm text-foreground font-medium">{lote_nombre}</span>
-                                  <span className="text-xs text-brand-brown/60">
-                                    {formatearNumero(lotes.find(l => l.lote_id === loteId)?.arboles ?? 0, 0)} árboles
-                                  </span>
-                                </div>
-                                <div className="flex items-center gap-4">
-                                  <span className="text-sm text-foreground font-medium">{formatearNumero(totalLote, 1)} jornales</span>
-                                  <span className="text-sm text-primary font-semibold">{formatearMoneda(costoLote)}</span>
-                                </div>
-                              </button>
-
-                              {/* Registros del lote */}
-                              {isExpanded && (
-                                <div className="overflow-x-auto">
-                                  <table className="w-full">
-                                    <thead className="bg-gray-50/50">
-                                      <tr>
-                                        <th className="px-4 py-2 text-left text-xs text-brand-brown/70">Fecha</th>
-                                        <th className="px-4 py-2 text-left text-xs text-brand-brown/70">Trabajador</th>
-                                        <th className="px-4 py-2 text-center text-xs text-brand-brown/70">Tipo</th>
-                                        <th className="px-4 py-2 text-center text-xs text-brand-brown/70">Fracción</th>
-                                        <th className="px-4 py-2 text-right text-xs text-brand-brown/70">Costo</th>
-                                        <th className="px-4 py-2 text-center text-xs text-brand-brown/70 w-20">Acciones</th>
-                                      </tr>
-                                    </thead>
-                                    <tbody className="divide-y divide-gray-100">
-                                      {regsLote.map((reg) => {
-                                        const regKey = reg.id || `new-${reg._index}`;
-                                        return (
-                                          <tr key={regKey} className={`hover:bg-gray-50 transition-colors ${reg._isNew ? 'bg-green-50/30' : ''}`}>
-                                            <td className="px-4 py-2 text-sm text-foreground">
-                                              {formatearFecha(reg.fecha_trabajo)}
-                                            </td>
-                                            <td className="px-4 py-2 text-sm text-foreground">
-                                              {reg.trabajador_nombre}
-                                            </td>
-                                            <td className="px-4 py-2 text-center">
-                                              <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs ${
-                                                reg.trabajador_tipo === 'empleado'
-                                                  ? 'bg-blue-100 text-blue-700'
-                                                  : 'bg-purple-100 text-purple-700'
-                                              }`}>
-                                                {reg.trabajador_tipo === 'empleado' ? 'Emp' : 'Cont'}
-                                              </span>
-                                            </td>
-                                            <td className="px-4 py-2 text-center">
-                                              {editandoRegistro === regKey ? (
-                                                <select
-                                                  autoFocus
-                                                  value={reg.fraccion_jornal}
-                                                  onChange={(e) => editarFraccion(regKey, parseFloat(e.target.value))}
-                                                  onBlur={() => setEditandoRegistro(null)}
-                                                  className="w-20 px-1 py-0.5 text-center border border-primary rounded text-sm"
-                                                >
-                                                  {FRACCION_OPTIONS.map(f => (
-                                                    <option key={f} value={f}>{f}</option>
-                                                  ))}
-                                                </select>
-                                              ) : (
-                                                <button
-                                                  onClick={() => setEditandoRegistro(regKey)}
-                                                  className="text-sm text-foreground font-medium hover:text-primary transition-colors cursor-pointer"
-                                                  title="Clic para editar"
-                                                >
-                                                  {reg.fraccion_jornal}
-                                                </button>
-                                              )}
-                                            </td>
-                                            <td className="px-4 py-2 text-sm text-right text-foreground">
-                                              {formatearMoneda(reg.costo_jornal)}
-                                              {reg.costo_jornal === 0 && (
-                                                <AlertTriangle className="w-3 h-3 text-yellow-500 inline ml-1" />
-                                              )}
-                                            </td>
-                                            <td className="px-4 py-2 text-center">
-                                              <div className="flex items-center justify-center gap-1">
-                                                <button
-                                                  onClick={() => setEditandoRegistro(regKey)}
-                                                  className="p-1 text-gray-400 hover:text-primary transition-colors"
-                                                  title="Editar fracción"
-                                                  aria-label="Editar fracción de jornal"
-                                                >
-                                                  <Edit3 className="w-3.5 h-3.5" />
-                                                </button>
-                                                <button
-                                                  onClick={() => eliminarRegistro(reg._index)}
-                                                  className="p-1 text-gray-400 hover:text-red-500 transition-colors"
-                                                  title="Eliminar"
-                                                  aria-label="Eliminar registro de jornal"
-                                                >
-                                                  <Trash2 className="w-3.5 h-3.5" />
-                                                </button>
-                                              </div>
-                                            </td>
-                                          </tr>
-                                        );
-                                      })}
-                                    </tbody>
-                                  </table>
-                                </div>
-                              )}
-                            </div>
-                          );
-                        })}
-                      </div>
-                    )}
-
-                    {/* Botón agregar registro */}
-                    {!mostrarAgregarRegistro ? (
-                      <button
-                        onClick={() => { setMostrarAgregarRegistro(true); cargarTrabajadores(); }}
-                        className="w-full py-3 border-2 border-dashed border-primary/30 text-primary rounded-xl hover:bg-primary/5 transition-colors flex items-center justify-center gap-2 text-sm"
-                      >
-                        <Plus className="w-4 h-4" />
-                        Agregar registro de trabajo faltante
-                      </button>
-                    ) : (
-                      <div className="bg-white border-2 border-primary/30 rounded-xl p-4">
-                        <h4 className="text-sm text-foreground font-medium mb-3">Nuevo Registro de Trabajo</h4>
-                        <div className="grid grid-cols-2 md:grid-cols-5 gap-3">
-                          <div>
-                            <label className="block text-xs text-brand-brown/70 mb-1">Trabajador</label>
-                            <select
-                              value={nuevoRegistro.trabajador_id}
-                              onChange={(e) => {
-                                const t = trabajadoresDisponibles.find(t => t.id === e.target.value);
-                                setNuevoRegistro(prev => ({
-                                  ...prev,
-                                  trabajador_id: e.target.value,
-                                  trabajador_tipo: t?.tipo || 'empleado',
-                                }));
-                              }}
-                              className="w-full px-2 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                            >
-                              <option value="">Seleccionar...</option>
-                              <optgroup label="Empleados">
-                                {trabajadoresDisponibles.filter(t => t.tipo === 'empleado').map(t => (
-                                  <option key={t.id} value={t.id}>{t.nombre}</option>
-                                ))}
-                              </optgroup>
-                              <optgroup label="Contratistas">
-                                {trabajadoresDisponibles.filter(t => t.tipo === 'contratista').map(t => (
-                                  <option key={t.id} value={t.id}>{t.nombre}</option>
-                                ))}
-                              </optgroup>
-                            </select>
-                          </div>
-                          <div>
-                            <label className="block text-xs text-brand-brown/70 mb-1">Lote</label>
-                            <select
-                              value={nuevoRegistro.lote_id}
-                              onChange={(e) => setNuevoRegistro(prev => ({ ...prev, lote_id: e.target.value }))}
-                              className="w-full px-2 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                            >
-                              <option value="">Seleccionar...</option>
-                              {lotes.map(l => (
-                                <option key={l.lote_id} value={l.lote_id}>{l.nombre}</option>
-                              ))}
-                            </select>
-                          </div>
-                          <div>
-                            <label className="block text-xs text-brand-brown/70 mb-1">Fecha</label>
-                            <input
-                              type="date"
-                              value={nuevoRegistro.fecha_trabajo}
-                              onChange={(e) => setNuevoRegistro(prev => ({ ...prev, fecha_trabajo: e.target.value }))}
-                              className="w-full px-2 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                            />
-                          </div>
-                          <div>
-                            <label className="block text-xs text-brand-brown/70 mb-1">Fracción</label>
-                            <select
-                              value={nuevoRegistro.fraccion_jornal}
-                              onChange={(e) => setNuevoRegistro(prev => ({ ...prev, fraccion_jornal: parseFloat(e.target.value) }))}
-                              className="w-full px-2 py-1.5 border border-gray-300 rounded-lg text-sm focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                            >
-                              {FRACCION_OPTIONS.map(f => (
-                                <option key={f} value={f}>{f}</option>
-                              ))}
-                            </select>
-                          </div>
-                          <div className="flex items-end gap-2">
-                            <button
-                              onClick={agregarRegistro}
-                              disabled={!nuevoRegistro.trabajador_id || !nuevoRegistro.lote_id}
-                              className="px-4 py-1.5 bg-primary text-white rounded-lg text-sm hover:bg-primary-dark disabled:opacity-50 disabled:cursor-not-allowed transition-colors"
-                            >
-                              Agregar
-                            </button>
-                            <button
-                              onClick={() => setMostrarAgregarRegistro(false)}
-                              className="px-3 py-1.5 text-brand-brown/70 rounded-lg text-sm hover:bg-gray-100 transition-colors"
-                            >
-                              Cancelar
-                            </button>
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Fechas y Observaciones */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-4 mt-6">
-                      <div>
-                        <label className="block text-sm text-brand-brown/70 mb-2">
-                          Fecha Inicio Real
-                        </label>
-                        <input
-                          type="date"
-                          value={datosFinales.fechaInicioReal}
-                          onChange={(e) =>
-                            setDatosFinales({ ...datosFinales, fechaInicioReal: e.target.value })
-                          }
-                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                        />
-                      </div>
-
-                      <div>
-                        <label className="block text-sm text-brand-brown/70 mb-2">
-                          Fecha Fin Real
-                        </label>
-                        <input
-                          type="date"
-                          value={datosFinales.fechaFinReal}
-                          onChange={(e) =>
-                            setDatosFinales({ ...datosFinales, fechaFinReal: e.target.value })
-                          }
-                          className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                        />
-                      </div>
-                    </div>
-
-                    <div className="mt-4">
-                      <label className="block text-sm text-brand-brown/70 mb-2">
-                        Observaciones de Cierre
-                      </label>
-                      <textarea
-                        rows={3}
-                        value={datosFinales.observaciones}
-                        onChange={(e) =>
-                          setDatosFinales({ ...datosFinales, observaciones: e.target.value })
-                        }
-                        className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                        placeholder="Describe cualquier incidencia, clima, rendimiento del personal, etc..."
-                      />
-                    </div>
-
-                    {/* Resumen de Costos */}
-                    <div className="bg-gradient-to-br from-primary/5 to-secondary/5 border border-primary/20 rounded-xl p-5 mt-6">
-                      <h4 className="text-sm text-foreground font-medium mb-3">Resumen de Costos</h4>
-                      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Insumos</p>
-                          <p className="text-lg text-foreground font-semibold">
-                            {formatearMoneda(costoInsumos)}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Mano de Obra</p>
-                          <p className="text-lg text-foreground font-semibold">
-                            {formatearMoneda(costoManoObra)}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Total</p>
-                          <p className="text-lg text-primary font-bold">
-                            {formatearMoneda(costoTotal)}
-                          </p>
-                        </div>
-                        <div>
-                          <p className="text-xs text-brand-brown/70 mb-1">Costo/Árbol</p>
-                          <p className="text-lg text-foreground font-semibold">
-                            {formatearMoneda(costoPorArbol)}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-                  </div>
-                </div>
-              )}
-
-              {/* ========================================= */}
-              {/* PASO 3: CONFIRMACIÓN */}
-              {/* ========================================= */}
-              {paso === 'confirmacion' && (
-                <div className="space-y-6">
-                  <div className="bg-gradient-to-br from-primary/5 to-secondary/5 border-2 border-primary/30 rounded-xl p-6">
-                    <div className="flex items-center gap-3 mb-4">
-                      <div className="w-12 h-12 bg-primary rounded-full flex items-center justify-center">
-                        <Check className="w-6 h-6 text-white" />
-                      </div>
-                      <div>
-                        <h3 className="text-lg text-foreground">Confirmar Cierre</h3>
-                        <p className="text-sm text-brand-brown/70">
-                          Revisa los datos antes de cerrar la aplicación
-                        </p>
-                      </div>
-                    </div>
-
-                    {/* Resumen Final */}
-                    <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-                      {/* Información General */}
-                      <div>
-                        <h4 className="text-sm text-foreground font-medium mb-3">Información General</h4>
-                        <div className="space-y-2 text-sm">
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Aplicación:</span>
-                            <span className="text-foreground font-medium">{aplicacion.nombre_aplicacion}</span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Tipo:</span>
-                            <span className="text-foreground">
-                              {aplicacion.tipo_aplicacion === 'Fumigación' ? 'Fumigación' :
-                               aplicacion.tipo_aplicacion === 'Fertilización' ? 'Fertilización' : 'Drench'}
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Lotes:</span>
-                            <span className="text-foreground">{lotes.length} lotes</span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Árboles:</span>
-                            <span className="text-foreground">{formatearNumero(totalArboles, 0)}</span>
-                          </div>
-                        </div>
-                      </div>
-
-                      {/* Ejecución */}
-                      <div>
-                        <h4 className="text-sm text-foreground font-medium mb-3">Ejecución</h4>
-                        <div className="space-y-2 text-sm">
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Inicio:</span>
-                            <span className="text-foreground">{formatearFecha(datosFinales.fechaInicioReal)}</span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Fin:</span>
-                            <span className="text-foreground">{formatearFecha(datosFinales.fechaFinReal)}</span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Jornales registrados:</span>
-                            <span className="text-foreground font-medium">{formatearNumero(totalJornales, 1)}</span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Trabajadores:</span>
-                            <span className="text-foreground">
-                              {new Set(registrosActivos.map(r => r.empleado_id || r.contratista_id)).size}
-                            </span>
-                          </div>
-                          <div className="flex justify-between">
-                            <span className="text-brand-brown/70">Días trabajados:</span>
-                            <span className="text-foreground">
-                              {new Set(registrosActivos.map(r => r.fecha_trabajo)).size}
-                            </span>
-                          </div>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Costos Totales */}
-                    <div className="mt-6 pt-6 border-t-2 border-primary/20">
-                      <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                        <div className="text-center">
-                          <p className="text-xs text-brand-brown/70 mb-1">Insumos</p>
-                          <p className="text-base text-foreground font-semibold">
-                            {formatearMoneda(costoInsumos)}
-                          </p>
-                        </div>
-                        <div className="text-center">
-                          <p className="text-xs text-brand-brown/70 mb-1">Mano de Obra</p>
-                          <p className="text-base text-foreground font-semibold">
-                            {formatearMoneda(costoManoObra)}
-                          </p>
-                        </div>
-                        <div className="text-center">
-                          <p className="text-xs text-brand-brown/70 mb-1">Costo Total</p>
-                          <p className="text-lg text-primary font-bold">
-                            {formatearMoneda(costoTotal)}
-                          </p>
-                        </div>
-                        <div className="text-center">
-                          <p className="text-xs text-brand-brown/70 mb-1">Costo/Árbol</p>
-                          <p className="text-base text-foreground font-semibold">
-                            {formatearMoneda(costoPorArbol)}
-                          </p>
-                        </div>
-                      </div>
-                    </div>
-
-                    {/* Observaciones */}
-                    {datosFinales.observaciones && (
-                      <div className="mt-6 pt-6 border-t-2 border-primary/20">
-                        <h4 className="text-sm text-foreground font-medium mb-2">Observaciones</h4>
-                        <p className="text-sm text-brand-brown/70 italic">
-                          &ldquo;{datosFinales.observaciones}&rdquo;
-                        </p>
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Advertencia */}
-                  <div className="bg-yellow-50 border-2 border-yellow-200 rounded-xl p-4">
-                    <p className="text-sm text-yellow-800">
-                      <strong>Importante:</strong> Al cerrar esta aplicación se descontarán los insumos del inventario,
-                      se marcará la tarea de labor como completada y no se podrán realizar más modificaciones.
-                    </p>
-                  </div>
-
-                  {/* Botón Descargar Reporte */}
-                  <button
-                    onClick={async () => {
-                      const fechaInicio = new Date(datosFinales.fechaInicioReal);
-                      const fechaFin = new Date(datosFinales.fechaFinReal);
-                      const diasCalc = Math.ceil((fechaFin.getTime() - fechaInicio.getTime()) / (1000 * 60 * 60 * 24)) + 1;
-                      const valorJornalProm = totalJornales > 0 ? costoManoObra / totalJornales : 0;
-                      const arbolesJornal = totalJornales > 0 ? totalArboles / totalJornales : 0;
-
-                      // Build per-product cost from movimientos
-                      const costosPorProducto = new Map<string, number>();
-                      movimientos.forEach((mov) => {
-                        const prev = costosPorProducto.get(mov.producto_id) || 0;
-                        costosPorProducto.set(mov.producto_id, prev + mov.cantidad_utilizada * mov.costo_unitario);
-                      });
-
-                      await generarPDFReporteCierre({
-                        nombre: aplicacion.nombre_aplicacion || '',
-                        tipo_aplicacion: aplicacion.tipo_aplicacion || '',
-                        proposito: aplicacion.proposito ?? undefined,
-                        fecha_inicio_planeada: aplicacion.fecha_inicio_planeada ?? undefined,
-                        fecha_inicio_ejecucion: datosFinales.fechaInicioReal,
-                        fecha_cierre: datosFinales.fechaFinReal,
-                        dias_aplicacion: diasCalc,
-                        lotes: lotes.map((l) => ({ nombre: l.nombre, arboles: l.arboles })),
-                        total_arboles: totalArboles,
-                        costo_total_insumos: costoInsumos,
-                        costo_total_mano_obra: costoManoObra,
-                        costo_total: costoTotal,
-                        costo_por_arbol: costoPorArbol,
-                        jornales_utilizados: totalJornales,
-                        valor_jornal: Math.round(valorJornalProm),
-                        arboles_por_jornal: arbolesJornal,
-                        comparacion_productos: resumenInsumos.map((i) => {
-                          const diferencia = i.aplicado - i.planeado;
-                          const porcentajeDesviacion = i.planeado > 0 ? (diferencia / i.planeado) * 100 : 0;
-                          // Find product cost from movimientos
-                          let costoProducto = 0;
-                          movimientos.forEach((mov) => {
-                            if (mov.producto_nombre === i.nombre) {
-                              costoProducto += mov.cantidad_utilizada * mov.costo_unitario;
-                            }
-                          });
-                          return {
-                            producto_nombre: i.nombre,
-                            producto_unidad: i.unidad,
-                            cantidad_planeada: i.planeado,
-                            cantidad_real: i.aplicado,
-                            diferencia,
-                            porcentaje_desviacion: porcentajeDesviacion,
-                            costo_total: costoProducto,
-                          };
-                        }),
-                        observaciones_cierre: datosFinales.observaciones || undefined,
-                      });
-                    }}
-                    className="w-full px-6 py-3 border-2 border-primary text-primary rounded-lg hover:bg-primary/5 transition-all flex items-center justify-center gap-2"
-                  >
-                    <Download className="w-5 h-5" />
-                    Descargar Reporte de Cierre (PDF)
-                  </button>
-                </div>
-              )}
-            </>
-          )}
-        </div>
-
-        {/* FOOTER - BOTONES */}
-        {!loading && !error && (
-          <div className="bg-gray-50 px-6 py-4 border-t border-gray-200 flex items-center justify-between">
-            <div>
-              {paso !== 'revision' && (
-                <button
-                  onClick={() => {
-                    if (paso === 'datos-finales') setPaso('revision');
-                    if (paso === 'confirmacion') setPaso('datos-finales');
-                  }}
-                  className="px-4 py-2 text-brand-brown/70 hover:text-foreground transition-colors"
-                >
-                  Anterior
-                </button>
-              )}
-            </div>
-
-            <div className="flex items-center gap-3">
-              <button
-                onClick={onClose}
-                className="px-4 py-2 border border-gray-300 text-brand-brown/70 rounded-lg hover:bg-gray-100 transition-colors"
-              >
-                Cancelar
-              </button>
-
-              {paso === 'revision' && (
-                <button
-                  onClick={() => setPaso('datos-finales')}
-                  className="px-6 py-2 bg-gradient-to-r from-primary to-secondary text-white rounded-lg hover:from-primary-dark hover:to-secondary-dark transition-all flex items-center gap-2"
-                >
-                  Continuar
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              )}
-
-              {paso === 'datos-finales' && (
-                <button
-                  onClick={() => setPaso('confirmacion')}
-                  className="px-6 py-2 bg-gradient-to-r from-primary to-secondary text-white rounded-lg hover:from-primary-dark hover:to-secondary-dark transition-all flex items-center gap-2"
-                >
-                  Continuar
-                  <ChevronRight className="w-4 h-4" />
-                </button>
-              )}
-
-              {paso === 'confirmacion' && (
-                <button
-                  onClick={cerrarAplicacion}
-                  disabled={procesando}
-                  className="px-6 py-2 bg-gradient-to-r from-green-600 to-green-500 text-white rounded-lg hover:from-green-700 hover:to-green-600 transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-                >
-                  {procesando ? (
-                    <>
-                      <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin" />
-                      Cerrando...
-                    </>
-                  ) : (
-                    <>
-                      <Check className="w-4 h-4" />
-                      Cerrar Aplicación
-                    </>
-                  )}
-                </button>
-              )}
-            </div>
-          </div>
-        )}
+        <SeccionConfirmarCierre
+          costoInsumos={costoInsumos}
+          costoManoObra={costoManoObra}
+          costoTotal={costoTotal}
+          costoPorArbol={costoPorArbol}
+          onDescargarPDF={handleDescargarPDF}
+        />
       </div>
-    </div>
+
+      {/* Footer único, sin variantes por paso (W03-cierre-v2.md §2) */}
+      <div className="sticky bottom-4 z-10 flex flex-col gap-3 rounded-2xl border bg-card/95 px-5 py-3.5 shadow-lg backdrop-blur sm:flex-row sm:items-center sm:justify-between sm:gap-4">
+        <div>
+          <p className="text-[10.5px] uppercase tracking-wide text-muted-foreground">Total del cierre</p>
+          <p className="text-lg font-bold tabular-nums text-primary-dark">{formatearMoneda(costoTotal)}</p>
+        </div>
+        <div className="flex items-center gap-3">
+          <Button
+            type="button"
+            variant="outline"
+            className="flex-1 sm:flex-none"
+            disabled={confirmDialogOpen || procesando}
+            onClick={() => navigate('/aplicaciones')}
+          >
+            Cancelar
+          </Button>
+          <Button
+            type="button"
+            className="flex-1 sm:flex-none"
+            disabled={confirmDialogOpen || procesando}
+            onClick={() => setConfirmDialogOpen(true)}
+          >
+            {procesando ? (
+              <>
+                <Spinner className="size-4" />
+                Cerrando...
+              </>
+            ) : (
+              <>
+                <Check className="size-4" />
+                Cerrar Aplicación
+              </>
+            )}
+          </Button>
+        </div>
+      </div>
+
+      {/* AlertDialog de confirmación — copia exacta de v1, aprobada por el dueño, sin cambios. */}
+      <AlertDialog open={confirmDialogOpen} onOpenChange={setConfirmDialogOpen}>
+        <AlertDialogContent>
+          <AlertDialogHeader>
+            <AlertDialogTitle>¿Cerrar esta aplicación?</AlertDialogTitle>
+            <AlertDialogDescription>
+              Esta acción no se puede deshacer. Al confirmar el cierre de &ldquo;
+              {aplicacion.nombre_aplicacion}&rdquo;:
+            </AlertDialogDescription>
+          </AlertDialogHeader>
+          <ul className="flex flex-col gap-2.5 border-t pt-4 text-sm">
+            {resumenInsumos.length > 0 && (
+              <li className="flex gap-2.5">
+                <Check className="mt-0.5 size-4 shrink-0 text-primary-dark" aria-hidden="true" />
+                <span>
+                  Se descontarán del inventario los{' '}
+                  <b className="font-semibold">{resumenInsumos.length} insumos aplicados</b>:{' '}
+                  {insumosParaDialogo}.
+                </span>
+              </li>
+            )}
+            {aplicacion.tarea_id && (
+              <li className="flex gap-2.5">
+                <Check className="mt-0.5 size-4 shrink-0 text-primary-dark" aria-hidden="true" />
+                <span>
+                  La <b className="font-semibold">tarea de labor</b> vinculada se marcará como{' '}
+                  <b className="font-semibold">Completada</b>.
+                </span>
+              </li>
+            )}
+            <li className="flex gap-2.5">
+              <Check className="mt-0.5 size-4 shrink-0 text-primary-dark" aria-hidden="true" />
+              <span>
+                Quedará registrado un costo total de <b className="font-semibold">{formatearMoneda(costoTotal)}</b>{' '}
+                ({formatearMoneda(costoInsumos)} en insumos + {formatearMoneda(costoManoObra)} en mano de obra).
+              </span>
+            </li>
+            <li className="flex gap-2.5">
+              <Check className="mt-0.5 size-4 shrink-0 text-primary-dark" aria-hidden="true" />
+              <span>
+                La aplicación pasará a estado <b className="font-semibold">Cerrada</b> y no se podrá editar: ni sus
+                insumos, ni sus registros de labor, ni las fechas de ejecución.
+              </span>
+            </li>
+          </ul>
+          <AlertDialogFooter>
+            <AlertDialogCancel disabled={procesando}>Cancelar</AlertDialogCancel>
+            <AlertDialogAction
+              disabled={procesando}
+              onClick={(e) => {
+                e.preventDefault();
+                cerrarAplicacion();
+              }}
+            >
+              {procesando ? (
+                <>
+                  <Spinner className="size-4" />
+                  Cerrando...
+                </>
+              ) : (
+                <>
+                  <Check className="size-4" />
+                  Sí, cerrar aplicación
+                </>
+              )}
+            </AlertDialogAction>
+          </AlertDialogFooter>
+        </AlertDialogContent>
+      </AlertDialog>
+    </AplicacionShell>
   );
 }

--- a/src/components/aplicaciones/CierreAplicacionWrapper.tsx
+++ b/src/components/aplicaciones/CierreAplicacionWrapper.tsx
@@ -1,11 +1,23 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { CierreAplicacion } from './CierreAplicacion';
+import { AplicacionShell } from './shared/AplicacionShell';
+import { Empty, EmptyContent, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { Skeleton } from '@/components/ui/skeleton';
 import { getSupabase } from '../../utils/supabase/client';
 import type { Aplicacion } from '../../types/aplicaciones';
 
+const APLICACION_NO_ENCONTRADA = 'Aplicación no encontrada';
+
 /**
- * Wrapper que obtiene la aplicación desde la URL y la pasa al cierre
+ * Wrapper que obtiene la aplicación desde la URL y la pasa al cierre.
+ *
+ * Solo fetch + pasar `aplicacion` — no absorbe lógica de UI propia (W03-cierre-v2.md §9 riesgo
+ * #6, heredado de v1 sin cambios): loading/error usan `AplicacionShell` + `Empty`, el mismo
+ * patrón que ya usa `DailyMovementsDashboardWrapper.tsx` en vez de markup a mano.
  */
 export function CierreAplicacionWrapper() {
   const { id } = useParams<{ id: string }>();
@@ -14,86 +26,83 @@ export function CierreAplicacionWrapper() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!id) {
-      navigate('/aplicaciones');
-      return;
-    }
-
-    loadAplicacion();
-  }, [id]);
-
-  const loadAplicacion = async () => {
+  const loadAplicacion = useCallback(async () => {
+    if (!id) return;
     try {
       setLoading(true);
       setError(null);
       const supabase = getSupabase();
 
-      const { data, error } = await supabase
+      const { data, error: fetchError } = await supabase
         .from('aplicaciones')
         .select('*')
-        .eq('id', id!)
+        .eq('id', id)
         .single();
 
-      if (error) throw error;
+      if (fetchError) throw fetchError;
 
       if (!data) {
-        setError('Aplicación no encontrada');
+        setError(APLICACION_NO_ENCONTRADA);
         return;
       }
 
       setAplicacion(data as Aplicacion);
     } catch (err: any) {
-      setError(err.message || 'Error cargando la aplicación');
+      setError(err?.message || 'Error cargando la aplicación');
     } finally {
       setLoading(false);
     }
-  };
+  }, [id]);
 
-  const handleClose = () => {
-    navigate('/aplicaciones');
-  };
-
-  const handleCerrado = () => {
-    navigate('/aplicaciones');
-  };
+  useEffect(() => {
+    if (!id) {
+      navigate('/aplicaciones');
+      return;
+    }
+    loadAplicacion();
+  }, [id, loadAplicacion, navigate]);
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-center">
-          <div className="inline-block w-12 h-12 border-4 border-primary/20 border-t-primary rounded-full animate-spin mb-4"></div>
-          <p className="text-brand-brown/70">Cargando aplicación...</p>
+      <AplicacionShell titulo="Cerrar Aplicación">
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+          <Spinner className="size-8 text-primary" />
+          <p className="text-sm text-muted-foreground">Cargando aplicación…</p>
         </div>
-      </div>
+        <div className="space-y-4">
+          <Skeleton className="h-24 w-full rounded-2xl" />
+          <Skeleton className="h-40 w-full rounded-2xl" />
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        </div>
+      </AplicacionShell>
     );
   }
 
   if (error || !aplicacion) {
+    const mensaje = error ?? 'No se pudo cargar la aplicación.';
     return (
-      <div className="text-center py-12">
-        <div className="inline-flex items-center justify-center w-20 h-20 bg-red-100 rounded-2xl mb-4">
-          <span className="text-3xl">⚠️</span>
-        </div>
-        <h2 className="text-2xl text-foreground mb-2">Error</h2>
-        <p className="text-brand-brown/70 mb-4">
-          {error || 'No se pudo cargar la aplicación'}
-        </p>
-        <button
-          onClick={handleClose}
-          className="px-6 py-2 bg-primary hover:bg-primary-dark text-white rounded-xl transition-colors"
-        >
-          Volver a Aplicaciones
-        </button>
-      </div>
+      <AplicacionShell titulo="Cerrar Aplicación">
+        <Empty>
+          <EmptyMedia variant="icon" className="bg-destructive/10 text-destructive">
+            <AlertTriangle />
+          </EmptyMedia>
+          <EmptyTitle>No pudimos cargar la aplicación</EmptyTitle>
+          <EmptyDescription>{mensaje}</EmptyDescription>
+          <EmptyContent>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Button onClick={loadAplicacion}>
+                <RefreshCw className="size-4" />
+                Reintentar
+              </Button>
+              <Button variant="outline" onClick={() => navigate('/aplicaciones')}>
+                Volver a Aplicaciones
+              </Button>
+            </div>
+          </EmptyContent>
+        </Empty>
+      </AplicacionShell>
     );
   }
 
-  return (
-    <CierreAplicacion 
-      aplicacion={aplicacion} 
-      onClose={handleClose}
-      onCerrado={handleCerrado}
-    />
-  );
+  return <CierreAplicacion aplicacion={aplicacion} />;
 }

--- a/src/components/aplicaciones/DailyMovementForm.tsx
+++ b/src/components/aplicaciones/DailyMovementForm.tsx
@@ -970,6 +970,7 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
                       variant="ghost"
                       size="sm"
                       className="text-red-600 hover:text-red-700 hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed"
+                      aria-label="Eliminar producto"
                     >
                       <Trash2 className="w-4 h-4" />
                     </Button>

--- a/src/components/aplicaciones/DailyMovementForm.tsx
+++ b/src/components/aplicaciones/DailyMovementForm.tsx
@@ -1,36 +1,63 @@
 import { useState, useEffect, useCallback, useMemo, useRef } from 'react';
 import { useFormDraft } from '@/hooks/useFormDraft';
 import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
-import { Save, X, Calendar, Package, Droplet, User, Plus, Trash2, AlertTriangle, FileText, Cloud, Clock } from 'lucide-react';
+import {
+  Save,
+  Calendar as CalendarIcon,
+  Package,
+  User,
+  Trash2,
+  AlertTriangle,
+  AlertCircle,
+  FileText,
+  Cloud,
+  Clock,
+  ArrowLeft,
+  ChevronRight,
+  Search,
+} from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
 import { obtenerFechaHoy } from '../../utils/fechas';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { Textarea } from '../ui/textarea';
+import { DateInput } from '../ui/date-input';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Field, FieldLabel, FieldDescription, FieldError } from '../ui/field';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
+import { Item, ItemMedia, ItemContent, ItemTitle, ItemDescription, ItemGroup } from '../ui/item';
+import { Tabs, TabsList, TabsTrigger, TabsContent } from '../ui/tabs';
+import { Tooltip, TooltipContent, TooltipProvider, TooltipTrigger } from '../ui/tooltip';
+import { Badge } from '../ui/badge';
+import { Alert, AlertTitle, AlertDescription } from '../ui/alert';
+import { Empty, EmptyDescription, EmptyMedia, EmptyTitle } from '../ui/empty';
+import { Spinner } from '../ui/spinner';
+import { Sheet, SheetContent, SheetFooter, SheetHeader, SheetTitle, SheetDescription } from '../ui/sheet';
+import { Drawer, DrawerContent, DrawerTitle, DrawerDescription } from '../ui/drawer';
+import { cn } from '../ui/utils';
 import type {
   Aplicacion,
-  MovimientoDiario,
   MovimientoDiarioProducto,
   LoteSeleccionado,
-  ProductoEnMezcla,
-  UnidadMedida, // 🚨 NUEVO: Importar el tipo ENUM
-  FraccionJornal
+  UnidadMedida,
+  FraccionJornal,
 } from '../../types/aplicaciones';
 import type {
   Empleado,
   Contratista,
   Trabajador,
-  Lote,
   WorkMatrix,
-  ObservacionesMatrix
+  ObservacionesMatrix,
 } from '../../types/shared';
-import { TrabajadorMultiSelect } from '../shared/TrabajadorMultiSelect';
 import { JornalFractionMatrix } from '../shared/JornalFractionMatrix';
 import { calculateLaborCost, calculateContractorCost } from '../../utils/laborCosts';
+import { formatearNumero } from '@/utils/format';
 
 interface DailyMovementFormProps {
   aplicacion: Aplicacion;
+  open: boolean;
+  onOpenChange: (open: boolean) => void;
   onSuccess: () => void;
-  onCancel: () => void;
 }
 
 interface ProductoFormulario {
@@ -38,26 +65,82 @@ interface ProductoFormulario {
   producto_nombre: string;
   producto_categoria: string;
   cantidad_utilizada: string;
-  unidad_producto: string; // 🚨 CAMBIO: Ahora es la unidad_medida del producto desde BD (Litros o Kilos)
+  unidad_producto: string; // unidad_medida del producto desde BD (Litros o Kilos)
   presentacion_kg_l?: number; // SOLO para fertilización: cuántos Kg por bulto
 }
 
-export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMovementFormProps) {
+interface ErroresCampo {
+  fecha?: string;
+  lote?: string;
+  canecas?: string;
+  bultos?: string;
+  responsable?: string;
+  productos?: string;
+}
+
+/** Nombre corto para la tira de chips ("Clara Yaneth Ríos Gómez" → "Clara Y."). */
+function nombreCorto(nombre: string): string {
+  const partes = nombre.trim().split(/\s+/).filter(Boolean);
+  if (partes.length <= 1) return partes[0] ?? '';
+  return `${partes[0]} ${partes[1][0].toUpperCase()}.`;
+}
+
+/** Iniciales para el avatar circular del chip/fila ("Clara Yaneth" → "CY"). */
+function iniciales(nombre: string): string {
+  const partes = nombre.trim().split(/\s+/).filter(Boolean);
+  const a = partes[0]?.[0] ?? '';
+  const b = partes[1]?.[0] ?? '';
+  return (a + b).toUpperCase() || '?';
+}
+
+function trabajadorKey(t: Trabajador): string {
+  return `${t.type}-${t.data.id ?? ''}`;
+}
+
+/** `true` si el error luce como el `TypeError: Failed to fetch` de una señal intermitente. */
+function esErrorDeRed(mensaje: string): boolean {
+  return /failed to fetch|network|conexión|connection/i.test(mensaje);
+}
+
+/** Breakpoint local para elegir Sheet (escritorio) vs Drawer de pantalla completa (móvil). */
+const MOBILE_BREAKPOINT = 768;
+
+export function DailyMovementForm({ aplicacion, open, onOpenChange, onSuccess }: DailyMovementFormProps) {
   const supabase = getSupabase();
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  const [erroresCampo, setErroresCampo] = useState<ErroresCampo>({});
 
-  // 🚨 DIAGNÓSTICO - Verificar tipo de aplicación
+  const [isMobile, setIsMobile] = useState(() =>
+    typeof window !== 'undefined' ? window.innerWidth < MOBILE_BREAKPOINT : false
+  );
+  useEffect(() => {
+    const onResize = () => setIsMobile(window.innerWidth < MOBILE_BREAKPOINT);
+    window.addEventListener('resize', onResize);
+    return () => window.removeEventListener('resize', onResize);
+  }, []);
+
+  // Vista interna: campos principales o selector de personal a pantalla completa dentro
+  // del mismo Sheet/Drawer (nunca se rediseñan TrabajadorMultiSelect/JornalFractionMatrix
+  // como componentes compartidos — viven en src/components/shared/ y los usa también
+  // Labores; esta vista es propia de este formulario, ver W02-movimientos.md §8).
+  const [vistaPersonal, setVistaPersonal] = useState(false);
+  const [searchTermPersonal, setSearchTermPersonal] = useState('');
+  const [workerTab, setWorkerTab] = useState<'empleados' | 'contratistas'>('empleados');
+
+  useEffect(() => {
+    if (open) setVistaPersonal(false);
+  }, [open]);
 
   // Estados del formulario
   const [fechaMovimiento, setFechaMovimiento] = useState(obtenerFechaHoy());
   const [loteId, setLoteId] = useState('');
   const [numeroCanecas, setNumeroCanecas] = useState(''); // Total para fumigación/drench
   const [numeroBultos, setNumeroBultos] = useState(''); // Total para fertilización
-  const [equipoAplicacion, setEquipoAplicacion] = useState(''); // 🆕 NUEVO CAMPO
-  const [personal, setPersonal] = useState(''); // 🆕 NUEVO CAMPO
-  const [horaInicio, setHoraInicio] = useState('07:20'); // 🆕 NUEVO CAMPO
-  const [horaFin, setHoraFin] = useState('15:50'); // 🆕 NUEVO CAMPO
+  const [equipoAplicacion, setEquipoAplicacion] = useState('');
+  const [personal, setPersonal] = useState('');
+  const [horaInicio, setHoraInicio] = useState('07:20');
+  const [horaFin, setHoraFin] = useState('15:50');
   const [responsable, setResponsable] = useState('');
   const [condicionesMeteorologicas, setCondicionesMeteorologicas] = useState('');
   const [notas, setNotas] = useState('');
@@ -127,12 +210,14 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
     return productosDisponibles;
   }, [loteId, loteToMezclaMap, productosPorMezcla, productosDisponibles]);
 
-  // Cargar datos al montar
+  // Cargar datos cuando el Sheet/Drawer se abre (el formulario permanece montado
+  // detrás para que la animación de cierre corra completa — ver §6 del diseño).
   useEffect(() => {
+    if (!open) return;
     cargarDatosAplicacion();
     cargarUsuarioActual();
     cargarTrabajadores();
-  }, [aplicacion.id]);
+  }, [open, aplicacion.id]);
 
   // 🔧 Precargar productos apenas se conocen, sin esperar a que se elija lote.
   // No hay forma manual de agregar productos en este formulario, así que si la
@@ -224,7 +309,7 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
       if (mezclasData && mezclasData.length > 0) {
         const mezclaIds = (mezclasData as any[]).map((m: any) => m.id);
 
-        const { data: productosData, error: errorProductos } = await supabase
+        const { data: productosData, error: errorProductosQuery } = await supabase
           .from('aplicaciones_productos')
           .select(`
             mezcla_id,
@@ -236,7 +321,7 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
           `)
           .in('mezcla_id', mezclaIds);
 
-        if (errorProductos) throw errorProductos;
+        if (errorProductosQuery) throw errorProductosQuery;
 
         // Organizar productos por mezcla
         const productosPorMezclaTemp: Record<string, any[]> = {};
@@ -298,13 +383,13 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
       const ids = productos.map(p => p.producto_id).filter(Boolean);
       if (ids.length > 0) {
         try {
-          const { data, error: errorProductos } = await supabase
+          const { data, error: errorProductosQuery } = await supabase
             .from('productos')
             .select('id, presentacion_kg_l')
             .in('id', ids);
 
-          if (errorProductos) {
-            console.error('Failed to fetch productos presentacion_kg_l:', errorProductos);
+          if (errorProductosQuery) {
+            console.error('Failed to fetch productos presentacion_kg_l:', errorProductosQuery);
           } else {
             (data || []).forEach((p: any) => {
               if (p.presentacion_kg_l != null) {
@@ -387,13 +472,15 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
     }
   };
 
+  // Pre-existente y sin uso desde la UI (no hay forma manual de agregar un producto
+  // fuera de la precarga por mezcla) — se conserva tal cual, fuera de alcance de este
+  // rediseño visual (ver reporte de la sesión).
   const agregarProducto = async () => {
     if (!productoSeleccionadoId) {
       setError('Selecciona un producto para agregar');
       return;
     }
 
-    // Verificar si ya está agregado
     if (productosAgregados.some(p => p.producto_id === productoSeleccionadoId)) {
       setError('Este producto ya fue agregado');
       return;
@@ -402,7 +489,6 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
     const producto = productosDisponibles.find(p => p.producto_id === productoSeleccionadoId);
     if (!producto) return;
 
-    // Cargar presentacion_kg_l del producto SOLO para fertilización
     let presentacionKgL: number | undefined;
     if (aplicacion.tipo_aplicacion === 'Fertilización') {
       try {
@@ -411,7 +497,7 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
           .select('presentacion_kg_l')
           .eq('id', productoSeleccionadoId)
           .single();
-        
+
         if (errorProducto) {
           console.error('Failed to fetch product presentacion_kg_l for selection:', errorProducto);
         } else {
@@ -427,7 +513,7 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
       producto_nombre: producto.producto_nombre,
       producto_categoria: producto.producto_categoria,
       cantidad_utilizada: '',
-      unidad_producto: producto.producto_unidad, // 🚨 CAMBIO: Ahora es la unidad_medida del producto desde BD (Litros o Kilos)
+      unidad_producto: producto.producto_unidad,
       presentacion_kg_l: presentacionKgL
     };
 
@@ -446,56 +532,57 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
     setProductosAgregados(nuevosProductos);
   };
 
+  // Pre-existente y sin uso desde la UI — se conserva tal cual (ver nota en agregarProducto).
   const actualizarUnidadProducto = (index: number, unidad: 'cc' | 'L') => {
     const nuevosProductos = [...productosAgregados];
     nuevosProductos[index].unidad_producto = unidad;
     setProductosAgregados(nuevosProductos);
   };
 
-  const validarFormulario = () => {
+  /**
+   * Valida el formulario y llena `erroresCampo` por campo (para `FieldError` puntual)
+   * en vez de un único string global. El banner global (`error`) queda reservado para
+   * fallas de envío no asociadas a un campo — típicamente de red (ver M8 del diseño).
+   */
+  const validarFormulario = (): boolean => {
+    const errores: ErroresCampo = {};
+
     if (!fechaMovimiento) {
-      setError('La fecha es requerida');
-      return false;
+      errores.fecha = 'La fecha es requerida';
     }
     if (!loteId) {
-      setError('Debes seleccionar un lote');
-      return false;
+      errores.lote = 'Debes seleccionar un lote';
     }
-    
-    // Validación según tipo de aplicación
+
     if (aplicacion.tipo_aplicacion === 'Fumigación' || aplicacion.tipo_aplicacion === 'Drench') {
       if (!numeroCanecas || parseFloat(numeroCanecas) <= 0) {
-        setError('El número de canecas debe ser mayor a 0');
-        return false;
+        errores.canecas = 'El número de canecas debe ser mayor a 0';
       }
     }
-    
+
     if (aplicacion.tipo_aplicacion === 'Fertilización') {
       if (!numeroBultos || parseFloat(numeroBultos) <= 0) {
-        setError('El número de bultos debe ser mayor a 0');
-        return false;
+        errores.bultos = 'El número de bultos debe ser mayor a 0';
       }
     }
-    
+
     if (!responsable.trim()) {
-      setError('El responsable es requerido');
-      return false;
-    }
-    
-    if (productosAgregados.length === 0) {
-      setError('Debes agregar al menos un producto');
-      return false;
+      errores.responsable = 'El responsable es requerido';
     }
 
-    // Validar que todos los productos tengan cantidad
-    for (const producto of productosAgregados) {
-      if (!producto.cantidad_utilizada || parseFloat(producto.cantidad_utilizada) <= 0) {
-        setError(`El producto "${producto.producto_nombre}" necesita una cantidad válida`);
-        return false;
+    if (productosAgregados.length === 0) {
+      errores.productos = 'Debes agregar al menos un producto';
+    } else {
+      const productoInvalido = productosAgregados.find(
+        p => !p.cantidad_utilizada || parseFloat(p.cantidad_utilizada) <= 0
+      );
+      if (productoInvalido) {
+        errores.productos = `El producto "${productoInvalido.producto_nombre}" necesita una cantidad válida`;
       }
     }
 
-    return true;
+    setErroresCampo(errores);
+    return Object.keys(errores).length === 0;
   };
 
   const handleSubmit = async (e: React.FormEvent) => {
@@ -504,10 +591,10 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
     if (!validarFormulario()) {
       return;
     }
+    setError(null);
 
     try {
       setLoading(true);
-      setError(null);
 
       // Obtener usuario actual
       const { data: { user } } = await supabase.auth.getUser();
@@ -659,6 +746,9 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
       setSelectedTrabajadores([]);
       setWorkMatrix({});
       setObservacionesMatrix({});
+      setErroresCampo({});
+      setVistaPersonal(false);
+      setSearchTermPersonal('');
 
       draft.clearDraft();
       onSuccess();
@@ -670,119 +760,319 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
     }
   };
 
-  return (
-    <div className="bg-white rounded-2xl border border-primary/10 p-6 shadow-[0_4px_24px_rgba(115,153,28,0.08)]">
-      <div className="flex items-center justify-between mb-6">
-        <div className="flex items-center gap-3">
-          <div className="w-12 h-12 bg-primary/10 rounded-xl flex items-center justify-center">
-            <Plus className="w-6 h-6 text-primary" />
-          </div>
-          <div>
-            <h3 className="text-lg text-foreground">Nuevo Movimiento Diario</h3>
-            <p className="text-sm text-brand-brown/60">
-              {aplicacion.tipo_aplicacion === 'Fertilización'
-                ? 'Registra bultos totales y bultos aplicados de cada producto'
-                : 'Registra canecas totales y canecas aplicadas de cada producto'
-              }
-            </p>
-          </div>
+  // ---------------------------------------------------------------------------------
+  // Selección de personal — filtrado, selección y helpers puramente presentacionales.
+  // ---------------------------------------------------------------------------------
+
+  const empleadosFiltrados = useMemo(() => {
+    if (!searchTermPersonal) return empleadosDisponibles;
+    const term = searchTermPersonal.toLowerCase();
+    return empleadosDisponibles.filter(
+      e => e.nombre.toLowerCase().includes(term) || (e.cargo ?? '').toLowerCase().includes(term)
+    );
+  }, [empleadosDisponibles, searchTermPersonal]);
+
+  const contratistasFiltrados = useMemo(() => {
+    if (!searchTermPersonal) return contratistasDisponibles;
+    const term = searchTermPersonal.toLowerCase();
+    return contratistasDisponibles.filter(
+      c => c.nombre.toLowerCase().includes(term) || (c.tipo_contrato ?? '').toLowerCase().includes(term)
+    );
+  }, [contratistasDisponibles, searchTermPersonal]);
+
+  const estaSeleccionado = useCallback(
+    (id: string | undefined, tipo: 'empleado' | 'contratista') => {
+      if (!id) return false;
+      return selectedTrabajadores.some(t => t.type === tipo && t.data.id === id);
+    },
+    [selectedTrabajadores]
+  );
+
+  const alternarTrabajador = useCallback(
+    (id: string, tipo: 'empleado' | 'contratista', data: Empleado | Contratista) => {
+      setSelectedTrabajadores(prev => {
+        const yaEsta = prev.some(t => t.type === tipo && t.data.id === id);
+        if (yaEsta) {
+          return prev.filter(t => !(t.type === tipo && t.data.id === id));
+        }
+        return [...prev, { type: tipo, data } as Trabajador];
+      });
+    },
+    []
+  );
+
+  const alternarSeleccionarTodos = useCallback(() => {
+    const lista = workerTab === 'empleados' ? empleadosFiltrados : contratistasFiltrados;
+    const tipo = workerTab === 'empleados' ? 'empleado' : 'contratista';
+    const todosSeleccionados = lista.length > 0 && lista.every(w => estaSeleccionado(w.id, tipo));
+
+    if (todosSeleccionados) {
+      setSelectedTrabajadores(prev =>
+        prev.filter(t => t.type !== tipo || !lista.some(w => w.id === t.data.id))
+      );
+    } else {
+      setSelectedTrabajadores(prev => {
+        const existentes = new Set(prev.filter(t => t.type === tipo).map(t => t.data.id));
+        const nuevos = lista
+          .filter(w => !existentes.has(w.id))
+          .map(w => ({ type: tipo, data: w } as Trabajador));
+        return [...prev, ...nuevos];
+      });
+    }
+  }, [workerTab, empleadosFiltrados, contratistasFiltrados, estaSeleccionado]);
+
+  // ---------------------------------------------------------------------------------
+  // Render
+  // ---------------------------------------------------------------------------------
+
+  const totalDisponibles = empleadosDisponibles.length + contratistasDisponibles.length;
+
+  const tituloHeader = vistaPersonal ? 'Selección de Personal' : 'Nuevo Movimiento';
+  const subtituloHeader = vistaPersonal
+    ? `${selectedTrabajadores.length} de ${totalDisponibles} seleccionados`
+    : aplicacion.nombre_aplicacion || 'Movimiento diario';
+
+  function renderListaTrabajadores(lista: (Empleado | Contratista)[], tipo: 'empleado' | 'contratista') {
+    const todosSeleccionados = lista.length > 0 && lista.every(w => estaSeleccionado(w.id, tipo));
+    return (
+      <div>
+        <div className="mb-2 flex items-center justify-between">
+          <span className="text-xs text-muted-foreground">{lista.length} activos</span>
+          {lista.length > 0 && (
+            <button
+              type="button"
+              onClick={alternarSeleccionarTodos}
+              className="text-xs font-semibold text-primary hover:underline"
+            >
+              {todosSeleccionados ? 'Deseleccionar todos' : 'Seleccionar todos'}
+            </button>
+          )}
         </div>
+
+        {lista.length === 0 ? (
+          <Empty className="border-none py-8">
+            <EmptyMedia variant="icon">
+              <Search />
+            </EmptyMedia>
+            <EmptyTitle>Sin resultados</EmptyTitle>
+            <EmptyDescription>
+              {searchTermPersonal
+                ? `No hay coincidencias para "${searchTermPersonal}"`
+                : `No hay ${tipo === 'empleado' ? 'empleados' : 'contratistas'} disponibles`}
+            </EmptyDescription>
+          </Empty>
+        ) : (
+          <ItemGroup className="max-h-[300px] overflow-y-auto pr-1">
+            {lista.map(w => {
+              const seleccionado = estaSeleccionado(w.id, tipo);
+              const cargoOCargoContrato = tipo === 'empleado' ? (w as Empleado).cargo : (w as Contratista).tipo_contrato;
+              return (
+                <Item
+                  key={w.id}
+                  asChild
+                  variant={seleccionado ? 'outline' : 'default'}
+                  className={cn(
+                    'cursor-pointer',
+                    seleccionado ? 'border-primary/30 bg-primary/5' : 'hover:bg-muted/70'
+                  )}
+                >
+                  <label>
+                    <ItemMedia
+                      variant="icon"
+                      className={cn('text-[0.7rem] font-bold', seleccionado && 'border-primary bg-primary text-primary-foreground')}
+                    >
+                      {iniciales(w.nombre)}
+                    </ItemMedia>
+                    <ItemContent>
+                      <ItemTitle>{w.nombre}</ItemTitle>
+                      {cargoOCargoContrato && (
+                        <ItemDescription className="line-clamp-none">{cargoOCargoContrato}</ItemDescription>
+                      )}
+                    </ItemContent>
+                    <input
+                      type="checkbox"
+                      checked={seleccionado}
+                      onChange={() => alternarTrabajador(w.id ?? '', tipo, w)}
+                      disabled={loading}
+                      aria-label={`Seleccionar a ${w.nombre}`}
+                      className="size-5 shrink-0 accent-primary disabled:opacity-50"
+                    />
+                  </label>
+                </Item>
+              );
+            })}
+          </ItemGroup>
+        )}
       </div>
+    );
+  }
 
-      <FormDraftBanner
-        variant="available"
-        show={draft.hasDraft}
-        onRestore={handleRestoreDraft}
-        onDiscard={draft.discardDraft}
-      />
+  function renderTiraSeleccionados(soloResumen: boolean) {
+    if (selectedTrabajadores.length === 0) return null;
+    const visibles = soloResumen ? selectedTrabajadores.slice(0, 5) : selectedTrabajadores;
+    const restantes = soloResumen ? selectedTrabajadores.length - visibles.length : 0;
+    return (
+      <TooltipProvider>
+        {visibles.map(t => (
+          <Tooltip key={trabajadorKey(t)}>
+            <TooltipTrigger asChild>
+              <span className="inline-flex items-center gap-1.5 rounded-full border border-border bg-card py-0.5 pl-0.5 pr-2 text-xs font-medium text-foreground">
+                <span className="flex size-[22px] shrink-0 items-center justify-center rounded-full bg-primary text-[0.6rem] font-bold text-primary-foreground">
+                  {iniciales(t.data.nombre)}
+                </span>
+                {nombreCorto(t.data.nombre)}
+              </span>
+            </TooltipTrigger>
+            <TooltipContent>{t.data.nombre}</TooltipContent>
+          </Tooltip>
+        ))}
+        {restantes > 0 && <span className="text-xs text-muted-foreground">+{restantes}</span>}
+      </TooltipProvider>
+    );
+  }
 
-      {/* Error */}
-      {error && (
-        <div className="mb-6 bg-red-50 border border-red-200 rounded-xl p-4 flex items-start gap-3">
-          <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-          <div>
-            <h4 className="text-red-800 text-sm mb-1">Error</h4>
-            <p className="text-red-700 text-sm">{error}</p>
+  function renderSelectorPersonal() {
+    return (
+      <div className="p-4">
+        {selectedTrabajadores.length > 0 && (
+          <div className="mb-3 flex flex-wrap items-center gap-2 rounded-xl bg-muted p-3">
+            <span className="text-xs font-semibold text-muted-foreground">Seleccionados</span>
+            {renderTiraSeleccionados(false)}
           </div>
-        </div>
-      )}
+        )}
 
-      <form onSubmit={handleSubmit} className="space-y-6">
-        {/* Fecha */}
-        <div>
-          <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-            <Calendar className="w-4 h-4 text-primary" />
-            Fecha del Movimiento
-            <span className="text-red-500">*</span>
-          </label>
-          <input
-            type="date"
-            value={fechaMovimiento}
-            onChange={(e) => setFechaMovimiento(e.target.value)}
-            max={obtenerFechaHoy()}
-            disabled={loading}
-            className="w-full px-4 py-3 border border-primary/20 rounded-xl bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+        <div className="relative mb-3">
+          <Search className="pointer-events-none absolute left-3 top-1/2 size-4 -translate-y-1/2 text-muted-foreground" />
+          <Input
+            type="text"
+            placeholder="Buscar por nombre…"
+            value={searchTermPersonal}
+            onChange={(e) => setSearchTermPersonal(e.target.value)}
+            className="pl-9"
           />
         </div>
 
-        {/* Lote */}
-        <div>
-          <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-            <Package className="w-4 h-4 text-primary" />
-            Lote Aplicado
-            <span className="text-red-500">*</span>
-          </label>
-          <select
-            value={loteId}
-            onChange={(e) => setLoteId(e.target.value)}
-            disabled={loading}
-            className="w-full px-4 py-3 border border-primary/20 rounded-xl bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <option value="">Selecciona un lote</option>
-            {lotes.map(lote => (
-              <option key={lote.lote_id} value={lote.lote_id}>
-                {lote.nombre}
-              </option>
-            ))}
-          </select>
+        <Tabs value={workerTab} onValueChange={(v) => setWorkerTab(v as 'empleados' | 'contratistas')}>
+          <TabsList className="w-full">
+            <TabsTrigger value="empleados" className="flex-1 gap-1.5">
+              Empleados
+              <Badge variant="outline" className="border-border bg-card">{empleadosDisponibles.length}</Badge>
+            </TabsTrigger>
+            <TabsTrigger value="contratistas" className="flex-1 gap-1.5">
+              Contratistas
+              <Badge variant="outline" className="border-border bg-card">{contratistasDisponibles.length}</Badge>
+            </TabsTrigger>
+          </TabsList>
+          <TabsContent value="empleados">{renderListaTrabajadores(empleadosFiltrados, 'empleado')}</TabsContent>
+          <TabsContent value="contratistas">{renderListaTrabajadores(contratistasFiltrados, 'contratista')}</TabsContent>
+        </Tabs>
+      </div>
+    );
+  }
+
+  function renderCamposPrincipales() {
+    return (
+      <div className="pb-2">
+        <FormDraftBanner
+          variant="available"
+          show={draft.hasDraft}
+          onRestore={handleRestoreDraft}
+          onDiscard={draft.discardDraft}
+        />
+
+        {error && (
+          esErrorDeRed(error) ? (
+            <Alert variant="warning" className="mx-4 mb-4 mt-4">
+              <AlertTriangle />
+              <AlertTitle>No se pudo guardar — sin conexión.</AlertTitle>
+              <AlertDescription>
+                Tu información quedó en este dispositivo. Vuelve a intentar cuando tengas señal; nada se perdió.
+              </AlertDescription>
+            </Alert>
+          ) : (
+            <Alert variant="destructive" className="mx-4 mb-4 mt-4">
+              <AlertCircle />
+              <AlertTitle>No se pudo guardar</AlertTitle>
+              <AlertDescription>{error}</AlertDescription>
+            </Alert>
+          )
+        )}
+
+        {/* Fecha y lote */}
+        <div className="px-4 pt-4">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <CalendarIcon className="size-4 text-primary" /> Fecha y lote
+          </div>
+
+          <Field>
+            <FieldLabel>
+              Fecha del Movimiento <span className="text-destructive">*</span>
+            </FieldLabel>
+            <DateInput value={fechaMovimiento} onChange={setFechaMovimiento} max={obtenerFechaHoy()} disabled={loading} />
+            <FieldDescription>Hoy en hora local — no permite fechas futuras</FieldDescription>
+            <FieldError>{erroresCampo.fecha}</FieldError>
+          </Field>
+
+          <Field className="mt-4">
+            <FieldLabel>
+              Lote Aplicado <span className="text-destructive">*</span>
+            </FieldLabel>
+            <Select value={loteId} onValueChange={setLoteId} disabled={loading}>
+              <SelectTrigger className="w-full" aria-invalid={!!erroresCampo.lote}>
+                <SelectValue placeholder="Selecciona un lote" />
+              </SelectTrigger>
+              <SelectContent>
+                {lotes.map(lote => (
+                  <SelectItem key={lote.lote_id} value={lote.lote_id}>
+                    {lote.nombre}
+                  </SelectItem>
+                ))}
+              </SelectContent>
+            </Select>
+            <FieldError>{erroresCampo.lote}</FieldError>
+          </Field>
+
+          <Field className="mt-4">
+            <FieldLabel>Equipo de Aplicación</FieldLabel>
+            <Select value={equipoAplicacion} onValueChange={setEquipoAplicacion} disabled={loading}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Selecciona el equipo (opcional)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="Bomba espalda">🎒 Bomba espalda</SelectItem>
+                <SelectItem value="Bomba estacionaria">⚙️ Bomba estacionaria</SelectItem>
+                <SelectItem value="Fumiducto">🚜 Fumiducto</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
         </div>
 
-        {/* 🆕 NUEVO: Equipo de Aplicación */}
-        <div>
-          <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-            <Droplet className="w-4 h-4 text-primary" />
-            Equipo de Aplicación
-          </label>
-          <select
-            value={equipoAplicacion}
-            onChange={(e) => setEquipoAplicacion(e.target.value)}
+        {/* Selección de Personal */}
+        <div className="border-t border-border/60 px-4 pt-4">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <User className="size-4 text-primary" /> Selección de Personal
+          </div>
+          <button
+            type="button"
+            onClick={() => setVistaPersonal(true)}
             disabled={loading}
-            className="w-full px-4 py-3 border border-primary/20 rounded-xl bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
+            className="flex w-full items-center gap-3 rounded-xl border border-border bg-muted/50 p-3 text-left transition-colors hover:bg-muted disabled:opacity-50"
           >
-            <option value="">Selecciona el equipo (opcional)</option>
-            <option value="Bomba espalda">🎒 Bomba espalda</option>
-            <option value="Bomba estacionaria">⚙️ Bomba estacionaria</option>
-            <option value="Fumiducto">🚜 Fumiducto</option>
-          </select>
-        </div>
-
-        {/* Worker Selection (Employees + Contractors) */}
-        <div className="border-t border-primary/10 pt-6">
-          <h4 className="text-sm text-foreground mb-4 flex items-center gap-2">
-            <User className="w-4 h-4 text-primary" />
-            Selección de Personal
-          </h4>
-
-          <TrabajadorMultiSelect
-            empleados={empleadosDisponibles}
-            contratistas={contratistasDisponibles}
-            selectedTrabajadores={selectedTrabajadores}
-            onSelectionChange={setSelectedTrabajadores}
-            disabled={loading}
-          />
+            {selectedTrabajadores.length === 0 ? (
+              <span className="text-sm text-muted-foreground">Seleccionar personal (opcional)</span>
+            ) : (
+              <div className="flex flex-1 flex-wrap items-center gap-2">
+                <span className="text-xs font-semibold text-muted-foreground">
+                  {selectedTrabajadores.length} seleccionado{selectedTrabajadores.length === 1 ? '' : 's'}
+                </span>
+                {renderTiraSeleccionados(true)}
+              </div>
+            )}
+            <ChevronRight className="ml-auto size-4 shrink-0 text-muted-foreground" />
+          </button>
 
           {selectedTrabajadores.length > 0 && loteId && (
-            <div className="mt-6">
+            <div className="mt-4">
               <JornalFractionMatrix
                 trabajadores={selectedTrabajadores}
                 lotes={lotes.filter(l => l.lote_id === loteId).map(l => ({
@@ -792,16 +1082,16 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
                 }))}
                 workMatrix={workMatrix}
                 observaciones={observacionesMatrix}
-                onFraccionChange={(trabajadorId, loteId, frac) => {
+                onFraccionChange={(trabajadorId, loteIdMatriz, frac) => {
                   setWorkMatrix(prev => ({
                     ...prev,
-                    [trabajadorId]: { ...prev[trabajadorId], [loteId]: frac }
+                    [trabajadorId]: { ...prev[trabajadorId], [loteIdMatriz]: frac }
                   }));
                 }}
-                onObservacionesChange={(trabajadorId, loteId, obs) => {
+                onObservacionesChange={(trabajadorId, loteIdMatriz, obs) => {
                   setObservacionesMatrix(prev => ({
                     ...prev,
-                    [trabajadorId]: { ...prev[trabajadorId], [loteId]: obs }
+                    [trabajadorId]: { ...prev[trabajadorId], [loteIdMatriz]: obs }
                   }));
                 }}
                 onRemoveTrabajador={(trabajadorId) => {
@@ -816,186 +1106,149 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
           )}
         </div>
 
-        {/* 🆕 NUEVO: Horario de Trabajo */}
-        <div className="grid grid-cols-2 gap-4">
-          <div>
-            <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-              <Clock className="w-4 h-4 text-primary" />
-              Hora de Inicio
-            </label>
-            <input
-              type="time"
-              value={horaInicio}
-              onChange={(e) => setHoraInicio(e.target.value)}
-              disabled={loading}
-              className="w-full px-4 py-3 border border-primary/20 rounded-xl bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
-            />
+        {/* Horario */}
+        <div className="border-t border-border/60 px-4 pt-4">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Clock className="size-4 text-primary" /> Horario
           </div>
-          <div>
-            <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-              <Clock className="w-4 h-4 text-primary" />
-              Hora de Fin
-            </label>
-            <input
-              type="time"
-              value={horaFin}
-              onChange={(e) => setHoraFin(e.target.value)}
-              disabled={loading}
-              className="w-full px-4 py-3 border border-primary/20 rounded-xl bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
-            />
+          <div className="flex gap-3">
+            <Field className="flex-1">
+              <FieldLabel>Hora Inicio</FieldLabel>
+              <Input type="time" value={horaInicio} onChange={(e) => setHoraInicio(e.target.value)} disabled={loading} />
+            </Field>
+            <Field className="flex-1">
+              <FieldLabel>Hora Fin</FieldLabel>
+              <Input type="time" value={horaFin} onChange={(e) => setHoraFin(e.target.value)} disabled={loading} />
+            </Field>
           </div>
         </div>
 
         {/* Número de Canecas - PARA FUMIGACIÓN Y DRENCH */}
         {(aplicacion.tipo_aplicacion === 'Fumigación' || aplicacion.tipo_aplicacion === 'Drench') && (
-          <div>
-            <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-              <Droplet className="w-4 h-4 text-primary" />
-              Número TOTAL de Canecas Aplicadas
-              <span className="text-red-500">*</span>
-            </label>
-            <div className="flex gap-3">
-              <Input
-                type="number"
-                value={numeroCanecas}
-                onChange={(e) => setNumeroCanecas(e.target.value)}
-                placeholder="0"
-                step="any"
-                min="0"
-                disabled={loading}
-                className="flex-1 bg-white border-primary/20 focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <div className="px-4 py-3 bg-muted border border-primary/20 rounded-xl text-foreground min-w-[120px] flex items-center justify-center">
-                canecas
-              </div>
-            </div>
-            {loteId && canecasPorLote[loteId] && (
-              <div className="mt-2 p-3 bg-primary/5 border border-primary/20 rounded-lg">
-                <p className="text-xs text-brand-brown/70">
-                  📊 <strong>Planeado:</strong> {canecasPorLote[loteId]} canecas para este lote
-                </p>
-              </div>
-            )}
+          <div className="border-t border-border/60 px-4 pt-4">
+            <Field>
+              <FieldLabel>
+                Número TOTAL de Canecas Aplicadas <span className="text-destructive">*</span>
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  type="number"
+                  step="any"
+                  min="0"
+                  value={numeroCanecas}
+                  onChange={(e) => setNumeroCanecas(e.target.value)}
+                  placeholder="0"
+                  disabled={loading}
+                  aria-invalid={!!erroresCampo.canecas}
+                />
+                <InputGroupAddon align="inline-end">canecas</InputGroupAddon>
+              </InputGroup>
+              <FieldError>{erroresCampo.canecas}</FieldError>
+              {loteId && canecasPorLote[loteId] ? (
+                <FieldDescription className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+                  Planeado: {formatearNumero(canecasPorLote[loteId], 1)} canecas para este lote
+                </FieldDescription>
+              ) : null}
+            </Field>
           </div>
         )}
 
         {/* Número de Bultos - SOLO PARA FERTILIZACIÓN */}
         {aplicacion.tipo_aplicacion === 'Fertilización' && (
-          <div>
-            <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-              <Package className="w-4 h-4 text-primary" />
-              Número TOTAL de Bultos Usados
-              <span className="text-red-500">*</span>
-            </label>
-            <div className="flex gap-3">
-              <Input
-                type="number"
-                value={numeroBultos}
-                onChange={(e) => setNumeroBultos(e.target.value)}
-                placeholder="0"
-                step="1"
-                min="0"
-                disabled={loading}
-                className="flex-1 bg-white border-primary/20 focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
-              />
-              <div className="px-4 py-3 bg-muted border border-primary/20 rounded-xl text-foreground min-w-[120px] flex items-center justify-center">
-                bultos
-              </div>
-            </div>
-            {loteId && bultosPorLote[loteId] && (
-              <div className="mt-2 p-3 bg-primary/5 border border-primary/20 rounded-lg">
-                <p className="text-xs text-brand-brown/70">
-                  📊 <strong>Planeado:</strong> {bultosPorLote[loteId]} bultos para este lote
-                </p>
-              </div>
-            )}
+          <div className="border-t border-border/60 px-4 pt-4">
+            <Field>
+              <FieldLabel>
+                Número TOTAL de Bultos Usados <span className="text-destructive">*</span>
+              </FieldLabel>
+              <InputGroup>
+                <InputGroupInput
+                  type="number"
+                  step="1"
+                  min="0"
+                  value={numeroBultos}
+                  onChange={(e) => setNumeroBultos(e.target.value)}
+                  placeholder="0"
+                  disabled={loading}
+                  aria-invalid={!!erroresCampo.bultos}
+                />
+                <InputGroupAddon align="inline-end">bultos</InputGroupAddon>
+              </InputGroup>
+              <FieldError>{erroresCampo.bultos}</FieldError>
+              {loteId && bultosPorLote[loteId] ? (
+                <FieldDescription className="rounded-md border border-primary/20 bg-primary/5 px-3 py-2 text-xs text-muted-foreground">
+                  Planeado: {formatearNumero(bultosPorLote[loteId], 0)} bultos para este lote
+                </FieldDescription>
+              ) : null}
+            </Field>
           </div>
         )}
 
         {/* Productos Utilizados */}
-        <div className="border-t border-primary/10 pt-6">
-          <h4 className="text-sm text-foreground mb-4 flex items-center gap-2">
-            <Package className="w-4 h-4 text-primary" />
+        <div className="border-t border-border/60 px-4 pt-4">
+          <div className="mb-3 flex items-center gap-2 text-sm font-semibold text-foreground">
+            <Package className="size-4 text-primary" />
             {aplicacion.tipo_aplicacion === 'Fertilización'
               ? 'Bultos Usados de cada Producto'
-              : 'Cantidad aplicada de cada producto'
-            }
-            <span className="text-red-500">*</span>
-          </h4>
+              : 'Cantidad aplicada de cada producto'}
+            <span className="text-destructive">*</span>
+          </div>
 
-          {/* Lista de productos precargados */}
+          {erroresCampo.productos && (
+            <p role="alert" className="mb-3 flex items-center gap-1.5 text-sm font-medium text-destructive">
+              <AlertCircle className="size-3.5 shrink-0" /> {erroresCampo.productos}
+            </p>
+          )}
+
           {productosAgregados.length > 0 ? (
-            <div className="space-y-3">
+            <div className="flex flex-col gap-3">
               {productosAgregados.map((producto, index) => (
-                <div
-                  key={index}
-                  className="bg-background border border-primary/20 rounded-xl p-4 flex items-center gap-4"
-                >
-                  <div className="flex-1">
-                    <p className="text-sm text-foreground mb-1">
-                      {producto.producto_nombre}
-                    </p>
-                    <p className="text-xs text-brand-brown/60">
-                      {producto.producto_categoria}
-                    </p>
-                  </div>
-
-                  <div className="flex items-center gap-3">
-                    <Input
-                      type="number"
-                      value={producto.cantidad_utilizada}
-                      onChange={(e) => actualizarCantidadProducto(index, e.target.value)}
-                      placeholder="0"
-                      step="0.01"
-                      min="0"
-                      disabled={loading}
-                      className="w-32 bg-white border-primary/20 focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
-                    />
-                    
-                    {/* Unidad estática desde BD (no editable) */}
-                    {aplicacion.tipo_aplicacion === 'Fertilización' ? (
-                      <div className="px-4 py-2 bg-muted border border-primary/20 rounded-lg text-foreground text-sm min-w-[80px] flex items-center justify-center">
-                        bultos
-                      </div>
-                    ) : (
-                      <div className="px-4 py-2 bg-muted border border-primary/20 rounded-lg text-foreground text-sm min-w-[80px] flex items-center justify-center">
-                        {producto.unidad_producto}
-                      </div>
-                    )}
-                    
-                    <Button
+                <Field key={index}>
+                  <FieldLabel>{producto.producto_nombre}</FieldLabel>
+                  <div className="flex items-center gap-2">
+                    <InputGroup className="flex-1">
+                      <InputGroupInput
+                        type="number"
+                        step="0.01"
+                        min="0"
+                        value={producto.cantidad_utilizada}
+                        onChange={(e) => actualizarCantidadProducto(index, e.target.value)}
+                        placeholder="0"
+                        disabled={loading}
+                      />
+                      <InputGroupAddon align="inline-end">
+                        {aplicacion.tipo_aplicacion === 'Fertilización' ? 'bultos' : producto.unidad_producto}
+                      </InputGroupAddon>
+                    </InputGroup>
+                    <button
                       type="button"
                       onClick={() => eliminarProducto(index)}
                       disabled={loading}
-                      variant="ghost"
-                      size="sm"
-                      className="text-red-600 hover:text-red-700 hover:bg-red-50 disabled:opacity-50 disabled:cursor-not-allowed"
-                      aria-label="Eliminar producto"
+                      aria-label={`Eliminar ${producto.producto_nombre}`}
+                      className="rounded-lg p-2.5 text-destructive transition-colors hover:bg-destructive/10 disabled:opacity-50"
                     >
-                      <Trash2 className="w-4 h-4" />
-                    </Button>
+                      <Trash2 className="size-4" />
+                    </button>
                   </div>
-                </div>
+                  <FieldDescription>{producto.producto_categoria}</FieldDescription>
+                </Field>
               ))}
             </div>
           ) : cargandoProductos ? (
-            <div className="p-8 text-center border-2 border-dashed border-primary/20 rounded-xl">
-              <Package className="w-12 h-12 text-primary/30 mx-auto mb-3 animate-pulse" />
-              <p className="text-sm text-brand-brown/50">
-                Cargando productos...
-              </p>
+            <div className="flex flex-col items-center gap-3 rounded-xl border-2 border-dashed border-border py-8 text-center">
+              <Spinner className="size-6 text-primary" />
+              <p className="text-sm text-muted-foreground">Cargando productos...</p>
             </div>
           ) : (
-            <div className="p-8 text-center border-2 border-dashed border-red-200 bg-red-50/50 rounded-xl">
-              <AlertTriangle className="w-12 h-12 text-red-400 mx-auto mb-3" />
-              <p className="text-sm text-red-700">
+            <div className="rounded-xl border-2 border-dashed border-destructive/30 bg-destructive/5 px-4 py-8 text-center">
+              <AlertTriangle className="mx-auto mb-3 size-10 text-destructive/60" />
+              <p className="text-sm text-destructive">
                 {errorProductos
                   ? errorProductos
                   : loteId
                     ? 'La mezcla asignada a este lote no tiene productos configurados.'
                     : 'Esta aplicación no tiene productos configurados en su mezcla.'}
               </p>
-              <p className="text-xs text-red-600/70 mt-2">
+              <p className="mt-2 text-xs text-destructive/70">
                 Revisa la mezcla de la aplicación en la Calculadora antes de registrar el movimiento.
               </p>
             </div>
@@ -1003,103 +1256,168 @@ export function DailyMovementForm({ aplicacion, onSuccess, onCancel }: DailyMove
         </div>
 
         {/* Responsable */}
-        <div>
-          <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-            <User className="w-4 h-4 text-primary" />
-            Responsable
-            <span className="text-red-500">*</span>
-          </label>
-          <Input
-            type="text"
-            value={responsable}
-            onChange={(e) => setResponsable(e.target.value)}
-            placeholder="Nombre del responsable"
-            disabled={loading}
-            className="bg-white border-primary/20 focus:border-primary disabled:opacity-50 disabled:cursor-not-allowed"
-          />
+        <div className="border-t border-border/60 px-4 pt-4">
+          <Field>
+            <FieldLabel>
+              Responsable <span className="text-destructive">*</span>
+            </FieldLabel>
+            <Input
+              type="text"
+              value={responsable}
+              onChange={(e) => setResponsable(e.target.value)}
+              placeholder="Nombre del responsable"
+              disabled={loading}
+              aria-invalid={!!erroresCampo.responsable}
+            />
+            <FieldError>{erroresCampo.responsable}</FieldError>
+          </Field>
         </div>
 
         {/* Condiciones Meteorológicas */}
-        <div>
-          <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-            <Cloud className="w-4 h-4 text-primary" />
-            Condiciones Meteorológicas
-          </label>
-          <select
-            value={condicionesMeteorologicas}
-            onChange={(e) => setCondicionesMeteorologicas(e.target.value)}
-            disabled={loading}
-            className="w-full px-4 py-3 border border-primary/20 rounded-xl bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <option value="">Selecciona las condiciones (opcional)</option>
-            <option value="soleadas">☀️ Soleadas</option>
-            <option value="nubladas">☁️ Nubladas</option>
-            <option value="lluvia suave">🌦️ Lluvia Suave</option>
-            <option value="lluvia fuerte">⛈️ Lluvia Fuerte</option>
-          </select>
+        <div className="px-4 pt-4">
+          <Field>
+            <FieldLabel>
+              <Cloud className="size-4 text-primary" /> Condiciones Meteorológicas
+            </FieldLabel>
+            <Select value={condicionesMeteorologicas} onValueChange={setCondicionesMeteorologicas} disabled={loading}>
+              <SelectTrigger className="w-full">
+                <SelectValue placeholder="Selecciona las condiciones (opcional)" />
+              </SelectTrigger>
+              <SelectContent>
+                <SelectItem value="soleadas">☀️ Soleadas</SelectItem>
+                <SelectItem value="nubladas">☁️ Nubladas</SelectItem>
+                <SelectItem value="lluvia suave">🌦️ Lluvia Suave</SelectItem>
+                <SelectItem value="lluvia fuerte">⛈️ Lluvia Fuerte</SelectItem>
+              </SelectContent>
+            </Select>
+          </Field>
         </div>
 
         {/* Notas */}
-        <div>
-          <label className="block text-sm text-foreground mb-2 flex items-center gap-2">
-            <FileText className="w-4 h-4 text-primary" />
-            Notas (Opcional)
-          </label>
-          <textarea
-            value={notas}
-            onChange={(e) => setNotas(e.target.value)}
-            placeholder="Observaciones adicionales..."
-            rows={3}
-            disabled={loading}
-            className="w-full px-4 py-3 border border-primary/20 rounded-xl bg-white text-foreground focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent resize-none disabled:opacity-50 disabled:cursor-not-allowed"
-          />
+        <div className="px-4 pt-4">
+          <Field>
+            <FieldLabel>
+              <FileText className="size-4 text-primary" /> Notas (Opcional)
+            </FieldLabel>
+            <Textarea
+              value={notas}
+              onChange={(e) => setNotas(e.target.value)}
+              placeholder="Observaciones adicionales..."
+              rows={3}
+              disabled={loading}
+            />
+          </Field>
         </div>
 
-        {/* Botones */}
-        <div className="flex items-center gap-3 pt-4 border-t border-primary/10">
-          <Button
-            type="button"
-            onClick={onCancel}
-            disabled={loading}
-            variant="outline"
-            className="flex-1 border-primary/20 hover:bg-primary/5 disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            <X className="w-4 h-4 mr-2" />
-            Cancelar
-          </Button>
-          <Button
-            type="submit"
-            disabled={loading}
-            className="flex-1 bg-primary hover:bg-primary-dark text-white disabled:opacity-50 disabled:cursor-not-allowed"
-          >
-            {loading ? (
-              <>
-                <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin mr-2" />
-                Guardando...
-              </>
-            ) : (
-              <>
-                <Save className="w-4 h-4 mr-2" />
-                Registrar Movimiento
-              </>
-            )}
-          </Button>
+        {/* Info de movimiento provisional */}
+        <div className="px-4 pb-4 pt-4">
+          <p className="flex items-start gap-2 rounded-xl border border-primary/20 bg-primary/5 p-3 text-xs text-muted-foreground">
+            <span className="mt-0.5 text-primary">ℹ️</span>
+            <span>
+              Este es un movimiento <strong>provisional</strong> que no afecta el inventario inmediatamente.
+              {aplicacion.tipo_aplicacion === 'Fertilización'
+                ? ' Se registran los bultos totales usados y los bultos de cada producto. Al cerrar la aplicación, se convertirán a Kg según la presentación de cada producto.'
+                : ' Se registran las canecas totales aplicadas y las canecas de cada producto. Al cerrar la aplicación, se convertirán a litros.'}
+            </span>
+          </p>
         </div>
-      </form>
-
-      {/* Info de movimiento provisional */}
-      <div className="mt-6 p-4 bg-primary/5 border border-primary/20 rounded-xl">
-        <p className="text-xs text-brand-brown/70 flex items-start gap-2">
-          <span className="text-primary mt-0.5">ℹ️</span>
-          <span>
-            Este es un movimiento <strong>provisional</strong> que no afecta el inventario inmediatamente.
-            {aplicacion.tipo_aplicacion === 'Fertilización' 
-              ? ' Se registran los bultos totales usados y los bultos de cada producto. Al cerrar la aplicación, se convertirán a Kg según la presentación de cada producto.'
-              : ' Se registran las canecas totales aplicadas y las canecas de cada producto. Al cerrar la aplicación, se convertirán a litros.'
-            }
-          </span>
-        </p>
       </div>
-    </div>
+    );
+  }
+
+  const pieVistaPersonal = (
+    <Button type="button" className="w-full" onClick={() => setVistaPersonal(false)}>
+      Confirmar personal ({selectedTrabajadores.length})
+    </Button>
+  );
+
+  const pieCamposPrincipales = (
+    <>
+      <Button type="button" variant="outline" className="flex-1" onClick={() => onOpenChange(false)} disabled={loading}>
+        Cancelar
+      </Button>
+      <Button type="submit" className="flex-1" disabled={loading}>
+        {loading ? (
+          <>
+            <Spinner className="size-4" /> Guardando…
+          </>
+        ) : (
+          <>
+            <Save className="size-4" /> Registrar Movimiento
+          </>
+        )}
+      </Button>
+    </>
+  );
+
+  const cuerpo = vistaPersonal ? renderSelectorPersonal() : renderCamposPrincipales();
+
+  return (
+    <>
+      {/* Escritorio: Sheet lateral, más ancho que el sm:max-w-sm por defecto — la
+          matriz de jornal×lote sería inutilizable a 384px (ver §6 del diseño). */}
+      <Sheet open={open && !isMobile} onOpenChange={onOpenChange}>
+        <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-[480px]">
+          <SheetHeader className="border-b border-border px-5 py-4">
+            <SheetTitle>{tituloHeader}</SheetTitle>
+            <SheetDescription>{subtituloHeader}</SheetDescription>
+          </SheetHeader>
+          {vistaPersonal && (
+            <div className="px-5 pt-3">
+              <Button type="button" variant="ghost" size="sm" onClick={() => setVistaPersonal(false)} className="gap-1.5 px-2 text-muted-foreground">
+                <ArrowLeft className="size-4" /> Volver
+              </Button>
+            </div>
+          )}
+          <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+            <div className="flex-1 overflow-y-auto">{cuerpo}</div>
+            <SheetFooter className="flex-row gap-3 border-t border-border px-5 py-4">
+              {vistaPersonal ? pieVistaPersonal : pieCamposPrincipales}
+            </SheetFooter>
+          </form>
+        </SheetContent>
+      </Sheet>
+
+      {/* Móvil: Drawer de PANTALLA COMPLETA — h-[100dvh], no el max-h-[80vh] parcial
+          por defecto de vaul (ver §6 del diseño: 14 campos + matriz no caben en 80vh). */}
+      <Drawer open={open && isMobile} onOpenChange={onOpenChange} direction="bottom">
+        <DrawerContent
+          className={cn(
+            'h-[100dvh] max-h-[100dvh]',
+            // Mismo selector con `data-[vaul-drawer-direction=bottom]:` que usa el primitivo
+            // (drawer.tsx) para estas 4 propiedades: como esa variante agrega un selector de
+            // atributo, tiene más especificidad que la clase plana equivalente y le ganaría a
+            // un simple `rounded-t-none`/`border-t-0` sin el mismo prefijo.
+            'data-[vaul-drawer-direction=bottom]:mt-0',
+            'data-[vaul-drawer-direction=bottom]:max-h-[100dvh]',
+            'data-[vaul-drawer-direction=bottom]:rounded-t-none',
+            'data-[vaul-drawer-direction=bottom]:border-t-0'
+          )}
+        >
+          <div className="flex h-full min-h-0 flex-col">
+            <div className="flex items-center gap-3 border-b border-border px-4 py-3">
+              <button
+                type="button"
+                onClick={() => (vistaPersonal ? setVistaPersonal(false) : onOpenChange(false))}
+                aria-label={vistaPersonal ? 'Volver' : 'Cerrar sin guardar'}
+                className="shrink-0 rounded-lg p-2 text-foreground hover:bg-muted"
+              >
+                <ArrowLeft className="size-5" />
+              </button>
+              <div className="min-w-0 flex-1">
+                <DrawerTitle className="text-[0.95rem] font-semibold">{tituloHeader}</DrawerTitle>
+                <DrawerDescription className="truncate text-xs">{subtituloHeader}</DrawerDescription>
+              </div>
+            </div>
+            <form onSubmit={handleSubmit} className="flex min-h-0 flex-1 flex-col">
+              <div className="flex-1 overflow-y-auto">{cuerpo}</div>
+              <div className="flex gap-3 border-t border-border p-4">
+                {vistaPersonal ? pieVistaPersonal : pieCamposPrincipales}
+              </div>
+            </form>
+          </div>
+        </DrawerContent>
+      </Drawer>
+    </>
   );
 }

--- a/src/components/aplicaciones/DailyMovementsDashboard.tsx
+++ b/src/components/aplicaciones/DailyMovementsDashboard.tsx
@@ -29,6 +29,7 @@ import type {
 } from '../../types/aplicaciones';
 import { obtenerFechaHoy } from '@/utils/fechas';
 import { usaCanecas } from '@/utils/calculosAplicaciones';
+import { formatearNumero } from '@/utils/format';
 
 interface DailyMovementsDashboardProps {
   aplicacion: Aplicacion;
@@ -295,14 +296,14 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
         nuevasAlertas.push({
           tipo: 'error',
           producto_nombre: item.producto_nombre,
-          mensaje: `Se ha excedido la cantidad planificada en ${Math.abs(item.diferencia).toFixed(2)} ${item.producto_unidad}`,
+          mensaje: `Se ha excedido la cantidad planificada en ${formatearNumero(Math.abs(item.diferencia), 2)} ${item.producto_unidad}`,
           porcentaje_usado: item.porcentaje_usado
         });
       } else if (item.porcentaje_usado >= 90) {
         nuevasAlertas.push({
           tipo: 'warning',
           producto_nombre: item.producto_nombre,
-          mensaje: `Cerca del límite planificado (${item.porcentaje_usado.toFixed(1)}%)`,
+          mensaje: `Cerca del límite planificado (${formatearNumero(item.porcentaje_usado, 1)}%)`,
           porcentaje_usado: item.porcentaje_usado
         });
       }
@@ -505,16 +506,16 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
             <div className="flex-1">
               <h3 className="text-sm text-brand-brown/70 mb-1">Progreso de Canecas</h3>
               <div className="flex items-baseline gap-2">
-                <span className="text-2xl text-foreground">{canecasTotales.utilizadas.toFixed(1)}</span>
-                <span className="text-sm text-brand-brown/60">/ {canecasTotales.planeadas.toFixed(1)} canecas</span>
+                <span className="text-2xl text-foreground">{formatearNumero(canecasTotales.utilizadas, 1)}</span>
+                <span className="text-sm text-brand-brown/60">/ {formatearNumero(canecasTotales.planeadas, 1)} canecas</span>
                 <span className={`ml-2 text-sm px-2 py-1 rounded-lg ${
-                  canecasTotales.porcentaje > 100 
-                    ? 'bg-red-100 text-red-700' 
-                    : canecasTotales.porcentaje >= 90 
-                    ? 'bg-amber-100 text-amber-700' 
+                  canecasTotales.porcentaje > 100
+                    ? 'bg-red-100 text-red-700'
+                    : canecasTotales.porcentaje >= 90
+                    ? 'bg-amber-100 text-amber-700'
                     : 'bg-primary/10 text-primary'
                 }`}>
-                  {canecasTotales.porcentaje.toFixed(0)}%
+                  {formatearNumero(canecasTotales.porcentaje, 0)}%
                 </span>
               </div>
               <div className="mt-3 w-full bg-white/50 rounded-full h-2 overflow-hidden">
@@ -620,17 +621,17 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
                       <div className="flex-1">
                         <p className="text-sm text-foreground">{item.producto_nombre}</p>
                         <p className="text-xs text-brand-brown/60 mt-1">
-                          {item.total_utilizado.toFixed(2)} / {item.cantidad_planeada.toFixed(2)} {item.producto_unidad}
+                          {formatearNumero(item.total_utilizado, 2)} / {formatearNumero(item.cantidad_planeada, 2)} {item.producto_unidad}
                         </p>
                       </div>
                       <div className="text-right">
                         {item.excede_planeado ? (
                           <span className="inline-block px-2 py-1 bg-red-100 text-red-700 rounded-lg text-xs">
-                            +{Math.abs(item.diferencia).toFixed(2)}
+                            +{formatearNumero(Math.abs(item.diferencia), 2)}
                           </span>
                         ) : (
                           <span className="inline-block px-2 py-1 bg-primary/10 text-primary rounded-lg text-xs">
-                            {item.porcentaje_usado.toFixed(0)}%
+                            {formatearNumero(item.porcentaje_usado, 0)}%
                           </span>
                         )}
                       </div>
@@ -738,6 +739,7 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
                         onClick={() => handleEliminarMovimiento(mov.id!)}
                         className="text-red-500 hover:text-red-700 p-2 rounded-lg hover:bg-red-50 transition-colors"
                         title="Eliminar movimiento"
+                        aria-label="Eliminar movimiento"
                       >
                         <Trash2 className="w-4 h-4" />
                       </button>

--- a/src/components/aplicaciones/DailyMovementsDashboard.tsx
+++ b/src/components/aplicaciones/DailyMovementsDashboard.tsx
@@ -6,6 +6,7 @@ import {
   Package,
   Calendar as CalendarIcon,
   User,
+  Users,
   Trash2,
   Plus,
   ChevronDown,
@@ -30,6 +31,7 @@ import {
   AccordionContent,
 } from '../ui/accordion';
 import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
+import { Item, ItemMedia, ItemContent, ItemTitle, ItemDescription, ItemGroup } from '../ui/item';
 import { Empty, EmptyContent, EmptyDescription, EmptyMedia, EmptyTitle } from '../ui/empty';
 import { Spinner } from '../ui/spinner';
 import { Skeleton } from '../ui/skeleton';
@@ -50,9 +52,30 @@ interface DailyMovementsDashboardProps {
   aplicacion: Aplicacion;
 }
 
-// Tipo extendido con productos cargados
+// Un trabajador (empleado o contratista) de la cuadrilla de un movimiento, ya resuelto a nombre.
+// El nombre viene de `empleados.nombre` o `contratistas.nombre` según cuál id no sea null
+// (constraint XOR en movimientos_diarios_trabajadores) — nunca ambos, nunca ninguno.
+interface TrabajadorMovimiento {
+  id: string;
+  nombre: string;
+  fraccion_jornal: number;
+}
+
+// Fila cruda que devuelve PostgREST al anidar movimientos_diarios_trabajadores con los dos
+// catálogos de nombre. empleados/contratistas vienen como objeto singular (no arreglo) porque
+// cada FK es many-to-one.
+interface FilaTrabajadorMovimiento {
+  id: string;
+  movimiento_diario_id: string;
+  fraccion_jornal: number;
+  empleados: { nombre: string } | null;
+  contratistas: { nombre: string } | null;
+}
+
+// Tipo extendido con productos y cuadrilla cargados
 interface MovimientoConProductos extends MovimientoDiario {
   productos: MovimientoDiarioProducto[];
+  trabajadores: TrabajadorMovimiento[];
 }
 
 /** Unidades abreviadas para las filas de producto dentro de un movimiento expandido. */
@@ -67,6 +90,14 @@ const MAPA_UNIDAD_CORTA: Record<string, string> = {
   kilos: 'Kg',
   Unidades: 'Unid.',
 };
+
+/** Iniciales para el avatar circular de cada fila de personal ("Clara Yaneth" → "CY"). */
+function iniciales(nombre: string): string {
+  const partes = nombre.trim().split(/\s+/).filter(Boolean);
+  const a = partes[0]?.[0] ?? '';
+  const b = partes[1]?.[0] ?? '';
+  return (a + b).toUpperCase() || '?';
+}
 
 type EstadoProgreso = 'ok' | 'warn' | 'over';
 
@@ -213,6 +244,28 @@ export function DailyMovementsDashboard({ aplicacion }: DailyMovementsDashboardP
 
       if (errorProductos) throw errorProductos;
 
+      // 2b. Cargar la cuadrilla de cada movimiento (empleados + contratistas), con el nombre
+      // resuelto vía embed — `movimientos_diarios_trabajadores` nunca se leía antes, así que
+      // el accordion solo mostraba `responsable` (un supervisor de texto libre).
+      const { data: trabajadoresData, error: errorTrabajadores } = await supabase
+        .from('movimientos_diarios_trabajadores')
+        .select('id, movimiento_diario_id, fraccion_jornal, empleados(nombre), contratistas(nombre)')
+        .in('movimiento_diario_id', movimientoIds);
+
+      if (errorTrabajadores) throw errorTrabajadores;
+
+      const trabajadoresPorMovimiento = new Map<string, TrabajadorMovimiento[]>();
+      ((trabajadoresData || []) as unknown as FilaTrabajadorMovimiento[]).forEach(fila => {
+        const nombre = fila.empleados?.nombre ?? fila.contratistas?.nombre ?? 'Sin nombre';
+        const lista = trabajadoresPorMovimiento.get(fila.movimiento_diario_id) ?? [];
+        lista.push({
+          id: fila.id,
+          nombre,
+          fraccion_jornal: Number(fila.fraccion_jornal),
+        });
+        trabajadoresPorMovimiento.set(fila.movimiento_diario_id, lista);
+      });
+
       // 3. Para fertilización, cargar presentacion_kg_l de cada producto
       const presentacionMap = new Map<string, number>();
       if (aplicacion.tipo_aplicacion === 'Fertilización') {
@@ -233,7 +286,7 @@ export function DailyMovementsDashboard({ aplicacion }: DailyMovementsDashboardP
         }
       }
 
-      // 4. Agrupar productos por movimiento
+      // 4. Agrupar productos y cuadrilla por movimiento
       const movimientosConProductos = movimientosData.map(mov => {
         const productosMovimiento = (productosData || []).filter(
           p => p.movimiento_diario_id === mov.id
@@ -242,6 +295,7 @@ export function DailyMovementsDashboard({ aplicacion }: DailyMovementsDashboardP
         return {
           ...mov,
           productos: productosMovimiento,
+          trabajadores: trabajadoresPorMovimiento.get(mov.id) ?? [],
         };
       });
 
@@ -714,15 +768,48 @@ export function DailyMovementsDashboard({ aplicacion }: DailyMovementsDashboardP
                       ))}
                     </div>
 
-                    <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/60 pt-3">
-                      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
-                        <User className="size-3" /> {mov.responsable}
+                    {/* Cuadrilla (movimientos_diarios_trabajadores) — distinta del responsable de
+                        abajo, que es un solo nombre de texto libre tecleado a mano. Ausencia de
+                        filas (movimientos antiguos, capturados antes de que el formulario pidiera
+                        cuadrilla) no renderiza sección ni "0" — es un dato que nunca se tuvo. */}
+                    {mov.trabajadores.length > 0 && (
+                      <div className="mt-3 border-t border-border/60 pt-3">
+                        <div className="mb-2 flex items-center gap-1.5 text-xs font-medium text-muted-foreground">
+                          <Users className="size-3.5" />
+                          Personal ({mov.trabajadores.length})
+                        </div>
+                        <ItemGroup className="gap-1.5">
+                          {mov.trabajadores.map(trabajador => (
+                            <Item
+                              key={trabajador.id}
+                              size="sm"
+                              className="rounded-lg border border-border/60 bg-muted/40"
+                            >
+                              <ItemMedia variant="icon" className="text-[0.7rem] font-bold">
+                                {iniciales(trabajador.nombre)}
+                              </ItemMedia>
+                              <ItemContent>
+                                <ItemTitle className="whitespace-normal">{trabajador.nombre}</ItemTitle>
+                                <ItemDescription className="line-clamp-none">
+                                  {formatearNumero(trabajador.fraccion_jornal, 2)} jornal
+                                </ItemDescription>
+                              </ItemContent>
+                            </Item>
+                          ))}
+                        </ItemGroup>
+                      </div>
+                    )}
+
+                    <div className="mt-3 flex items-start justify-between gap-3 border-t border-border/60 pt-3">
+                      <span className="flex min-w-0 items-start gap-1.5 text-xs text-muted-foreground">
+                        <User className="mt-0.5 size-3 shrink-0" />
+                        <span className="break-words">Responsable: {mov.responsable}</span>
                       </span>
                       <button
                         type="button"
                         onClick={() => handleEliminarMovimiento(mov.id!)}
                         aria-label="Eliminar movimiento"
-                        className="rounded-lg p-1.5 text-destructive transition-colors hover:bg-destructive/10"
+                        className="shrink-0 rounded-lg p-1.5 text-destructive transition-colors hover:bg-destructive/10"
                       >
                         <Trash2 className="size-4" />
                       </button>

--- a/src/components/aplicaciones/DailyMovementsDashboard.tsx
+++ b/src/components/aplicaciones/DailyMovementsDashboard.tsx
@@ -1,39 +1,53 @@
 import { useState, useEffect } from 'react';
+import { useNavigate } from 'react-router-dom';
 import {
   AlertTriangle,
-  TrendingUp,
+  AlertCircle,
   Package,
-  Calendar,
+  Calendar as CalendarIcon,
   User,
   Trash2,
   Plus,
-  X,
   ChevronDown,
-  ChevronUp,
   Download,
-  Droplet
+  Droplet,
+  TrendingUp,
 } from 'lucide-react';
 import { toast } from 'sonner';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { getSupabase } from '../../utils/supabase/client';
 import { DailyMovementForm } from './DailyMovementForm';
 import { IniciarEjecucionModal } from './IniciarEjecucionModal';
+import { AplicacionShell } from './shared/AplicacionShell';
 import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { Progress } from '../ui/progress';
+import { Alert, AlertTitle, AlertDescription } from '../ui/alert';
+import {
+  Accordion,
+  AccordionItem,
+  AccordionTrigger,
+  AccordionContent,
+} from '../ui/accordion';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '../ui/collapsible';
+import { Empty, EmptyContent, EmptyDescription, EmptyMedia, EmptyTitle } from '../ui/empty';
+import { Spinner } from '../ui/spinner';
+import { Skeleton } from '../ui/skeleton';
+import { cn } from '../ui/utils';
 import type {
   Aplicacion,
   MovimientoDiario,
   MovimientoDiarioProducto,
   ResumenMovimientoDiario,
   AlertaMovimiento,
-  ProductoEnMezcla
+  ProductoEnMezcla,
 } from '../../types/aplicaciones';
 import { obtenerFechaHoy } from '@/utils/fechas';
-import { usaCanecas } from '@/utils/calculosAplicaciones';
-import { formatearNumero } from '@/utils/format';
+import { usaCanecas, unidadAplicacion } from '@/utils/calculosAplicaciones';
+import { formatearNumero, formatShortDate } from '@/utils/format';
 
 interface DailyMovementsDashboardProps {
   aplicacion: Aplicacion;
-  onClose?: () => void;
 }
 
 // Tipo extendido con productos cargados
@@ -41,15 +55,94 @@ interface MovimientoConProductos extends MovimientoDiario {
   productos: MovimientoDiarioProducto[];
 }
 
-export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsDashboardProps) {
+/** Unidades abreviadas para las filas de producto dentro de un movimiento expandido. */
+const MAPA_UNIDAD_CORTA: Record<string, string> = {
+  L: 'L',
+  cc: 'cc',
+  Kg: 'Kg',
+  g: 'g',
+  Litros: 'L',
+  Kilos: 'Kg',
+  litros: 'L',
+  kilos: 'Kg',
+  Unidades: 'Unid.',
+};
+
+type EstadoProgreso = 'ok' | 'warn' | 'over';
+
+/**
+ * Único punto que decide "¿este progreso está bien, cerca del límite, o excedido?".
+ *
+ * La condición de excedido SIEMPRE se evalúa contra el valor exacto (via el parámetro
+ * `excede`, calculado por el llamante como `utilizado > planeado`) — nunca contra el
+ * porcentaje redondeado. Es el bug real que este workflow corrige: 76,0/75,8 canecas
+ * redondea a "100%" y esconde un exceso real de 0,2 canecas.
+ */
+function estadoProgreso(porcentajeUsado: number, excede: boolean): EstadoProgreso {
+  if (excede) return 'over';
+  if (porcentajeUsado >= 90) return 'warn';
+  return 'ok';
+}
+
+const CLASE_BARRA: Record<EstadoProgreso, string> = {
+  ok: '[&>[data-slot=progress-indicator]]:bg-primary',
+  warn: '[&>[data-slot=progress-indicator]]:bg-warning',
+  over: '[&>[data-slot=progress-indicator]]:bg-destructive',
+};
+
+const CLASE_BADGE: Record<EstadoProgreso, string> = {
+  ok: 'border-primary/20 bg-primary/10 text-primary',
+  warn: 'border-warning/40 bg-warning/15 text-warning-foreground',
+  over: 'border-destructive/30 bg-destructive/10 text-destructive',
+};
+
+/** Barra de progreso + marca de desborde cuando excede el 100% del track. */
+function BarraProgreso({ porcentaje, estado }: { porcentaje: number; estado: EstadoProgreso }) {
+  return (
+    <div className="relative mt-2.5">
+      <Progress value={Math.min(porcentaje, 100)} className={cn('h-2', CLASE_BARRA[estado])} />
+      {estado === 'over' && (
+        <div
+          aria-hidden="true"
+          className="absolute inset-y-0 right-0 w-[3px] rounded-full bg-destructive ring-4 ring-destructive/25"
+        />
+      )}
+    </div>
+  );
+}
+
+/**
+ * Badge de progreso. Nunca dice solo "100%" cuando está excedido — dice
+ * "Excedido +delta" con el valor real. Por debajo de 100% muestra el porcentaje con
+ * UN decimal (99,7%), nunca redondeado a entero.
+ */
+function BadgeProgreso({
+  excede,
+  porcentaje,
+  delta,
+  decimalesDelta = 2,
+}: {
+  excede: boolean;
+  porcentaje: number;
+  delta: number;
+  decimalesDelta?: number;
+}) {
+  const estado = estadoProgreso(porcentaje, excede);
+  return (
+    <Badge variant="outline" className={cn('shrink-0', CLASE_BADGE[estado])}>
+      {excede
+        ? `Excedido +${formatearNumero(Math.abs(delta), decimalesDelta)}`
+        : `${formatearNumero(porcentaje, 1)}%`}
+    </Badge>
+  );
+}
+
+export function DailyMovementsDashboard({ aplicacion }: DailyMovementsDashboardProps) {
   const supabase = getSupabase();
+  const navigate = useNavigate();
   const [loading, setLoading] = useState(true);
-  const [showForm, setShowForm] = useState(false);
-  const [expandedSections, setExpandedSections] = useState({
-    alertas: true,
-    resumen: true,
-    movimientos: true
-  });
+  const [formOpen, setFormOpen] = useState(false);
+  const [resumenAbierto, setResumenAbierto] = useState(true);
 
   // Datos — declared before any conditional return to satisfy Rules of Hooks
   const [movimientos, setMovimientos] = useState<MovimientoConProductos[]>([]);
@@ -64,12 +157,12 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
   const [confirmEliminarMovimientoId, setConfirmEliminarMovimientoId] = useState<string | null>(null);
   const [showIniciarEjecucion, setShowIniciarEjecucion] = useState(false);
 
-  // Auto-cerrar si la aplicación se cierra mientras estamos aquí
+  // Salir si la aplicación se cierra mientras estamos aquí
   useEffect(() => {
-    if (aplicacion.estado === 'Cerrada' && onClose) {
-      onClose();
+    if (aplicacion.estado === 'Cerrada') {
+      navigate('/aplicaciones');
     }
-  }, [aplicacion.estado, onClose]);
+  }, [aplicacion.estado, navigate]);
 
   useEffect(() => {
     loadData();
@@ -86,7 +179,7 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
       await Promise.all([
         loadMovimientos(),
         loadProductosPlanificados(),
-        loadCanecasPlaneadas()
+        loadCanecasPlaneadas(),
       ]);
     } catch {
       // individual loaders handle their own errors
@@ -140,21 +233,15 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
         }
       }
 
-      // 4. Agrupar productos por movimiento y convertir Kg a bultos si aplica
+      // 4. Agrupar productos por movimiento
       const movimientosConProductos = movimientosData.map(mov => {
-        const productosMovimiento = (productosData || [])
-          .filter(p => p.movimiento_diario_id === mov.id)
-          .map(p => {
-            // Para fertilización, convertir Kg a bultos para mostrar en UI
-            if (aplicacion.tipo_aplicacion === 'Fertilización' && presentacionMap.has(p.producto_id)) {
-              const presentacion = presentacionMap.get(p.producto_id)!;
-            }
-            return p;
-          });
+        const productosMovimiento = (productosData || []).filter(
+          p => p.movimiento_diario_id === mov.id
+        );
 
         return {
           ...mov,
-          productos: productosMovimiento
+          productos: productosMovimiento,
         };
       });
 
@@ -220,7 +307,7 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
       const totalPlaneadas = (calculosData || []).reduce((sum, calc) => sum + (calc.numero_canecas || 0), 0);
 
       return totalPlaneadas;
-    } catch (err: any) {
+    } catch {
       return 0;
     }
   };
@@ -239,7 +326,7 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
         cantidad_planeada: pp.cantidad_total_necesaria,
         diferencia: -pp.cantidad_total_necesaria,
         porcentaje_usado: 0,
-        excede_planeado: false
+        excede_planeado: false,
       });
     });
 
@@ -252,12 +339,11 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
         let cantidadEnUnidadBase = producto.cantidad_utilizada;
 
         if ((producto.unidad as string) === 'bultos' && (producto as any).presentacion_kg_l) {
-          // Para bultos: convertir de nuevo a Kg usando presentacion_kg_l
           cantidadEnUnidadBase = producto.cantidad_utilizada * (producto as any).presentacion_kg_l;
         } else if ((producto.unidad as string) === 'cc') {
-          cantidadEnUnidadBase = producto.cantidad_utilizada / 1000; // cc a L
+          cantidadEnUnidadBase = producto.cantidad_utilizada / 1000;
         } else if ((producto.unidad as string) === 'g') {
-          cantidadEnUnidadBase = producto.cantidad_utilizada / 1000; // g a Kg
+          cantidadEnUnidadBase = producto.cantidad_utilizada / 1000;
         }
 
         if (resumenItem) {
@@ -268,7 +354,6 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
             : 0;
           resumenItem.excede_planeado = resumenItem.total_utilizado > resumenItem.cantidad_planeada;
         } else {
-          // Producto no planificado pero usado
           resumenMap.set(producto.producto_id, {
             producto_id: producto.producto_id,
             producto_nombre: producto.producto_nombre,
@@ -277,7 +362,7 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
             cantidad_planeada: 0,
             diferencia: cantidadEnUnidadBase,
             porcentaje_usado: Infinity,
-            excede_planeado: true
+            excede_planeado: true,
           });
         }
       });
@@ -290,21 +375,21 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
           tipo: 'warning',
           producto_nombre: item.producto_nombre,
           mensaje: 'Producto utilizado sin planificación previa',
-          porcentaje_usado: Infinity
+          porcentaje_usado: Infinity,
         });
       } else if (item.porcentaje_usado > 100) {
         nuevasAlertas.push({
           tipo: 'error',
           producto_nombre: item.producto_nombre,
           mensaje: `Se ha excedido la cantidad planificada en ${formatearNumero(Math.abs(item.diferencia), 2)} ${item.producto_unidad}`,
-          porcentaje_usado: item.porcentaje_usado
+          porcentaje_usado: item.porcentaje_usado,
         });
       } else if (item.porcentaje_usado >= 90) {
         nuevasAlertas.push({
           tipo: 'warning',
           producto_nombre: item.producto_nombre,
           mensaje: `Cerca del límite planificado (${formatearNumero(item.porcentaje_usado, 1)}%)`,
-          porcentaje_usado: item.porcentaje_usado
+          porcentaje_usado: item.porcentaje_usado,
         });
       }
     });
@@ -315,76 +400,19 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
 
   const calcularCanecasTotales = async () => {
     try {
-      // Obtener canecas planeadas
       const totalPlaneadas = await loadCanecasPlaneadas();
-
-      // Sumar canecas utilizadas de todos los movimientos
       const totalUtilizadas = movimientos.reduce((sum, mov) => sum + (mov.numero_canecas || 0), 0);
-
       const porcentaje = totalPlaneadas > 0 ? (totalUtilizadas / totalPlaneadas) * 100 : 0;
 
       setCanecasTotales({
         planeadas: totalPlaneadas,
         utilizadas: totalUtilizadas,
-        porcentaje
+        porcentaje,
       });
     } catch {
       // error logged by caller
     }
   };
-
-  // Validar que la aplicación esté en ejecución SOLO si estamos en modo modal
-  // Si NO hay onClose (página dedicada), permitir visualización en cualquier estado
-  if (aplicacion.estado !== 'En ejecución' && aplicacion.estado !== 'Cerrada' && onClose) {
-    return (
-      <>
-        <div className="flex items-center justify-center min-h-[400px] p-4">
-          <div className="bg-white rounded-2xl max-w-md w-full p-6 shadow-lg border border-yellow-200">
-            <div className="flex items-center gap-3 mb-4">
-              <div className="w-12 h-12 bg-yellow-100 rounded-full flex items-center justify-center">
-                <AlertTriangle className="w-6 h-6 text-yellow-600" />
-              </div>
-              <div>
-                <h3 className="text-lg text-foreground">Aplicación No Iniciada</h3>
-                <p className="text-sm text-brand-brown/70">No se pueden registrar movimientos</p>
-              </div>
-            </div>
-
-            <p className="text-sm text-brand-brown/70 mb-6">
-              Esta aplicación está en estado <span className="font-medium text-foreground">"{aplicacion.estado}"</span>.
-              {' '}Debes iniciar la ejecución antes de poder registrar movimientos diarios.
-            </p>
-
-            <div className="flex gap-3">
-              <button
-                onClick={onClose}
-                className="flex-1 px-4 py-2 border border-brand-brown/20 text-brand-brown rounded-lg hover:bg-brand-brown/5 transition-all"
-              >
-                Volver
-              </button>
-              <button
-                onClick={() => setShowIniciarEjecucion(true)}
-                className="flex-1 px-4 py-2 bg-gradient-to-r from-green-600 to-green-500 text-white rounded-lg hover:from-green-700 hover:to-green-600 transition-all"
-              >
-                Iniciar Ejecución
-              </button>
-            </div>
-          </div>
-        </div>
-
-        {showIniciarEjecucion && (
-          <IniciarEjecucionModal
-            aplicacion={aplicacion}
-            onClose={() => setShowIniciarEjecucion(false)}
-            onSuccess={() => {
-              setShowIniciarEjecucion(false);
-              window.location.reload();
-            }}
-          />
-        )}
-      </>
-    );
-  }
 
   const handleEliminarMovimiento = (movimientoId: string) => {
     setConfirmEliminarMovimientoId(movimientoId);
@@ -405,29 +433,20 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
       if (error) throw error;
 
       await loadMovimientos();
-    } catch (err: any) {
+    } catch {
       toast.error('Error al eliminar el movimiento');
     }
   };
 
-  const toggleSection = (section: keyof typeof expandedSections) => {
-    setExpandedSections(prev => ({
-      ...prev,
-      [section]: !prev[section]
-    }));
-  };
-
   const exportarACSV = () => {
-    // Generar CSV con la información completa
     let csv = 'Fecha,Lote,Canecas,Producto,Cantidad,Unidad,Responsable,Notas\n';
-    
+
     movimientos.forEach(mov => {
       mov.productos.forEach(producto => {
         csv += `${mov.fecha_movimiento},${mov.lote_nombre},${mov.numero_canecas},${producto.producto_nombre},${producto.cantidad_utilizada},${producto.unidad},${mov.responsable},"${mov.notas || ''}"\n`;
       });
     });
 
-    // Descargar archivo
     const blob = new Blob([csv], { type: 'text/csv;charset=utf-8;' });
     const link = document.createElement('a');
     const url = URL.createObjectURL(blob);
@@ -439,389 +458,319 @@ export function DailyMovementsDashboard({ aplicacion, onClose }: DailyMovementsD
     document.body.removeChild(link);
   };
 
+  const subtitulo = aplicacion.nombre_aplicacion
+    ? `${aplicacion.nombre_aplicacion} · ${movimientos.length} ${movimientos.length === 1 ? 'registro' : 'registros'}`
+    : undefined;
+
+  // Validar que la aplicación esté en ejecución. Aunque ya cerrada navega fuera
+  // (ver efecto arriba), 'Calculada' u otro estado intermedio no permite registrar.
+  if (aplicacion.estado !== 'En ejecución' && aplicacion.estado !== 'Cerrada') {
+    return (
+      <AplicacionShell titulo="Movimientos Diarios" subtitulo={subtitulo} estado={aplicacion.estado}>
+        <Empty>
+          <EmptyMedia variant="icon" className="bg-warning/15 text-warning-foreground">
+            <AlertTriangle />
+          </EmptyMedia>
+          <EmptyTitle>Aplicación no iniciada</EmptyTitle>
+          <EmptyDescription>
+            Esta aplicación está en estado "{aplicacion.estado ?? '—'}". Debes iniciar la ejecución antes
+            de poder registrar movimientos diarios.
+          </EmptyDescription>
+          <EmptyContent>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Button onClick={() => setShowIniciarEjecucion(true)}>Iniciar Ejecución</Button>
+              <Button variant="outline" onClick={() => navigate('/aplicaciones')}>
+                Volver
+              </Button>
+            </div>
+          </EmptyContent>
+        </Empty>
+
+        {showIniciarEjecucion && (
+          <IniciarEjecucionModal
+            aplicacion={aplicacion}
+            onClose={() => setShowIniciarEjecucion(false)}
+            onSuccess={() => {
+              setShowIniciarEjecucion(false);
+              window.location.reload();
+            }}
+          />
+        )}
+      </AplicacionShell>
+    );
+  }
+
   if (loading) {
     return (
-      <div className="flex items-center justify-center py-12">
-        <div className="text-center">
-          <div className="w-12 h-12 border-4 border-primary/20 border-t-primary rounded-full animate-spin mx-auto"></div>
-          <p className="text-sm text-brand-brown/60 mt-4">Cargando movimientos...</p>
+      <AplicacionShell titulo="Movimientos Diarios" subtitulo={subtitulo} estado={aplicacion.estado}>
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+          <Spinner className="size-8 text-primary" />
+          <p className="text-sm text-muted-foreground">Cargando movimientos…</p>
         </div>
-      </div>
+        <div className="space-y-4">
+          <Skeleton className="h-24 w-full rounded-2xl" />
+          <Skeleton className="h-40 w-full rounded-2xl" />
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        </div>
+      </AplicacionShell>
     );
   }
 
-  if (showForm) {
-    return (
-      <DailyMovementForm
-        aplicacion={aplicacion}
-        onSuccess={() => {
-          setShowForm(false);
-          loadMovimientos();
-        }}
-        onCancel={() => setShowForm(false)}
-      />
-    );
-  }
+  const canecasExcede = canecasTotales.utilizadas > canecasTotales.planeadas;
+  const canecasEstado = estadoProgreso(canecasTotales.porcentaje, canecasExcede);
+  const hayMovimientos = movimientos.length > 0;
 
   return (
-    <div className="space-y-6">
-      {/* Header */}
-      <div className="flex items-center justify-between">
-        <div>
-          <h2 className="text-2xl text-foreground">Movimientos Diarios</h2>
-          <p className="text-sm text-brand-brown/60 mt-1">
-            {aplicacion.nombre_aplicacion} • {movimientos.length} {movimientos.length === 1 ? 'registro' : 'registros'}
-          </p>
-        </div>
-        <div className="flex items-center gap-3">
-          <Button
-            onClick={() => setShowForm(true)}
-            className="bg-primary hover:bg-primary-dark text-white"
-          >
-            <Plus className="w-4 h-4 mr-2" />
-            Nuevo Movimiento
-          </Button>
-          {onClose && (
-            <Button
-              onClick={onClose}
-              variant="outline"
-              className="border-primary/20"
-            >
-              <X className="w-4 h-4 mr-2" />
-              Cerrar
+    <AplicacionShell
+      titulo="Movimientos Diarios"
+      subtitulo={subtitulo}
+      estado={aplicacion.estado}
+      acciones={
+        <div className="hidden items-center gap-3 sm:flex">
+          {hayMovimientos && (
+            <Button variant="outline" onClick={exportarACSV}>
+              <Download className="size-4" />
+              Exportar CSV
             </Button>
           )}
+          <Button onClick={() => setFormOpen(true)}>
+            <Plus className="size-4" />
+            Nuevo Movimiento
+          </Button>
         </div>
-      </div>
-
-      {/* Resumen de Canecas/Bultos Totales */}
-      {/* Drench se mide en canecas igual que Fumigación: loadCanecasPlaneadas() lee
-          numero_canecas, que es justamente lo que la calculadora escribe para ambos. */}
-      {usaCanecas(aplicacion.tipo_aplicacion) && canecasTotales && (
-        <div className="bg-gradient-to-br from-primary/10 to-secondary/10 rounded-2xl border border-primary/20 p-6">
-          <div className="flex items-center gap-4">
-            <div className="w-14 h-14 bg-primary/20 rounded-xl flex items-center justify-center">
-              <Droplet className="w-7 h-7 text-primary" />
-            </div>
-            <div className="flex-1">
-              <h3 className="text-sm text-brand-brown/70 mb-1">Progreso de Canecas</h3>
-              <div className="flex items-baseline gap-2">
-                <span className="text-2xl text-foreground">{formatearNumero(canecasTotales.utilizadas, 1)}</span>
-                <span className="text-sm text-brand-brown/60">/ {formatearNumero(canecasTotales.planeadas, 1)} canecas</span>
-                <span className={`ml-2 text-sm px-2 py-1 rounded-lg ${
-                  canecasTotales.porcentaje > 100
-                    ? 'bg-red-100 text-red-700'
-                    : canecasTotales.porcentaje >= 90
-                    ? 'bg-amber-100 text-amber-700'
-                    : 'bg-primary/10 text-primary'
-                }`}>
-                  {formatearNumero(canecasTotales.porcentaje, 0)}%
-                </span>
+      }
+    >
+      {!hayMovimientos ? (
+        <Empty>
+          <EmptyMedia variant="icon">
+            <Package />
+          </EmptyMedia>
+          <EmptyTitle>Sin movimientos todavía</EmptyTitle>
+          <EmptyDescription>Registra el primer movimiento diario de esta aplicación.</EmptyDescription>
+          <EmptyContent>
+            <Button onClick={() => setFormOpen(true)}>Registrar el primero</Button>
+          </EmptyContent>
+        </Empty>
+      ) : (
+        <div className="space-y-5">
+          {/* Progreso de Canecas/Bultos */}
+          {usaCanecas(aplicacion.tipo_aplicacion) && (
+            <div className="flex gap-4 rounded-2xl border border-border bg-card p-5 shadow-sm">
+              <div
+                className={cn(
+                  'flex size-12 shrink-0 items-center justify-center rounded-xl',
+                  canecasEstado === 'over' ? 'bg-destructive/10 text-destructive' : 'bg-primary/10 text-primary'
+                )}
+              >
+                <Droplet className="size-6" />
               </div>
-              <div className="mt-3 w-full bg-white/50 rounded-full h-2 overflow-hidden">
-                <div
-                  className={`h-full transition-all ${
-                    canecasTotales.porcentaje > 100
-                      ? 'bg-red-500'
-                      : canecasTotales.porcentaje >= 90
-                      ? 'bg-amber-500'
-                      : 'bg-primary'
-                  }`}
-                  style={{ width: `${Math.min(canecasTotales.porcentaje, 100)}%` }}
-                />
-              </div>
-            </div>
-          </div>
-        </div>
-      )}
-
-      {/* Alertas */}
-      {alertas.length > 0 && (
-        <div className="bg-white rounded-2xl border border-primary/10 shadow-[0_4px_24px_rgba(115,153,28,0.08)] overflow-hidden">
-          <button
-            onClick={() => toggleSection('alertas')}
-            className="w-full px-6 py-4 flex items-center justify-between hover:bg-primary/5 transition-colors"
-          >
-            <div className="flex items-center gap-3">
-              <AlertTriangle className="w-5 h-5 text-amber-600" />
-              <h3 className="text-lg text-foreground">
-                Alertas ({alertas.length})
-              </h3>
-            </div>
-            {expandedSections.alertas ? (
-              <ChevronUp className="w-5 h-5 text-brand-brown/40" />
-            ) : (
-              <ChevronDown className="w-5 h-5 text-brand-brown/40" />
-            )}
-          </button>
-
-          {expandedSections.alertas && (
-            <div className="px-6 pb-4 space-y-2">
-              {alertas.map((alerta, idx) => (
-                <div
-                  key={idx}
-                  className={`p-3 rounded-xl flex items-start gap-3 border ${
-                    alerta.tipo === 'error'
-                      ? 'bg-red-50 border-red-200'
-                      : alerta.tipo === 'warning'
-                      ? 'bg-amber-50 border-amber-200'
-                      : 'bg-blue-50 border-blue-200'
-                  }`}
-                >
-                  <AlertTriangle
-                    className={`w-5 h-5 flex-shrink-0 mt-0.5 ${
-                      alerta.tipo === 'error'
-                        ? 'text-red-600'
-                        : alerta.tipo === 'warning'
-                        ? 'text-amber-600'
-                        : 'text-blue-600'
-                    }`}
+              <div className="min-w-0 flex-1">
+                <p className="text-sm text-muted-foreground">Progreso de Canecas</p>
+                <div className="mt-1 flex flex-wrap items-baseline gap-2">
+                  <span className="text-2xl font-semibold tabular-nums text-foreground">
+                    {formatearNumero(canecasTotales.utilizadas, 1)}
+                  </span>
+                  <span className="text-sm tabular-nums text-muted-foreground">
+                    / {formatearNumero(canecasTotales.planeadas, 1)} {unidadAplicacion(aplicacion.tipo_aplicacion)}
+                  </span>
+                  <BadgeProgreso
+                    excede={canecasExcede}
+                    porcentaje={canecasTotales.porcentaje}
+                    delta={canecasTotales.utilizadas - canecasTotales.planeadas}
+                    decimalesDelta={1}
                   />
-                  <div className="flex-1">
-                    <p className="text-sm text-foreground">{alerta.producto_nombre}</p>
-                    <p className="text-xs text-brand-brown/70 mt-1">
-                      {alerta.mensaje}
-                    </p>
-                  </div>
                 </div>
-              ))}
+                <BarraProgreso porcentaje={canecasTotales.porcentaje} estado={canecasEstado} />
+                {canecasEstado === 'over' && (
+                  <p className="mt-2 text-xs text-muted-foreground">
+                    {formatearNumero(canecasTotales.porcentaje, 1)}% de lo planeado — el redondeo a 100% nunca
+                    oculta el exceso
+                  </p>
+                )}
+              </div>
             </div>
           )}
-        </div>
-      )}
 
-      {/* Resumen de Productos */}
-      <div className="bg-white rounded-2xl border border-primary/10 shadow-[0_4px_24px_rgba(115,153,28,0.08)] overflow-hidden">
-        <button
-          onClick={() => toggleSection('resumen')}
-          className="w-full px-6 py-4 flex items-center justify-between hover:bg-primary/5 transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <Package className="w-5 h-5 text-primary" />
-            <h3 className="text-lg text-foreground">Resumen de Productos</h3>
-          </div>
-          {expandedSections.resumen ? (
-            <ChevronUp className="w-5 h-5 text-brand-brown/40" />
-          ) : (
-            <ChevronDown className="w-5 h-5 text-brand-brown/40" />
-          )}
-        </button>
-
-        {expandedSections.resumen && (
-          <div className="px-6 pb-4">
-            {resumen.length === 0 ? (
-              <p className="text-sm text-brand-brown/60 text-center py-8">
-                No hay productos planificados
-              </p>
-            ) : (
-              <div className="space-y-4">
-                {resumen.map(item => (
-                  <div key={item.producto_id} className="border-b border-primary/10 pb-4 last:border-0">
-                    <div className="flex items-start justify-between mb-2">
-                      <div className="flex-1">
-                        <p className="text-sm text-foreground">{item.producto_nombre}</p>
-                        <p className="text-xs text-brand-brown/60 mt-1">
-                          {formatearNumero(item.total_utilizado, 2)} / {formatearNumero(item.cantidad_planeada, 2)} {item.producto_unidad}
-                        </p>
-                      </div>
-                      <div className="text-right">
-                        {item.excede_planeado ? (
-                          <span className="inline-block px-2 py-1 bg-red-100 text-red-700 rounded-lg text-xs">
-                            +{formatearNumero(Math.abs(item.diferencia), 2)}
-                          </span>
-                        ) : (
-                          <span className="inline-block px-2 py-1 bg-primary/10 text-primary rounded-lg text-xs">
-                            {formatearNumero(item.porcentaje_usado, 0)}%
-                          </span>
-                        )}
-                      </div>
-                    </div>
-
-                    {/* Barra de progreso */}
-                    <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
-                      <div
-                        className={`h-full transition-all ${
-                          item.excede_planeado
-                            ? 'bg-red-500'
-                            : item.porcentaje_usado >= 90
-                            ? 'bg-amber-500'
-                            : 'bg-primary'
-                        }`}
-                        style={{ width: `${Math.min(item.porcentaje_usado, 100)}%` }}
-                      />
-                    </div>
-                  </div>
-                ))}
+          <div className="grid gap-5 md:grid-cols-2">
+            {/* Alertas */}
+            {alertas.length > 0 && (
+              <div className="rounded-2xl border border-border bg-card p-5 shadow-sm">
+                <div className="mb-3 flex items-center gap-2">
+                  <AlertTriangle className="size-[18px] text-warning" />
+                  <h3 className="text-[0.92rem] font-semibold text-foreground">Alertas</h3>
+                  <Badge variant="outline" className="ml-auto border-border bg-muted text-muted-foreground">
+                    {alertas.length}
+                  </Badge>
+                </div>
+                <div className="flex flex-col gap-2">
+                  {alertas.map((alerta, idx) => (
+                    <Alert
+                      key={idx}
+                      variant={alerta.tipo === 'error' ? 'destructive' : alerta.tipo === 'warning' ? 'warning' : 'default'}
+                    >
+                      {alerta.tipo === 'error' ? <AlertCircle /> : <AlertTriangle />}
+                      <AlertTitle>{alerta.producto_nombre}</AlertTitle>
+                      <AlertDescription>{alerta.mensaje}</AlertDescription>
+                    </Alert>
+                  ))}
+                </div>
               </div>
             )}
-          </div>
-        )}
-      </div>
 
-      {/* Lista de Movimientos */}
-      <div className="bg-white rounded-2xl border border-primary/10 shadow-[0_4px_24px_rgba(115,153,28,0.08)] overflow-hidden">
-        <button
-          onClick={() => toggleSection('movimientos')}
-          className="w-full px-6 py-4 flex items-center justify-between hover:bg-primary/5 transition-colors"
-        >
-          <div className="flex items-center gap-3">
-            <TrendingUp className="w-5 h-5 text-primary" />
-            <h3 className="text-lg text-foreground">
-              Movimientos Registrados ({movimientos.length})
-            </h3>
-          </div>
-          {expandedSections.movimientos ? (
-            <ChevronUp className="w-5 h-5 text-brand-brown/40" />
-          ) : (
-            <ChevronDown className="w-5 h-5 text-brand-brown/40" />
-          )}
-        </button>
-
-        {expandedSections.movimientos && (
-          <div className="px-6 pb-4">
-            {movimientos.length === 0 ? (
-              <div className="text-center py-8">
-                <Package className="w-12 h-12 text-primary/20 mx-auto mb-3" />
-                <p className="text-sm text-brand-brown/60">
-                  No hay movimientos registrados
-                </p>
-                <p className="text-xs text-brand-brown/40 mt-1">
-                  Registra el primer movimiento diario
-                </p>
-              </div>
-            ) : (
-              <div className="space-y-3">
-                {movimientos.map(mov => (
-                  <div
-                    key={mov.id}
-                    className="bg-background border border-primary/20 rounded-xl p-4 hover:border-primary/40 transition-colors"
-                  >
-                    {/* Header del movimiento */}
-                    <div className="flex items-start justify-between mb-3">
-                      <div className="flex-1">
-                        <div className="flex items-center gap-3 mb-2">
-                          <div className="flex items-center gap-2 text-sm text-foreground">
-                            <Calendar className="w-4 h-4 text-primary" />
-                            {/* 🚨 FIX: Parsear fecha sin conversión de timezone */}
-                            {(() => {
-                              const [year, month, day] = mov.fecha_movimiento.split('-');
-                              const fecha = new Date(parseInt(year), parseInt(month) - 1, parseInt(day));
-                              return fecha.toLocaleDateString('es-CO', {
-                                day: '2-digit',
-                                month: 'short',
-                                year: 'numeric'
-                              });
-                            })()}
+            {/* Resumen de Productos */}
+            <div className={cn('rounded-2xl border border-border bg-card shadow-sm', alertas.length === 0 && 'md:col-span-2')}>
+              <Collapsible open={resumenAbierto} onOpenChange={setResumenAbierto}>
+                <CollapsibleTrigger className="flex w-full items-center gap-2 rounded-t-2xl px-5 py-4 text-left hover:bg-primary/5">
+                  <Package className="size-[18px] text-primary" />
+                  <h3 className="text-[0.92rem] font-semibold text-foreground">Resumen de Productos</h3>
+                  <ChevronDown
+                    className={cn('ml-auto size-4 text-muted-foreground transition-transform', resumenAbierto && 'rotate-180')}
+                  />
+                </CollapsibleTrigger>
+                <CollapsibleContent className="px-5 pb-5">
+                  {resumen.length === 0 ? (
+                    <p className="py-6 text-center text-sm text-muted-foreground">No hay productos planificados</p>
+                  ) : (
+                    <div className="flex flex-col">
+                      {resumen.map((item, idx) => {
+                        const estado = estadoProgreso(item.porcentaje_usado, item.excede_planeado);
+                        return (
+                          <div key={item.producto_id} className={cn('py-3', idx > 0 && 'border-t border-border/60')}>
+                            <div className="mb-1 flex items-start justify-between gap-3">
+                              <div>
+                                <p className="text-sm font-medium text-foreground">{item.producto_nombre}</p>
+                                <p className="mt-0.5 text-xs tabular-nums text-muted-foreground">
+                                  {formatearNumero(item.total_utilizado, 2)} / {formatearNumero(item.cantidad_planeada, 2)}{' '}
+                                  {item.producto_unidad}
+                                </p>
+                              </div>
+                              <BadgeProgreso
+                                excede={item.excede_planeado}
+                                porcentaje={item.porcentaje_usado}
+                                delta={item.diferencia}
+                                decimalesDelta={2}
+                              />
+                            </div>
+                            <BarraProgreso porcentaje={item.porcentaje_usado} estado={estado} />
                           </div>
-                          
-                          {/* Mostrar canecas o bultos según el tipo de aplicación */}
-                          {mov.numero_canecas !== undefined && mov.numero_canecas !== null && (
-                            <div className="flex items-center gap-2 px-3 py-1 bg-primary/10 rounded-lg">
-                              <Droplet className="w-4 h-4 text-primary" />
-                              <span className="text-sm text-foreground">
-                                {mov.numero_canecas} caneca{mov.numero_canecas !== 1 ? 's' : ''}
-                              </span>
-                            </div>
-                          )}
-                          
-                          {mov.numero_bultos !== undefined && mov.numero_bultos !== null && (
-                            <div className="flex items-center gap-2 px-3 py-1 bg-primary/10 rounded-lg">
-                              <Package className="w-4 h-4 text-primary" />
-                              <span className="text-sm text-foreground">
-                                {mov.numero_bultos} bulto{mov.numero_bultos !== 1 ? 's' : ''}
-                              </span>
-                            </div>
-                          )}
-                        </div>
-                        <p className="text-xs text-brand-brown/70">{mov.lote_nombre}</p>
-                      </div>
-                      <button
-                        onClick={() => handleEliminarMovimiento(mov.id!)}
-                        className="text-red-500 hover:text-red-700 p-2 rounded-lg hover:bg-red-50 transition-colors"
-                        title="Eliminar movimiento"
-                        aria-label="Eliminar movimiento"
-                      >
-                        <Trash2 className="w-4 h-4" />
-                      </button>
+                        );
+                      })}
                     </div>
+                  )}
+                </CollapsibleContent>
+              </Collapsible>
+            </div>
+          </div>
 
-                    {/* Productos del movimiento */}
-                    <div className="space-y-2 mb-3">
+          {/* Movimientos Registrados */}
+          <div className="rounded-2xl border border-border bg-card shadow-sm">
+            <div className="flex items-center gap-3 px-5 py-4">
+              <div className="flex size-8 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <TrendingUp className="size-4" />
+              </div>
+              <h3 className="text-[0.95rem] font-semibold text-foreground">Movimientos Registrados</h3>
+              <Badge variant="outline" className="ml-auto border-border bg-muted text-muted-foreground">
+                {movimientos.length}
+              </Badge>
+            </div>
+
+            <Accordion
+              type="multiple"
+              defaultValue={movimientos[0]?.id ? [movimientos[0].id] : []}
+              key={movimientos[0]?.id ?? 'sin-movimientos'}
+              className="border-t border-border"
+            >
+              {movimientos.map(mov => (
+                <AccordionItem key={mov.id} value={mov.id!} className="border-t-0 border-b border-border px-5 last:border-b-0">
+                  <AccordionTrigger className="items-center hover:no-underline">
+                    <div className="min-w-0 flex-1 text-left">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="flex items-center gap-1.5 text-sm font-medium text-foreground">
+                          <CalendarIcon className="size-[13px] text-primary" />
+                          {formatShortDate(mov.fecha_movimiento)}
+                        </span>
+                        <span className="inline-flex items-center rounded-md bg-primary/10 px-2 py-0.5 text-xs font-medium text-primary">
+                          {mov.numero_canecas != null
+                            ? `${formatearNumero(mov.numero_canecas, 1)} caneca${mov.numero_canecas === 1 ? '' : 's'}`
+                            : `${formatearNumero(mov.numero_bultos ?? 0, 0)} bulto${mov.numero_bultos === 1 ? '' : 's'}`}
+                        </span>
+                      </div>
+                      <p className="mt-0.5 text-xs text-muted-foreground">{mov.lote_nombre}</p>
+                    </div>
+                  </AccordionTrigger>
+                  <AccordionContent>
+                    <div className="flex flex-col gap-2 sm:grid sm:grid-cols-2">
                       {mov.productos.map((producto, idx) => (
-                        <div
-                          key={idx}
-                          className="flex items-center justify-between bg-white rounded-lg p-3 border border-primary/10"
-                        >
-                          <div className="flex items-center gap-3">
-                            <Package className="w-4 h-4 text-primary" />
-                            <div>
-                              <p className="text-sm text-foreground">{producto.producto_nombre}</p>
-                              <p className="text-xs text-brand-brown/60">{producto.producto_categoria}</p>
-                            </div>
+                        <div key={idx} className="flex items-center justify-between gap-3 rounded-lg bg-muted px-3 py-2.5">
+                          <div className="min-w-0">
+                            <p className="text-sm font-medium text-foreground">{producto.producto_nombre}</p>
+                            <p className="text-xs text-muted-foreground">{producto.producto_categoria}</p>
                           </div>
-                          <div className="text-right">
-                            <p className="text-sm text-foreground">
-                              {/* 🚨 FIX: Mapear unidades abreviadas a nombres amigables */}
-                              {producto.cantidad_utilizada} {(() => {
-                                const unidadMap: Record<string, string> = {
-                                  'L': 'L',
-                                  'cc': 'cc',
-                                  'Kg': 'Kg',
-                                  'g': 'g',
-                                  'litros': 'L',
-                                  'kilos': 'Kg'
-                                };
-                                return unidadMap[producto.unidad] || producto.unidad;
-                              })()}
-                            </p>
-                          </div>
+                          <p className="whitespace-nowrap text-sm font-medium tabular-nums text-foreground">
+                            {formatearNumero(producto.cantidad_utilizada, 2)}{' '}
+                            {MAPA_UNIDAD_CORTA[producto.unidad] ?? producto.unidad}
+                          </p>
                         </div>
                       ))}
                     </div>
 
-                    {/* Footer del movimiento */}
-                    <div className="flex items-center justify-between pt-3 border-t border-primary/10">
-                      <div className="flex items-center gap-2 text-xs text-brand-brown/70">
-                        <User className="w-3 h-3" />
-                        {mov.responsable}
-                      </div>
-                      {mov.notas && (
-                        <p className="text-xs text-brand-brown/60 italic max-w-xs truncate">
-                          "{mov.notas}"
-                        </p>
-                      )}
+                    <div className="mt-3 flex items-center justify-between gap-3 border-t border-border/60 pt-3">
+                      <span className="flex items-center gap-1.5 text-xs text-muted-foreground">
+                        <User className="size-3" /> {mov.responsable}
+                      </span>
+                      <button
+                        type="button"
+                        onClick={() => handleEliminarMovimiento(mov.id!)}
+                        aria-label="Eliminar movimiento"
+                        className="rounded-lg p-1.5 text-destructive transition-colors hover:bg-destructive/10"
+                      >
+                        <Trash2 className="size-4" />
+                      </button>
                     </div>
-                  </div>
-                ))}
-              </div>
-            )}
+
+                    {mov.notas && <p className="mt-2 text-xs italic text-muted-foreground">"{mov.notas}"</p>}
+                  </AccordionContent>
+                </AccordionItem>
+              ))}
+            </Accordion>
           </div>
-        )}
-      </div>
+
+          {/* CTA fijo al alcance del pulgar en móvil — en escritorio vive en las acciones del header.
+              El pr-20 no es estético: la burbuja flotante de Esco es `fixed` abajo a la derecha
+              (56px + su margen) y se monta ENCIMA de este botón. Medido a 375px sin el padding, le
+              tapaba 48px del borde derecho al único CTA primario de la pantalla más usada en campo.
+              El padding lo aparta en vez de bajar el z-index de Esco, que es global y no de esta pantalla. */}
+          <div className="sticky bottom-4 z-10 pr-20 sm:hidden">
+            <Button onClick={() => setFormOpen(true)} className="w-full shadow-lg">
+              <Plus className="size-4" />
+              Nuevo Movimiento
+            </Button>
+          </div>
+        </div>
+      )}
+
+      <DailyMovementForm
+        aplicacion={aplicacion}
+        open={formOpen}
+        onOpenChange={setFormOpen}
+        onSuccess={() => {
+          setFormOpen(false);
+          loadMovimientos();
+        }}
+      />
 
       {/* CONFIRM DIALOG — ELIMINAR MOVIMIENTO */}
       <ConfirmDialog
         open={confirmEliminarMovimientoId !== null}
-        onOpenChange={(open) => { if (!open) setConfirmEliminarMovimientoId(null); }}
+        onOpenChange={(open) => {
+          if (!open) setConfirmEliminarMovimientoId(null);
+        }}
         title="¿Estás seguro de eliminar este movimiento y todos sus productos?"
         description="Esta acción no se puede deshacer."
         confirmLabel="Eliminar"
         onConfirm={confirmarEliminarMovimiento}
         destructive
       />
-
-      {/* Botón para exportar */}
-      {movimientos.length > 0 && (
-        <div className="text-right">
-          <Button
-            onClick={exportarACSV}
-            className="bg-primary hover:bg-primary-dark text-white"
-          >
-            <Download className="w-4 h-4 mr-2" />
-            Exportar a CSV
-          </Button>
-        </div>
-      )}
-    </div>
+    </AplicacionShell>
   );
 }

--- a/src/components/aplicaciones/DailyMovementsDashboardWrapper.tsx
+++ b/src/components/aplicaciones/DailyMovementsDashboardWrapper.tsx
@@ -1,11 +1,33 @@
-import { useState, useEffect } from 'react';
+import { useCallback, useEffect, useState } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
+import { AlertTriangle, RefreshCw } from 'lucide-react';
 import { DailyMovementsDashboard } from './DailyMovementsDashboard';
+import { AplicacionShell } from './shared/AplicacionShell';
+import { Empty, EmptyContent, EmptyDescription, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { Button } from '@/components/ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import { Skeleton } from '@/components/ui/skeleton';
 import { getSupabase } from '../../utils/supabase/client';
 import type { Aplicacion } from '../../types/aplicaciones';
 
+const APLICACION_NO_ENCONTRADA = 'Aplicación no encontrada';
+
 /**
- * Wrapper que obtiene la aplicación desde la URL y la pasa al dashboard
+ * `true` si el error luce como el `TypeError: Failed to fetch` que dispara D8 en
+ * navegación fría (señal intermitente, servidor caído a mitad de carga). Distinto de
+ * "Aplicación no encontrada", que es un 404 real donde reintentar no cambia nada.
+ */
+function esErrorDeRed(mensaje: string): boolean {
+  return /failed to fetch|network|conexión|connection/i.test(mensaje);
+}
+
+/**
+ * Wrapper que obtiene la aplicación desde la URL y la pasa al dashboard.
+ *
+ * D8: la navegación fría a esta ruta puede fallar con `TypeError: Failed to fetch`
+ * (señal de campo intermitente). Antes el único camino era "Volver a Aplicaciones" —
+ * ahora el estado de error ofrece Reintentar como acción primaria (vuelve a llamar
+ * loadAplicacion) y Volver como secundaria.
  */
 export function DailyMovementsDashboardWrapper() {
   const { id } = useParams<{ id: string }>();
@@ -14,81 +36,93 @@ export function DailyMovementsDashboardWrapper() {
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
 
-  useEffect(() => {
-    if (!id) {
-      navigate('/aplicaciones');
-      return;
-    }
-
-    loadAplicacion();
-  }, [id]);
-
-  const loadAplicacion = async () => {
+  const loadAplicacion = useCallback(async () => {
+    if (!id) return;
     try {
       setLoading(true);
       setError(null);
       const supabase = getSupabase();
 
-      const { data, error } = await supabase
+      const { data, error: fetchError } = await supabase
         .from('aplicaciones')
         .select('*')
-        .eq('id', id!)
+        .eq('id', id)
         .single();
 
-      if (error) throw error;
+      if (fetchError) throw fetchError;
 
       if (!data) {
-        setError('Aplicación no encontrada');
+        setError(APLICACION_NO_ENCONTRADA);
         return;
       }
 
       setAplicacion(data as Aplicacion);
     } catch (err: any) {
-      setError(err.message || 'Error cargando la aplicación');
+      setError(err?.message || 'Error cargando la aplicación');
     } finally {
       setLoading(false);
     }
-  };
+  }, [id]);
 
-  const handleClose = () => {
-    navigate('/aplicaciones');
-  };
+  useEffect(() => {
+    if (!id) {
+      navigate('/aplicaciones');
+      return;
+    }
+    loadAplicacion();
+  }, [id, loadAplicacion, navigate]);
 
   if (loading) {
     return (
-      <div className="flex items-center justify-center min-h-[400px]">
-        <div className="text-center">
-          <div className="inline-block w-12 h-12 border-4 border-primary/20 border-t-primary rounded-full animate-spin mb-4"></div>
-          <p className="text-brand-brown/70">Cargando aplicación...</p>
+      <AplicacionShell titulo="Movimientos Diarios">
+        <div className="flex flex-col items-center justify-center gap-3 py-10">
+          <Spinner className="size-8 text-primary" />
+          <p className="text-sm text-muted-foreground">Cargando aplicación…</p>
         </div>
-      </div>
+        <div className="space-y-4">
+          <Skeleton className="h-24 w-full rounded-2xl" />
+          <Skeleton className="h-40 w-full rounded-2xl" />
+          <Skeleton className="h-24 w-full rounded-2xl" />
+        </div>
+      </AplicacionShell>
     );
   }
 
   if (error || !aplicacion) {
+    const mensaje = error ?? 'No se pudo cargar la aplicación.';
+    // "Aplicación no encontrada" es un 404 real — reintentar no cambia nada, así que se
+    // muestra tal cual. Cualquier otra falla que luzca como `Failed to fetch` (D8, señal
+    // intermitente) recibe el mensaje orientado a conexión; el resto muestra el error real.
+    const descripcion =
+      mensaje === APLICACION_NO_ENCONTRADA
+        ? mensaje
+        : esErrorDeRed(mensaje)
+          ? 'Parece un problema de conexión. Verifica tu señal e intenta de nuevo — no se perdió ningún dato.'
+          : mensaje;
+
     return (
-      <div className="text-center py-12">
-        <div className="inline-flex items-center justify-center w-20 h-20 bg-red-100 rounded-2xl mb-4">
-          <span className="text-3xl">⚠️</span>
-        </div>
-        <h2 className="text-2xl text-foreground mb-2">Error</h2>
-        <p className="text-brand-brown/70 mb-4">
-          {error || 'No se pudo cargar la aplicación'}
-        </p>
-        <button
-          onClick={handleClose}
-          className="px-6 py-2 bg-primary hover:bg-primary-dark text-white rounded-xl transition-colors"
-        >
-          Volver a Aplicaciones
-        </button>
-      </div>
+      <AplicacionShell titulo="Movimientos Diarios">
+        <Empty>
+          <EmptyMedia variant="icon" className="bg-destructive/10 text-destructive">
+            <AlertTriangle />
+          </EmptyMedia>
+          <EmptyTitle>No pudimos cargar los movimientos</EmptyTitle>
+          <EmptyDescription>{descripcion}</EmptyDescription>
+          <EmptyContent>
+            <div className="flex flex-wrap items-center justify-center gap-3">
+              <Button onClick={loadAplicacion}>
+                <RefreshCw className="size-4" />
+                Reintentar
+              </Button>
+              <Button variant="outline" onClick={() => navigate('/aplicaciones')}>
+                Volver a Aplicaciones
+              </Button>
+            </div>
+          </EmptyContent>
+        </Empty>
+      </AplicacionShell>
     );
   }
 
-  return (
-    <DailyMovementsDashboard 
-      aplicacion={aplicacion} 
-      onClose={handleClose}
-    />
-  );
+  return <DailyMovementsDashboard aplicacion={aplicacion} />;
 }

--- a/src/components/aplicaciones/DetalleAplicacion.tsx
+++ b/src/components/aplicaciones/DetalleAplicacion.tsx
@@ -8,6 +8,7 @@ import { generarPDFReporteCierre } from '../../utils/generarPDFReporteCierre';
 import { fetchDatosReporteCierre } from '../../utils/fetchDatosReporteCierre';
 import type { Aplicacion, ListaCompras } from '../../types/aplicaciones';
 import { toast } from 'sonner';
+import { formatearNumero } from '../../utils/format';
 
 interface DetalleAplicacionProps {
   aplicacion: Aplicacion;
@@ -481,9 +482,10 @@ export function DetalleAplicacion({
               <span className={`px-3 py-1.5 rounded-lg text-sm border ${getEstadoBadge(aplicacion.estado ?? '')}`}>
                 {aplicacion.estado}
               </span>
-              <button 
-                onClick={onClose} 
+              <button
+                onClick={onClose}
                 className="p-2 hover:bg-white/20 rounded-lg transition-colors text-white"
+                aria-label="Cerrar"
               >
                 <X className="w-5 h-5" />
               </button>
@@ -591,13 +593,13 @@ export function DetalleAplicacion({
                   <div className="grid grid-cols-3 gap-4">
                     <div className="text-center p-4 bg-background rounded-xl">
                       <p className="text-xs text-brand-brown/60 mb-1">Planeado</p>
-                      <p className="text-2xl text-foreground">{canecasPlaneadas.toFixed(1)}</p>
+                      <p className="text-2xl text-foreground">{formatearNumero(canecasPlaneadas, 1)}</p>
                     </div>
                     <div className="text-center p-4 bg-primary/5 rounded-xl">
                       <p className="text-xs text-brand-brown/60 mb-1">Aplicado</p>
-                      <p className="text-2xl text-primary">{canecasAplicadas.toFixed(1)}</p>
+                      <p className="text-2xl text-primary">{formatearNumero(canecasAplicadas, 1)}</p>
                       <p className="text-xs text-brand-brown/60 mt-1">
-                        ({canecasPlaneadas > 0 ? ((canecasAplicadas / canecasPlaneadas) * 100).toFixed(0) : 0}%)
+                        ({canecasPlaneadas > 0 ? formatearNumero((canecasAplicadas / canecasPlaneadas) * 100, 0) : 0}%)
                       </p>
                     </div>
                     <div className="text-center p-4 bg-background rounded-xl">
@@ -610,20 +612,20 @@ export function DetalleAplicacion({
                           : 'text-gray-600'
                       }`}>
                         {canecasAplicadas > canecasPlaneadas ? '+' : ''}
-                        {(canecasAplicadas - canecasPlaneadas).toFixed(1)}
+                        {formatearNumero(canecasAplicadas - canecasPlaneadas, 1)}
                       </p>
                       <p className="text-xs text-brand-brown/60 mt-1">
-                        ({canecasPlaneadas > 0 ? (((canecasAplicadas - canecasPlaneadas) / canecasPlaneadas) * 100).toFixed(0) : 0}%)
+                        ({canecasPlaneadas > 0 ? formatearNumero(((canecasAplicadas - canecasPlaneadas) / canecasPlaneadas) * 100, 0) : 0}%)
                       </p>
                     </div>
                   </div>
-                  
+
                   {/* Barra de progreso */}
                   <div className="mt-4">
                     <div className="flex items-center justify-between mb-2">
                       <span className="text-xs text-brand-brown/60">Progreso</span>
                       <span className="text-xs text-foreground">
-                        {canecasPlaneadas > 0 ? ((canecasAplicadas / canecasPlaneadas) * 100).toFixed(0) : 0}%
+                        {canecasPlaneadas > 0 ? formatearNumero((canecasAplicadas / canecasPlaneadas) * 100, 0) : 0}%
                       </span>
                     </div>
                     <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
@@ -682,14 +684,14 @@ export function DetalleAplicacion({
                                 <div className="text-xs text-brand-brown/50 mt-0.5">{insumo.unidad}</div>
                               </td>
                               <td className="py-3 px-4 text-right text-sm text-foreground">
-                                {insumo.planeado.toFixed(2)}
+                                {formatearNumero(insumo.planeado, 2)}
                               </td>
                               <td className="py-3 px-4 text-right">
                                 <div className="text-sm text-primary">
-                                  {insumo.aplicado.toFixed(2)}
+                                  {formatearNumero(insumo.aplicado, 2)}
                                 </div>
                                 <div className="text-xs text-brand-brown/50 mt-0.5">
-                                  {porcentaje.toFixed(0)}%
+                                  {formatearNumero(porcentaje, 0)}%
                                 </div>
                               </td>
                               <td className="py-3 px-4 text-right">
@@ -702,7 +704,7 @@ export function DetalleAplicacion({
                                 }`}>
                                   {diferencia > 0 && <TrendingUp className="w-3 h-3" />}
                                   {diferencia > 0 ? '+' : ''}
-                                  {diferencia.toFixed(2)}
+                                  {formatearNumero(diferencia, 2)}
                                 </span>
                               </td>
                             </tr>

--- a/src/components/aplicaciones/DetalleAplicacion.tsx
+++ b/src/components/aplicaciones/DetalleAplicacion.tsx
@@ -1,14 +1,46 @@
 import { useState, useEffect } from 'react';
 import { useNavigate } from 'react-router-dom';
-import { X, Edit, PlayCircle, CheckCircle, Calendar, Droplet, Package, MapPin, Target, TrendingUp, ShoppingCart, FileText, DollarSign, Users, Loader2, BarChart2, Play } from 'lucide-react';
+import {
+  Edit,
+  CheckCircle,
+  Calendar,
+  Droplet,
+  Package,
+  MapPin,
+  Target,
+  TrendingUp,
+  ShoppingCart,
+  FileText,
+  DollarSign,
+  Users,
+  BarChart2,
+  Play,
+  ClipboardList,
+  type LucideIcon,
+} from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
 import { Button } from '../ui/button';
+import { Spinner } from '@/components/ui/spinner';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogDescription,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { Progress } from '@/components/ui/progress';
+import { Table, TableBody, TableCell, TableHead, TableHeader, TableRow } from '@/components/ui/table';
+import { ToggleGroup, ToggleGroupItem } from '@/components/ui/toggle-group';
+import { cn } from '@/components/ui/utils';
+import { EstadoAplicacionBadge } from './shared/EstadoAplicacionBadge';
 import { generarPDFListaCompras } from '../../utils/generarPDFListaCompras';
 import { generarPDFReporteCierre } from '../../utils/generarPDFReporteCierre';
 import { fetchDatosReporteCierre } from '../../utils/fetchDatosReporteCierre';
 import type { Aplicacion, ListaCompras } from '../../types/aplicaciones';
 import { toast } from 'sonner';
-import { formatearNumero } from '../../utils/format';
+import { formatearNumero, formatearMoneda } from '../../utils/format';
 
 interface DetalleAplicacionProps {
   aplicacion: Aplicacion;
@@ -24,6 +56,31 @@ interface ResumenInsumo {
   unidad: string;
   planeado: number;
   aplicado: number;
+}
+
+/** Marco de sub-sección compartido dentro del diálogo: icono + título + cuerpo con padding.
+ * Local a este archivo — no se promueve a `shared/` porque solo lo usan las 3 secciones de
+ * abajo (Información General, Resumen de Canecas/Bultos, Resumen de Cierre). La sección de
+ * productos NO lo usa: `Table` ya trae su propio borde/redondeo y anidarla aquí dibujaría un
+ * borde dentro de otro borde. */
+function SeccionDetalle({
+  icon: Icon,
+  titulo,
+  children,
+}: {
+  icon: LucideIcon;
+  titulo: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div className="overflow-hidden rounded-2xl border border-border bg-card">
+      <div className="flex items-center gap-2 border-b border-border bg-primary/5 px-5 py-3">
+        <Icon className="size-4 text-primary" aria-hidden="true" />
+        <h3 className="text-sm font-medium text-foreground">{titulo}</h3>
+      </div>
+      <div className="p-5">{children}</div>
+    </div>
+  );
 }
 
 export function DetalleAplicacion({
@@ -107,7 +164,7 @@ export function DetalleAplicacion({
               .from('plagas_enfermedades_catalogo')
               .select('nombre')
               .in('id', bb);
-            
+
             setBlancoBiologico(plagas?.map(p => p.nombre).join(', ') || 'No especificado');
           } else {
             setBlancoBiologico('No especificado');
@@ -222,7 +279,7 @@ export function DetalleAplicacion({
 
       if (mezclas && mezclas.length > 0) {
         const mezclasIds = mezclas.map(m => m.id);
-        
+
         const result = await supabase
           .from('aplicaciones_productos')
           .select('producto_id, producto_nombre, producto_unidad, cantidad_total_necesaria, mezcla_id, dosis_grandes, dosis_medianos, dosis_pequenos, dosis_clonales')
@@ -306,7 +363,7 @@ export function DetalleAplicacion({
       // Agregar aplicados (convirtiendo a unidad base si es necesario)
       productosAplicados?.forEach((prod) => {
         const key = prod.producto_id;
-        
+
         // Convertir a unidad base (L o Kg)
         let cantidadEnUnidadBase = prod.cantidad_utilizada;
         if (prod.unidad === 'cc') {
@@ -314,7 +371,7 @@ export function DetalleAplicacion({
         } else if (prod.unidad === 'g') {
           cantidadEnUnidadBase = prod.cantidad_utilizada / 1000;
         }
-        
+
         if (!insumosMap.has(key)) {
           // Si no existe en planeados, crear entrada
           insumosMap.set(key, {
@@ -342,27 +399,17 @@ export function DetalleAplicacion({
     if (!fecha) return '-';
     // Extraer año, mes, día directamente del string para evitar problemas de zona horaria
     const [year, month, day] = fecha.split('T')[0].split('-');
-    
+
     const meses = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
     const mesNombre = meses[parseInt(month) - 1];
-    
+
     return `${parseInt(day)} de ${mesNombre} de ${year}`;
   };
 
-  const getEstadoBadge = (estado: string) => {
-    const styles = {
-      Calculada: 'bg-blue-50 border-blue-200 text-blue-700',
-      Programada: 'bg-purple-50 border-purple-200 text-purple-700',
-      'En ejecución': 'bg-amber-50 border-amber-200 text-amber-700',
-      Cerrada: 'bg-green-50 border-green-200 text-green-700',
-    };
-    return styles[estado as keyof typeof styles] || 'bg-gray-50 border-gray-200 text-gray-700';
-  };
-
   const getTipoIcon = () => {
-    if (aplicacion.tipo_aplicacion === 'Fumigación') return <Droplet className="w-5 h-5" />;
-    if (aplicacion.tipo_aplicacion === 'Fertilización') return <Package className="w-5 h-5" />;
-    return <Target className="w-5 h-5" />;
+    if (aplicacion.tipo_aplicacion === 'Fumigación') return <Droplet className="size-[18px]" aria-hidden="true" />;
+    if (aplicacion.tipo_aplicacion === 'Fertilización') return <Package className="size-[18px]" aria-hidden="true" />;
+    return <Target className="size-[18px]" aria-hidden="true" />;
   };
 
   const getTipoNombre = () => {
@@ -446,442 +493,357 @@ export function DetalleAplicacion({
     }
   };
 
-  const formatearMonedaLocal = (valor: number) => {
-    return new Intl.NumberFormat('es-CO', {
-      style: 'currency',
-      currency: 'COP',
-      minimumFractionDigits: 0,
-    }).format(valor);
-  };
+  const diferenciaCanecas = canecasAplicadas - canecasPlaneadas;
+  const porcentajeAplicado = canecasPlaneadas > 0 ? (canecasAplicadas / canecasPlaneadas) * 100 : 0;
+  const progresoPct = canecasPlaneadas > 0 ? Math.min((canecasAplicadas / canecasPlaneadas) * 100, 100) : 0;
 
   return (
-    <div
-      className="fixed inset-0 bg-black/40 backdrop-blur-sm flex items-center justify-center z-50 p-4"
-      onClick={onClose}
-    >
-      <div 
-        className="bg-background rounded-3xl shadow-[0_8px_48px_rgba(115,153,28,0.15)] max-w-5xl w-full max-h-[92vh] overflow-hidden flex flex-col"
-        onClick={(e) => e.stopPropagation()}
-      >
-        {/* HEADER con diseño mejorado */}
-        <div className="relative bg-gradient-to-r from-primary to-primary-dark px-6 py-5">
-          <div className="absolute inset-0 bg-[url('data:image/svg+xml;base64,PHN2ZyB3aWR0aD0iMjAwIiBoZWlnaHQ9IjIwMCIgeG1sbnM9Imh0dHA6Ly93d3cudzMub3JnLzIwMDAvc3ZnIj48ZGVmcz48cGF0dGVybiBpZD0iZ3JpZCIgd2lkdGg9IjQwIiBoZWlnaHQ9IjQwIiBwYXR0ZXJuVW5pdHM9InVzZXJTcGFjZU9uVXNlIj48cGF0aCBkPSJNIDQwIDAgTCAwIDAgMCA0MCIgZmlsbD0ibm9uZSIgc3Ryb2tlPSJ3aGl0ZSIgc3Ryb2tlLW9wYWNpdHk9IjAuMSIgc3Ryb2tlLXdpZHRoPSIxIi8+PC9wYXR0ZXJuPjwvZGVmcz48cmVjdCB3aWR0aD0iMTAwJSIgaGVpZ2h0PSIxMDAlIiBmaWxsPSJ1cmwoI2dyaWQpIi8+PC9zdmc+')] opacity-30"></div>
-          
-          <div className="relative flex items-center justify-between">
-            <div className="flex items-center gap-4">
-              <div className="w-12 h-12 bg-white/20 backdrop-blur-sm rounded-xl flex items-center justify-center text-white">
+    <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+      <DialogContent size="lg">
+        <DialogHeader>
+          <div className="flex items-start justify-between gap-4 pr-6">
+            <div className="flex min-w-0 items-center gap-3">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
                 {getTipoIcon()}
               </div>
-              <div>
-                <h2 className="text-xl text-white">{aplicacion.nombre_aplicacion}</h2>
-                <p className="text-sm text-white/80 mt-0.5">{getTipoNombre()}</p>
+              <div className="min-w-0">
+                <DialogTitle className="truncate">{aplicacion.nombre_aplicacion}</DialogTitle>
+                <p className="mt-0.5 text-sm text-muted-foreground">{getTipoNombre()}</p>
               </div>
             </div>
-            
-            <div className="flex items-center gap-3">
-              <span className={`px-3 py-1.5 rounded-lg text-sm border ${getEstadoBadge(aplicacion.estado ?? '')}`}>
-                {aplicacion.estado}
-              </span>
-              <button
-                onClick={onClose}
-                className="p-2 hover:bg-white/20 rounded-lg transition-colors text-white"
-                aria-label="Cerrar"
-              >
-                <X className="w-5 h-5" />
-              </button>
-            </div>
+            <EstadoAplicacionBadge estado={aplicacion.estado} className="shrink-0" />
           </div>
-        </div>
+          <DialogDescription className="sr-only">
+            Detalle de la aplicación {aplicacion.nombre_aplicacion}: información general,
+            resumen de canecas o bultos, productos y — si está cerrada — resumen de cierre.
+          </DialogDescription>
+        </DialogHeader>
 
-        {/* CONTENIDO */}
-        <div className="flex-1 overflow-y-auto p-6">
+        <DialogBody className="space-y-4">
           {loading ? (
-            <div className="flex items-center justify-center h-64">
-              <div className="w-10 h-10 border-4 border-primary/20 border-t-primary rounded-full animate-spin" />
+            <div className="flex h-64 items-center justify-center">
+              <Spinner className="size-8 text-primary" />
             </div>
           ) : (
-            <div className="space-y-5">
-              {/* Card de Información General */}
-              <div className="bg-white rounded-2xl border border-primary/10 shadow-[0_2px_12px_rgba(115,153,28,0.06)] overflow-hidden">
-                <div className="px-5 py-3 bg-gradient-to-r from-primary/5 to-transparent border-b border-primary/10">
-                  <h3 className="text-sm text-foreground flex items-center gap-2">
-                    <Calendar className="w-4 h-4 text-primary" />
-                    Información General
-                  </h3>
-                </div>
-                <div className="p-5">
-                  <div className="grid grid-cols-2 gap-4">
-                    <div className="space-y-1">
-                      <p className="text-xs text-brand-brown/60">Fecha Inicio (Planeada)</p>
-                      <p className="text-sm text-foreground">{formatearFecha(aplicacion.fecha_inicio_planeada ?? null)}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-xs text-brand-brown/60">Fecha Fin (Planeada)</p>
-                      <p className="text-sm text-foreground">{formatearFecha(fechaFinEstimada)}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-xs text-brand-brown/60">Fecha Inicio (Real)</p>
-                      <p className="text-sm text-foreground">{formatearFecha(aplicacion.fecha_inicio_ejecucion ?? null)}</p>
-                    </div>
-                    <div className="space-y-1">
-                      <p className="text-xs text-brand-brown/60">Fecha Fin (Real)</p>
-                      <p className="text-sm text-foreground">
-                        {aplicacion.fecha_cierre ? formatearFecha(aplicacion.fecha_cierre) : (
-                          <span className="text-amber-600">En progreso</span>
-                        )}
-                      </p>
-                    </div>
-                    <div className="space-y-1 col-span-2">
-                      <p className="text-xs text-brand-brown/60">Propósito</p>
-                      <p className="text-sm text-foreground">{aplicacion.proposito || 'No especificado'}</p>
-                    </div>
-                    <div className="space-y-1 col-span-2">
-                      <p className="text-xs text-brand-brown/60 flex items-center gap-1">
-                        <Target className="w-3 h-3" />
-                        Blanco Biológico
-                      </p>
-                      <p className="text-sm text-foreground">{blancoBiologico}</p>
-                    </div>
-                    <div className="space-y-1 col-span-2">
-                      <p className="text-xs text-brand-brown/60 flex items-center gap-1">
-                        <MapPin className="w-3 h-3" />
-                        Lotes {selectedLote && <span className="text-primary font-medium">(filtrado)</span>}
-                      </p>
-                      <div className="flex flex-wrap gap-2">
-                        <button
-                          onClick={() => setSelectedLote(null)}
-                          className={`px-2 py-1 rounded-lg text-xs transition-all ${
-                            !selectedLote
-                              ? 'bg-primary text-white shadow-sm'
-                              : 'bg-gray-100 text-gray-600 hover:bg-gray-200'
-                          }`}
-                        >
-                          Todos
-                        </button>
-                        {lotesData.map((lote, idx) => (
-                          <button
-                            key={idx}
-                            onClick={() => setSelectedLote(lote.id)}
-                            className={`px-2 py-1 rounded-lg text-xs transition-all ${
-                              selectedLote === lote.id
-                                ? 'bg-primary text-white shadow-sm'
-                                : 'bg-primary/10 text-primary hover:bg-primary/20'
-                            }`}
-                          >
-                            {lote.nombre}
-                          </button>
-                        ))}
-                      </div>
-                    </div>
+            <>
+              {/* Información General */}
+              <SeccionDetalle icon={Calendar} titulo="Información General">
+                <div className="grid grid-cols-2 gap-4">
+                  <div className="space-y-1">
+                    <p className="text-xs text-muted-foreground">Fecha Inicio (Planeada)</p>
+                    <p className="text-sm text-foreground">{formatearFecha(aplicacion.fecha_inicio_planeada ?? null)}</p>
                   </div>
-                </div>
-              </div>
-
-              {/* Card de Resumen de Canecas/Bultos */}
-              <div className="bg-white rounded-2xl border border-primary/10 shadow-[0_2px_12px_rgba(115,153,28,0.06)] overflow-hidden">
-                <div className="px-5 py-3 bg-gradient-to-r from-primary/5 to-transparent border-b border-primary/10">
-                  <h3 className="text-sm text-foreground flex items-center gap-2">
-                    {aplicacion.tipo_aplicacion === 'Fertilización' ? (
-                      <Package className="w-4 h-4 text-primary" />
-                    ) : (
-                      <Droplet className="w-4 h-4 text-primary" />
-                    )}
-                    {aplicacion.tipo_aplicacion === 'Fertilización' ? 'Resumen de Bultos' : 'Resumen de Canecas'}
-                  </h3>
-                </div>
-                <div className="p-5">
-                  <div className="grid grid-cols-3 gap-4">
-                    <div className="text-center p-4 bg-background rounded-xl">
-                      <p className="text-xs text-brand-brown/60 mb-1">Planeado</p>
-                      <p className="text-2xl text-foreground">{formatearNumero(canecasPlaneadas, 1)}</p>
-                    </div>
-                    <div className="text-center p-4 bg-primary/5 rounded-xl">
-                      <p className="text-xs text-brand-brown/60 mb-1">Aplicado</p>
-                      <p className="text-2xl text-primary">{formatearNumero(canecasAplicadas, 1)}</p>
-                      <p className="text-xs text-brand-brown/60 mt-1">
-                        ({canecasPlaneadas > 0 ? formatearNumero((canecasAplicadas / canecasPlaneadas) * 100, 0) : 0}%)
-                      </p>
-                    </div>
-                    <div className="text-center p-4 bg-background rounded-xl">
-                      <p className="text-xs text-brand-brown/60 mb-1">Diferencia</p>
-                      <p className={`text-2xl ${
-                        canecasAplicadas > canecasPlaneadas
-                          ? 'text-red-600'
-                          : canecasAplicadas < canecasPlaneadas
-                          ? 'text-amber-600'
-                          : 'text-gray-600'
-                      }`}>
-                        {canecasAplicadas > canecasPlaneadas ? '+' : ''}
-                        {formatearNumero(canecasAplicadas - canecasPlaneadas, 1)}
-                      </p>
-                      <p className="text-xs text-brand-brown/60 mt-1">
-                        ({canecasPlaneadas > 0 ? formatearNumero(((canecasAplicadas - canecasPlaneadas) / canecasPlaneadas) * 100, 0) : 0}%)
-                      </p>
-                    </div>
+                  <div className="space-y-1">
+                    <p className="text-xs text-muted-foreground">Fecha Fin (Planeada)</p>
+                    <p className="text-sm text-foreground">{formatearFecha(fechaFinEstimada)}</p>
                   </div>
-
-                  {/* Barra de progreso */}
-                  <div className="mt-4">
-                    <div className="flex items-center justify-between mb-2">
-                      <span className="text-xs text-brand-brown/60">Progreso</span>
-                      <span className="text-xs text-foreground">
-                        {canecasPlaneadas > 0 ? formatearNumero((canecasAplicadas / canecasPlaneadas) * 100, 0) : 0}%
-                      </span>
-                    </div>
-                    <div className="w-full bg-gray-200 rounded-full h-2 overflow-hidden">
-                      <div
-                        className={`h-full transition-all ${
-                          canecasAplicadas > canecasPlaneadas
-                            ? 'bg-red-500'
-                            : canecasAplicadas >= canecasPlaneadas * 0.9
-                            ? 'bg-amber-500'
-                            : 'bg-primary'
-                        }`}
-                        style={{ 
-                          width: `${canecasPlaneadas > 0 ? Math.min((canecasAplicadas / canecasPlaneadas) * 100, 100) : 0}%` 
-                        }}
-                      />
-                    </div>
+                  <div className="space-y-1">
+                    <p className="text-xs text-muted-foreground">Fecha Inicio (Real)</p>
+                    <p className="text-sm text-foreground">{formatearFecha(aplicacion.fecha_inicio_ejecucion ?? null)}</p>
                   </div>
-                </div>
-              </div>
-
-              {/* Card de Resumen de Insumos */}
-              <div className="bg-white rounded-2xl border border-primary/10 shadow-[0_2px_12px_rgba(115,153,28,0.06)] overflow-hidden">
-                <div className="px-5 py-3 bg-gradient-to-r from-primary/5 to-transparent border-b border-primary/10">
-                  <h3 className="text-sm text-foreground flex items-center gap-2">
-                    <Package className="w-4 h-4 text-primary" />
-                    Resumen de Productos
-                  </h3>
-                </div>
-                <div className="overflow-x-auto">
-                  <table className="w-full">
-                    <thead className="bg-background">
-                      <tr>
-                        <th className="text-left py-3 px-5 text-xs text-brand-brown/70">Producto</th>
-                        <th className="text-right py-3 px-4 text-xs text-brand-brown/70">Planeado</th>
-                        <th className="text-right py-3 px-4 text-xs text-brand-brown/70">Aplicado</th>
-                        <th className="text-right py-3 px-4 text-xs text-brand-brown/70">Diferencia</th>
-                      </tr>
-                    </thead>
-                    <tbody className="divide-y divide-primary/5">
-                      {resumenInsumos.length === 0 ? (
-                        <tr>
-                          <td colSpan={4} className="py-8 text-center">
-                            <Package className="w-10 h-10 text-primary/20 mx-auto mb-2" />
-                            <p className="text-sm text-brand-brown/50">No hay productos registrados</p>
-                          </td>
-                        </tr>
-                      ) : (
-                        resumenInsumos.map((insumo, index) => {
-                          const diferencia = insumo.aplicado - insumo.planeado;
-                          const porcentaje = insumo.planeado > 0 ? (insumo.aplicado / insumo.planeado) * 100 : 0;
-                          
-                          return (
-                            <tr key={index} className="hover:bg-background transition-colors">
-                              <td className="py-3 px-5">
-                                <div className="text-sm text-foreground">{insumo.nombre}</div>
-                                <div className="text-xs text-brand-brown/50 mt-0.5">{insumo.unidad}</div>
-                              </td>
-                              <td className="py-3 px-4 text-right text-sm text-foreground">
-                                {formatearNumero(insumo.planeado, 2)}
-                              </td>
-                              <td className="py-3 px-4 text-right">
-                                <div className="text-sm text-primary">
-                                  {formatearNumero(insumo.aplicado, 2)}
-                                </div>
-                                <div className="text-xs text-brand-brown/50 mt-0.5">
-                                  {formatearNumero(porcentaje, 0)}%
-                                </div>
-                              </td>
-                              <td className="py-3 px-4 text-right">
-                                <span className={`inline-flex items-center gap-1 px-2 py-1 rounded-lg text-sm ${
-                                  diferencia > 0.1
-                                    ? 'bg-red-50 text-red-700'
-                                    : diferencia < -0.1
-                                    ? 'bg-amber-50 text-amber-700'
-                                    : 'bg-gray-50 text-gray-700'
-                                }`}>
-                                  {diferencia > 0 && <TrendingUp className="w-3 h-3" />}
-                                  {diferencia > 0 ? '+' : ''}
-                                  {formatearNumero(diferencia, 2)}
-                                </span>
-                              </td>
-                            </tr>
-                          );
-                        })
+                  <div className="space-y-1">
+                    <p className="text-xs text-muted-foreground">Fecha Fin (Real)</p>
+                    <p className="text-sm text-foreground">
+                      {aplicacion.fecha_cierre ? formatearFecha(aplicacion.fecha_cierre) : (
+                        <span className="text-warning-foreground">En progreso</span>
                       )}
-                    </tbody>
-                  </table>
+                    </p>
+                  </div>
+                  <div className="col-span-2 space-y-1">
+                    <p className="text-xs text-muted-foreground">Propósito</p>
+                    <p className="text-sm text-foreground">{aplicacion.proposito || 'No especificado'}</p>
+                  </div>
+                  <div className="col-span-2 space-y-1">
+                    <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <Target className="size-3" aria-hidden="true" />
+                      Blanco Biológico
+                    </p>
+                    <p className="text-sm text-foreground">{blancoBiologico}</p>
+                  </div>
+                  <div className="col-span-2 space-y-1.5">
+                    <p className="flex items-center gap-1 text-xs text-muted-foreground">
+                      <MapPin className="size-3" aria-hidden="true" />
+                      Lotes {selectedLote && <span className="font-medium text-primary">(filtrado)</span>}
+                    </p>
+                    <ToggleGroup
+                      type="single"
+                      variant="outline"
+                      value={selectedLote ?? 'todos'}
+                      onValueChange={(value) => setSelectedLote(!value || value === 'todos' ? null : value)}
+                      className="h-auto flex-wrap justify-start"
+                      aria-label="Filtrar por lote"
+                    >
+                      <ToggleGroupItem value="todos">Todos</ToggleGroupItem>
+                      {lotesData.map((lote) => (
+                        <ToggleGroupItem key={lote.id} value={lote.id}>
+                          {lote.nombre}
+                        </ToggleGroupItem>
+                      ))}
+                    </ToggleGroup>
+                  </div>
                 </div>
+              </SeccionDetalle>
+
+              {/* Resumen de Canecas/Bultos */}
+              <SeccionDetalle
+                icon={aplicacion.tipo_aplicacion === 'Fertilización' ? Package : Droplet}
+                titulo={aplicacion.tipo_aplicacion === 'Fertilización' ? 'Resumen de Bultos' : 'Resumen de Canecas'}
+              >
+                <div className="grid grid-cols-3 gap-3">
+                  <div className="rounded-xl bg-muted p-4 text-center">
+                    <p className="mb-1 text-xs text-muted-foreground">Planeado</p>
+                    <p className="text-xl font-semibold tabular-nums text-foreground">
+                      {formatearNumero(canecasPlaneadas, 1)}
+                    </p>
+                  </div>
+                  <div className="rounded-xl bg-primary/5 p-4 text-center">
+                    <p className="mb-1 text-xs text-muted-foreground">Aplicado</p>
+                    <p className="text-xl font-semibold tabular-nums text-primary">
+                      {formatearNumero(canecasAplicadas, 1)}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      ({canecasPlaneadas > 0 ? formatearNumero(porcentajeAplicado, 0) : 0}%)
+                    </p>
+                  </div>
+                  <div
+                    className={cn(
+                      'rounded-xl p-4 text-center',
+                      diferenciaCanecas > 0
+                        ? 'bg-destructive/10'
+                        : diferenciaCanecas < 0
+                          ? 'bg-warning/15'
+                          : 'bg-muted',
+                    )}
+                  >
+                    <p className="mb-1 text-xs text-muted-foreground">Diferencia</p>
+                    <p
+                      className={cn(
+                        'text-xl font-semibold tabular-nums',
+                        diferenciaCanecas > 0
+                          ? 'text-destructive'
+                          : diferenciaCanecas < 0
+                            ? 'text-warning-foreground'
+                            : 'text-foreground',
+                      )}
+                    >
+                      {diferenciaCanecas > 0 ? '+' : ''}
+                      {formatearNumero(diferenciaCanecas, 1)}
+                    </p>
+                    <p className="mt-1 text-xs text-muted-foreground">
+                      ({canecasPlaneadas > 0 ? formatearNumero((diferenciaCanecas / canecasPlaneadas) * 100, 0) : 0}%)
+                    </p>
+                  </div>
+                </div>
+
+                <div className="mt-4">
+                  <div className="mb-2 flex items-center justify-between text-xs text-muted-foreground">
+                    <span>Progreso</span>
+                    <span className="text-foreground">
+                      {canecasPlaneadas > 0 ? formatearNumero(porcentajeAplicado, 0) : 0}%
+                    </span>
+                  </div>
+                  <Progress value={progresoPct} />
+                </div>
+              </SeccionDetalle>
+
+              {/* Resumen de Productos — Table ya trae su propio borde/redondeo; no se anida en
+                  SeccionDetalle para no dibujar un borde dentro de otro borde. */}
+              <div>
+                <div className="mb-3 flex items-center gap-2">
+                  <Package className="size-4 text-primary" aria-hidden="true" />
+                  <h3 className="text-sm font-medium text-foreground">Resumen de Productos</h3>
+                </div>
+                <Table>
+                  <TableHeader>
+                    <TableRow>
+                      <TableHead>Producto</TableHead>
+                      <TableHead className="text-right">Planeado</TableHead>
+                      <TableHead className="text-right">Aplicado</TableHead>
+                      <TableHead className="text-right">Diferencia</TableHead>
+                    </TableRow>
+                  </TableHeader>
+                  <TableBody>
+                    {resumenInsumos.length === 0 ? (
+                      <TableRow>
+                        <TableCell colSpan={4} className="whitespace-normal py-8 text-center">
+                          <Package className="mx-auto mb-2 size-8 text-primary/20" aria-hidden="true" />
+                          <p className="text-sm text-muted-foreground">No hay productos registrados</p>
+                        </TableCell>
+                      </TableRow>
+                    ) : (
+                      resumenInsumos.map((insumo, index) => {
+                        const diferencia = insumo.aplicado - insumo.planeado;
+                        const porcentaje = insumo.planeado > 0 ? (insumo.aplicado / insumo.planeado) * 100 : 0;
+
+                        return (
+                          <TableRow key={index}>
+                            <TableCell className="whitespace-normal">
+                              <div className="text-sm text-foreground">{insumo.nombre}</div>
+                              <div className="text-xs text-muted-foreground">{insumo.unidad}</div>
+                            </TableCell>
+                            <TableCell className="text-right">{formatearNumero(insumo.planeado, 2)}</TableCell>
+                            <TableCell className="text-right">
+                              <div className="text-primary">{formatearNumero(insumo.aplicado, 2)}</div>
+                              <div className="text-xs text-muted-foreground">{formatearNumero(porcentaje, 0)}%</div>
+                            </TableCell>
+                            <TableCell className="text-right">
+                              <span
+                                className={cn(
+                                  'inline-flex items-center gap-1 rounded-lg px-2 py-1 text-sm',
+                                  diferencia > 0.1
+                                    ? 'bg-destructive/10 text-destructive'
+                                    : diferencia < -0.1
+                                      ? 'bg-warning/15 text-warning-foreground'
+                                      : 'bg-muted text-muted-foreground',
+                                )}
+                              >
+                                {diferencia > 0 && <TrendingUp className="size-3" aria-hidden="true" />}
+                                {diferencia > 0 ? '+' : ''}
+                                {formatearNumero(diferencia, 2)}
+                              </span>
+                            </TableCell>
+                          </TableRow>
+                        );
+                      })
+                    )}
+                  </TableBody>
+                </Table>
               </div>
 
-              {/* Card de Resumen de Cierre (solo para apps cerradas) */}
+              {/* Resumen de Cierre (solo para apps cerradas) */}
               {aplicacion.estado === 'Cerrada' && datosCompletos && (
-                <div className="bg-white rounded-2xl border border-primary/10 shadow-[0_2px_12px_rgba(115,153,28,0.06)] overflow-hidden">
-                  <div className="px-5 py-3 bg-gradient-to-r from-primary/5 to-transparent border-b border-primary/10">
-                    <h3 className="text-sm text-foreground flex items-center gap-2">
-                      <DollarSign className="w-4 h-4 text-primary" />
-                      Resumen de Cierre
-                    </h3>
-                  </div>
-                  <div className="p-5">
-                    <div className="grid grid-cols-2 md:grid-cols-4 gap-4">
-                      <div className="text-center p-3 bg-blue-50 rounded-xl">
-                        <p className="text-xs text-blue-700 mb-1">Insumos</p>
-                        <p className="text-lg text-blue-900 font-semibold">
-                          {formatearMonedaLocal(datosCompletos.costo_total_insumos || 0)}
-                        </p>
-                      </div>
-                      <div className="text-center p-3 bg-purple-50 rounded-xl">
-                        <p className="text-xs text-purple-700 mb-1">Mano de Obra</p>
-                        <p className="text-lg text-purple-900 font-semibold">
-                          {formatearMonedaLocal(datosCompletos.costo_total_mano_obra || 0)}
-                        </p>
-                      </div>
-                      <div className="text-center p-3 bg-primary/10 rounded-xl">
-                        <p className="text-xs text-primary mb-1">Costo Total</p>
-                        <p className="text-lg text-foreground font-bold">
-                          {formatearMonedaLocal(datosCompletos.costo_total || 0)}
-                        </p>
-                      </div>
-                      <div className="text-center p-3 bg-orange-50 rounded-xl">
-                        <p className="text-xs text-orange-700 mb-1">Costo / Árbol</p>
-                        <p className="text-lg text-orange-900 font-semibold">
-                          {formatearMonedaLocal(datosCompletos.costo_por_arbol || 0)}
-                        </p>
-                      </div>
+                <SeccionDetalle icon={DollarSign} titulo="Resumen de Cierre">
+                  <div className="grid grid-cols-2 gap-3 md:grid-cols-4">
+                    <div className="rounded-xl bg-muted p-3 text-center">
+                      <p className="mb-1 text-xs text-muted-foreground">Insumos</p>
+                      <p className="text-base font-semibold text-foreground">
+                        {formatearMoneda(datosCompletos.costo_total_insumos || 0)}
+                      </p>
                     </div>
-
-                    {/* Labor info */}
-                    {(datosCompletos.jornales_utilizados > 0 || datosCompletos.valor_jornal > 0) && (
-                      <div className="mt-4 pt-4 border-t border-gray-100 flex flex-wrap gap-4">
-                        {datosCompletos.jornales_utilizados > 0 && (
-                          <div className="flex items-center gap-2 text-sm">
-                            <Users className="w-4 h-4 text-primary" />
-                            <span className="text-brand-brown/60">Jornales:</span>
-                            <span className="text-foreground font-medium">{datosCompletos.jornales_utilizados}</span>
-                          </div>
-                        )}
-                        {datosCompletos.valor_jornal > 0 && (
-                          <div className="flex items-center gap-2 text-sm">
-                            <DollarSign className="w-4 h-4 text-primary" />
-                            <span className="text-brand-brown/60">Valor jornal:</span>
-                            <span className="text-foreground font-medium">{formatearMonedaLocal(datosCompletos.valor_jornal)}</span>
-                          </div>
-                        )}
-                      </div>
-                    )}
-
-                    {/* Observations */}
-                    {datosCompletos.observaciones_cierre && (
-                      <div className="mt-4 pt-4 border-t border-gray-100">
-                        <p className="text-xs text-brand-brown/60 mb-1">Observaciones de cierre</p>
-                        <p className="text-sm text-foreground bg-background rounded-lg p-3 italic">
-                          {datosCompletos.observaciones_cierre}
-                        </p>
-                      </div>
-                    )}
+                    <div className="rounded-xl bg-muted p-3 text-center">
+                      <p className="mb-1 text-xs text-muted-foreground">Mano de Obra</p>
+                      <p className="text-base font-semibold text-foreground">
+                        {formatearMoneda(datosCompletos.costo_total_mano_obra || 0)}
+                      </p>
+                    </div>
+                    <div className="rounded-xl bg-primary/5 p-3 text-center">
+                      <p className="mb-1 text-xs text-primary">Costo Total</p>
+                      <p className="text-base font-bold text-foreground">
+                        {formatearMoneda(datosCompletos.costo_total || 0)}
+                      </p>
+                    </div>
+                    <div className="rounded-xl bg-muted p-3 text-center">
+                      <p className="mb-1 text-xs text-muted-foreground">Costo / Árbol</p>
+                      <p className="text-base font-semibold text-foreground">
+                        {formatearMoneda(datosCompletos.costo_por_arbol || 0)}
+                      </p>
+                    </div>
                   </div>
-                </div>
-              )}
-            </div>
-          )}
-        </div>
 
-        {/* FOOTER con botones mejorados */}
-        <div className="border-t border-primary/10 p-5 bg-white/50 backdrop-blur-sm">
-          <div className="flex flex-wrap items-center justify-between gap-3">
-            {/* Botón de lista de compras a la izquierda */}
-            <Button
-              onClick={descargarListaCompras}
-              variant="outline"
-              className="border-brand-brown/30 text-brand-brown hover:bg-brand-brown/10 hover:border-brand-brown"
-              disabled={descargandoPDF}
-            >
-              <ShoppingCart className="w-4 h-4 mr-2" />
-              Ver Lista de Compras
-            </Button>
-
-            {/* Botones de acción a la derecha */}
-            <div className="flex flex-wrap items-center gap-3">
-              {aplicacion.estado === 'Cerrada' ? (
-                <>
-                  <Button
-                    onClick={() => {
-                      onClose();
-                      navigate(`/aplicaciones/${aplicacion.id}/reporte`);
-                    }}
-                    variant="outline"
-                    className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary"
-                  >
-                    <BarChart2 className="w-4 h-4 mr-2" />
-                    Ver Reporte Completo
-                  </Button>
-
-                  <Button
-                    onClick={descargarReporteCierre}
-                    disabled={generandoReporte}
-                    className="bg-primary hover:bg-primary-dark text-white"
-                  >
-                    {generandoReporte ? (
-                      <>
-                        <Loader2 className="w-4 h-4 mr-2 animate-spin" />
-                        Generando...
-                      </>
-                    ) : (
-                      <>
-                        <FileText className="w-4 h-4 mr-2" />
-                        Exportar PDF
-                      </>
-                    )}
-                  </Button>
-                </>
-              ) : (
-                <>
-                  <Button
-                    onClick={onEditar}
-                    disabled={(aplicacion.estado as string) !== 'Calculada'}
-                    variant="outline"
-                    className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary"
-                  >
-                    <Edit className="w-4 h-4 mr-2" />
-                    Editar
-                  </Button>
-
-                  {(aplicacion.estado as string) === 'Calculada' && onIniciarEjecucion ? (
-                    <Button
-                      onClick={onIniciarEjecucion}
-                      className="bg-gradient-to-r from-green-600 to-green-500 hover:from-green-700 hover:to-green-600 text-white"
-                    >
-                      <Play className="w-4 h-4 mr-2" />
-                      Iniciar Ejecución
-                    </Button>
-                  ) : (
-                    <Button
-                      onClick={onRegistrarMovimientos}
-                      disabled={(aplicacion.estado as string) !== 'En ejecución'}
-                      className="bg-brand-brown hover:bg-brand-brown text-white"
-                    >
-                      <PlayCircle className="w-4 h-4 mr-2" />
-                      Registrar Movimientos
-                    </Button>
+                  {/* Labor info */}
+                  {(datosCompletos.jornales_utilizados > 0 || datosCompletos.valor_jornal > 0) && (
+                    <div className="mt-4 flex flex-wrap gap-4 border-t border-border pt-4">
+                      {datosCompletos.jornales_utilizados > 0 && (
+                        <div className="flex items-center gap-2 text-sm">
+                          <Users className="size-4 text-primary" aria-hidden="true" />
+                          <span className="text-muted-foreground">Jornales:</span>
+                          <span className="font-medium text-foreground">{datosCompletos.jornales_utilizados}</span>
+                        </div>
+                      )}
+                      {datosCompletos.valor_jornal > 0 && (
+                        <div className="flex items-center gap-2 text-sm">
+                          <DollarSign className="size-4 text-primary" aria-hidden="true" />
+                          <span className="text-muted-foreground">Valor jornal:</span>
+                          <span className="font-medium text-foreground">{formatearMoneda(datosCompletos.valor_jornal)}</span>
+                        </div>
+                      )}
+                    </div>
                   )}
 
-                  <Button
-                    onClick={onCerrarAplicacion}
-                    disabled={(aplicacion.estado as string) !== 'En ejecución'}
-                    className="bg-primary hover:bg-primary-dark text-white"
-                  >
-                    <CheckCircle className="w-4 h-4 mr-2" />
-                    Cerrar Aplicación
-                  </Button>
-                </>
+                  {/* Observations */}
+                  {datosCompletos.observaciones_cierre && (
+                    <div className="mt-4 border-t border-border pt-4">
+                      <p className="mb-1 text-xs text-muted-foreground">Observaciones de cierre</p>
+                      <p className="rounded-lg bg-muted p-3 text-sm italic text-foreground">
+                        {datosCompletos.observaciones_cierre}
+                      </p>
+                    </div>
+                  )}
+                </SeccionDetalle>
               )}
-            </div>
+            </>
+          )}
+        </DialogBody>
+
+        <DialogFooter className="sm:justify-between">
+          {/* Botón de lista de compras a la izquierda */}
+          <Button onClick={descargarListaCompras} variant="outline" disabled={descargandoPDF}>
+            <ShoppingCart className="size-4" aria-hidden="true" />
+            Ver Lista de Compras
+          </Button>
+
+          {/* Botones de acción a la derecha */}
+          <div className="flex flex-wrap items-center gap-3">
+            {aplicacion.estado === 'Cerrada' ? (
+              <>
+                <Button
+                  onClick={() => {
+                    onClose();
+                    navigate(`/aplicaciones/${aplicacion.id}/reporte`);
+                  }}
+                  variant="outline"
+                  className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary"
+                >
+                  <BarChart2 className="size-4" aria-hidden="true" />
+                  Ver Reporte Completo
+                </Button>
+
+                <Button onClick={descargarReporteCierre} disabled={generandoReporte}>
+                  {generandoReporte ? <Spinner className="size-4" /> : <FileText className="size-4" aria-hidden="true" />}
+                  {generandoReporte ? 'Generando...' : 'Exportar PDF'}
+                </Button>
+              </>
+            ) : (
+              <>
+                <Button
+                  onClick={onEditar}
+                  disabled={(aplicacion.estado as string) !== 'Calculada'}
+                  variant="outline"
+                  className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary"
+                >
+                  <Edit className="size-4" aria-hidden="true" />
+                  Editar
+                </Button>
+
+                {(aplicacion.estado as string) === 'Calculada' && onIniciarEjecucion ? (
+                  <Button onClick={onIniciarEjecucion}>
+                    <Play className="size-4" aria-hidden="true" />
+                    Iniciar Ejecución
+                  </Button>
+                ) : (
+                  <Button
+                    onClick={onRegistrarMovimientos}
+                    disabled={(aplicacion.estado as string) !== 'En ejecución'}
+                    variant="outline"
+                    className="border-primary/30 text-primary hover:bg-primary/10 hover:border-primary"
+                  >
+                    <ClipboardList className="size-4" aria-hidden="true" />
+                    Registrar Movimientos
+                  </Button>
+                )}
+
+                <Button
+                  onClick={onCerrarAplicacion}
+                  disabled={(aplicacion.estado as string) !== 'En ejecución'}
+                >
+                  <CheckCircle className="size-4" aria-hidden="true" />
+                  Cerrar Aplicación
+                </Button>
+              </>
+            )}
           </div>
-        </div>
-      </div>
-    </div>
+        </DialogFooter>
+      </DialogContent>
+    </Dialog>
   );
 }

--- a/src/components/aplicaciones/IniciarEjecucionModal.tsx
+++ b/src/components/aplicaciones/IniciarEjecucionModal.tsx
@@ -6,6 +6,7 @@ import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import type { Aplicacion } from '../../types/aplicaciones';
 import { obtenerFechaHoy } from '@/utils/fechas';
+import { formatearNumero } from '@/utils/format';
 
 interface IniciarEjecucionModalProps {
   aplicacion: Aplicacion;
@@ -202,7 +203,7 @@ export function IniciarEjecucionModal({
   const confirmStockDescription = productosFaltantes.length > 0
     ? `${productosFaltantes.length} producto(s) no tienen suficiente inventario:\n` +
       productosFaltantes.map(
-        (p) => `${p.nombre}: necesita ${p.necesario.toFixed(2)} ${p.unidad}, disponible ${p.disponible.toFixed(2)} ${p.unidad}`
+        (p) => `${p.nombre}: necesita ${formatearNumero(p.necesario, 2)} ${p.unidad}, disponible ${formatearNumero(p.disponible, 2)} ${p.unidad}`
       ).join(' / ') +
       '\n\nEsta acción no se puede deshacer.'
     : 'Esta acción no se puede deshacer.';
@@ -234,6 +235,7 @@ export function IniciarEjecucionModal({
           <button
             onClick={onClose}
             className="text-brand-brown/40 hover:text-brand-brown transition-colors"
+            aria-label="Cerrar"
           >
             <X className="w-5 h-5" />
           </button>

--- a/src/components/aplicaciones/IniciarEjecucionModal.tsx
+++ b/src/components/aplicaciones/IniciarEjecucionModal.tsx
@@ -1,9 +1,19 @@
 import { useState } from 'react';
-import { Play, X, Calendar, AlertCircle, Package } from 'lucide-react';
+import { Play, Calendar, AlertCircle } from 'lucide-react';
 import { ConfirmDialog } from '../ui/confirm-dialog';
 import { getSupabase } from '../../utils/supabase/client';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import {
+  Dialog,
+  DialogBody,
+  DialogContent,
+  DialogFooter,
+  DialogHeader,
+  DialogTitle,
+} from '@/components/ui/dialog';
+import { EstadoAplicacionBadge } from './shared/EstadoAplicacionBadge';
 import type { Aplicacion } from '../../types/aplicaciones';
 import { obtenerFechaHoy } from '@/utils/fechas';
 import { formatearNumero } from '@/utils/format';
@@ -80,7 +90,7 @@ export function IniciarEjecucionModal({
 
       // 2. Consolidar cantidades por producto (puede haber duplicados en diferentes mezclas)
       const necesidadesPorProducto = new Map<string, { nombre: string; cantidad: number; unidad: string }>();
-      
+
       productosNecesarios.forEach(p => {
         const actual = necesidadesPorProducto.get(p.producto_id);
         if (actual) {
@@ -96,7 +106,7 @@ export function IniciarEjecucionModal({
 
       // 3. Cargar stock actual de productos
       const productosIds = Array.from(necesidadesPorProducto.keys());
-      
+
       const { data: productosStock, error: errorStock } = await supabase
         .from('productos')
         .select('id, nombre, cantidad_actual, unidad_medida')
@@ -186,7 +196,7 @@ export function IniciarEjecucionModal({
       return;
     }
 
-    // 🆕 VALIDAR STOCK si no se ha validado aún
+    // Validar stock si no se ha validado aún
     if (!stockValidado) {
       const stockSuficiente = await validarStockSuficiente();
       if (!stockSuficiente) {
@@ -210,135 +220,99 @@ export function IniciarEjecucionModal({
 
   return (
     <>
-    <ConfirmDialog
-      open={showConfirmStockInsuficiente}
-      onOpenChange={(open) => { if (!open) setShowConfirmStockInsuficiente(false); }}
-      title="Stock insuficiente — ¿Iniciar de todos modos?"
-      description={confirmStockDescription}
-      confirmLabel="Iniciar de todos modos"
-      onConfirm={() => { setShowConfirmStockInsuficiente(false); ejecutarInicio(); }}
-      destructive
-    />
-    <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-50 p-4">
-      <div className="bg-white rounded-2xl shadow-2xl max-w-md w-full">
-        {/* Header */}
-        <div className="flex items-center justify-between p-6 border-b border-gray-200">
-          <div className="flex items-center gap-3">
-            <div className="w-10 h-10 bg-primary/10 rounded-xl flex items-center justify-center">
-              <Play className="w-5 h-5 text-primary" />
-            </div>
-            <div>
-              <h2 className="text-lg text-foreground">Iniciar Ejecución</h2>
-              <p className="text-sm text-brand-brown/60">{aplicacion.nombre_aplicacion}</p>
-            </div>
-          </div>
-          <button
-            onClick={onClose}
-            className="text-brand-brown/40 hover:text-brand-brown transition-colors"
-            aria-label="Cerrar"
-          >
-            <X className="w-5 h-5" />
-          </button>
-        </div>
+      <ConfirmDialog
+        open={showConfirmStockInsuficiente}
+        onOpenChange={(open) => { if (!open) setShowConfirmStockInsuficiente(false); }}
+        title="Stock insuficiente — ¿Iniciar de todos modos?"
+        description={confirmStockDescription}
+        confirmLabel="Iniciar de todos modos"
+        onConfirm={() => { setShowConfirmStockInsuficiente(false); ejecutarInicio(); }}
+        destructive
+      />
 
-        {/* Content */}
-        <div className="p-6 space-y-4">
-          {/* Info */}
-          <div className="bg-blue-50 border border-blue-200 rounded-xl p-4">
-            <div className="flex items-start gap-3">
-              <AlertCircle className="w-5 h-5 text-blue-600 flex-shrink-0 mt-0.5" />
-              <div>
-                <p className="text-sm text-blue-900 mb-1">
-                  Al iniciar la ejecución podrás:
-                </p>
-                <ul className="text-xs text-blue-800 space-y-1 ml-4 list-disc">
+      <Dialog open onOpenChange={(open) => { if (!open) onClose(); }}>
+        <DialogContent size="sm">
+          <DialogHeader>
+            <div className="flex items-center gap-3">
+              <div className="flex size-10 shrink-0 items-center justify-center rounded-lg bg-primary/10 text-primary">
+                <Play className="size-[18px]" aria-hidden="true" />
+              </div>
+              <div className="min-w-0">
+                <DialogTitle>Iniciar Ejecución</DialogTitle>
+                <p className="text-sm text-muted-foreground truncate">{aplicacion.nombre_aplicacion}</p>
+              </div>
+            </div>
+          </DialogHeader>
+
+          <DialogBody className="space-y-4">
+            {/* Info */}
+            <Alert>
+              <AlertCircle aria-hidden="true" />
+              <AlertDescription>
+                <p className="font-medium text-foreground">Al iniciar la ejecución podrás:</p>
+                <ul className="ml-4 list-disc space-y-0.5">
                   <li>Registrar movimientos diarios de productos</li>
                   <li>Mantener trazabilidad</li>
                   <li>Comparar lo planificado vs lo ejecutado</li>
                 </ul>
-              </div>
-            </div>
-          </div>
+              </AlertDescription>
+            </Alert>
 
-          {/* Fecha de inicio */}
-          <div>
-            <label className="block text-sm text-foreground mb-2">
-              <Calendar className="w-4 h-4 inline mr-1" />
-              Fecha de inicio de ejecución
-            </label>
-            <Input
-              type="date"
-              value={fechaInicio}
-              onChange={(e) => setFechaInicio(e.target.value)}
-              max={obtenerFechaHoy()}
-              className="w-full"
-            />
-            <p className="text-xs text-brand-brown/60 mt-1">
-              Fecha en que comenzó la aplicación en campo
-            </p>
-          </div>
+            {/* Fecha de inicio */}
+            <div>
+              <label htmlFor="fecha-inicio-ejecucion" className="mb-2 flex items-center gap-1.5 text-sm text-foreground">
+                <Calendar className="size-4" aria-hidden="true" />
+                Fecha de inicio de ejecución
+              </label>
+              <Input
+                id="fecha-inicio-ejecucion"
+                type="date"
+                value={fechaInicio}
+                onChange={(e) => setFechaInicio(e.target.value)}
+                max={obtenerFechaHoy()}
+                className="w-full"
+              />
+              <p className="mt-1 text-xs text-muted-foreground">
+                Fecha en que comenzó la aplicación en campo
+              </p>
+            </div>
 
-          {/* Error */}
-          {error && (
-            <div className="bg-red-50 border border-red-200 rounded-xl p-4">
-              <div className="flex items-center gap-2 text-red-600">
-                <AlertCircle className="w-4 h-4" />
-                <p className="text-sm">{error}</p>
-              </div>
-            </div>
-          )}
-
-          {/* Resumen */}
-          <div className="bg-background rounded-xl p-4 space-y-2 text-sm">
-            <div className="flex justify-between">
-              <span className="text-brand-brown/70">Estado actual:</span>
-              <span className="text-foreground px-2 py-0.5 bg-yellow-100 rounded">
-                {aplicacion.estado}
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-brand-brown/70">Nuevo estado:</span>
-              <span className="text-foreground px-2 py-0.5 bg-blue-100 rounded">
-                En ejecución
-              </span>
-            </div>
-            <div className="flex justify-between">
-              <span className="text-brand-brown/70">Tipo:</span>
-              <span className="text-foreground">{aplicacion.tipo_aplicacion}</span>
-            </div>
-          </div>
-        </div>
-
-        {/* Footer */}
-        <div className="flex items-center gap-3 p-6 border-t border-gray-200">
-          <Button
-            onClick={onClose}
-            variant="outline"
-            className="flex-1 border-gray-300 hover:bg-gray-50"
-            disabled={loading}
-          >
-            Cancelar
-          </Button>
-          <Button
-            onClick={handleIniciar}
-            className="flex-1 bg-primary hover:bg-primary-dark text-white"
-            disabled={loading}
-          >
-            {loading ? (
-              <>
-                <div className="w-4 h-4 border-2 border-white/30 border-t-white rounded-full animate-spin mr-2" />
-                Iniciando...
-              </>
-            ) : (
-              <>
-                <Play className="w-4 h-4 mr-2" />
-                Iniciar Ejecución
-              </>
+            {/* Error */}
+            {error && (
+              <Alert variant="destructive">
+                <AlertCircle aria-hidden="true" />
+                <AlertDescription>{error}</AlertDescription>
+              </Alert>
             )}
-          </Button>
-        </div>
-      </div>
-    </div>
+
+            {/* Resumen */}
+            <div className="space-y-2 rounded-xl bg-muted p-4 text-sm">
+              <div className="flex items-center justify-between">
+                <span className="text-brand-brown/70">Estado actual:</span>
+                <EstadoAplicacionBadge estado={aplicacion.estado} />
+              </div>
+              <div className="flex items-center justify-between">
+                <span className="text-brand-brown/70">Nuevo estado:</span>
+                <EstadoAplicacionBadge estado="En ejecución" />
+              </div>
+              <div className="flex justify-between">
+                <span className="text-brand-brown/70">Tipo:</span>
+                <span className="text-foreground">{aplicacion.tipo_aplicacion}</span>
+              </div>
+            </div>
+          </DialogBody>
+
+          <DialogFooter>
+            <Button onClick={onClose} variant="outline" disabled={loading}>
+              Cancelar
+            </Button>
+            <Button onClick={handleIniciar} disabled={loading || validandoStock}>
+              <Play className="size-4" aria-hidden="true" />
+              {loading ? 'Iniciando...' : validandoStock ? 'Validando stock...' : 'Iniciar Ejecución'}
+            </Button>
+          </DialogFooter>
+        </DialogContent>
+      </Dialog>
     </>
   );
 }

--- a/src/components/aplicaciones/PasoConfiguracion.tsx
+++ b/src/components/aplicaciones/PasoConfiguracion.tsx
@@ -1,28 +1,78 @@
 import { useState, useEffect, useRef } from 'react';
-import { Sprout, Calendar, MapPin, Plus, X, AlertCircle, Bug } from 'lucide-react';
+import { MapPin, AlertCircle, Search, ChevronDown, X, Bug, ShoppingCart } from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
-import { formatearFecha } from '../../utils/fechas';
-import { formatearNumero } from '../../utils/format';
+import { formatearNumero, formatearMoneda } from '../../utils/format';
 import { DateInput } from '../ui/date-input';
+import { ToggleGroup, ToggleGroupItem } from '../ui/toggle-group';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '../ui/select';
+import { Field, FieldLabel, FieldDescription, FieldGroup } from '../ui/field';
+import { Input } from '../ui/input';
+import { Textarea } from '../ui/textarea';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
+import { Checkbox } from '../ui/checkbox';
+import { Badge } from '../ui/badge';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '../ui/collapsible';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../ui/command';
+import { Alert, AlertDescription } from '../ui/alert';
+import { Card } from '../ui/card';
+import { cn } from '../ui/utils';
+import { sugerirFechaFin, sugerirNombreAplicacion } from '../../utils/calculadoraAplicacionesHelpers';
+import { MezclaPlanSection, type EstimadoCompra, type EstadoAsignacionMezcla } from './PasoMezcla';
 import type {
   ConfiguracionAplicacion,
   LoteSeleccionado,
   LoteCatalogo,
-  TipoAplicacion,
   TipoAplicacionLocal,
   BlancoBiologico,
+  Mezcla,
+  CalculosPorLote,
 } from '../../types/aplicaciones';
-import { toast } from 'sonner';
 
 interface PasoConfiguracionProps {
   configuracion: ConfiguracionAplicacion | null;
   onUpdate: (configuracion: ConfiguracionAplicacion) => void;
+  mezclas: Mezcla[];
+  onUpdateMezclas: (mezclas: Mezcla[], calculos: CalculosPorLote[]) => void;
+  estadosAsignacion?: Record<string, EstadoAsignacionMezcla>;
+  onReintentarAsignacion?: () => void;
+  /** El error de validación general del wizard (se mantiene a nivel de paso, no inline por
+   * campo — decisión ya tomada en W01-calculadora-v2.md §9, no se re-abre acá). */
+  errorGeneral?: string;
 }
 
-export function PasoConfiguracion({ configuracion, onUpdate }: PasoConfiguracionProps) {
+const TIPO_OPCIONES: { value: TipoAplicacionLocal; label: string }[] = [
+  { value: 'fumigacion', label: 'Fumigación' },
+  { value: 'fertilizacion', label: 'Fertilización' },
+  { value: 'drench', label: 'Drench' },
+];
+
+/**
+ * Paso "Plan" (1 de 2) de la Calculadora — W01 v2. Absorbe lo que antes eran DOS pasos
+ * separados (Configuración y Mezcla): tipo, fechas, lotes, mezcla, productos y dosis viven
+ * en una sola pantalla con scroll, con un rail lateral de resumen + estimado de compra en
+ * vivo (`W01-calculadora-v2.md`). La lógica de mezcla/productos/dosis vive en
+ * `MezclaPlanSection` (PasoMezcla.tsx) — este archivo es dueño de nombre/tipo/fechas/
+ * recomendación/lotes y compone esa sección debajo.
+ */
+export function PasoConfiguracion({
+  configuracion,
+  onUpdate,
+  mezclas,
+  onUpdateMezclas,
+  estadosAsignacion,
+  onReintentarAsignacion,
+  errorGeneral,
+}: PasoConfiguracionProps) {
   const supabase = getSupabase();
 
-  // Estado del formulario
   const [formData, setFormData] = useState<Partial<ConfiguracionAplicacion>>({
     nombre: configuracion?.nombre || '',
     tipo: configuracion?.tipo || 'fumigacion',
@@ -35,906 +85,643 @@ export function PasoConfiguracion({ configuracion, onUpdate }: PasoConfiguracion
     lotes_seleccionados: configuracion?.lotes_seleccionados || [],
   });
 
-  // Catálogo de lotes disponibles
+  // El nombre deja de auto-sugerirse en cuanto el usuario lo toca (o ya traía un valor al
+  // montar — edición, o un borrador restaurado por useFormPersistence). Nunca se pisa una
+  // edición real con la sugerencia (riesgo señalado en W01-calculadora-v2.md §7).
+  const nombreTocadoRef = useRef(!!configuracion?.nombre?.trim());
+  const fechaFinTocadaRef = useRef(!!configuracion?.fecha_fin_planeada);
+
   const [lotesCatalogo, setLotesCatalogo] = useState<LoteCatalogo[]>([]);
   const [cargandoLotes, setCargandoLotes] = useState(true);
-  
-  // Catálogo de blancos biológicos
+  const [busquedaLote, setBusquedaLote] = useState('');
+
   const [blancosBiologicos, setBlancosBiologicos] = useState<BlancoBiologico[]>([]);
-  const [cargandoBlancos, setCargandoBlancos] = useState(true);
-  
-  // Búsqueda de blancos biológicos
   const [busquedaBlanco, setBusquedaBlanco] = useState('');
-  const [mostrarSugerencias, setMostrarSugerencias] = useState(false);
+  const [blancoAbierto, setBlancoAbierto] = useState(false);
 
-  // Lote seleccionado para agregar
-  const [loteAAgregar, setLoteAAgregar] = useState<string>('');
-
-  // Búsqueda de lotes
-  const [busquedaLote, setBusquedaLote] = useState<string>('');
-
-  // Errores de validación
   const [errores, setErrores] = useState<Record<string, string>>({});
+  const [estimado, setEstimado] = useState<EstimadoCompra | null>(null);
 
-  /**
-   * CARGAR LOTES DEL CATÁLOGO
-   */
-  useEffect(() => {
-    cargarLotes();
-  }, []);
-
-  const cargarLotes = async () => {
-    try {
-      const { data, error } = await supabase
-        .from('lotes')
-        .select(
-          `
-          id,
-          nombre,
-          area_hectareas,
-          arboles_grandes,
-          arboles_medianos,
-          arboles_pequenos,
-          arboles_clonales,
-          total_arboles,
-          sublotes (
-            id,
-            nombre,
-            arboles_grandes,
-            arboles_medianos,
-            arboles_pequenos,
-            arboles_clonales,
-            total_arboles
-          )
-        `
-        )
-        .eq('activo', true)
-        .order('nombre');
-
-      if (error) throw error;
-
-      const lotesFormateados: LoteCatalogo[] = data.map((lote) => ({
-        id: lote.id,
-        nombre: lote.nombre,
-        area_hectareas: lote.area_hectareas ?? 0,
-        sublotes: lote.sublotes || [],
-        conteo_arboles: {
-          grandes: lote.arboles_grandes || 0,
-          medianos: lote.arboles_medianos || 0,
-          pequenos: lote.arboles_pequenos || 0,
-          clonales: lote.arboles_clonales || 0,
-          total: lote.total_arboles || 0,
-        },
-      }));
-
-      // Debug: Verificar datos de lotes
-
-      setLotesCatalogo(lotesFormateados);
-    } catch (err) {
-      console.error('Failed to load lotes catalog:', err);
-    } finally {
-      setCargandoLotes(false);
-    }
-  };
-
-  /**
-   * CARGAR BLANCOS BIÓLOGICOS
-   */
-  useEffect(() => {
-    cargarBlancosBiologicos();
-  }, []);
-
-  const cargarBlancosBiologicos = async () => {
-    try {
-      
-      const { data, error } = await supabase
-        .from('plagas_enfermedades_catalogo')
-        .select('id, nombre, tipo, descripcion, link_info, activo')
-        .eq('activo', true)
-        .order('nombre');
-
-
-      if (error) {
-        throw error;
-      }
-
-      setBlancosBiologicos((data || []) as BlancoBiologico[]);
-    } catch (error) {
-      setBlancosBiologicos([]);
-    } finally {
-      setCargandoBlancos(false);
-    }
-  };
-
-  /**
-   * AGREGAR BLANCO BIOLÓGICO
-   */
-  const agregarBlanco = (blancoId: string) => {
-    if (!formData.blanco_biologico?.includes(blancoId)) {
-      setFormData((prev) => ({
-        ...prev,
-        blanco_biologico: [...(prev.blanco_biologico || []), blancoId],
-      }));
-    }
-    setBusquedaBlanco('');
-    setMostrarSugerencias(false);
-  };
-
-  /**
-   * QUITAR BLANCO BIOLÓGICO
-   */
-  const quitarBlanco = (blancoId: string) => {
-    setFormData((prev) => ({
-      ...prev,
-      blanco_biologico: (prev.blanco_biologico || []).filter((id) => id !== blancoId),
-    }));
-  };
-
-  /**
-   * FILTRAR BLANCOS POR BÚSQUEDA
-   */
-  const blancosFiltrados = blancosBiologicos.filter((blanco) => {
-    // No mostrar los ya seleccionados
-    if (formData.blanco_biologico?.includes(blanco.id)) return false;
-    
-    // Filtrar por búsqueda
-    if (!busquedaBlanco.trim()) return false;
-    
-    const busqueda = busquedaBlanco.toLowerCase();
-    return (
-      blanco.nombre.toLowerCase().includes(busqueda) ||
-      blanco.tipo?.toLowerCase().includes(busqueda) ||
-      blanco.descripcion?.toLowerCase().includes(busqueda)
-    );
-  });
-
-  /**
-   * OBTENER BLANCOS SELECCIONADOS
-   */
-  const blancosSeleccionados = blancosBiologicos.filter((blanco) =>
-    formData.blanco_biologico?.includes(blanco.id)
+  const tipoActual = formData.tipo;
+  const tieneDatosRecomendacion = !!(
+    configuracion?.proposito ||
+    configuracion?.agronomo_responsable ||
+    configuracion?.fecha_recomendacion ||
+    (configuracion?.blanco_biologico && configuracion.blanco_biologico.length > 0)
+  );
+  const [detalleAbierto, setDetalleAbierto] = useState(
+    () => tipoActual === 'fumigacion' || tieneDatosRecomendacion,
   );
 
-  /**
-   * AGREGAR LOTE A LA SELECCIÓN
-   */
-  const agregarLote = () => {
-    if (!loteAAgregar) return;
+  useEffect(() => {
+    if (tipoActual === 'fumigacion' && (formData.blanco_biologico?.length ?? 0) === 0) {
+      setDetalleAbierto(true);
+    }
+  }, [tipoActual]); // eslint-disable-line react-hooks/exhaustive-deps
 
-    const lote = lotesCatalogo.find((l) => l.id === loteAAgregar);
-    if (!lote) return;
+  /** CARGAR LOTES DEL CATÁLOGO */
+  useEffect(() => {
+    (async () => {
+      try {
+        const { data, error } = await supabase
+          .from('lotes')
+          .select(
+            `
+            id, nombre, area_hectareas,
+            arboles_grandes, arboles_medianos, arboles_pequenos, arboles_clonales, total_arboles,
+            sublotes ( id, nombre )
+          `,
+          )
+          .eq('activo', true)
+          .order('nombre');
 
-    // Verificar que no esté ya agregado
-    if (formData.lotes_seleccionados?.some((l) => l.lote_id === lote.id)) {
-      toast('Este lote ya está agregado');
+        if (error) throw error;
+
+        setLotesCatalogo(
+          (data || []).map((lote) => ({
+            id: lote.id,
+            nombre: lote.nombre,
+            area_hectareas: lote.area_hectareas ?? 0,
+            sublotes: lote.sublotes || [],
+            conteo_arboles: {
+              grandes: lote.arboles_grandes || 0,
+              medianos: lote.arboles_medianos || 0,
+              pequenos: lote.arboles_pequenos || 0,
+              clonales: lote.arboles_clonales || 0,
+              total: lote.total_arboles || 0,
+            },
+          })),
+        );
+      } catch (err) {
+        console.error('Failed to load lotes catalog:', err);
+      } finally {
+        setCargandoLotes(false);
+      }
+    })();
+  }, []); // eslint-disable-line react-hooks/exhaustive-deps
+
+  /** CARGAR BLANCOS BIOLÓGICOS */
+  useEffect(() => {
+    (async () => {
+      try {
+        const { data, error } = await supabase
+          .from('plagas_enfermedades_catalogo')
+          .select('id, nombre, tipo, descripcion, link_info, activo')
+          .eq('activo', true)
+          .order('nombre');
+        if (error) throw error;
+        setBlancosBiologicos((data || []) as BlancoBiologico[]);
+      } catch {
+        setBlancosBiologicos([]);
+      }
+    })();
+  }, []);
+
+  const blancosSeleccionados = blancosBiologicos.filter((b) => formData.blanco_biologico?.includes(b.id));
+  const blancosDisponibles = blancosBiologicos.filter((b) => !formData.blanco_biologico?.includes(b.id));
+
+  const agregarBlanco = (id: string) => {
+    setFormData((prev) => ({ ...prev, blanco_biologico: [...(prev.blanco_biologico || []), id] }));
+    setBusquedaBlanco('');
+    setBlancoAbierto(false);
+  };
+  const quitarBlanco = (id: string) => {
+    setFormData((prev) => ({ ...prev, blanco_biologico: (prev.blanco_biologico || []).filter((b) => b !== id) }));
+  };
+
+  /** TOGGLE LOTE — misma interacción para seleccionar y para quitar (tocar la tarjeta). No
+   * hay una segunda lista de "lotes seleccionados" debajo (campo #10 de la auditoría). */
+  const toggleLote = (lote: LoteCatalogo) => {
+    const yaSeleccionado = formData.lotes_seleccionados?.some((l) => l.lote_id === lote.id);
+    if (yaSeleccionado) {
+      setFormData((prev) => ({
+        ...prev,
+        lotes_seleccionados: prev.lotes_seleccionados?.filter((l) => l.lote_id !== lote.id),
+      }));
       return;
     }
-
     const nuevoLote: LoteSeleccionado = {
       lote_id: lote.id,
       nombre: lote.nombre,
       sublotes_ids: lote.sublotes.map((s) => s.id),
       area_hectareas: lote.area_hectareas,
       conteo_arboles: lote.conteo_arboles,
-      // Valores por defecto para fumigación y drench (ambos usan canecas)
-      calibracion_litros_arbol: (formData.tipo === 'fumigacion' || formData.tipo === 'drench') ? 20 : undefined,
-      tamano_caneca: (formData.tipo === 'fumigacion' || formData.tipo === 'drench') ? 200 : undefined,
+      calibracion_litros_arbol:
+        formData.tipo === 'fumigacion' || formData.tipo === 'drench' ? 20 : undefined,
+      tamano_caneca: formData.tipo === 'fumigacion' || formData.tipo === 'drench' ? 200 : undefined,
     };
-
     setFormData((prev) => ({
       ...prev,
       lotes_seleccionados: [...(prev.lotes_seleccionados || []), nuevoLote],
     }));
-
-    setLoteAAgregar('');
   };
 
-  /**
-   * QUITAR LOTE DE LA SELECCIÓN
-   */
-  const quitarLote = (loteId: string) => {
+  const actualizarLote = (loteId: string, campo: 'calibracion_litros_arbol' | 'tamano_caneca', valor: number) => {
     setFormData((prev) => ({
       ...prev,
-      lotes_seleccionados: prev.lotes_seleccionados?.filter((l) => l.lote_id !== loteId),
+      lotes_seleccionados: prev.lotes_seleccionados?.map((l) => (l.lote_id === loteId ? { ...l, [campo]: valor } : l)),
     }));
   };
 
-  /**
-   * ACTUALIZAR CONFIGURACIÓN DE LOTE
-   */
-  const actualizarLote = (loteId: string, campo: string, valor: any) => {
-    setFormData((prev) => ({
-      ...prev,
-      lotes_seleccionados: prev.lotes_seleccionados?.map((lote) =>
-        lote.lote_id === loteId ? { ...lote, [campo]: valor } : lote
-      ),
-    }));
-  };
-
-  /**
-   * VALIDAR FORMULARIO
-   */
-  const validar = (): boolean => {
+  /** VALIDAR (mismo criterio que antes, ahora en un solo lugar porque ya no hay Paso 2 aparte) */
+  const validar = (data: Partial<ConfiguracionAplicacion>): boolean => {
     const nuevosErrores: Record<string, string> = {};
-
-    if (!formData.nombre?.trim()) {
-      nuevosErrores.nombre = 'El nombre es requerido';
-    }
-
-    if (!formData.fecha_inicio_planeada) {
-      nuevosErrores.fecha_inicio_planeada = 'La fecha de inicio es requerida';
-    }
-
-    if (!formData.lotes_seleccionados || formData.lotes_seleccionados.length === 0) {
+    if (!data.nombre?.trim()) nuevosErrores.nombre = 'El nombre es requerido';
+    if (!data.fecha_inicio_planeada) nuevosErrores.fecha_inicio_planeada = 'La fecha de inicio es requerida';
+    if (!data.lotes_seleccionados || data.lotes_seleccionados.length === 0) {
       nuevosErrores.lotes = 'Debes seleccionar al menos un lote';
     }
-
-    // Validaciones específicas de fumigación
-    if (formData.tipo === 'fumigacion') {
-      // Validar blanco biológico solo en fumigación (OBLIGATORIO)
-      if (!formData.blanco_biologico || formData.blanco_biologico.length === 0) {
-        nuevosErrores.blanco_biologico = 'Debes seleccionar al menos un blanco biológico para fumigaciones';
-      }
-
-      // Validar calibración y canecas
-      formData.lotes_seleccionados?.forEach((lote) => {
-        if (!lote.calibracion_litros_arbol || lote.calibracion_litros_arbol <= 0) {
-          nuevosErrores[`lote_${lote.lote_id}`] = 'Falta calibración';
-        }
-        if (!lote.tamano_caneca) {
-          nuevosErrores[`lote_${lote.lote_id}`] = 'Falta tamaño de caneca';
+    if (data.tipo === 'fumigacion' && (!data.blanco_biologico || data.blanco_biologico.length === 0)) {
+      nuevosErrores.blanco_biologico = 'Debes seleccionar al menos un blanco biológico para fumigaciones';
+    }
+    if (data.tipo === 'fumigacion' || data.tipo === 'drench') {
+      data.lotes_seleccionados?.forEach((lote) => {
+        if (!lote.calibracion_litros_arbol || lote.calibracion_litros_arbol <= 0 || !lote.tamano_caneca) {
+          nuevosErrores[`lote_${lote.lote_id}`] = 'Falta calibración o tamaño de caneca';
         }
       });
     }
-
-    // Validaciones específicas de drench (igual a fumigación pero blanco biológico OPCIONAL)
-    if (formData.tipo === 'drench') {
-      // Blanco biológico es opcional para drench
-
-      // Validar calibración y canecas (igual a fumigación)
-      formData.lotes_seleccionados?.forEach((lote) => {
-        if (!lote.calibracion_litros_arbol || lote.calibracion_litros_arbol <= 0) {
-          nuevosErrores[`lote_${lote.lote_id}`] = 'Falta calibración';
-        }
-        if (!lote.tamano_caneca) {
-          nuevosErrores[`lote_${lote.lote_id}`] = 'Falta tamaño de caneca';
-        }
-      });
-    }
-
     setErrores(nuevosErrores);
     return Object.keys(nuevosErrores).length === 0;
   };
 
-  /**
-   * AUTO-GUARDAR AL CAMBIAR
-   */
+  /** AUTO-SUGERIR nombre y fecha fin, y propagar al padre en cuanto lo mínimo esté completo —
+   * mismo patrón de auto-guardado que ya usaba este paso, extendido con las dos sugerencias. */
   useEffect(() => {
-    // Auto-guardar configuración válida
-    if (
-      formData.nombre &&
-      formData.tipo &&
-      formData.fecha_inicio_planeada &&
-      formData.lotes_seleccionados &&
-      formData.lotes_seleccionados.length > 0
-    ) {
-      const esValido = validar();
-      if (esValido) {
-        onUpdate(formData as ConfiguracionAplicacion);
+    const numLotes = formData.lotes_seleccionados?.length ?? 0;
+
+    let nombreEfectivo = formData.nombre || '';
+    if (!nombreTocadoRef.current) {
+      const sugerido = sugerirNombreAplicacion(formData.tipo, numLotes, formData.fecha_inicio_planeada || '');
+      if (sugerido && sugerido !== nombreEfectivo) {
+        nombreEfectivo = sugerido;
+        setFormData((prev) => ({ ...prev, nombre: sugerido }));
+        return; // el cambio de estado dispara este mismo efecto de nuevo con el valor ya puesto
       }
     }
+
+    let fechaFinEfectiva = formData.fecha_fin_planeada || '';
+    if (!fechaFinTocadaRef.current && formData.fecha_inicio_planeada) {
+      const sugerida = sugerirFechaFin(formData.fecha_inicio_planeada);
+      if (sugerida && sugerida !== fechaFinEfectiva) {
+        fechaFinEfectiva = sugerida;
+        setFormData((prev) => ({ ...prev, fecha_fin_planeada: sugerida }));
+        return;
+      }
+    }
+
+    if (formData.nombre && formData.tipo && formData.fecha_inicio_planeada && numLotes > 0) {
+      validar(formData);
+      onUpdate(formData as ConfiguracionAplicacion);
+    }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [formData]);
 
-  /**
-   * CALCULAR TOTALES
-   */
-  const totales =
-    formData.lotes_seleccionados?.reduce(
-      (acc, lote) => ({
-        area: acc.area + lote.area_hectareas,
-        arboles: acc.arboles + lote.conteo_arboles.total,
-      }),
-      { area: 0, arboles: 0 }
-    ) || { area: 0, arboles: 0 };
+  const totales = (formData.lotes_seleccionados || []).reduce(
+    (acc, lote) => ({
+      area: acc.area + lote.area_hectareas,
+      arboles: acc.arboles + lote.conteo_arboles.total,
+    }),
+    { area: 0, arboles: 0 },
+  );
+
+  const usaCalibracion = formData.tipo === 'fumigacion' || formData.tipo === 'drench';
 
   return (
-    <div className="space-y-6">
-      {/* INFORMACIÓN GENERAL */}
-      <div>
-        <h2 className="text-lg text-foreground mb-4">Información General</h2>
+    <div className="grid grid-cols-1 xl:grid-cols-[1fr_300px] gap-6 items-start">
+      <div className="space-y-8 min-w-0">
+        {errorGeneral && (
+          <Alert variant="destructive">
+            <AlertCircle />
+            <AlertDescription>{errorGeneral}</AlertDescription>
+          </Alert>
+        )}
 
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4">
-          {/* Nombre */}
-          <div>
-            <label className="block text-sm text-brand-brown mb-1">
-              Nombre de la Aplicación *
-            </label>
-            <input
-              type="text"
-              value={formData.nombre}
-              onChange={(e) => setFormData((prev) => ({ ...prev, nombre: e.target.value }))}
-              placeholder="Ej: Fumigación Control Trips - Nov 2025"
-              className={`
-                w-full px-3 py-2 border rounded-lg
-                ${errores.nombre ? 'border-red-300' : 'border-gray-300'}
-                focus:ring-2 focus:ring-primary/20 focus:border-primary
-              `}
-            />
-            {errores.nombre && (
-              <p className="text-red-600 text-sm mt-1 flex items-center gap-1">
-                <AlertCircle className="w-4 h-4" />
-                {errores.nombre}
-              </p>
-            )}
-          </div>
+        {/* NOMBRE — sugerido automáticamente, editable con un clic. AplicacionShell (fuera de
+            este alcance) solo acepta un título de texto plano en el header, así que el campo
+            editable real vive acá, primero en la pantalla — ver nota en el reporte final. */}
+        <Field>
+          <FieldLabel htmlFor="nombre-aplicacion">
+            Nombre de la Aplicación <span className="text-destructive">*</span>
+          </FieldLabel>
+          <Input
+            id="nombre-aplicacion"
+            value={formData.nombre || ''}
+            onChange={(e) => {
+              nombreTocadoRef.current = true;
+              setFormData((prev) => ({ ...prev, nombre: e.target.value }));
+            }}
+            placeholder="Se sugiere automáticamente al elegir tipo, lotes y fecha"
+            aria-invalid={!!errores.nombre}
+          />
+          {errores.nombre ? (
+            <p className="text-sm text-destructive flex items-center gap-1">
+              <AlertCircle className="w-3.5 h-3.5" />
+              {errores.nombre}
+            </p>
+          ) : (
+            <FieldDescription>
+              Se sugiere solo — puedes aceptarla tal cual o escribir la tuya en cualquier momento.
+            </FieldDescription>
+          )}
+        </Field>
 
-          {/* Tipo */}
-          <div>
-            <label className="block text-sm text-brand-brown mb-1">
-              Tipo de Aplicación *
-            </label>
-            <select
-              value={formData.tipo}
-              onChange={(e) =>
-                setFormData((prev) => ({
-                  ...prev,
-                  tipo: e.target.value as TipoAplicacionLocal,
-                }))
-              }
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary"
-            >
-              <option value="fumigacion">Fumigación</option>
-              <option value="fertilizacion">Fertilización</option>
-              <option value="drench">Drench</option>
-            </select>
-          </div>
+        {/* TIPO + FECHAS */}
+        <FieldGroup className="grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-6">
+          <Field>
+            <FieldLabel>
+              Tipo de Aplicación <span className="text-destructive">*</span>
+            </FieldLabel>
+            <div className="hidden sm:block">
+              <ToggleGroup
+                type="single"
+                variant="outline"
+                value={formData.tipo}
+                onValueChange={(v) => {
+                  if (!v) return;
+                  setFormData((prev) => ({
+                    ...prev,
+                    tipo: v as TipoAplicacionLocal,
+                    lotes_seleccionados: prev.lotes_seleccionados?.map((l) => ({
+                      ...l,
+                      calibracion_litros_arbol: v === 'fumigacion' || v === 'drench' ? l.calibracion_litros_arbol ?? 20 : undefined,
+                      tamano_caneca: v === 'fumigacion' || v === 'drench' ? l.tamano_caneca ?? 200 : undefined,
+                    })),
+                  }));
+                }}
+                aria-label="Tipo de aplicación"
+              >
+                {TIPO_OPCIONES.map((opt) => (
+                  <ToggleGroupItem key={opt.value} value={opt.value} aria-label={opt.label}>
+                    {opt.label}
+                  </ToggleGroupItem>
+                ))}
+              </ToggleGroup>
+            </div>
+            <div className="sm:hidden">
+              <Select
+                value={formData.tipo}
+                onValueChange={(v) => setFormData((prev) => ({ ...prev, tipo: v as TipoAplicacionLocal }))}
+              >
+                <SelectTrigger aria-label="Tipo de aplicación">
+                  <SelectValue />
+                </SelectTrigger>
+                <SelectContent>
+                  {TIPO_OPCIONES.map((opt) => (
+                    <SelectItem key={opt.value} value={opt.value}>
+                      {opt.label}
+                    </SelectItem>
+                  ))}
+                </SelectContent>
+              </Select>
+            </div>
+            <FieldDescription>Determina si abajo se piden canecas o dosis por tamaño de árbol.</FieldDescription>
+          </Field>
 
-          {/* Fecha Inicio Planeada */}
-          <div>
-            <label className="block text-sm text-brand-brown mb-1">
-              Fecha Inicio Planeada *
-            </label>
-            <DateInput
-              value={formData.fecha_inicio_planeada || ''}
-              onChange={(valor) =>
-                setFormData((prev) => ({ ...prev, fecha_inicio_planeada: valor }))
-              }
-              required
-            />
-            {errores.fecha_inicio_planeada && (
-              <p className="text-red-600 text-sm mt-1 flex items-center gap-1">
-                <AlertCircle className="w-4 h-4" />
+          <Field>
+            <FieldLabel>
+              Ventana de ejecución <span className="text-destructive">*</span>
+            </FieldLabel>
+            <div className="flex items-center gap-2.5">
+              <div className="flex-1">
+                <DateInput
+                  value={formData.fecha_inicio_planeada || ''}
+                  onChange={(v) => setFormData((prev) => ({ ...prev, fecha_inicio_planeada: v }))}
+                  required
+                />
+              </div>
+              <span className="text-sm text-muted-foreground flex-shrink-0">→</span>
+              <div className="flex-1">
+                <DateInput
+                  value={formData.fecha_fin_planeada || ''}
+                  onChange={(v) => {
+                    fechaFinTocadaRef.current = true;
+                    setFormData((prev) => ({ ...prev, fecha_fin_planeada: v }));
+                  }}
+                />
+              </div>
+            </div>
+            {errores.fecha_inicio_planeada ? (
+              <p className="text-sm text-destructive flex items-center gap-1">
+                <AlertCircle className="w-3.5 h-3.5" />
                 {errores.fecha_inicio_planeada}
               </p>
+            ) : (
+              <FieldDescription>
+                Fecha fin se propone a partir del inicio (+1 mes) — editable.
+              </FieldDescription>
             )}
-          </div>
+          </Field>
+        </FieldGroup>
 
-          {/* Fecha Fin Planeada */}
-          <div>
-            <label className="block text-sm text-brand-brown mb-1">
-              Fecha Fin Planeada
-            </label>
-            <DateInput
-              value={formData.fecha_fin_planeada || ''}
-              onChange={(valor) =>
-                setFormData((prev) => ({ ...prev, fecha_fin_planeada: valor }))
-              }
-            />
-          </div>
-
-          {/* Fecha de Recomendación */}
-          <div>
-            <label className="block text-sm text-brand-brown mb-1">
-              Fecha de Recomendación
-            </label>
-            <DateInput
-              value={formData.fecha_recomendacion || ''}
-              onChange={(valor) =>
-                setFormData((prev) => ({ ...prev, fecha_recomendacion: valor }))
-              }
-            />
-          </div>
-
-          {/* Agrónomo */}
-          <div>
-            <label className="block text-sm text-brand-brown mb-1">
-              Agrónomo Responsable
-            </label>
-            <input
-              type="text"
-              value={formData.agronomo_responsable}
-              onChange={(e) =>
-                setFormData((prev) => ({ ...prev, agronomo_responsable: e.target.value }))
-              }
-              placeholder="Nombre del agrónomo"
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary"
-            />
-          </div>
-
-          {/* Propósito */}
-          <div className="md:col-span-2">
-            <label className="block text-sm text-brand-brown mb-1">
-              Propósito / Observaciones
-            </label>
-            <textarea
-              value={formData.proposito}
-              onChange={(e) => setFormData((prev) => ({ ...prev, proposito: e.target.value }))}
-              placeholder="Describe el objetivo de esta aplicación..."
-              rows={3}
-              className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary"
-            />
-          </div>
-
-          {/* Blancos Biológicos - Solo para fumigación */}
-          {formData.tipo === 'fumigacion' && (
-            <div className="md:col-span-2">
-              <label className="block text-sm text-brand-brown mb-2">
-                Blancos Biológicos (Plagas/Enfermedades) *
-              </label>
-              
-              {cargandoBlancos ? (
-                <div className="p-4 bg-gray-50 rounded-lg text-center">
-                  <p className="text-sm text-brand-brown/70">Cargando blancos biológicos...</p>
-                </div>
-              ) : blancosBiologicos.length === 0 ? (
-                <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-                  <p className="text-sm text-yellow-800">
-                    ⚠️ No hay blancos biológicos disponibles. Verifica la tabla en Supabase.
-                  </p>
-                </div>
-              ) : (
-                <div className="space-y-3">
-                  {/* Input de búsqueda con sugerencias */}
-                  <div className="relative">
-                    <div className="relative">
-                      <input
-                        type="text"
-                        value={busquedaBlanco}
-                        onChange={(e) => {
-                          setBusquedaBlanco(e.target.value);
-                          setMostrarSugerencias(true);
-                        }}
-                        onFocus={() => setMostrarSugerencias(true)}
-                        placeholder="Buscar plaga o enfermedad... (ej: trips, phytophthora)"
-                        className="w-full px-4 py-2.5 pl-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
-                      />
-                      <Bug className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-brand-brown/50" />
-                    </div>
-
-                    {/* Sugerencias desplegables */}
-                    {mostrarSugerencias && blancosFiltrados.length > 0 && (
-                      <div className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto">
-                        {blancosFiltrados.map((blanco) => (
-                          <button
-                            key={blanco.id}
-                            type="button"
-                            onClick={() => agregarBlanco(blanco.id)}
-                            className="w-full text-left px-4 py-3 hover:bg-primary/5 transition-colors border-b border-gray-100 last:border-b-0"
-                          >
-                            <div className="flex items-center gap-2">
-                              <span className="text-lg">
-                                {blanco.tipo === 'plaga' ? '🐛' : '🍄'}
-                              </span>
-                              <div className="flex-1 min-w-0">
-                                <div className="text-sm text-foreground font-medium">
-                                  {blanco.nombre}
-                                </div>
-                                {blanco.descripcion && (
-                                  <div className="text-xs text-brand-brown/60 truncate">
-                                    {blanco.descripcion}
-                                  </div>
-                                )}
-                                <div className="text-xs text-primary capitalize mt-0.5">
-                                  {blanco.tipo}
-                                </div>
-                              </div>
-                              <Plus className="w-4 h-4 text-primary" />
-                            </div>
-                          </button>
-                        ))}
-                      </div>
-                    )}
-                  </div>
-
-                  {/* Blancos seleccionados (chips/tags) */}
-                  {blancosSeleccionados.length > 0 && (
-                    <div className="border border-primary/30 bg-primary/5 rounded-lg p-4">
-                      <div className="text-xs text-brand-brown/70 mb-2">
-                        Seleccionados ({blancosSeleccionados.length}):
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {blancosSeleccionados.map((blanco) => (
-                          <div
-                            key={blanco.id}
-                            className="inline-flex items-center gap-2 px-3 py-1.5 bg-white border-2 border-primary rounded-full text-sm"
-                          >
-                            <span>{blanco.tipo === 'plaga' ? '🐛' : '🍄'}</span>
-                            <span className="text-foreground">{blanco.nombre}</span>
-                            <button
-                              type="button"
-                              onClick={() => quitarBlanco(blanco.id)}
-                              className="ml-1 text-brand-brown/70 hover:text-red-600 transition-colors"
-                              aria-label={`Quitar ${blanco.nombre}`}
-                            >
-                              <X className="w-4 h-4" />
-                            </button>
-                          </div>
-                        ))}
-                      </div>
-                    </div>
-                  )}
-                </div>
-              )}
-              
-              {errores.blanco_biologico && (
-                <p className="text-red-600 text-sm mt-2 flex items-center gap-1">
-                  <AlertCircle className="w-4 h-4" />
-                  {errores.blanco_biologico}
+        {/* DETALLES DE LA RECOMENDACIÓN — colapsable, se auto-abre si es obligatorio o si ya
+            trae datos (nunca esconde un campo requerido). */}
+        <Collapsible open={detalleAbierto} onOpenChange={setDetalleAbierto} className="border border-border rounded-xl overflow-hidden">
+          <CollapsibleTrigger className="w-full flex items-center justify-between gap-3 px-4 py-3.5 bg-card text-left">
+            <div className="flex items-center gap-3">
+              <div className="w-8 h-8 rounded-lg bg-primary/10 text-primary flex items-center justify-center flex-shrink-0">
+                <Bug className="w-4 h-4" />
+              </div>
+              <div>
+                <p className="text-sm font-bold text-foreground">Detalles de la recomendación</p>
+                <p className="text-xs text-muted-foreground">
+                  Fecha de recomendación, agrónomo, propósito y blanco biológico — opcional, no bloquea el cálculo
                 </p>
-              )}
+              </div>
             </div>
-          )}
+            <ChevronDown className={cn('w-4.5 h-4.5 text-muted-foreground transition-transform flex-shrink-0', detalleAbierto && 'rotate-180')} />
+          </CollapsibleTrigger>
+          <CollapsibleContent className="px-4 pb-5 pt-1 border-t border-border bg-background">
+            <FieldGroup className="grid grid-cols-1 sm:grid-cols-2 gap-5 pt-4">
+              <Field>
+                <FieldLabel>
+                  Fecha de Recomendación <span className="text-muted-foreground font-normal text-xs">(opcional)</span>
+                </FieldLabel>
+                <DateInput
+                  value={formData.fecha_recomendacion || ''}
+                  onChange={(v) => setFormData((prev) => ({ ...prev, fecha_recomendacion: v }))}
+                />
+                <FieldDescription>Puede ser muy anterior a la ejecución — no se autocompleta.</FieldDescription>
+              </Field>
 
-          {/* Blancos Biológicos - Para drench (OPCIONAL) */}
-          {formData.tipo === 'drench' && (
-            <div className="md:col-span-2">
-              <label className="block text-sm text-brand-brown mb-2">
-                Blancos Biológicos (Plagas/Enfermedades) <span className="text-gray-400 text-xs">(Opcional)</span>
-              </label>
-              
-              {cargandoBlancos ? (
-                <div className="p-4 bg-gray-50 rounded-lg text-center">
-                  <p className="text-sm text-brand-brown/70">Cargando blancos biológicos...</p>
-                </div>
-              ) : blancosBiologicos.length === 0 ? (
-                <div className="p-4 bg-yellow-50 border border-yellow-200 rounded-lg">
-                  <p className="text-sm text-yellow-800">
-                    ⚠️ No hay blancos biológicos disponibles. Verifica la tabla en Supabase.
-                  </p>
+              <Field>
+                <FieldLabel htmlFor="agronomo">
+                  Agrónomo Responsable <span className="text-muted-foreground font-normal text-xs">(opcional)</span>
+                </FieldLabel>
+                <Input
+                  id="agronomo"
+                  value={formData.agronomo_responsable || ''}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, agronomo_responsable: e.target.value }))}
+                  placeholder="Nombre del agrónomo"
+                />
+                <FieldDescription>Hoy solo queda registrado — no se muestra aún en PDF ni reportes.</FieldDescription>
+              </Field>
+
+              <Field className="sm:col-span-2">
+                <FieldLabel htmlFor="proposito">
+                  Propósito / Observaciones <span className="text-muted-foreground font-normal text-xs">(opcional)</span>
+                </FieldLabel>
+                <Textarea
+                  id="proposito"
+                  value={formData.proposito || ''}
+                  onChange={(e) => setFormData((prev) => ({ ...prev, proposito: e.target.value }))}
+                  placeholder="Describe el objetivo de esta aplicación..."
+                  rows={3}
+                />
+              </Field>
+
+              {tipoActual === 'fertilizacion' ? (
+                <div className="sm:col-span-2">
+                  <Alert>
+                    <Bug />
+                    <AlertDescription>
+                      <strong>Blanco Biológico</strong> no aplica a Fertilización — es exclusivo de tratamientos
+                      fitosanitarios (Fumigación / Drench).
+                    </AlertDescription>
+                  </Alert>
                 </div>
               ) : (
-                <div className="space-y-3">
-                  {/* Input de búsqueda con sugerencias */}
-                  <div className="relative">
-                    <div className="relative">
-                      <input
-                        type="text"
-                        value={busquedaBlanco}
-                        onChange={(e) => {
-                          setBusquedaBlanco(e.target.value);
-                          setMostrarSugerencias(true);
-                        }}
-                        onFocus={() => setMostrarSugerencias(true)}
-                        placeholder="Buscar plaga o enfermedad... (ej: trips, phytophthora)"
-                        className="w-full px-4 py-2.5 pl-10 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary transition-all"
-                      />
-                      <Bug className="absolute left-3 top-1/2 -translate-y-1/2 w-5 h-5 text-brand-brown/50" />
-                    </div>
-
-                    {/* Sugerencias desplegables */}
-                    {mostrarSugerencias && blancosFiltrados.length > 0 && (
-                      <div className="absolute z-10 w-full mt-1 bg-white border border-gray-200 rounded-lg shadow-lg max-h-64 overflow-y-auto">
-                        {blancosFiltrados.map((blanco) => (
-                          <button
-                            key={blanco.id}
-                            type="button"
-                            onClick={() => agregarBlanco(blanco.id)}
-                            className="w-full text-left px-4 py-3 hover:bg-primary/5 transition-colors border-b border-gray-100 last:border-b-0"
-                          >
-                            <div className="flex items-center gap-2">
-                              <span className="text-lg">
-                                {blanco.tipo === 'plaga' ? '🐛' : '🍄'}
-                              </span>
-                              <div className="flex-1 min-w-0">
-                                <div className="text-sm text-foreground font-medium">
-                                  {blanco.nombre}
-                                </div>
-                                {blanco.descripcion && (
-                                  <div className="text-xs text-brand-brown/60 truncate">
-                                    {blanco.descripcion}
-                                  </div>
-                                )}
-                                <div className="text-xs text-primary capitalize mt-0.5">
-                                  {blanco.tipo}
-                                </div>
-                              </div>
-                              <Plus className="w-4 h-4 text-primary" />
-                            </div>
-                          </button>
-                        ))}
-                      </div>
+                <div className="sm:col-span-2 space-y-2.5">
+                  <FieldLabel>
+                    Blancos Biológicos (Plagas/Enfermedades){' '}
+                    {tipoActual === 'fumigacion' ? (
+                      <span className="text-destructive">*</span>
+                    ) : (
+                      <span className="text-muted-foreground font-normal text-xs">(opcional)</span>
                     )}
-                  </div>
-
-                  {/* Blancos seleccionados (chips/tags) */}
+                  </FieldLabel>
+                  <Popover open={blancoAbierto} onOpenChange={setBlancoAbierto}>
+                    <PopoverTrigger asChild>
+                      <button
+                        type="button"
+                        className="w-full flex items-center gap-2 px-3 py-2.5 border border-input rounded-md text-sm text-muted-foreground hover:border-ring transition-colors"
+                      >
+                        <Search className="w-4 h-4 flex-shrink-0" />
+                        Buscar plaga o enfermedad…
+                      </button>
+                    </PopoverTrigger>
+                    <PopoverContent align="start" className="p-0" style={{ width: 'var(--radix-popover-trigger-width)' }}>
+                      <Command>
+                        <CommandInput placeholder="Buscar..." value={busquedaBlanco} onValueChange={setBusquedaBlanco} />
+                        <CommandList>
+                          <CommandEmpty>Sin resultados.</CommandEmpty>
+                          <CommandGroup>
+                            {blancosDisponibles.map((blanco) => (
+                              <CommandItem key={blanco.id} value={blanco.nombre} onSelect={() => agregarBlanco(blanco.id)}>
+                                <span className="flex-1 min-w-0 truncate">{blanco.nombre}</span>
+                                <span className="text-xs text-muted-foreground capitalize flex-shrink-0">{blanco.tipo}</span>
+                              </CommandItem>
+                            ))}
+                          </CommandGroup>
+                        </CommandList>
+                      </Command>
+                    </PopoverContent>
+                  </Popover>
                   {blancosSeleccionados.length > 0 && (
-                    <div className="border border-primary/30 bg-primary/5 rounded-lg p-4">
-                      <div className="text-xs text-brand-brown/70 mb-2">
-                        Seleccionados ({blancosSeleccionados.length}):
-                      </div>
-                      <div className="flex flex-wrap gap-2">
-                        {blancosSeleccionados.map((blanco) => (
-                          <div
-                            key={blanco.id}
-                            className="inline-flex items-center gap-2 px-3 py-1.5 bg-white border-2 border-primary rounded-full text-sm"
+                    <div className="flex flex-wrap gap-2">
+                      {blancosSeleccionados.map((blanco) => (
+                        <Badge key={blanco.id} variant="secondary" className="gap-1.5 py-1 pl-2.5 pr-1.5">
+                          {blanco.nombre}
+                          <button
+                            type="button"
+                            onClick={() => quitarBlanco(blanco.id)}
+                            aria-label={`Quitar ${blanco.nombre}`}
+                            className="hover:text-destructive"
                           >
-                            <span>{blanco.tipo === 'plaga' ? '🐛' : '🍄'}</span>
-                            <span className="text-foreground">{blanco.nombre}</span>
-                            <button
-                              type="button"
-                              onClick={() => quitarBlanco(blanco.id)}
-                              className="ml-1 text-brand-brown/70 hover:text-red-600 transition-colors"
-                              aria-label={`Quitar ${blanco.nombre}`}
-                            >
-                              <X className="w-4 h-4" />
-                            </button>
-                          </div>
-                        ))}
-                      </div>
+                            <X className="w-3 h-3" />
+                          </button>
+                        </Badge>
+                      ))}
                     </div>
+                  )}
+                  {errores.blanco_biologico && (
+                    <p className="text-sm text-destructive flex items-center gap-1">
+                      <AlertCircle className="w-3.5 h-3.5" />
+                      {errores.blanco_biologico}
+                    </p>
                   )}
                 </div>
               )}
-            </div>
-          )}
-        </div>
-      </div>
+            </FieldGroup>
+          </CollapsibleContent>
+        </Collapsible>
 
-      {/* SELECCIÓN DE LOTES */}
-      <div>
-        <h2 className="text-lg text-foreground mb-4">Lotes a Aplicar</h2>
+        {/* LOTES A APLICAR */}
+        <div>
+          <h4 className="text-sm font-bold text-foreground mb-1">Lotes a Aplicar</h4>
+          <p className="text-xs text-muted-foreground mb-3">Toca una tarjeta para seleccionarla o quitarla — la misma acción sirve para ambas.</p>
 
-        {/* Barra de búsqueda de lotes */}
-        <div className="mb-4">
-          <input
-            type="text"
-            value={busquedaLote}
-            onChange={(e) => setBusquedaLote(e.target.value)}
-            placeholder="Buscar lote por nombre..."
-            className="w-full px-4 py-2 border border-gray-300 rounded-lg focus:ring-2 focus:ring-primary/20 focus:border-primary"
-            disabled={cargandoLotes}
-          />
-        </div>
-
-        {/* Grid de lotes disponibles con checkboxes */}
-        {cargandoLotes ? (
-          <div className="p-8 bg-gray-50 rounded-lg text-center">
-            <p className="text-sm text-brand-brown/70">Cargando lotes...</p>
+          <div className="relative mb-3.5">
+            <Search className="w-4 h-4 text-muted-foreground absolute left-3 top-1/2 -translate-y-1/2 pointer-events-none" />
+            <Input
+              value={busquedaLote}
+              onChange={(e) => setBusquedaLote(e.target.value)}
+              placeholder="Buscar lote por nombre..."
+              className="pl-9"
+              disabled={cargandoLotes}
+            />
           </div>
-        ) : (
-          <div className="grid grid-cols-1 md:grid-cols-2 lg:grid-cols-3 gap-3 mb-6">
-            {lotesCatalogo
-              .filter((lote) => 
-                lote.nombre.toLowerCase().includes(busquedaLote.toLowerCase())
-              )
-              .map((lote) => {
-                const yaSeleccionado = formData.lotes_seleccionados?.some((l) => l.lote_id === lote.id);
 
-                return (
-                  <button
-                    key={lote.id}
-                    type="button"
-                    onClick={() => {
-                      if (yaSeleccionado) {
-                        // Quitar lote
-                        quitarLote(lote.id);
-                      } else {
-                        // Agregar lote
-                        const nuevoLote: LoteSeleccionado = {
-                          lote_id: lote.id,
-                          nombre: lote.nombre,
-                          sublotes_ids: lote.sublotes.map((s) => s.id),
-                          area_hectareas: lote.area_hectareas,
-                          conteo_arboles: lote.conteo_arboles,
-                          calibracion_litros_arbol: (formData.tipo === 'fumigacion' || formData.tipo === 'drench') ? 20 : undefined,
-                          tamano_caneca: (formData.tipo === 'fumigacion' || formData.tipo === 'drench') ? 200 : undefined,
-                        };
-                        setFormData((prev) => ({
-                          ...prev,
-                          lotes_seleccionados: [...(prev.lotes_seleccionados || []), nuevoLote],
-                        }));
-                      }
-                    }}
-                    className={`
-                      p-4 rounded-xl border-2 text-left transition-all
-                      ${yaSeleccionado
-                        ? 'border-primary bg-primary/5'
-                        : 'border-gray-200 hover:border-gray-300'
-                      }
-                    `}
-                  >
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
-                        <p className="text-foreground mb-1">{lote.nombre}</p>
-                        <p className="text-xs text-brand-brown/70">
-                          {lote.area_hectareas}ha • {lote.conteo_arboles.total} árboles
-                        </p>
-                      </div>
-                      {yaSeleccionado && (
-                        <div className="w-6 h-6 bg-primary rounded-full flex items-center justify-center text-white flex-shrink-0">
-                          <svg className="w-4 h-4" viewBox="0 0 24 24" fill="none" stroke="currentColor" strokeWidth="3" strokeLinecap="round" strokeLinejoin="round">
-                            <polyline points="20 6 9 17 4 12"></polyline>
-                          </svg>
-                        </div>
+          {cargandoLotes ? (
+            <div className="p-8 bg-muted rounded-xl text-center text-sm text-muted-foreground">Cargando lotes...</div>
+          ) : (
+            <div className="grid grid-cols-1 sm:grid-cols-2 xl:grid-cols-3 gap-3">
+              {lotesCatalogo
+                .filter((lote) => lote.nombre.toLowerCase().includes(busquedaLote.toLowerCase()))
+                .map((lote) => {
+                  const seleccionado = formData.lotes_seleccionados?.some((l) => l.lote_id === lote.id);
+                  return (
+                    <label
+                      key={lote.id}
+                      className={cn(
+                        'flex items-start gap-3 rounded-xl border px-4 py-3.5 cursor-pointer transition-colors min-h-11',
+                        seleccionado ? 'border-primary bg-primary/5' : 'border-border hover:border-secondary',
                       )}
-                    </div>
-                  </button>
-                );
-              })}
-          </div>
-        )}
-
-        {errores.lotes && (
-          <p className="text-red-600 text-sm mb-4 flex items-center gap-1">
-            <AlertCircle className="w-4 h-4" />
-            {errores.lotes}
-          </p>
-        )}
-
-        {/* Lista de lotes seleccionados */}
-        <div className="space-y-4">
-          {formData.lotes_seleccionados?.map((lote) => (
-            <div
-              key={lote.lote_id}
-              className="border border-gray-200 rounded-xl p-4 bg-gradient-to-br from-primary/5 to-secondary/5"
-            >
-              <div className="flex items-start justify-between mb-3">
-                <div>
-                  <h3 className="text-foreground flex items-center gap-2">
-                    <MapPin className="w-4 h-4 text-primary" />
-                    {lote.nombre}
-                  </h3>
-                  <p className="text-sm text-brand-brown/70">
-                    {lote.area_hectareas} ha • {lote.conteo_arboles.total} árboles
-                  </p>
-                </div>
-                <button
-                  type="button"
-                  onClick={() => quitarLote(lote.lote_id)}
-                  className="text-red-600 hover:text-red-800 transition-colors"
-                  aria-label={`Quitar lote ${lote.nombre}`}
-                >
-                  <X className="w-5 h-5" />
-                </button>
-              </div>
-
-              {/* Desglose de árboles */}
-              <div className="grid grid-cols-4 gap-2 mb-3">
-                <div className="text-center p-2 bg-white rounded-lg">
-                  <div className="text-xs text-brand-brown/70">Grandes</div>
-                  <div className="text-foreground">{lote.conteo_arboles.grandes}</div>
-                </div>
-                <div className="text-center p-2 bg-white rounded-lg">
-                  <div className="text-xs text-brand-brown/70">Medianos</div>
-                  <div className="text-foreground">{lote.conteo_arboles.medianos}</div>
-                </div>
-                <div className="text-center p-2 bg-white rounded-lg">
-                  <div className="text-xs text-brand-brown/70">Pequeños</div>
-                  <div className="text-foreground">{lote.conteo_arboles.pequenos}</div>
-                </div>
-                <div className="text-center p-2 bg-white rounded-lg">
-                  <div className="text-xs text-brand-brown/70">Clonales</div>
-                  <div className="text-foreground">{lote.conteo_arboles.clonales}</div>
-                </div>
-              </div>
-
-              {/* Configuración específica de fumigación */}
-              {formData.tipo === 'fumigacion' && (
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-xs text-brand-brown mb-1">
-                      Calibración (L/árbol)
-                    </label>
-                    <input
-                      type="number"
-                      onWheel={(e) => e.currentTarget.blur()}
-                      step="0.1"
-                      value={lote.calibracion_litros_arbol || ''}
-                      onChange={(e) =>
-                        actualizarLote(
-                          lote.lote_id,
-                          'calibracion_litros_arbol',
-                          parseFloat(e.target.value)
-                        )
-                      }
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-xs text-brand-brown mb-1">
-                      Tamaño Caneca (L)
-                    </label>
-                    <select
-                      value={lote.tamano_caneca || 200}
-                      onChange={(e) =>
-                        actualizarLote(lote.lote_id, 'tamano_caneca', parseInt(e.target.value))
-                      }
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary/20 focus:border-primary"
                     >
-                      <option value={20}>20L</option>
-                      <option value={200}>200L</option>
-                      <option value={500}>500L</option>
-                      <option value={1000}>1000L</option>
-                    </select>
-                  </div>
-                </div>
-              )}
-
-              {/* Configuración específica de drench (igual a fumigación) */}
-              {formData.tipo === 'drench' && (
-                <div className="grid grid-cols-2 gap-3">
-                  <div>
-                    <label className="block text-xs text-brand-brown mb-1">
-                      Calibración (L/árbol)
+                      <Checkbox checked={!!seleccionado} onCheckedChange={() => toggleLote(lote)} className="mt-0.5" />
+                      <span className="flex-1 min-w-0">
+                        <span className="block text-sm font-medium text-foreground">{lote.nombre}</span>
+                        <span className="block text-xs text-muted-foreground mt-0.5">
+                          {formatearNumero(lote.area_hectareas, 1)} ha · {formatearNumero(lote.conteo_arboles.total, 0)} árboles
+                        </span>
+                      </span>
                     </label>
-                    <input
-                      type="number"
-                      onWheel={(e) => e.currentTarget.blur()}
-                      step="0.1"
-                      value={lote.calibracion_litros_arbol || ''}
-                      onChange={(e) =>
-                        actualizarLote(
-                          lote.lote_id,
-                          'calibracion_litros_arbol',
-                          parseFloat(e.target.value)
-                        )
-                      }
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                    />
-                  </div>
-                  <div>
-                    <label className="block text-xs text-brand-brown mb-1">
-                      Tamaño Caneca (L)
-                    </label>
-                    <select
-                      value={lote.tamano_caneca || 200}
-                      onChange={(e) =>
-                        actualizarLote(lote.lote_id, 'tamano_caneca', parseInt(e.target.value))
-                      }
-                      className="w-full px-2 py-1 text-sm border border-gray-300 rounded focus:ring-2 focus:ring-primary/20 focus:border-primary"
-                    >
-                      <option value={20}>20L</option>
-                      <option value={200}>200L</option>
-                      <option value={500}>500L</option>
-                      <option value={1000}>1000L</option>
-                    </select>
-                  </div>
-                </div>
-              )}
-
-              {errores[`lote_${lote.lote_id}`] && (
-                <p className="text-red-600 text-xs mt-2 flex items-center gap-1">
-                  <AlertCircle className="w-3 h-3" />
-                  {errores[`lote_${lote.lote_id}`]}
-                </p>
-              )}
+                  );
+                })}
             </div>
-          ))}
+          )}
+
+          {errores.lotes && (
+            <p className="text-sm text-destructive flex items-center gap-1 mt-3">
+              <AlertCircle className="w-3.5 h-3.5" />
+              {errores.lotes}
+            </p>
+          )}
+
+          {/* Calibración / caneca por lote — solo Fumigación/Drench (KEEP-reducido, campo #10) */}
+          {usaCalibracion && (formData.lotes_seleccionados?.length ?? 0) > 0 && (
+            <div className="mt-4 space-y-2.5">
+              <h5 className="text-xs font-bold text-foreground uppercase tracking-wide">Calibración por lote</h5>
+              {formData.lotes_seleccionados?.map((lote) => (
+                <div key={lote.lote_id} className="border border-border rounded-lg p-3.5 bg-card">
+                  <p className="text-sm font-medium text-foreground flex items-center gap-1.5 mb-2.5">
+                    <MapPin className="w-3.5 h-3.5 text-primary" />
+                    {lote.nombre}
+                  </p>
+                  <div className="grid grid-cols-2 gap-3">
+                    <Field>
+                      <FieldLabel htmlFor={`calibracion-${lote.lote_id}`} className="text-xs">
+                        Calibración
+                      </FieldLabel>
+                      <InputGroup>
+                        <InputGroupInput
+                          id={`calibracion-${lote.lote_id}`}
+                          type="number"
+                          onWheel={(e) => e.currentTarget.blur()}
+                          step="0.1"
+                          min={0}
+                          value={lote.calibracion_litros_arbol ?? ''}
+                          onChange={(e) =>
+                            actualizarLote(lote.lote_id, 'calibracion_litros_arbol', parseFloat(e.target.value) || 0)
+                          }
+                        />
+                        <InputGroupAddon align="inline-end">L/árbol</InputGroupAddon>
+                      </InputGroup>
+                    </Field>
+                    <Field>
+                      <FieldLabel className="text-xs">Tamaño de Caneca</FieldLabel>
+                      <Select
+                        value={String(lote.tamano_caneca ?? 200)}
+                        onValueChange={(v) => actualizarLote(lote.lote_id, 'tamano_caneca', parseInt(v, 10))}
+                      >
+                        <SelectTrigger size="sm">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {[20, 200, 500, 1000].map((v) => (
+                            <SelectItem key={v} value={String(v)}>
+                              {v}L
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    </Field>
+                  </div>
+                  {errores[`lote_${lote.lote_id}`] && (
+                    <p className="text-xs text-destructive flex items-center gap-1 mt-2">
+                      <AlertCircle className="w-3 h-3" />
+                      {errores[`lote_${lote.lote_id}`]}
+                    </p>
+                  )}
+                </div>
+              ))}
+            </div>
+          )}
         </div>
+
+        {/* MEZCLA Y PRODUCTOS */}
+        {formData.lotes_seleccionados && formData.lotes_seleccionados.length > 0 && (
+          <MezclaPlanSection
+            configuracion={formData as ConfiguracionAplicacion}
+            mezclas={mezclas}
+            estadosAsignacion={estadosAsignacion}
+            onUpdate={onUpdateMezclas}
+            onEstimadoChange={setEstimado}
+            onReintentarAsignacion={onReintentarAsignacion}
+          />
+        )}
       </div>
 
-      {/* RESUMEN TOTALES */}
-      {formData.lotes_seleccionados && formData.lotes_seleccionados.length > 0 && (
-        <div className="bg-gradient-to-br from-primary/10 to-secondary/10 border border-primary/20 rounded-xl p-6">
-          <h3 className="text-foreground mb-4">Resumen Total</h3>
-          <div className="grid grid-cols-3 gap-4 text-center">
+      {/* RAIL — resumen + estimado de compra en vivo. Se apila debajo del contenido en
+          pantallas angostas (sin Drawer: mismo dato, layout de una columna). */}
+      <div className="xl:sticky xl:top-6 space-y-4">
+        <Card className="p-4">
+          <h5 className="text-sm font-bold text-foreground mb-3">Resumen</h5>
+          <div className="grid grid-cols-3 gap-2 text-center">
             <div>
-              <div className="text-sm text-brand-brown/70">Lotes</div>
-              <div className="text-2xl text-foreground">
-                {formData.lotes_seleccionados.length}
-              </div>
+              <p className="text-lg font-bold tabular-nums text-foreground">{formData.lotes_seleccionados?.length ?? 0}</p>
+              <p className="text-xs text-muted-foreground">Lotes</p>
             </div>
             <div>
-              <div className="text-sm text-brand-brown/70">Área Total</div>
-              <div className="text-2xl text-foreground">{formatearNumero(totales.area, 1)} ha</div>
+              <p className="text-lg font-bold tabular-nums text-foreground">{formatearNumero(totales.area, 1)}</p>
+              <p className="text-xs text-muted-foreground">ha</p>
             </div>
             <div>
-              <div className="text-sm text-brand-brown/70">Árboles</div>
-              <div className="text-2xl text-foreground">{formatearNumero(totales.arboles, 0)}</div>
+              <p className="text-lg font-bold tabular-nums text-foreground">{formatearNumero(totales.arboles, 0)}</p>
+              <p className="text-xs text-muted-foreground">Árboles</p>
             </div>
           </div>
-        </div>
-      )}
+        </Card>
+
+        <Card className="p-4">
+          <h5 className="text-sm font-bold text-foreground mb-3 flex items-center gap-1.5">
+            <ShoppingCart className="w-4 h-4" />
+            Estimado de Compra
+          </h5>
+          {estimado === null || estimado.items.length === 0 ? (
+            <p className="text-xs text-muted-foreground">
+              {mezclas.length === 0
+                ? 'Agrega una mezcla con productos para ver el impacto en compras.'
+                : 'Todo lo necesario ya está disponible en inventario.'}
+            </p>
+          ) : (
+            <div className="space-y-2">
+              {estimado.items.map((item) => (
+                <div key={item.producto_id} className="rounded-lg bg-destructive/5 border border-destructive/20 px-3 py-2">
+                  <p className="text-sm font-bold text-foreground">{item.producto_nombre}</p>
+                  <p className="text-xs text-destructive">
+                    Faltante {formatearNumero(item.cantidad_faltante)} {item.unidad}
+                    {item.costo_estimado ? ` · ≈ ${formatearMoneda(item.costo_estimado)}` : ''}
+                  </p>
+                </div>
+              ))}
+              <p className="text-[0.6875rem] text-muted-foreground pt-1">
+                Se recalcula con cada producto que agregas — no hace falta llegar al Paso 2 para ver el impacto.
+              </p>
+            </div>
+          )}
+        </Card>
+      </div>
     </div>
   );
 }

--- a/src/components/aplicaciones/PasoConfiguracion.tsx
+++ b/src/components/aplicaciones/PasoConfiguracion.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect, useRef } from 'react';
 import { Sprout, Calendar, MapPin, Plus, X, AlertCircle, Bug } from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
 import { formatearFecha } from '../../utils/fechas';
+import { formatearNumero } from '../../utils/format';
 import { DateInput } from '../ui/date-input';
 import type {
   ConfiguracionAplicacion,
@@ -553,6 +554,7 @@ export function PasoConfiguracion({ configuracion, onUpdate }: PasoConfiguracion
                               type="button"
                               onClick={() => quitarBlanco(blanco.id)}
                               className="ml-1 text-brand-brown/70 hover:text-red-600 transition-colors"
+                              aria-label={`Quitar ${blanco.nombre}`}
                             >
                               <X className="w-4 h-4" />
                             </button>
@@ -662,6 +664,7 @@ export function PasoConfiguracion({ configuracion, onUpdate }: PasoConfiguracion
                               type="button"
                               onClick={() => quitarBlanco(blanco.id)}
                               className="ml-1 text-brand-brown/70 hover:text-red-600 transition-colors"
+                              aria-label={`Quitar ${blanco.nombre}`}
                             >
                               <X className="w-4 h-4" />
                             </button>
@@ -789,6 +792,7 @@ export function PasoConfiguracion({ configuracion, onUpdate }: PasoConfiguracion
                   type="button"
                   onClick={() => quitarLote(lote.lote_id)}
                   className="text-red-600 hover:text-red-800 transition-colors"
+                  aria-label={`Quitar lote ${lote.nombre}`}
                 >
                   <X className="w-5 h-5" />
                 </button>
@@ -922,11 +926,11 @@ export function PasoConfiguracion({ configuracion, onUpdate }: PasoConfiguracion
             </div>
             <div>
               <div className="text-sm text-brand-brown/70">Área Total</div>
-              <div className="text-2xl text-foreground">{totales.area.toFixed(1)} ha</div>
+              <div className="text-2xl text-foreground">{formatearNumero(totales.area, 1)} ha</div>
             </div>
             <div>
               <div className="text-sm text-brand-brown/70">Árboles</div>
-              <div className="text-2xl text-foreground">{totales.arboles.toLocaleString()}</div>
+              <div className="text-2xl text-foreground">{formatearNumero(totales.arboles, 0)}</div>
             </div>
           </div>
         </div>

--- a/src/components/aplicaciones/PasoConfiguracion.tsx
+++ b/src/components/aplicaciones/PasoConfiguracion.tsx
@@ -326,8 +326,13 @@ export function PasoConfiguracion({
           )}
         </Field>
 
-        {/* TIPO + FECHAS */}
-        <FieldGroup className="grid grid-cols-1 sm:grid-cols-[auto_1fr] gap-6">
+        {/* TIPO + FECHAS.
+            Antes: `sm:grid-cols-[auto_1fr]`. Con el rail de 300px a la derecha, a "Ventana de
+            ejecución" le quedaban ~180px para DOS DateInput, y cada uno arrastra 72px de padding
+            (`px-4 pr-10`) — el texto se quedaba sin espacio y solo se veía el ícono de calendario,
+            como si el campo estuviera roto. Ahora cada uno ocupa su propia fila hasta lg, y desde
+            lg comparten en 50/50 (no auto/1fr), que es cuando de verdad hay ancho. */}
+        <FieldGroup className="grid grid-cols-1 lg:grid-cols-2 gap-x-6 gap-y-5">
           <Field>
             <FieldLabel>
               Tipo de Aplicación <span className="text-destructive">*</span>
@@ -382,16 +387,16 @@ export function PasoConfiguracion({
             <FieldLabel>
               Ventana de ejecución <span className="text-destructive">*</span>
             </FieldLabel>
-            <div className="flex items-center gap-2.5">
-              <div className="flex-1">
+            <div className="flex flex-col gap-2 min-[520px]:flex-row min-[520px]:items-center min-[520px]:gap-2.5">
+              <div className="min-w-0 flex-1">
                 <DateInput
                   value={formData.fecha_inicio_planeada || ''}
                   onChange={(v) => setFormData((prev) => ({ ...prev, fecha_inicio_planeada: v }))}
                   required
                 />
               </div>
-              <span className="text-sm text-muted-foreground flex-shrink-0">→</span>
-              <div className="flex-1">
+              <span aria-hidden="true" className="hidden min-[520px]:block text-sm text-muted-foreground flex-shrink-0">→</span>
+              <div className="min-w-0 flex-1">
                 <DateInput
                   value={formData.fecha_fin_planeada || ''}
                   onChange={(v) => {

--- a/src/components/aplicaciones/PasoListaCompras.tsx
+++ b/src/components/aplicaciones/PasoListaCompras.tsx
@@ -1,25 +1,28 @@
 import { useState, useEffect } from 'react';
 import {
-  Package,
   ShoppingCart,
   CheckCircle,
   AlertTriangle,
-  DollarSign,
   Download,
   Edit2,
   Save,
   X as XIcon,
-  TrendingUp
 } from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
 import { useSafeMode } from '../../contexts/SafeModeContext';
 import { generarPDFListaCompras } from '../../utils/generarPDFListaCompras';
-import {
-  calcularTotalesGlobalesProductos,
-  generarListaCompras
-} from '../../utils/calculosAplicaciones';
+import { calcularTotalesGlobalesProductos, generarListaCompras } from '../../utils/calculosAplicaciones';
 import { formatearMoneda, formatearNumero } from '../../utils/format';
 import { toast } from 'sonner';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { Alert, AlertDescription } from '../ui/alert';
+import { Card } from '../ui/card';
+import { Field, FieldLabel } from '../ui/field';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
+import { Empty, EmptyHeader, EmptyMedia, EmptyTitle, EmptyDescription } from '../ui/empty';
+import { Table, TableHeader, TableBody, TableFooter, TableHead, TableRow, TableCell } from '../ui/table';
+import { cn } from '../ui/utils';
 import type {
   ConfiguracionAplicacion,
   Mezcla,
@@ -40,7 +43,6 @@ interface PasoListaComprasProps {
 export function PasoListaCompras({
   configuracion,
   mezclas,
-  calculos,
   lista_compras,
   onUpdate,
 }: PasoListaComprasProps) {
@@ -49,44 +51,30 @@ export function PasoListaCompras({
 
   const [lista, setLista] = useState<ListaCompras | null>(lista_compras);
   const [cargando, setCargando] = useState(false);
-  const [inventario, setInventario] = useState<ProductoCatalogo[]>([]);
-  
-  // Estado para edición manual - inline directa
+
   const [modoEdicion, setModoEdicion] = useState(false);
   const [itemsEditables, setItemsEditables] = useState<Record<string, ItemListaCompras>>({});
 
-  /**
-   * GENERAR LISTA DE COMPRAS AL MONTAR
-   */
   useEffect(() => {
     if (!lista_compras) {
       generarLista();
     } else {
-      // Inicializar items editables
       const editables: Record<string, ItemListaCompras> = {};
       lista_compras.items.forEach((item) => {
         editables[item.producto_id] = { ...item };
       });
       setItemsEditables(editables);
     }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
-  /**
-   * CARGAR INVENTARIO Y GENERAR LISTA
-   */
   const generarLista = async () => {
     setCargando(true);
     try {
-      // Obtener IDs de productos necesarios (usando totales desde mezclas)
       const productosNecesarios = calcularTotalesGlobalesProductos(mezclas);
       const productosIds = productosNecesarios.map((p) => p.producto_id);
 
-      // Cargar inventario actual de esos productos
-      const { data, error } = await supabase
-        .from('productos')
-        .select('*')
-        .in('id', productosIds);
-
+      const { data, error } = await supabase.from('productos').select('*').in('id', productosIds);
       if (error) throw error;
 
       let inventarioActual = data.map((p) => ({
@@ -96,66 +84,48 @@ export function PasoListaCompras({
         grupo: p.grupo,
         unidad_medida: p.unidad_medida,
         estado_fisico: p.estado_fisico,
-        // Construir presentación: "50 Kg" o fallback a "1 Kg/L"
-        presentacion_comercial: p.presentacion_kg_l && p.presentacion_kg_l > 0
-          ? `${p.presentacion_kg_l} ${(p.unidad_medida as string) === 'kilos' || p.unidad_medida === 'Kilos' ? 'Kg' : (p.unidad_medida as string) === 'litros' || p.unidad_medida === 'Litros' ? 'L' : p.unidad_medida}`
-          : `1 ${(p.unidad_medida as string) === 'kilos' || p.unidad_medida === 'Kilos' ? 'Kg' : (p.unidad_medida as string) === 'litros' || p.unidad_medida === 'Litros' ? 'L' : p.unidad_medida}`,
-        ultimo_precio_unitario: p.precio_unitario || 0,      // Precio por Kg/L
-        precio_presentacion: p.precio_por_presentacion || 0, // Precio por bulto/envase
+        presentacion_comercial:
+          p.presentacion_kg_l && p.presentacion_kg_l > 0
+            ? `${p.presentacion_kg_l} ${(p.unidad_medida as string) === 'kilos' || p.unidad_medida === 'Kilos' ? 'Kg' : (p.unidad_medida as string) === 'litros' || p.unidad_medida === 'Litros' ? 'L' : p.unidad_medida}`
+            : `1 ${(p.unidad_medida as string) === 'kilos' || p.unidad_medida === 'Kilos' ? 'Kg' : (p.unidad_medida as string) === 'litros' || p.unidad_medida === 'Litros' ? 'L' : p.unidad_medida}`,
+        ultimo_precio_unitario: p.precio_unitario || 0,
+        precio_presentacion: p.precio_por_presentacion || 0,
         cantidad_actual: p.cantidad_actual || 0,
         permitido_gerencia: p.permitido_gerencia ?? undefined,
       })) as unknown as ProductoCatalogo[];
 
-      // Filtrar productos no permitidos si modo seguro está activado
       if (isSafeModeEnabled) {
         inventarioActual = inventarioActual.filter((p) => p.permitido_gerencia !== false);
       }
 
-      setInventario(inventarioActual);
-
-      // Generar lista de compras
       const nuevaLista = generarListaCompras(productosNecesarios, inventarioActual);
       setLista(nuevaLista);
       onUpdate(nuevaLista);
-    } catch (error) {
+    } catch {
       toast.error('Error al generar lista de compras');
     } finally {
       setCargando(false);
     }
   };
 
-  /**
-   * EXPORTAR LISTA A PDF
-   */
   const exportarPDF = async () => {
-    if (lista) {
-      // Datos de la empresa (podrías cargarlos de configuración global)
-      const datosEmpresa = {
-        nombre: 'Escocia Hass',
-        nit: '900.XXX.XXX-X', // Actualizar con NIT real
-        direccion: 'Dirección del cultivo', // Actualizar con dirección real
-        telefono: '+57 XXX XXX XXXX', // Actualizar con teléfono real
-        email: 'contacto@escocia-hass.com', // Actualizar con email real
-      };
-
-      await generarPDFListaCompras(lista, configuracion, datosEmpresa);
-    } else {
+    if (!lista) {
       toast.error('No hay lista de compras para exportar');
+      return;
     }
+    const datosEmpresa = {
+      nombre: 'Escocia Hass',
+      nit: '900.XXX.XXX-X',
+      direccion: 'Dirección del cultivo',
+      telefono: '+57 XXX XXX XXXX',
+      email: 'contacto@escocia-hass.com',
+    };
+    await generarPDFListaCompras(lista, configuracion, datosEmpresa);
   };
 
-  /**
-   * ACTIVAR MODO EDICIÓN
-   */
-  const activarEdicion = () => {
-    setModoEdicion(true);
-  };
+  const activarEdicion = () => setModoEdicion(true);
 
-  /**
-   * CANCELAR EDICIÓN
-   */
   const cancelarEdicion = () => {
-    // Restaurar valores originales
     if (lista) {
       const editables: Record<string, ItemListaCompras> = {};
       lista.items.forEach((item) => {
@@ -163,104 +133,56 @@ export function PasoListaCompras({
       });
       setItemsEditables(editables);
     }
-
     setModoEdicion(false);
   };
 
-  /**
-   * Extrae el tamaño numérico de una presentación comercial
-   */
   const extraerTamanoPresentacion = (presentacion: string | undefined): number => {
     if (!presentacion) return 1;
-    
-    // Normalizar: reemplazar coma europea por punto decimal
     const normalizada = presentacion.replace(/,/g, '.');
-    
-    // Buscar primer número (entero o decimal)
     const match = normalizada.match(/(\d+\.?\d*)/);
     const valor = match ? parseFloat(match[1]) : 1;
-    
-    // Validar que sea un número válido
     return isNaN(valor) || valor <= 0 ? 1 : valor;
   };
 
-  /**
-   * EDITAR CANTIDAD DE UN PRODUCTO
-   */
   const editarCantidad = (
     productoId: string,
     campo: 'unidades_a_comprar' | 'cantidad_faltante',
-    valor: number
+    valor: number,
   ) => {
     const item = itemsEditables[productoId];
     if (!item) return;
 
     const itemActualizado = { ...item };
-
     if (campo === 'unidades_a_comprar') {
       itemActualizado.unidades_a_comprar = Math.max(0, valor);
-
-      // Recalcular cantidad faltante basado en unidades
       const tamanoPresentacion = extraerTamanoPresentacion(item.presentacion_comercial);
-      const nuevaCantidadFaltante = itemActualizado.unidades_a_comprar * tamanoPresentacion;
-      itemActualizado.cantidad_faltante = nuevaCantidadFaltante;
-    } else if (campo === 'cantidad_faltante') {
+      itemActualizado.cantidad_faltante = itemActualizado.unidades_a_comprar * tamanoPresentacion;
+    } else {
       itemActualizado.cantidad_faltante = Math.max(0, valor);
-
-      // Recalcular unidades basado en cantidad
       const tamanoPresentacion = extraerTamanoPresentacion(item.presentacion_comercial);
       itemActualizado.unidades_a_comprar = Math.ceil(valor / tamanoPresentacion);
     }
-
-    // Recalcular costo usando precio_presentacion
     itemActualizado.costo_estimado = itemActualizado.unidades_a_comprar * (item.precio_presentacion || 0);
 
-    setItemsEditables((prev) => ({
-      ...prev,
-      [productoId]: itemActualizado,
-    }));
+    setItemsEditables((prev) => ({ ...prev, [productoId]: itemActualizado }));
   };
 
-  /**
-   * EDITAR PRECIO DE PRESENTACIÓN (precio por bulto/envase completo)
-   * Este precio NO afecta la tabla de productos, solo el reporte de lista de compras
-   */
   const editarPrecioPresentacion = (productoId: string, nuevoPrecio: number) => {
     const item = itemsEditables[productoId];
     if (!item) return;
-
-    const itemActualizado = { ...item };
-    itemActualizado.precio_presentacion = Math.max(0, nuevoPrecio);
-
-    // Recalcular costo con el nuevo precio
-    itemActualizado.costo_estimado = itemActualizado.unidades_a_comprar * nuevoPrecio;
-
-    setItemsEditables((prev) => ({
-      ...prev,
-      [productoId]: itemActualizado,
-    }));
+    const itemActualizado = { ...item, precio_presentacion: Math.max(0, nuevoPrecio) };
+    itemActualizado.costo_estimado = itemActualizado.unidades_a_comprar * itemActualizado.precio_presentacion;
+    setItemsEditables((prev) => ({ ...prev, [productoId]: itemActualizado }));
   };
 
-  /**
-   * GUARDAR CAMBIOS DE EDICIÓN
-   */
   const guardarCambios = () => {
     if (!lista) return;
-
-    // Crear nueva lista con items editados
     const itemsActualizados = Object.values(itemsEditables);
-
-    // Recalcular totales
     const nuevosCostos = itemsActualizados
       .filter((item) => item.cantidad_faltante > 0)
       .reduce((sum, item) => sum + (item.costo_estimado || 0), 0);
 
-    const nuevaLista: ListaCompras = {
-      ...lista,
-      items: itemsActualizados,
-      costo_total_estimado: nuevosCostos,
-    };
-
+    const nuevaLista: ListaCompras = { ...lista, items: itemsActualizados, costo_total_estimado: nuevosCostos };
     setLista(nuevaLista);
     onUpdate(nuevaLista);
     setModoEdicion(false);
@@ -268,10 +190,10 @@ export function PasoListaCompras({
 
   if (cargando) {
     return (
-      <div className="flex items-center justify-center py-12">
+      <div className="flex items-center justify-center py-16">
         <div className="text-center">
-          <div className="animate-spin rounded-full h-12 w-12 border-4 border-primary/20 border-t-primary mx-auto mb-4"></div>
-          <p className="text-brand-brown/70">Generando lista de compras...</p>
+          <div className="animate-spin rounded-full h-10 w-10 border-4 border-primary/20 border-t-primary mx-auto mb-3" />
+          <p className="text-sm text-muted-foreground">Generando lista de compras...</p>
         </div>
       </div>
     );
@@ -279,168 +201,125 @@ export function PasoListaCompras({
 
   if (!lista) {
     return (
-      <div className="text-center py-12">
-        <Package className="w-16 h-16 text-primary/50 mx-auto mb-4" />
-        <p className="text-brand-brown/70 mb-4">No se pudo generar la lista de compras</p>
-        <button
-          onClick={generarLista}
-          className="px-4 py-2 bg-gradient-to-r from-primary to-secondary text-white rounded-lg hover:from-primary-dark hover:to-secondary-dark transition-all"
-        >
+      <Empty>
+        <EmptyHeader>
+          <EmptyMedia variant="icon">
+            <ShoppingCart />
+          </EmptyMedia>
+          <EmptyTitle>No se pudo generar la lista de compras</EmptyTitle>
+          <EmptyDescription>Intenta de nuevo — puede ser un problema temporal de conexión.</EmptyDescription>
+        </EmptyHeader>
+        <Button type="button" onClick={generarLista}>
           Reintentar
-        </button>
-      </div>
+        </Button>
+      </Empty>
     );
   }
 
-  // Separar productos: a comprar vs disponibles
-  const productosAComprar = modoEdicion 
-    ? Object.values(itemsEditables).filter((item) => item.cantidad_faltante > 0) 
+  const productosAComprar = modoEdicion
+    ? Object.values(itemsEditables).filter((item) => item.cantidad_faltante > 0)
     : lista.items.filter((item) => item.cantidad_faltante > 0);
   const productosDisponibles = modoEdicion
     ? Object.values(itemsEditables).filter((item) => item.cantidad_faltante === 0)
     : lista.items.filter((item) => item.cantidad_faltante === 0);
-  
-  // Recalcular costo total en tiempo real cuando está en modo edición
+
   const costoTotalActual = modoEdicion
     ? productosAComprar.reduce((sum, item) => sum + (item.costo_estimado || 0), 0)
     : lista.costo_total_estimado;
 
   return (
     <div className="space-y-6">
-      {/* HEADER */}
-      <div className="flex items-center justify-between">
+      <div className="flex items-start justify-between gap-4 flex-wrap">
         <div>
-          <h2 className="text-lg text-foreground">Lista de Compras</h2>
-          <p className="text-sm text-brand-brown/70 mt-1">Comparación con inventario disponible</p>
+          <h3 className="text-base font-bold text-foreground">Lista de Compras</h3>
+          <p className="text-sm text-muted-foreground mt-0.5">Comparación con inventario disponible</p>
         </div>
 
         <div className="flex gap-2">
-          {/* Botón Editar/Guardar/Cancelar */}
           {!modoEdicion ? (
-            <button
-              onClick={activarEdicion}
-              className="px-4 py-2 border border-gray-300 text-brand-brown rounded-lg hover:bg-gray-50 transition-all flex items-center gap-2"
-            >
+            <Button type="button" variant="outline" size="sm" onClick={activarEdicion}>
               <Edit2 className="w-4 h-4" />
               <span className="hidden sm:inline">Editar Cantidades</span>
-            </button>
+            </Button>
           ) : (
             <>
-              <button
-                onClick={cancelarEdicion}
-                className="px-4 py-2 border border-gray-300 text-brand-brown rounded-lg hover:bg-gray-50 transition-all flex items-center gap-2"
-              >
+              <Button type="button" variant="outline" size="sm" onClick={cancelarEdicion}>
                 <XIcon className="w-4 h-4" />
                 <span className="hidden sm:inline">Cancelar</span>
-              </button>
-              <button
-                onClick={guardarCambios}
-                className="px-4 py-2 bg-blue-600 text-white rounded-lg hover:bg-blue-700 disabled:bg-gray-300 disabled:cursor-not-allowed transition-all flex items-center gap-2"
-              >
+              </Button>
+              <Button type="button" size="sm" onClick={guardarCambios}>
                 <Save className="w-4 h-4" />
                 <span className="hidden sm:inline">Guardar Cambios</span>
-              </button>
+              </Button>
             </>
           )}
-
-          {/* Botón Exportar PDF */}
-          <button
-            onClick={exportarPDF}
-            disabled={modoEdicion}
-            className="px-4 py-2 border border-gray-300 text-brand-brown rounded-lg hover:bg-gray-50 disabled:opacity-50 disabled:cursor-not-allowed transition-all flex items-center gap-2"
-          >
+          <Button type="button" variant="outline" size="sm" onClick={exportarPDF} disabled={modoEdicion}>
             <Download className="w-4 h-4" />
             <span className="hidden sm:inline">Exportar PDF</span>
-          </button>
+          </Button>
         </div>
       </div>
 
-      {/* ALERTA DE MODO EDICIÓN */}
       {modoEdicion && (
-        <div className="bg-blue-50 border border-blue-200 rounded-xl p-4 flex items-center gap-3">
-          <Edit2 className="w-5 h-5 text-blue-600 flex-shrink-0" />
-          <div className="flex-1">
-            <p className="text-blue-900">Modo de edición activado</p>
-            <p className="text-blue-700 text-sm">
-              Puedes modificar las cantidades y los precios unitarios. Los costos se recalcularán automáticamente. 
-              <strong> Los precios editados aquí NO afectan el inventario</strong>, solo se usan para este reporte.
-            </p>
-          </div>
-        </div>
+        <Alert>
+          <Edit2 />
+          <AlertDescription>
+            <strong className="text-foreground">Modo de edición activado.</strong> Puedes modificar las cantidades y
+            precios. Los costos se recalculan al vuelo.{' '}
+            <strong className="text-foreground">Los precios editados aquí no afectan el inventario</strong>, solo
+            este reporte.
+          </AlertDescription>
+        </Alert>
       )}
 
-      {/* RESUMEN GENERAL */}
-      <div className="grid grid-cols-1 md:grid-cols-3 gap-4">
-        <div className="bg-gradient-to-br from-red-50 to-red-100/50 border border-red-200 rounded-xl p-4">
-          <div className="flex items-center gap-3 mb-2">
-            <div className="p-2 bg-red-100 rounded-lg">
-              <ShoppingCart className="w-5 h-5 text-red-600" />
-            </div>
-            <div className="text-sm text-red-700">Productos a Comprar</div>
-          </div>
-          <div className="text-2xl text-red-900">{productosAComprar.length}</div>
-        </div>
-
-        <div className="bg-gradient-to-br from-primary/10 to-secondary/10 border border-primary/20 rounded-xl p-4">
-          <div className="flex items-center gap-3 mb-2">
-            <div className="p-2 bg-primary/10 rounded-lg">
-              <CheckCircle className="w-5 h-5 text-primary" />
-            </div>
-            <div className="text-sm text-brand-brown/70">Disponibles en Stock</div>
-          </div>
-          <div className="text-2xl text-foreground">{productosDisponibles.length}</div>
-        </div>
-
-        <div className="bg-gradient-to-br from-yellow-50 to-yellow-100/50 border border-yellow-200 rounded-xl p-4">
-          <div className="flex items-center gap-3 mb-2">
-            <div className="p-2 bg-yellow-100 rounded-lg">
-              <DollarSign className="w-5 h-5 text-yellow-600" />
-            </div>
-            <div className="text-sm text-yellow-700">Inversión Estimada</div>
-          </div>
-          <div className="text-2xl text-yellow-900">
-            {formatearMoneda(costoTotalActual)}
-          </div>
-        </div>
+      {/* RESUMEN */}
+      <div className="grid grid-cols-1 sm:grid-cols-3 gap-4">
+        <Card className="p-4">
+          <p className={cn('text-2xl font-bold tabular-nums', productosAComprar.length > 0 && 'text-destructive')}>
+            {productosAComprar.length}
+          </p>
+          <p className="text-sm text-muted-foreground mt-0.5">Productos a Comprar</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-2xl font-bold tabular-nums text-foreground">{productosDisponibles.length}</p>
+          <p className="text-sm text-muted-foreground mt-0.5">Disponibles en Stock</p>
+        </Card>
+        <Card className="p-4">
+          <p className="text-2xl font-bold tabular-nums text-foreground">{formatearMoneda(costoTotalActual)}</p>
+          <p className="text-sm text-muted-foreground mt-0.5">Inversión Estimada</p>
+        </Card>
       </div>
 
       {/* ALERTAS */}
       {(lista.productos_sin_precio > 0 || lista.productos_sin_stock > 0) && (
         <div className="space-y-2">
           {lista.productos_sin_precio > 0 && (
-            <div className="bg-yellow-50 border border-yellow-200 rounded-xl p-4 flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 text-yellow-600 flex-shrink-0 mt-0.5" />
-              <p className="text-yellow-800 text-sm">
-                <strong>{lista.productos_sin_precio}</strong> producto(s) no tienen precio
-                registrado. El costo estimado puede ser inexacto.
-              </p>
-            </div>
+            <Alert variant="warning">
+              <AlertTriangle />
+              <AlertDescription>
+                <strong className="text-foreground">{lista.productos_sin_precio}</strong> producto(s) no tienen
+                precio registrado. El costo estimado puede ser inexacto.
+              </AlertDescription>
+            </Alert>
           )}
-
           {lista.productos_sin_stock > 0 && (
-            <div className="bg-red-50 border border-red-200 rounded-xl p-4 flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-              <p className="text-red-800 text-sm">
-                <strong>{lista.productos_sin_stock}</strong> producto(s) no tienen stock
+            <Alert variant="destructive">
+              <AlertTriangle />
+              <AlertDescription>
+                <strong className="text-foreground">{lista.productos_sin_stock}</strong> producto(s) no tienen stock
                 disponible y deben comprarse en su totalidad.
-              </p>
-            </div>
+              </AlertDescription>
+            </Alert>
           )}
-
-          {/* Alerta si hay productos sin presentación configurada */}
-          {lista.items.some(item => item.presentacion_comercial.startsWith('1 ')) && (
-            <div className="bg-orange-50 border border-orange-200 rounded-xl p-4 flex items-start gap-3">
-              <AlertTriangle className="w-5 h-5 text-orange-600 flex-shrink-0 mt-0.5" />
-              <div className="flex-1">
-                <p className="text-orange-900">
-                  <strong>Algunos productos no tienen presentación comercial configurada</strong>
-                </p>
-                <p className="text-orange-700 text-sm mt-1">
-                  Los productos sin tamaño de presentación se calcularán en unidades individuales (1 Kg/L). 
-                  Para calcular correctamente en bultos, configura el campo "presentacion_kg_l" en la tabla de productos.
-                </p>
-              </div>
-            </div>
+          {lista.items.some((item) => item.presentacion_comercial.startsWith('1 ')) && (
+            <Alert variant="warning">
+              <AlertTriangle />
+              <AlertDescription>
+                <strong className="text-foreground">Algunos productos no tienen presentación comercial configurada.</strong>{' '}
+                Se calculan en unidades individuales (1 Kg/L). Configura "presentacion_kg_l" en Inventario para
+                calcular en bultos.
+              </AlertDescription>
+            </Alert>
           )}
         </div>
       )}
@@ -448,289 +327,305 @@ export function PasoListaCompras({
       {/* PRODUCTOS A COMPRAR */}
       {productosAComprar.length > 0 && (
         <div>
-          <h3 className="text-foreground mb-3 flex items-center gap-2">
-            <ShoppingCart className="w-5 h-5 text-red-600" />
+          <h4 className="text-sm font-bold text-foreground mb-3 flex items-center gap-2">
+            <ShoppingCart className="w-4 h-4 text-destructive" />
             Productos a Comprar ({productosAComprar.length})
-          </h3>
+          </h4>
 
-          <div className="border border-gray-200 rounded-xl overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs text-brand-brown uppercase tracking-wider">
-                      Producto
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      En Stock
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      Necesario
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      Faltante
-                    </th>
-                    <th className="px-4 py-3 text-center text-xs text-brand-brown uppercase tracking-wider">
-                      A Comprar
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      Precio Unit.
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      Costo Est.
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
-                  {productosAComprar.map((item) => (
-                    <tr key={item.producto_id} className="hover:bg-gray-50 transition-colors">
-                      <td className="px-4 py-3">
-                        <div>
-                          <div className={`${item.permitido_gerencia === false ? 'text-red-600 font-bold' : 'text-foreground'}`}>{item.producto_nombre}</div>
-                          <div className="text-sm text-brand-brown/70">{item.producto_categoria}</div>
-                        </div>
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm">
-                        <span className="text-brand-brown/70">
-                          {formatearNumero(item.inventario_actual)} {item.unidad}
+          {/* Escritorio: tabla */}
+          <div className="hidden sm:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Producto</TableHead>
+                  <TableHead className="text-right">En Stock</TableHead>
+                  <TableHead className="text-right">Necesario</TableHead>
+                  <TableHead className="text-right">Faltante</TableHead>
+                  <TableHead className="text-center">A Comprar</TableHead>
+                  <TableHead className="text-right">Precio / Presentación</TableHead>
+                  <TableHead className="text-right">Costo Est.</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {productosAComprar.map((item) => (
+                  <TableRow key={item.producto_id}>
+                    <TableCell className="whitespace-normal">
+                      <p className={cn('font-medium', item.permitido_gerencia === false && 'text-destructive font-bold')}>
+                        {item.producto_nombre}
+                      </p>
+                      <p className="text-xs text-muted-foreground">{item.producto_categoria}</p>
+                    </TableCell>
+                    <TableCell className="text-right text-muted-foreground tabular-nums">
+                      {formatearNumero(item.inventario_actual)} {item.unidad}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {formatearNumero(item.cantidad_necesaria)} {item.unidad}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {modoEdicion ? (
+                        <InputGroupInput
+                          type="number"
+                          step="0.01"
+                          value={item.cantidad_faltante}
+                          onChange={(e) => editarCantidad(item.producto_id, 'cantidad_faltante', parseFloat(e.target.value) || 0)}
+                          className="w-28 text-right ml-auto"
+                          aria-label={`Faltante de ${item.producto_nombre}`}
+                        />
+                      ) : (
+                        <span className="text-destructive font-semibold">
+                          {formatearNumero(item.cantidad_faltante)} {item.unidad}
                         </span>
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm text-foreground">
-                        {formatearNumero(item.cantidad_necesaria)} {item.unidad}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm">
-                        {modoEdicion ? (
-                          <input
-                            type="number"
-                            onWheel={(e) => e.currentTarget.blur()}
-                            step="0.01"
-                            value={item.cantidad_faltante}
-                            onChange={(e) =>
-                              editarCantidad(
-                                item.producto_id,
-                                'cantidad_faltante',
-                                parseFloat(e.target.value) || 0
-                              )
-                            }
-                            className="w-24 px-2 py-1 text-sm text-right border border-blue-300 rounded focus:ring-2 focus:ring-blue-500 focus:outline-none"
-                          />
-                        ) : (
-                          <span className="text-red-600">
-                            {formatearNumero(item.cantidad_faltante)} {item.unidad}
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-center">
-                        {modoEdicion ? (
-                          <div className="flex items-center justify-center gap-1">
-                            <input
-                              type="number"
-                              onWheel={(e) => e.currentTarget.blur()}
-                              min="0"
-                              value={item.unidades_a_comprar}
-                              onChange={(e) =>
-                                editarCantidad(
-                                  item.producto_id,
-                                  'unidades_a_comprar',
-                                  parseInt(e.target.value) || 0
-                                )
-                              }
-                              className="w-16 px-2 py-1 text-sm text-center border border-blue-300 rounded focus:ring-2 focus:ring-blue-500 focus:outline-none"
-                            />
-                            <span className="text-xs text-brand-brown/70">×</span>
-                            <span className="text-xs text-brand-brown/70">{item.presentacion_comercial}</span>
-                          </div>
-                        ) : (
-                          <div className="flex flex-col items-center gap-1">
-                            <div className={`inline-flex items-center px-3 py-1 rounded-full text-sm ${
-                              item.presentacion_comercial.startsWith('1 ')
-                                ? 'bg-orange-100 text-orange-800'
-                                : 'bg-red-100 text-red-800'
-                            }`}>
-                              {item.unidades_a_comprar} × {item.presentacion_comercial}
-                            </div>
-                            {item.presentacion_comercial.startsWith('1 ') && (
-                              <span className="text-xs text-orange-600">Sin presentación</span>
-                            )}
-                          </div>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm">
-                        {modoEdicion ? (
-                          <div className="flex items-center justify-end gap-1">
-                            <span className="text-xs text-brand-brown/70">$</span>
-                            <input
-                              type="number"
-                              onWheel={(e) => e.currentTarget.blur()}
-                              step="1000"
-                              min="0"
-                              value={item.precio_presentacion || 0}
-                              onChange={(e) =>
-                                editarPrecioPresentacion(
-                                  item.producto_id,
-                                  parseFloat(e.target.value) || 0
-                                )
-                              }
-                              className="w-28 px-2 py-1 text-sm text-right border border-blue-300 rounded focus:ring-2 focus:ring-blue-500 focus:outline-none"
-                              placeholder="0"
-                            />
-                          </div>
-                        ) : item.alerta === 'sin_precio' ? (
-                          <span className="text-yellow-600">Sin precio</span>
-                        ) : (
-                          <span className="text-foreground">
-                            {formatearMoneda(item.precio_presentacion || 0)}
-                          </span>
-                        )}
-                      </td>
-                      <td className="px-4 py-3 text-right text-sm">
-                        {item.alerta === 'sin_precio' ? (
-                          <span className="text-yellow-600">Sin precio</span>
-                        ) : (
-                          <span className="text-foreground">
-                            {formatearMoneda(item.costo_estimado || 0)}
-                          </span>
-                        )}
-                      </td>
-                    </tr>
-                  ))}
-                </tbody>
-                <tfoot className="bg-gray-50">
-                  <tr>
-                    <td colSpan={6} className="px-4 py-3 text-right text-foreground">
-                      TOTAL A COMPRAR:
-                    </td>
-                    <td className="px-4 py-3 text-right text-foreground">
-                      {formatearMoneda(
-                        productosAComprar.reduce((sum, item) => sum + (item.costo_estimado || 0), 0)
                       )}
-                    </td>
-                  </tr>
-                </tfoot>
-              </table>
-            </div>
+                    </TableCell>
+                    <TableCell className="text-center">
+                      {modoEdicion ? (
+                        <div className="flex items-center justify-center gap-1.5">
+                          <InputGroupInput
+                            type="number"
+                            min={0}
+                            value={item.unidades_a_comprar}
+                            onChange={(e) =>
+                              editarCantidad(item.producto_id, 'unidades_a_comprar', parseInt(e.target.value, 10) || 0)
+                            }
+                            className="w-16 text-center"
+                            aria-label={`Unidades a comprar de ${item.producto_nombre}`}
+                          />
+                          <span className="text-xs text-muted-foreground">× {item.presentacion_comercial}</span>
+                        </div>
+                      ) : (
+                        <Badge variant="destructive">
+                          {item.unidades_a_comprar} × {item.presentacion_comercial}
+                        </Badge>
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums">
+                      {modoEdicion ? (
+                        <InputGroup className="w-32 ml-auto">
+                          <InputGroupAddon>$</InputGroupAddon>
+                          <InputGroupInput
+                            type="number"
+                            step="1000"
+                            min={0}
+                            value={item.precio_presentacion || 0}
+                            onChange={(e) => editarPrecioPresentacion(item.producto_id, parseFloat(e.target.value) || 0)}
+                            aria-label={`Precio por presentación de ${item.producto_nombre}`}
+                          />
+                        </InputGroup>
+                      ) : item.alerta === 'sin_precio' ? (
+                        <span className="text-warning">Sin precio</span>
+                      ) : (
+                        formatearMoneda(item.precio_presentacion || 0)
+                      )}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums font-medium">
+                      {item.alerta === 'sin_precio' ? (
+                        <span className="text-warning">Sin precio</span>
+                      ) : (
+                        formatearMoneda(item.costo_estimado || 0)
+                      )}
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+              <TableFooter>
+                <TableRow>
+                  <TableCell colSpan={6} className="text-right">
+                    TOTAL A COMPRAR
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {formatearMoneda(productosAComprar.reduce((sum, item) => sum + (item.costo_estimado || 0), 0))}
+                  </TableCell>
+                </TableRow>
+              </TableFooter>
+            </Table>
+          </div>
+
+          {/* Móvil: tarjetas (Patrón A del sistema visual — no la misma tabla con scroll horizontal) */}
+          <div className="sm:hidden space-y-3">
+            {productosAComprar.map((item) => (
+              <div key={item.producto_id} className="border border-border rounded-xl p-4 bg-card">
+                <div className="flex justify-between gap-3 mb-3">
+                  <div>
+                    <p className={cn('font-bold text-sm', item.permitido_gerencia === false && 'text-destructive')}>
+                      {item.producto_nombre}
+                    </p>
+                    <p className="text-xs text-muted-foreground">{item.producto_categoria}</p>
+                  </div>
+                  <div className="text-right flex-shrink-0">
+                    <p className="text-lg font-bold tabular-nums text-destructive">{formatearNumero(item.cantidad_faltante)}</p>
+                    <p className="text-[0.625rem] uppercase tracking-wide text-muted-foreground">Faltante · {item.unidad}</p>
+                  </div>
+                </div>
+                <div className="flex gap-5 text-xs text-muted-foreground mb-3">
+                  <span>
+                    En stock <b className="text-foreground">{formatearNumero(item.inventario_actual)}</b>
+                  </span>
+                  <span>
+                    Necesario <b className="text-foreground">{formatearNumero(item.cantidad_necesaria)}</b>
+                  </span>
+                </div>
+                {modoEdicion ? (
+                  <div className="grid grid-cols-2 gap-2.5 pt-3 border-t border-border">
+                    <Field>
+                      <FieldLabel className="text-xs">A Comprar</FieldLabel>
+                      <InputGroupInput
+                        type="number"
+                        min={0}
+                        value={item.unidades_a_comprar}
+                        onChange={(e) => editarCantidad(item.producto_id, 'unidades_a_comprar', parseInt(e.target.value, 10) || 0)}
+                        aria-label={`Unidades a comprar de ${item.producto_nombre}`}
+                      />
+                    </Field>
+                    <Field>
+                      <FieldLabel className="text-xs">Precio</FieldLabel>
+                      <InputGroup>
+                        <InputGroupAddon>$</InputGroupAddon>
+                        <InputGroupInput
+                          type="number"
+                          step="1000"
+                          min={0}
+                          value={item.precio_presentacion || 0}
+                          onChange={(e) => editarPrecioPresentacion(item.producto_id, parseFloat(e.target.value) || 0)}
+                          aria-label={`Precio por presentación de ${item.producto_nombre}`}
+                        />
+                      </InputGroup>
+                    </Field>
+                  </div>
+                ) : (
+                  <div className="flex justify-between items-center pt-3 border-t border-border">
+                    <Badge variant="destructive">
+                      {item.unidades_a_comprar} × {item.presentacion_comercial}
+                    </Badge>
+                    <span className="font-bold text-sm tabular-nums">
+                      {item.alerta === 'sin_precio' ? 'Sin precio' : formatearMoneda(item.costo_estimado || 0)}
+                    </span>
+                  </div>
+                )}
+              </div>
+            ))}
           </div>
         </div>
       )}
 
       {/* PRODUCTOS DISPONIBLES */}
-      {productosDisponibles.length > 0 && (
-        <div>
-          <h3 className="text-foreground mb-3 flex items-center gap-2">
-            <CheckCircle className="w-5 h-5 text-primary" />
-            Productos Disponibles en Stock ({productosDisponibles.length})
-          </h3>
+      <div>
+        <h4 className="text-sm font-bold text-foreground mb-3 flex items-center gap-2">
+          <CheckCircle className="w-4 h-4 text-primary" />
+          Productos Disponibles en Stock ({productosDisponibles.length})
+        </h4>
 
-          <div className="border border-gray-200 rounded-xl overflow-hidden">
-            <div className="overflow-x-auto">
-              <table className="min-w-full divide-y divide-gray-200">
-                <thead className="bg-gray-50">
-                  <tr>
-                    <th className="px-4 py-3 text-left text-xs text-brand-brown uppercase tracking-wider">
-                      Producto
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      En Stock
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      Necesario
-                    </th>
-                    <th className="px-4 py-3 text-right text-xs text-brand-brown uppercase tracking-wider">
-                      Sobrante
-                    </th>
-                  </tr>
-                </thead>
-                <tbody className="bg-white divide-y divide-gray-200">
-                  {productosDisponibles.map((item) => {
-                    const sobrante = item.inventario_actual - item.cantidad_necesaria;
-                    return (
-                      <tr key={item.producto_id} className="hover:bg-gray-50 transition-colors">
-                        <td className="px-4 py-3">
-                          <div>
-                            <div className={`${item.permitido_gerencia === false ? 'text-red-600 font-bold' : 'text-foreground'}`}>{item.producto_nombre}</div>
-                            <div className="text-sm text-brand-brown/70">
-                              {item.producto_categoria}
-                            </div>
-                          </div>
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm text-primary">
-                          {formatearNumero(item.inventario_actual)} {item.unidad}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm text-foreground">
-                          {formatearNumero(item.cantidad_necesaria)} {item.unidad}
-                        </td>
-                        <td className="px-4 py-3 text-right text-sm text-primary">
-                          +{formatearNumero(sobrante)} {item.unidad}
-                        </td>
-                      </tr>
-                    );
-                  })}
-                </tbody>
-              </table>
-            </div>
+        {productosDisponibles.length === 0 ? (
+          <Empty className="py-8">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <CheckCircle />
+              </EmptyMedia>
+              <EmptyTitle>Sin productos disponibles en este cálculo</EmptyTitle>
+              <EmptyDescription>
+                Todo lo necesario para esta aplicación debe comprarse — no hay excedente de inventario que mostrar aquí.
+              </EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        ) : (
+          <div className="hidden sm:block">
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Producto</TableHead>
+                  <TableHead className="text-right">En Stock</TableHead>
+                  <TableHead className="text-right">Necesario</TableHead>
+                  <TableHead className="text-right">Sobrante</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {productosDisponibles.map((item) => {
+                  const sobrante = item.inventario_actual - item.cantidad_necesaria;
+                  return (
+                    <TableRow key={item.producto_id}>
+                      <TableCell className="whitespace-normal">
+                        <p className={cn('font-medium', item.permitido_gerencia === false && 'text-destructive font-bold')}>
+                          {item.producto_nombre}
+                        </p>
+                        <p className="text-xs text-muted-foreground">{item.producto_categoria}</p>
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-primary">
+                        {formatearNumero(item.inventario_actual)} {item.unidad}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums">
+                        {formatearNumero(item.cantidad_necesaria)} {item.unidad}
+                      </TableCell>
+                      <TableCell className="text-right tabular-nums text-primary">
+                        +{formatearNumero(sobrante)} {item.unidad}
+                      </TableCell>
+                    </TableRow>
+                  );
+                })}
+              </TableBody>
+            </Table>
           </div>
-        </div>
-      )}
-
-      {/* RESUMEN FINAL */}
-      <div className="bg-gradient-to-br from-primary/10 to-secondary/10 border border-primary/20 rounded-xl p-6">
-        <h3 className="text-foreground mb-4 flex items-center gap-2">
-          <TrendingUp className="w-5 h-5 text-primary" />
-          Resumen de la Aplicación
-        </h3>
-
-        <div className="grid grid-cols-1 md:grid-cols-2 gap-4 text-sm">
-          <div>
-            <div className="text-brand-brown/70 mb-1">Nombre:</div>
-            <div className="text-foreground">{configuracion.nombre}</div>
+        )}
+        {productosDisponibles.length > 0 && (
+          <div className="sm:hidden space-y-3">
+            {productosDisponibles.map((item) => {
+              const sobrante = item.inventario_actual - item.cantidad_necesaria;
+              return (
+                <div key={item.producto_id} className="border border-border rounded-xl p-4 bg-card">
+                  <p className={cn('font-bold text-sm', item.permitido_gerencia === false && 'text-destructive')}>
+                    {item.producto_nombre}
+                  </p>
+                  <p className="text-xs text-muted-foreground mb-2">{item.producto_categoria}</p>
+                  <div className="flex gap-5 text-xs text-muted-foreground">
+                    <span>
+                      Stock <b className="text-foreground">{formatearNumero(item.inventario_actual)}</b>
+                    </span>
+                    <span>
+                      Sobrante <b className="text-primary">+{formatearNumero(sobrante)}</b>
+                    </span>
+                  </div>
+                </div>
+              );
+            })}
           </div>
-
-          <div>
-            <div className="text-brand-brown/70 mb-1">Tipo:</div>
-            <div className="text-foreground capitalize">{configuracion.tipo}</div>
-          </div>
-
-          <div>
-            <div className="text-brand-brown/70 mb-1">Fecha Inicio:</div>
-            <div className="text-foreground">
-              {new Date(configuracion.fecha_inicio ?? configuracion.fecha_inicio_planeada).toLocaleDateString('es-CO', {
-                year: 'numeric',
-                month: 'long',
-                day: 'numeric',
-              })}
-            </div>
-          </div>
-
-          <div>
-            <div className="text-brand-brown/70 mb-1">Lotes:</div>
-            <div className="text-foreground">
-              {configuracion.lotes_seleccionados.length} lotes seleccionados
-            </div>
-          </div>
-
-          <div>
-            <div className="text-brand-brown/70 mb-1">Productos en Mezcla:</div>
-            <div className="text-foreground">{mezclas[0]?.productos.length || 0} productos</div>
-          </div>
-
-          <div>
-            <div className="text-brand-brown/70 mb-1">Inversión Estimada:</div>
-            <div className="text-foreground text-lg">
-              {formatearMoneda(costoTotalActual)}
-            </div>
-          </div>
-        </div>
+        )}
       </div>
 
-      {/* MENSAJE DE ÉXITO */}
-      {productosAComprar.length === 0 && (
-        <div className="bg-gradient-to-br from-primary/10 to-secondary/10 border border-primary/20 rounded-xl p-6 text-center">
-          <CheckCircle className="w-12 h-12 text-primary mx-auto mb-3" />
-          <h4 className="text-lg text-foreground mb-2">¡Todos los productos están disponibles!</h4>
-          <p className="text-sm text-brand-brown/70">
-            No necesitas comprar nada. Tienes suficiente stock para realizar la aplicación.
-          </p>
+      {/* RESUMEN FINAL */}
+      <Card className="p-5">
+        <h4 className="text-sm font-bold text-foreground mb-4">Resumen de la Aplicación</h4>
+        <div className="grid grid-cols-1 sm:grid-cols-2 gap-4 text-sm">
+          <div>
+            <p className="text-muted-foreground mb-0.5">Nombre</p>
+            <p className="text-foreground font-medium">{configuracion.nombre}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground mb-0.5">Tipo</p>
+            <p className="text-foreground font-medium capitalize">{configuracion.tipo}</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground mb-0.5">Lotes</p>
+            <p className="text-foreground font-medium">{configuracion.lotes_seleccionados.length} lotes seleccionados</p>
+          </div>
+          <div>
+            <p className="text-muted-foreground mb-0.5">Productos en Mezcla</p>
+            <p className="text-foreground font-medium">{mezclas[0]?.productos.length || 0} productos</p>
+          </div>
+          <div className="sm:col-span-2">
+            <p className="text-muted-foreground mb-0.5">Inversión Estimada</p>
+            <p className="text-foreground font-bold text-lg tabular-nums">{formatearMoneda(costoTotalActual)}</p>
+          </div>
         </div>
+      </Card>
+
+      {productosAComprar.length === 0 && (
+        <Empty>
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <CheckCircle />
+            </EmptyMedia>
+            <EmptyTitle>¡Todos los productos están disponibles!</EmptyTitle>
+            <EmptyDescription>No necesitas comprar nada. Tienes suficiente stock para realizar la aplicación.</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
       )}
     </div>
   );

--- a/src/components/aplicaciones/PasoMezcla.tsx
+++ b/src/components/aplicaciones/PasoMezcla.tsx
@@ -481,6 +481,7 @@ export function PasoMezcla({ configuracion, mezclas, calculos: calculosIniciales
                       onClick={() => editarMezcla(mezcla)}
                       className="p-2 text-primary hover:bg-primary/10 rounded-lg transition-colors"
                       title="Editar"
+                      aria-label={`Editar mezcla ${mezcla.nombre}`}
                     >
                       <Edit2 className="w-4 h-4" />
                     </button>
@@ -488,6 +489,7 @@ export function PasoMezcla({ configuracion, mezclas, calculos: calculosIniciales
                       onClick={() => eliminarMezcla(mezcla.id)}
                       className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
                       title="Eliminar"
+                      aria-label={`Eliminar mezcla ${mezcla.nombre}`}
                     >
                       <Trash2 className="w-4 h-4" />
                     </button>
@@ -665,6 +667,7 @@ export function PasoMezcla({ configuracion, mezclas, calculos: calculosIniciales
                       <button
                         onClick={() => quitarProducto(producto.producto_id)}
                         className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
+                        aria-label={`Quitar ${producto.producto_nombre}`}
                       >
                         <X className="w-5 h-5" />
                       </button>

--- a/src/components/aplicaciones/PasoMezcla.tsx
+++ b/src/components/aplicaciones/PasoMezcla.tsx
@@ -1,249 +1,334 @@
-import { useState, useEffect } from 'react';
-import { Plus, X, Calculator, AlertTriangle, Package, Beaker, Check, Edit2, Trash2 } from 'lucide-react';
+import { useState, useEffect, useMemo } from 'react';
+import { Plus, X, AlertTriangle, Beaker, Trash2, RefreshCw, Search } from 'lucide-react';
 import { toast } from 'sonner';
 import { ConfirmDialog } from '../ui/confirm-dialog';
+import { Button } from '../ui/button';
+import { Badge } from '../ui/badge';
+import { Alert, AlertDescription } from '../ui/alert';
+import { Field, FieldLabel, FieldDescription } from '../ui/field';
+import { InputGroup, InputGroupAddon, InputGroupInput } from '../ui/input-group';
+import { Checkbox } from '../ui/checkbox';
+import { Popover, PopoverContent, PopoverTrigger } from '../ui/popover';
+import {
+  Command,
+  CommandEmpty,
+  CommandGroup,
+  CommandInput,
+  CommandItem,
+  CommandList,
+} from '../ui/command';
 import { getSupabase } from '../../utils/supabase/client';
 import { useSafeMode } from '../../contexts/SafeModeContext';
 import {
   calcularFumigacion,
   calcularFertilizacion,
-  calcularTotalesProductos,
+  calcularTotalesGlobalesProductos,
+  generarListaCompras,
   validarLoteFumigacion,
-  validarProductoFumigacion,
-  validarProductoFertilizacion,
 } from '../../utils/calculosAplicaciones';
 import { formatearNumero } from '../../utils/format';
+import { cn } from '../ui/utils';
 import type {
   ConfiguracionAplicacion,
   Mezcla,
   ProductoEnMezcla,
   CalculosPorLote,
   ProductoCatalogo,
+  ItemListaCompras,
 } from '../../types/aplicaciones';
 
-interface PasoMezclaProps {
-  configuracion: ConfiguracionAplicacion;
-  mezclas: Mezcla[];
-  calculos: CalculosPorLote[];
-  onUpdate: (mezclas: Mezcla[], calculos: CalculosPorLote[]) => void;
+export interface EstimadoCompra {
+  items: ItemListaCompras[];
+  costoTotal: number;
 }
 
-export function PasoMezcla({ configuracion, mezclas, calculos: calculosIniciales, onUpdate }: PasoMezclaProps) {
+/**
+ * Estado de asignación mezcla↔lotes por mezcla, keyed por `mezcla.id`. Solo tiene sentido
+ * cuando hay 2+ mezclas — con una sola mezcla la asignación se hereda estructuralmente de
+ * `configuracion.lotes_seleccionados` y no hay mapeo separado que perder (ver W01-calculadora-v2.md
+ * §5). 'ok' es el default implícito cuando una mezcla no tiene entrada en este mapa.
+ */
+export type EstadoAsignacionMezcla = 'ok' | 'sin_asignar' | 'error';
+
+interface MezclaPlanSectionProps {
+  configuracion: ConfiguracionAplicacion;
+  mezclas: Mezcla[];
+  estadosAsignacion?: Record<string, EstadoAsignacionMezcla>;
+  onUpdate: (mezclas: Mezcla[], calculos: CalculosPorLote[]) => void;
+  onEstimadoChange?: (estimado: EstimadoCompra | null) => void;
+  onReintentarAsignacion?: () => void;
+}
+
+/**
+ * Sección "Mezcla y Productos" del Paso 1 (Plan). Antes era un paso propio con su propia
+ * ceremonia de Nueva Mezcla / Confirmar Mezcla — ahora es edición directa e inline dentro
+ * de la misma pantalla que los lotes (W01-calculadora-v2.md §2). El cambio de mayor
+ * impacto: con una sola mezcla (el caso típico) sus lotes se heredan de
+ * `configuracion.lotes_seleccionados` sin volver a preguntarlos — el picker de lotes
+ * repetido solo reaparece cuando existen 2+ mezclas.
+ */
+export function MezclaPlanSection({
+  configuracion,
+  mezclas,
+  estadosAsignacion,
+  onUpdate,
+  onEstimadoChange,
+  onReintentarAsignacion,
+}: MezclaPlanSectionProps) {
   const supabase = getSupabase();
   const { isSafeModeEnabled } = useSafeMode();
 
-  // Estado
-  const [mezclas_guardadas, setMezclasGuardadas] = useState<Mezcla[]>(mezclas);
-  const [mezcla_en_edicion, setMezclaEnEdicion] = useState<Mezcla | null>(null);
-  const [modo_edicion, setModoEdicion] = useState<'crear' | 'editar'>('crear');
-
   const [productosCatalogo, setProductosCatalogo] = useState<ProductoCatalogo[]>([]);
   const [cargandoProductos, setCargandoProductos] = useState(true);
+  const [productosInfo, setProductosInfo] = useState<Map<string, { presentacion_kg_l: number }>>(
+    new Map(),
+  );
 
-  const [productoSeleccionado, setProductoSeleccionado] = useState<string>('');
-  const [busquedaProducto, setBusquedaProducto] = useState<string>('');
-  const [mostrarResultados, setMostrarResultados] = useState<boolean>(false);
-  const [calculos, setCalculos] = useState<CalculosPorLote[]>(calculosIniciales);
+  const [confirmEliminarMezclaId, setConfirmEliminarMezclaId] = useState<string | null>(null);
+  const [confirmEliminarProducto, setConfirmEliminarProducto] = useState<{
+    mezclaId: string;
+    productoId: string;
+    nombre: string;
+  } | null>(null);
   const [errores, setErrores] = useState<string[]>([]);
-  const [confirmEliminarId, setConfirmEliminarId] = useState<string | null>(null);
+
+  const tipo = configuracion.tipo;
+  const usaDosisPorCaneca = tipo === 'fumigacion' || tipo === 'drench';
 
   /**
-   * CARGAR PRODUCTOS DEL CATÁLOGO
+   * CARGAR CATÁLOGO DE PRODUCTOS
+   * Incluye presentacion_kg_l y precio_por_presentacion (además de cantidad_actual) porque
+   * el catálogo alimenta DOS cosas: el combobox de selección (stock) y el rail de Estimado
+   * de Compra en vivo (necesita precio, no solo cantidad — riesgo #7 de W01-calculadora-v2.md).
    */
   useEffect(() => {
-    cargarProductos();
-  }, [configuracion.tipo, isSafeModeEnabled]);
+    let cancelado = false;
+    (async () => {
+      setCargandoProductos(true);
+      try {
+        const { data, error } = await supabase
+          .from('productos')
+          .select('*')
+          .eq('estado', 'OK')
+          .eq('activo', true)
+          .eq('grupo', 'Agroinsumos')
+          .order('nombre');
 
-  const cargarProductos = async () => {
-    try {
-      // 🚨 CARGAR SOLO PRODUCTOS DE AGROINSUMOS (como blancos biológicos)
-      
-      const { data, error } = await supabase
-        .from('productos')
-        .select('*')
-        .eq('estado', 'OK')
-        .eq('activo', true)
-        .eq('grupo', 'Agroinsumos') // 🚨 FILTRAR POR GRUPO
-        .order('nombre');
+        if (error) throw error;
 
-      if (error) {
-        throw error;
+        let formateados = (data || []).map((p) => {
+          const unidadCorta =
+            (p.unidad_medida as string) === 'Kilos' ? 'Kg' : (p.unidad_medida as string) === 'Litros' ? 'L' : p.unidad_medida;
+          return {
+            id: p.id,
+            nombre: p.nombre,
+            categoria: p.categoria,
+            grupo: p.grupo,
+            unidad_medida: p.unidad_medida,
+            estado_fisico: p.estado_fisico,
+            presentacion_comercial:
+              p.presentacion_kg_l && p.presentacion_kg_l > 0
+                ? `${p.presentacion_kg_l} ${unidadCorta}`
+                : `1 ${unidadCorta}`,
+            ultimo_precio_unitario: p.precio_unitario || 0,
+            precio_presentacion: p.precio_por_presentacion || 0,
+            cantidad_actual: p.cantidad_actual || 0,
+            display_nombre: `${p.nombre} (${p.categoria} · ${p.estado_fisico})`,
+            permitido_gerencia: p.permitido_gerencia ?? undefined,
+          };
+        }) as unknown as ProductoCatalogo[];
+
+        if (isSafeModeEnabled) {
+          formateados = formateados.filter((p) => p.permitido_gerencia !== false);
+        }
+
+        if (!cancelado) setProductosCatalogo(formateados);
+      } catch {
+        if (!cancelado) setProductosCatalogo([]);
+      } finally {
+        if (!cancelado) setCargandoProductos(false);
       }
-
-
-      let productosFormateados = (data || []).map((p) => ({
-        id: p.id,
-        nombre: p.nombre,
-        categoria: p.categoria,
-        grupo: p.grupo,
-        unidad_medida: p.unidad_medida,
-        estado_fisico: p.estado_fisico,
-        presentacion_comercial: p.presentacion_kg_l ? `${p.presentacion_kg_l} ${p.unidad_medida}` : p.unidad_medida,
-        ultimo_precio_unitario: p.precio_unitario || 0,
-        cantidad_actual: p.cantidad_actual || 0,
-        display_nombre: `${p.nombre} (${p.categoria} - ${p.estado_fisico}) - Stock: ${p.cantidad_actual || 0} ${p.unidad_medida}`,
-        permitido_gerencia: p.permitido_gerencia ?? undefined,
-      })) as unknown as ProductoCatalogo[];
-
-      // Filtrar productos no permitidos si modo seguro está activado
-      if (isSafeModeEnabled) {
-        productosFormateados = productosFormateados.filter((p) => p.permitido_gerencia !== false);
-      }
-
-      setProductosCatalogo(productosFormateados);
-    } catch (error) {
-      setProductosCatalogo([]);
-    } finally {
-      setCargandoProductos(false);
-    }
-  };
-
-  /**
-   * CREAR NUEVA MEZCLA
-   */
-  const crearNuevaMezcla = () => {
-    const numeroMezcla = mezclas_guardadas.length + 1;
-    const nuevaMezcla: Mezcla = {
-      id: crypto.randomUUID(),
-      nombre: `Mezcla ${numeroMezcla}`,
-      numero_orden: numeroMezcla,
-      productos: [],
-      lotes_asignados: [], // Inicialmente sin lotes
+    })();
+    return () => {
+      cancelado = true;
     };
-    
-    setMezclaEnEdicion(nuevaMezcla);
-    setModoEdicion('crear');
-    setErrores([]);
-  };
+  }, [tipo, isSafeModeEnabled]);
 
   /**
-   * EDITAR MEZCLA EXISTENTE
+   * CARGAR presentacion_kg_l DE LOS PRODUCTOS EN USO (para fertilización)
+   * Solo se refresca cuando cambia el CONJUNTO de ids de producto en las mezclas — no en
+   * cada tecla de dosis — para no repetir el fetch en cada carácter escrito.
    */
-  const editarMezcla = (mezcla: Mezcla) => {
-    setMezclaEnEdicion({ ...mezcla });
-    setModoEdicion('editar');
-    setErrores([]);
-  };
+  const productosIdsClave = useMemo(
+    () =>
+      Array.from(new Set(mezclas.flatMap((m) => m.productos.map((p) => p.producto_id)))).sort().join(','),
+    [mezclas],
+  );
 
-  /**
-   * CANCELAR EDICIÓN
-   */
-  const cancelarEdicion = () => {
-    setMezclaEnEdicion(null);
-    setModoEdicion('crear');
-    setProductoSeleccionado('');
-    setErrores([]);
-  };
-
-  /**
-   * CONFIRMAR/GUARDAR MEZCLA
-   */
-  const confirmarMezcla = () => {
-    if (!mezcla_en_edicion) return;
-
-    // Validación
-    if (mezcla_en_edicion.productos.length === 0) {
-      setErrores(['Debes agregar al menos un producto a la mezcla']);
+  useEffect(() => {
+    if (tipo !== 'fertilizacion' || !productosIdsClave) {
+      setProductosInfo(new Map());
       return;
     }
-
-    if (!mezcla_en_edicion.lotes_asignados || mezcla_en_edicion.lotes_asignados.length === 0) {
-      setErrores(['Debes asignar al menos un lote a esta mezcla']);
-      return;
-    }
-
-    // Validar dosis de productos
-    const nuevosErrores: string[] = [];
-    mezcla_en_edicion.productos.forEach((producto) => {
-      if (configuracion.tipo === 'fumigacion' || configuracion.tipo === 'drench') {
-        const error = validarProductoFumigacion(producto);
-        if (error) nuevosErrores.push(error);
-      } else {
-        const error = validarProductoFertilizacion(producto);
-        if (error) nuevosErrores.push(error);
+    let cancelado = false;
+    (async () => {
+      const ids = productosIdsClave.split(',');
+      try {
+        const { data, error } = await supabase
+          .from('productos')
+          .select('id, presentacion_kg_l')
+          .in('id', ids);
+        if (error) throw error;
+        const mapa = new Map<string, { presentacion_kg_l: number }>();
+        (data || []).forEach((p) => {
+          if (p.presentacion_kg_l) mapa.set(p.id, { presentacion_kg_l: p.presentacion_kg_l });
+        });
+        if (!cancelado) setProductosInfo(mapa);
+      } catch {
+        if (!cancelado) setProductosInfo(new Map());
       }
+    })();
+    return () => {
+      cancelado = true;
+    };
+  }, [tipo, productosIdsClave]);
+
+  /**
+   * RECALCULAR (síncrono) — reemplaza al viejo `recalcularTodo` async. La única parte
+   * async (presentación de productos para fertilización) ya vive en `productosInfo`
+   * (arriba), cargada una vez por conjunto de productos, no en cada mutación. Esto es lo
+   * que permite llamar a esta función en CADA edición de dosis sin esperar una red.
+   */
+  const recalcular = (mezclasParaCalcular: Mezcla[]) => {
+    const nuevosCalculos: CalculosPorLote[] = [];
+    const nuevosErrores: string[] = [];
+
+    mezclasParaCalcular.forEach((mezcla) => {
+      const lotesAsignados = obtenerLotesEfectivos(mezcla);
+      lotesAsignados.forEach((loteId) => {
+        const lote = configuracion.lotes_seleccionados.find((l) => l.lote_id === loteId);
+        if (!lote) return;
+
+        if (usaDosisPorCaneca) {
+          const error = validarLoteFumigacion(lote);
+          if (error) nuevosErrores.push(error);
+        }
+
+        const calculo = usaDosisPorCaneca
+          ? calcularFumigacion(lote, mezcla)
+          : calcularFertilizacion(lote, mezcla, productosInfo);
+
+        nuevosCalculos.push(calculo);
+      });
     });
 
-    if (nuevosErrores.length > 0) {
-      setErrores(nuevosErrores);
-      return;
-    }
+    const mezclasActualizadas = mezclasParaCalcular.map((mezcla) => {
+      const lotesAsignados = obtenerLotesEfectivos(mezcla);
+      const calculosDeEstaMezcla = nuevosCalculos.filter((c) => lotesAsignados.includes(c.lote_id));
 
-    // Guardar o actualizar
-    let nuevasMezclas: Mezcla[];
-    
-    if (modo_edicion === 'crear') {
-      nuevasMezclas = [...mezclas_guardadas, mezcla_en_edicion];
-    } else {
-      nuevasMezclas = mezclas_guardadas.map((m) =>
-        m.id === mezcla_en_edicion.id ? mezcla_en_edicion : m
-      );
-    }
+      return {
+        ...mezcla,
+        productos: mezcla.productos.map((productoEnMezcla) => {
+          const cantidadTotal = calculosDeEstaMezcla.reduce((sum, calculo) => {
+            const enCalculo = calculo.productos.find((p) => p.producto_id === productoEnMezcla.producto_id);
+            return sum + (enCalculo?.cantidad_necesaria || 0);
+          }, 0);
+          return {
+            ...productoEnMezcla,
+            cantidad_total_necesaria: Math.ceil(cantidadTotal * 100) / 100,
+          };
+        }),
+      };
+    });
 
-    setMezclasGuardadas(nuevasMezclas);
-    
-    // Recalcular con todas las mezclas
-    recalcularTodo(nuevasMezclas);
-    
-    // Limpiar edición
-    setMezclaEnEdicion(null);
-    setModoEdicion('crear');
-    setErrores([]);
+    setErrores(nuevosErrores);
+    onUpdate(mezclasActualizadas, nuevosCalculos);
+
+    // Estimado de Compra en vivo — mismo motor que la Lista de Compras (Paso 2), pero con el
+    // catálogo ya cargado acá, así se ve el impacto sin llegar al Paso 2.
+    if (onEstimadoChange) {
+      if (productosCatalogo.length === 0 && mezclasActualizadas.some((m) => m.productos.length > 0)) {
+        onEstimadoChange(null);
+      } else {
+        const necesarios = calcularTotalesGlobalesProductos(mezclasActualizadas);
+        if (necesarios.length === 0) {
+          onEstimadoChange(null);
+        } else {
+          const lista = generarListaCompras(necesarios, productosCatalogo);
+          const faltantes = lista.items.filter((i) => i.cantidad_faltante > 0);
+          onEstimadoChange({ items: faltantes, costoTotal: lista.costo_total_estimado });
+        }
+      }
+    }
   };
 
-  /**
-   * ELIMINAR MEZCLA
-   */
-  const eliminarMezcla = (mezclaId: string) => {
-    setConfirmEliminarId(mezclaId);
+  /** Los lotes "efectivos" de una mezcla: heredados de la selección global cuando hay una
+   * sola mezcla (ver docstring del componente), o su `lotes_asignados` explícito si hay 2+. */
+  const obtenerLotesEfectivos = (mezcla: Mezcla): string[] => {
+    if (mezclas.length <= 1) {
+      return configuracion.lotes_seleccionados.map((l) => l.lote_id);
+    }
+    return mezcla.lotes_asignados || [];
+  };
+
+  // Recalcular cuando cambian los lotes seleccionados arriba (Paso 1), cuando termina de
+  // cargar el catálogo de productos, o cuando llega `productosInfo` (presentación para
+  // fertilización) — mantiene el rail y los totales sincronizados sin que el usuario tenga
+  // que tocar nada. Las mutaciones directas (crear mezcla, agregar producto, editar dosis,
+  // (re)asignar lotes) llaman a `recalcular` ellas mismas — este efecto solo cubre los
+  // disparadores que vienen de FUERA de esta sección.
+  const configLotesClave = configuracion.lotes_seleccionados.map((l) => l.lote_id).join(',');
+  useEffect(() => {
+    if (mezclas.length === 0) {
+      onEstimadoChange?.(null);
+      return;
+    }
+    recalcular(mezclas);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [configLotesClave, productosInfo, productosCatalogo, tipo]);
+
+  /** CREAR NUEVA MEZCLA — sin ceremonia de confirmación: aparece ya en la lista, editable. */
+  const crearMezcla = () => {
+    const numero = mezclas.length + 1;
+    const nueva: Mezcla = {
+      id: crypto.randomUUID(),
+      nombre: `Mezcla ${numero}`,
+      numero_orden: numero,
+      productos: [],
+      lotes_asignados: [],
+    };
+    recalcular([...mezclas, nueva]);
   };
 
   const confirmarEliminarMezcla = () => {
-    if (!confirmEliminarId) return;
-    const mezclaId = confirmEliminarId;
-    setConfirmEliminarId(null);
-
-    const nuevasMezclas = mezclas_guardadas.filter((m) => m.id !== mezclaId);
-    
-    // Renumerar mezclas
-    const mezclasRenumeradas = nuevasMezclas.map((m, index) => ({
-      ...m,
-      nombre: `Mezcla ${index + 1}`,
-      numero_orden: index + 1,
-    }));
-
-    setMezclasGuardadas(mezclasRenumeradas);
-    recalcularTodo(mezclasRenumeradas);
+    if (!confirmEliminarMezclaId) return;
+    const restantes = mezclas
+      .filter((m) => m.id !== confirmEliminarMezclaId)
+      .map((m, i) => ({ ...m, nombre: `Mezcla ${i + 1}`, numero_orden: i + 1 }));
+    setConfirmEliminarMezclaId(null);
+    recalcular(restantes);
   };
 
-  /**
-   * TOGGLE LOTE ASIGNADO A MEZCLA EN EDICIÓN
-   */
-  const toggleLoteAsignado = (loteId: string) => {
-    if (!mezcla_en_edicion) return;
-
-    const lotesActuales = mezcla_en_edicion.lotes_asignados || [];
-    const yaAsignado = lotesActuales.includes(loteId);
-
-    setMezclaEnEdicion({
-      ...mezcla_en_edicion,
-      lotes_asignados: yaAsignado
-        ? lotesActuales.filter((id) => id !== loteId)
-        : [...lotesActuales, loteId],
+  const toggleLoteAsignado = (mezclaId: string, loteId: string) => {
+    const actualizadas = mezclas.map((m) => {
+      if (m.id !== mezclaId) return m;
+      const actuales = m.lotes_asignados || [];
+      return {
+        ...m,
+        lotes_asignados: actuales.includes(loteId)
+          ? actuales.filter((id) => id !== loteId)
+          : [...actuales, loteId],
+      };
     });
+    recalcular(actualizadas);
   };
 
-  /**
-   * AGREGAR PRODUCTO A MEZCLA EN EDICIÓN
-   */
-  const agregarProducto = () => {
-    if (!mezcla_en_edicion || !productoSeleccionado) return;
-
-    const producto = productosCatalogo.find((p) => p.id === productoSeleccionado);
+  const agregarProducto = (mezclaId: string, productoId: string) => {
+    const producto = productosCatalogo.find((p) => p.id === productoId);
     if (!producto) return;
 
-    // Verificar que no esté ya agregado
-    if (mezcla_en_edicion.productos.some((p) => p.producto_id === producto.id)) {
+    const mezcla = mezclas.find((m) => m.id === mezclaId);
+    if (mezcla?.productos.some((p) => p.producto_id === productoId)) {
       toast('Este producto ya está en la mezcla');
       return;
     }
@@ -255,12 +340,10 @@ export function PasoMezcla({ configuracion, mezclas, calculos: calculosIniciales
       producto_unidad: producto.unidad_medida,
       cantidad_total_necesaria: 0,
       inventario_disponible: producto.cantidad_actual,
-
-      // Inicializar dosis según tipo
-      ...(configuracion.tipo === 'fumigacion' || configuracion.tipo === 'drench'
+      ...(usaDosisPorCaneca
         ? {
             dosis_por_caneca: 0,
-            unidad_dosis: ((producto.estado_fisico as string) === 'Líquido' || producto.estado_fisico === 'liquido' ? 'cc' : 'gramos') as 'cc' | 'gramos',
+            unidad_dosis: (producto.estado_fisico === 'liquido' ? 'cc' : 'gramos') as 'cc' | 'gramos',
           }
         : {
             dosis_grandes: 0,
@@ -270,269 +353,369 @@ export function PasoMezcla({ configuracion, mezclas, calculos: calculosIniciales
           }),
     };
 
-    setMezclaEnEdicion({
-      ...mezcla_en_edicion,
-      productos: [...mezcla_en_edicion.productos, nuevoProducto],
-    });
-
-    setProductoSeleccionado('');
-    setBusquedaProducto('');
-    setMostrarResultados(false);
+    const actualizadas = mezclas.map((m) =>
+      m.id === mezclaId ? { ...m, productos: [...m.productos, nuevoProducto] } : m,
+    );
+    recalcular(actualizadas);
   };
 
-  /**
-   * QUITAR PRODUCTO DE MEZCLA EN EDICIÓN
-   */
-  const quitarProducto = (productoId: string) => {
-    if (!mezcla_en_edicion) return;
-
-    setMezclaEnEdicion({
-      ...mezcla_en_edicion,
-      productos: mezcla_en_edicion.productos.filter((p) => p.producto_id !== productoId),
-    });
+  const confirmarQuitarProducto = () => {
+    if (!confirmEliminarProducto) return;
+    const { mezclaId, productoId } = confirmEliminarProducto;
+    const actualizadas = mezclas.map((m) =>
+      m.id === mezclaId
+        ? { ...m, productos: m.productos.filter((p) => p.producto_id !== productoId) }
+        : m,
+    );
+    setConfirmEliminarProducto(null);
+    recalcular(actualizadas);
   };
 
-  /**
-   * ACTUALIZAR DOSIS DE PRODUCTO EN EDICIÓN
-   */
-  const actualizarDosis = (productoId: string, campo: string, valor: number) => {
-    if (!mezcla_en_edicion) return;
-
-    setMezclaEnEdicion({
-      ...mezcla_en_edicion,
-      productos: mezcla_en_edicion.productos.map((p) =>
-        p.producto_id === productoId ? { ...p, [campo]: valor } : p
-      ),
-    });
-  };
-
-  /**
-   * RECALCULAR TODO (TODAS LAS MEZCLAS)
-   */
-  const recalcularTodo = async (mezclasParaCalcular: Mezcla[]) => {
-    const nuevosCalculos: CalculosPorLote[] = [];
-    const nuevosErrores: string[] = [];
-
-    // 🆕 Para fertilización: cargar presentaciones de productos
-    let productosInfo: Map<string, { presentacion_kg_l: number }> | undefined;
-    
-    if (configuracion.tipo === 'fertilizacion') {
-      productosInfo = new Map();
-      
-      // Obtener IDs únicos de todos los productos en todas las mezclas
-      const productosIds = Array.from(new Set(
-        mezclasParaCalcular.flatMap(m => m.productos.map(p => p.producto_id))
-      ));
-      
-      if (productosIds.length > 0) {
-        try {
-          const { data: productosData, error: errorProductos } = await supabase
-            .from('productos')
-            .select('id, presentacion_kg_l')
-            .in('id', productosIds);
-          
-          if (!errorProductos && productosData) {
-            productosData.forEach(p => {
-              if (p.presentacion_kg_l) {
-                productosInfo!.set(p.id, {
-                  presentacion_kg_l: p.presentacion_kg_l
-                });
-              }
-            });
-          } else {
-            console.error('Failed to load product presentacion data:', errorProductos);
+  const actualizarDosis = (mezclaId: string, productoId: string, campo: string, valor: number) => {
+    const actualizadas = mezclas.map((m) =>
+      m.id === mezclaId
+        ? {
+            ...m,
+            productos: m.productos.map((p) => (p.producto_id === productoId ? { ...p, [campo]: valor } : p)),
           }
-        } catch (err) {
-          console.error('Failed to fetch product presentacion info for calculations:', err);
-        }
-      }
-    }
-
-    // Calcular por cada mezcla y sus lotes asignados
-    mezclasParaCalcular.forEach((mezcla) => {
-      const lotesAsignados = mezcla.lotes_asignados || [];
-      
-      lotesAsignados.forEach((loteId) => {
-        const lote = configuracion.lotes_seleccionados.find((l) => l.lote_id === loteId);
-        if (!lote) return;
-
-        // Validar lote (fumigación y drench usan la misma validación)
-        if (configuracion.tipo === 'fumigacion' || configuracion.tipo === 'drench') {
-          const error = validarLoteFumigacion(lote);
-          if (error) nuevosErrores.push(error);
-        }
-
-        // Calcular (drench usa el mismo cálculo que fumigación)
-        const calculo =
-          configuracion.tipo === 'fumigacion' || configuracion.tipo === 'drench'
-            ? calcularFumigacion(lote, mezcla)
-            : calcularFertilizacion(lote, mezcla, productosInfo); // 👈 Pasar productosInfo
-
-        nuevosCalculos.push(calculo);
-      });
-    });
-
-    // Calcular totales por producto PER MEZCLA (solo para lotes asignados a cada mezcla)
-    const mezclasActualizadas = mezclasParaCalcular.map((mezcla) => {
-      // Filtrar cálculos solo para los lotes asignados a ESTA mezcla
-      const calculosDeEstaMezcla = nuevosCalculos.filter(calculo =>
-        mezcla.lotes_asignados?.includes(calculo.lote_id)
-      );
-
-      return {
-        ...mezcla,
-        productos: mezcla.productos.map((productoEnMezcla) => {
-          // Sumar cantidad solo de los lotes asignados a ESTA mezcla
-          const cantidadTotal = calculosDeEstaMezcla.reduce((sum, calculo) => {
-            const productoEnCalculo = calculo.productos.find(
-              p => p.producto_id === productoEnMezcla.producto_id
-            );
-            return sum + (productoEnCalculo?.cantidad_necesaria || 0);
-          }, 0);
-
-          return {
-            ...productoEnMezcla,
-            cantidad_total_necesaria: Math.ceil(cantidadTotal * 100) / 100
-          };
-        })
-      };
-    });
-
-    setCalculos(nuevosCalculos);
-    setErrores(nuevosErrores);
-
-    // Notificar al padre
-    onUpdate(mezclasActualizadas, nuevosCalculos);
+        : m,
+    );
+    recalcular(actualizadas);
   };
 
   return (
-    <div className="space-y-6">
-      {/* HEADER */}
-      <div className="flex items-center justify-between">
+    <div className="space-y-4">
+      <div className="flex items-center justify-between gap-3 flex-wrap">
         <div>
-          <h2 className="text-lg text-foreground">Definición de Mezclas</h2>
-          <p className="text-sm text-brand-brown/70 mt-1">
-            Crea mezclas, asigna lotes y define productos con sus dosis
+          <h4 className="text-sm font-bold text-foreground">Mezcla y Productos</h4>
+          <p className="text-xs text-muted-foreground mt-0.5">
+            {mezclas.length <= 1
+              ? 'La mezcla aplica automáticamente a los lotes seleccionados arriba.'
+              : `${mezclas.length} mezclas — asigna qué lotes le corresponde a cada una.`}
           </p>
         </div>
+        {mezclas.length === 0 && (
+          <Button type="button" size="sm" onClick={crearMezcla}>
+            <Plus className="w-4 h-4" />
+            Nueva mezcla
+          </Button>
+        )}
+      </div>
 
-        {!mezcla_en_edicion && (
+      {errores.length > 0 && (
+        <Alert variant="destructive">
+          <AlertTriangle />
+          <AlertDescription>
+            <ul className="list-disc list-inside space-y-0.5">
+              {errores.map((e, i) => (
+                <li key={i}>{e}</li>
+              ))}
+            </ul>
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {mezclas.length === 0 ? (
+        <div className="text-center py-10 bg-background rounded-xl border-2 border-dashed border-border">
+          <div className="w-12 h-12 bg-primary rounded-xl flex items-center justify-center text-primary-foreground mx-auto mb-3">
+            <Beaker className="w-6 h-6" />
+          </div>
+          <p className="text-sm font-medium text-foreground mb-1">Sin mezclas todavía</p>
+          <p className="text-xs text-muted-foreground mb-4">Agrega la primera mezcla para definir productos y dosis</p>
+          <Button type="button" size="sm" onClick={crearMezcla}>
+            <Plus className="w-4 h-4" />
+            Crear primera mezcla
+          </Button>
+        </div>
+      ) : (
+        <div className="space-y-4">
+          {mezclas.map((mezcla) => (
+            <MezclaCard
+              key={mezcla.id}
+              mezcla={mezcla}
+              totalMezclas={mezclas.length}
+              configuracion={configuracion}
+              usaDosisPorCaneca={usaDosisPorCaneca}
+              estadoAsignacion={estadosAsignacion?.[mezcla.id] ?? 'ok'}
+              productosCatalogo={productosCatalogo}
+              cargandoProductos={cargandoProductos}
+              onToggleLote={(loteId) => toggleLoteAsignado(mezcla.id, loteId)}
+              onAgregarProducto={(productoId) => agregarProducto(mezcla.id, productoId)}
+              onQuitarProducto={(productoId, nombre) =>
+                setConfirmEliminarProducto({ mezclaId: mezcla.id, productoId, nombre })
+              }
+              onActualizarDosis={(productoId, campo, valor) => actualizarDosis(mezcla.id, productoId, campo, valor)}
+              onEliminarMezcla={() => setConfirmEliminarMezclaId(mezcla.id)}
+              onReintentarAsignacion={onReintentarAsignacion}
+              onCrearNuevaMezcla={mezcla.numero_orden === Math.max(...mezclas.map((m) => m.numero_orden)) ? crearMezcla : undefined}
+            />
+          ))}
+        </div>
+      )}
+
+      <ConfirmDialog
+        open={confirmEliminarMezclaId !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmEliminarMezclaId(null);
+        }}
+        title="¿Eliminar esta mezcla?"
+        description="Se perderán sus productos y dosis. Esta acción no se puede deshacer."
+        confirmLabel="Eliminar"
+        onConfirm={confirmarEliminarMezcla}
+        destructive
+      />
+
+      <ConfirmDialog
+        open={confirmEliminarProducto !== null}
+        onOpenChange={(open) => {
+          if (!open) setConfirmEliminarProducto(null);
+        }}
+        title={confirmEliminarProducto ? `¿Quitar ${confirmEliminarProducto.nombre} de la mezcla?` : ''}
+        confirmLabel="Quitar"
+        onConfirm={confirmarQuitarProducto}
+        destructive
+      />
+    </div>
+  );
+}
+
+// ============================================================================
+// TARJETA DE MEZCLA
+// ============================================================================
+
+interface MezclaCardProps {
+  mezcla: Mezcla;
+  totalMezclas: number;
+  configuracion: ConfiguracionAplicacion;
+  usaDosisPorCaneca: boolean;
+  estadoAsignacion: EstadoAsignacionMezcla;
+  productosCatalogo: ProductoCatalogo[];
+  cargandoProductos: boolean;
+  onToggleLote: (loteId: string) => void;
+  onAgregarProducto: (productoId: string) => void;
+  onQuitarProducto: (productoId: string, nombre: string) => void;
+  onActualizarDosis: (productoId: string, campo: string, valor: number) => void;
+  onEliminarMezcla: () => void;
+  onReintentarAsignacion?: () => void;
+  onCrearNuevaMezcla?: () => void;
+}
+
+function MezclaCard({
+  mezcla,
+  totalMezclas,
+  configuracion,
+  usaDosisPorCaneca,
+  estadoAsignacion,
+  productosCatalogo,
+  cargandoProductos,
+  onToggleLote,
+  onAgregarProducto,
+  onQuitarProducto,
+  onActualizarDosis,
+  onEliminarMezcla,
+  onReintentarAsignacion,
+  onCrearNuevaMezcla,
+}: MezclaCardProps) {
+  const [comboAbierto, setComboAbierto] = useState(false);
+  const [busqueda, setBusqueda] = useState('');
+
+  const esMezclaUnica = totalMezclas <= 1;
+  const lotesAsignados = esMezclaUnica
+    ? configuracion.lotes_seleccionados.map((l) => l.lote_id)
+    : mezcla.lotes_asignados || [];
+
+  const nombresLotesAsignados = lotesAsignados
+    .map((id) => configuracion.lotes_seleccionados.find((l) => l.lote_id === id)?.nombre)
+    .filter(Boolean)
+    .join(', ');
+
+  const productosDisponibles = productosCatalogo.filter(
+    (p) => !mezcla.productos.some((mp) => mp.producto_id === p.id),
+  );
+
+  return (
+    <div className="border border-border rounded-2xl p-5 bg-card">
+      <div className="flex items-start justify-between gap-3 mb-4">
+        <div className="flex items-center gap-3">
+          <div className="w-10 h-10 bg-primary rounded-lg flex items-center justify-center text-primary-foreground flex-shrink-0">
+            <Beaker className="w-5 h-5" />
+          </div>
+          <div>
+            <p className="text-sm font-bold text-foreground">{mezcla.nombre}</p>
+            <p className="text-xs text-muted-foreground">
+              {mezcla.productos.length} {mezcla.productos.length === 1 ? 'producto' : 'productos'}
+              {esMezclaUnica ? ' · aplica a todos los lotes seleccionados' : ` · ${lotesAsignados.length} lotes asignados`}
+            </p>
+          </div>
+        </div>
+        {totalMezclas > 1 && (
           <button
-            onClick={crearNuevaMezcla}
-            className="flex items-center gap-2 px-4 py-2 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:from-primary-dark hover:to-secondary-dark transition-all"
+            type="button"
+            onClick={onEliminarMezcla}
+            className="p-2 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-lg transition-colors"
+            aria-label={`Eliminar ${mezcla.nombre}`}
           >
-            <Plus className="w-5 h-5" />
-            <span>Nueva Mezcla</span>
+            <Trash2 className="w-4 h-4" />
           </button>
         )}
       </div>
 
-      {/* ERRORES */}
-      {errores.length > 0 && (
-        <div className="bg-red-50 border border-red-200 rounded-xl p-4">
-          <div className="flex items-start gap-3">
-            <AlertTriangle className="w-5 h-5 text-red-600 flex-shrink-0 mt-0.5" />
-            <div className="flex-1">
-              <h4 className="text-red-800 mb-2">Errores de validación:</h4>
-              <ul className="list-disc list-inside space-y-1 text-sm text-red-700">
-                {errores.map((error, index) => (
-                  <li key={index}>{error}</li>
-                ))}
-              </ul>
-            </div>
+      {/* ASIGNACIÓN DE LOTES — solo se pide de nuevo cuando hay 2+ mezclas */}
+      {esMezclaUnica ? (
+        <div className="flex flex-wrap items-center justify-between gap-3 rounded-lg bg-muted px-3.5 py-3 mb-4">
+          <p className="text-sm text-foreground">
+            <span className="block text-[0.6875rem] font-bold uppercase tracking-wide text-muted-foreground mb-0.5">
+              Lotes
+            </span>
+            {nombresLotesAsignados || 'Selecciona lotes arriba para que esta mezcla los herede.'}
+          </p>
+          {onCrearNuevaMezcla && (
+            <Button type="button" variant="ghost" size="sm" onClick={onCrearNuevaMezcla}>
+              <Plus className="w-3.5 h-3.5" />
+              ¿Dividir en otra mezcla?
+            </Button>
+          )}
+        </div>
+      ) : (
+        <div className="mb-4 space-y-3">
+          {estadoAsignacion === 'error' ? (
+            <Alert variant="destructive">
+              <AlertTriangle />
+              <AlertDescription>
+                <p className="font-medium text-foreground">No se pudo cargar la asignación de lotes</p>
+                <p>
+                  Esta mezcla existe en la base de datos pero no se pudo confirmar a qué lotes aplica. No
+                  asumas que aplica a todos ni a ninguno.
+                </p>
+                {onReintentarAsignacion && (
+                  <Button type="button" variant="outline" size="sm" className="mt-2" onClick={onReintentarAsignacion}>
+                    <RefreshCw className="w-3.5 h-3.5" />
+                    Reintentar
+                  </Button>
+                )}
+              </AlertDescription>
+            </Alert>
+          ) : lotesAsignados.length === 0 ? (
+            <Alert variant="warning">
+              <AlertTriangle />
+              <AlertDescription>
+                <p className="font-medium text-foreground">Sin lotes asignados a esta mezcla</p>
+                <p>Elige cuáles de los lotes seleccionados le corresponden a {mezcla.nombre}.</p>
+              </AlertDescription>
+            </Alert>
+          ) : null}
+
+          <div className="grid grid-cols-1 sm:grid-cols-2 gap-2">
+            {configuracion.lotes_seleccionados.map((lote) => {
+              const seleccionado = lotesAsignados.includes(lote.lote_id);
+              return (
+                <label
+                  key={lote.lote_id}
+                  className={cn(
+                    'flex items-start gap-2.5 rounded-lg border px-3 py-2.5 text-sm cursor-pointer transition-colors min-h-11',
+                    seleccionado ? 'border-primary bg-primary/5' : 'border-border hover:border-secondary',
+                  )}
+                >
+                  <Checkbox
+                    checked={seleccionado}
+                    onCheckedChange={() => onToggleLote(lote.lote_id)}
+                    className="mt-0.5"
+                  />
+                  <span className="flex-1 min-w-0">
+                    <span className="block font-medium text-foreground">{lote.nombre}</span>
+                    <span className="block text-xs text-muted-foreground">{lote.conteo_arboles.total} árboles</span>
+                  </span>
+                </label>
+              );
+            })}
           </div>
         </div>
       )}
 
-      {/* MEZCLAS GUARDADAS */}
-      {!mezcla_en_edicion && mezclas_guardadas.length > 0 && (
-        <div className="space-y-4">
-          <h3 className="text-sm text-foreground">Mezclas Creadas ({mezclas_guardadas.length})</h3>
-          
-          {mezclas_guardadas.map((mezcla) => {
-            const lotesAsignados = mezcla.lotes_asignados || [];
-            const nombreLotes = lotesAsignados
-              .map((loteId) => {
-                const lote = configuracion.lotes_seleccionados.find((l) => l.lote_id === loteId);
-                return lote ? lote.nombre : 'Desconocido';
-              })
-              .join(', ');
-
+      {/* PRODUCTOS EN LA MEZCLA */}
+      {mezcla.productos.length > 0 && (
+        <div className="space-y-2.5 mb-4">
+          {mezcla.productos.map((producto) => {
+            const noPermitido = productosCatalogo.find((p) => p.id === producto.producto_id)?.permitido_gerencia === false;
             return (
-              <div
-                key={mezcla.id}
-                className="border border-gray-200 rounded-xl p-4 hover:border-primary transition-colors"
-              >
-                <div className="flex items-start justify-between mb-3">
-                  <div className="flex items-center gap-3">
-                    <div className="w-10 h-10 bg-gradient-to-br from-primary to-secondary rounded-xl flex items-center justify-center text-white">
-                      <Beaker className="w-5 h-5" />
-                    </div>
-                    <div>
-                      <h4 className="text-foreground">{mezcla.nombre}</h4>
-                      <p className="text-sm text-brand-brown/70">
-                        {mezcla.productos.length} productos • {lotesAsignados.length} lotes
-                      </p>
-                    </div>
+              <div key={producto.producto_id} className="border border-border rounded-lg p-3.5 bg-background">
+                <div className="flex items-start justify-between gap-3 mb-3">
+                  <div>
+                    <p className={cn('text-sm font-bold', noPermitido ? 'text-destructive' : 'text-foreground')}>
+                      {producto.producto_nombre}
+                    </p>
+                    <p className="text-xs text-muted-foreground">{producto.producto_categoria}</p>
                   </div>
-
-                  <div className="flex items-center gap-2">
-                    <button
-                      onClick={() => editarMezcla(mezcla)}
-                      className="p-2 text-primary hover:bg-primary/10 rounded-lg transition-colors"
-                      title="Editar"
-                      aria-label={`Editar mezcla ${mezcla.nombre}`}
-                    >
-                      <Edit2 className="w-4 h-4" />
-                    </button>
-                    <button
-                      onClick={() => eliminarMezcla(mezcla.id)}
-                      className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                      title="Eliminar"
-                      aria-label={`Eliminar mezcla ${mezcla.nombre}`}
-                    >
-                      <Trash2 className="w-4 h-4" />
-                    </button>
-                  </div>
+                  <button
+                    type="button"
+                    onClick={() => onQuitarProducto(producto.producto_id, producto.producto_nombre)}
+                    className="p-1.5 text-muted-foreground hover:text-destructive hover:bg-destructive/10 rounded-md transition-colors"
+                    aria-label={`Quitar ${producto.producto_nombre} de la mezcla`}
+                  >
+                    <X className="w-4 h-4" />
+                  </button>
                 </div>
 
-                {/* Lotes asignados */}
-                {lotesAsignados.length > 0 && (
-                  <div className="mb-3 p-3 bg-background rounded-lg">
-                    <p className="text-xs text-brand-brown/70 mb-1">Lotes asignados:</p>
-                    <p className="text-sm text-foreground">{nombreLotes}</p>
+                {usaDosisPorCaneca ? (
+                  <Field className="max-w-xs">
+                    <FieldLabel htmlFor={`dosis-caneca-${producto.producto_id}`}>Dosis por caneca</FieldLabel>
+                    <InputGroup>
+                      <InputGroupInput
+                        id={`dosis-caneca-${producto.producto_id}`}
+                        type="number"
+                        onWheel={(e) => e.currentTarget.blur()}
+                        min={0}
+                        step="0.01"
+                        value={producto.dosis_por_caneca ?? ''}
+                        onChange={(e) =>
+                          onActualizarDosis(producto.producto_id, 'dosis_por_caneca', parseFloat(e.target.value) || 0)
+                        }
+                      />
+                      <InputGroupAddon align="inline-end">
+                        {producto.unidad_dosis === 'cc' ? 'cc' : 'g'}
+                      </InputGroupAddon>
+                    </InputGroup>
+                  </Field>
+                ) : (
+                  <div className="grid grid-cols-2 sm:grid-cols-4 gap-2.5">
+                    {(
+                      [
+                        ['dosis_grandes', 'Grandes'],
+                        ['dosis_medianos', 'Medianos'],
+                        ['dosis_pequenos', 'Pequeños'],
+                        ['dosis_clonales', 'Clonales'],
+                      ] as const satisfies readonly (readonly [keyof Pick<ProductoEnMezcla, 'dosis_grandes' | 'dosis_medianos' | 'dosis_pequenos' | 'dosis_clonales'>, string])[]
+                    ).map(([campo, etiqueta]) => (
+                      <Field key={campo}>
+                        <FieldLabel htmlFor={`${campo}-${producto.producto_id}`} className="text-xs">
+                          {etiqueta}
+                        </FieldLabel>
+                        <InputGroup>
+                          <InputGroupInput
+                            id={`${campo}-${producto.producto_id}`}
+                            type="number"
+                            onWheel={(e) => e.currentTarget.blur()}
+                            min={0}
+                            step="0.01"
+                            value={producto[campo] ?? ''}
+                            onChange={(e) => onActualizarDosis(producto.producto_id, campo, parseFloat(e.target.value) || 0)}
+                          />
+                          <InputGroupAddon align="inline-end">
+                            {producto.producto_unidad === 'Litros' ? 'cc' : 'g'}
+                          </InputGroupAddon>
+                        </InputGroup>
+                      </Field>
+                    ))}
                   </div>
                 )}
 
-                {/* Productos */}
-                <div className="space-y-2">
-                  {mezcla.productos.map((producto) => (
-                    <div
-                      key={producto.producto_id}
-                      className="flex items-center justify-between text-sm p-2 bg-white rounded-lg"
-                    >
-                      <div className="flex-1">
-                        <p className={`${productosCatalogo.find(p => p.id === producto.producto_id)?.permitido_gerencia === false ? 'text-red-600 font-bold' : 'text-foreground'}`}>
-                          {producto.producto_nombre}
-                        </p>
-                        <p className="text-xs text-brand-brown/70">{producto.producto_categoria}</p>
-                      </div>
-                      <div className="text-right">
-                        {(configuracion.tipo === 'fumigacion' || configuracion.tipo === 'drench') ? (
-                          <p className="text-primary">
-                            {producto.dosis_por_caneca} {producto.unidad_dosis}/caneca
-                          </p>
-                        ) : (
-                          <p className="text-primary text-xs">
-                            G:{producto.dosis_grandes} M:{producto.dosis_medianos} P:{producto.dosis_pequenos} C:{producto.dosis_clonales} {producto.producto_unidad === 'Litros' ? 'cc' : 'g'}/árbol
-                          </p>
-                        )}
-                        <p className="text-xs text-brand-brown/70">
-                          Total: {formatearNumero(producto.cantidad_total_necesaria)} {producto.producto_unidad}
-                        </p>
-                      </div>
-                    </div>
-                  ))}
+                <div className="flex justify-end mt-2.5 text-sm">
+                  <span className="text-muted-foreground">
+                    Total necesario:&nbsp;
+                    <span className="font-bold text-foreground tabular-nums">
+                      {formatearNumero(producto.cantidad_total_necesaria)} {producto.producto_unidad}
+                    </span>
+                  </span>
                 </div>
               </div>
             );
@@ -540,419 +723,58 @@ export function PasoMezcla({ configuracion, mezclas, calculos: calculosIniciales
         </div>
       )}
 
-      {/* FORMULARIO DE CREACIÓN/EDICIÓN */}
-      {mezcla_en_edicion && (
-        <div className="border-2 border-primary rounded-2xl p-6 bg-white">
-          <div className="flex items-center justify-between mb-6">
-            <div className="flex items-center gap-3">
-              <div className="w-12 h-12 bg-gradient-to-br from-primary to-secondary rounded-xl flex items-center justify-center text-white">
-                <Beaker className="w-6 h-6" />
-              </div>
-              <div>
-                <h3 className="text-lg text-foreground">
-                  {modo_edicion === 'crear' ? 'Crear' : 'Editar'} {mezcla_en_edicion.nombre}
-                </h3>
-                <p className="text-sm text-brand-brown/70">
-                  Asigna lotes y productos a esta mezcla
-                </p>
-              </div>
-            </div>
-          </div>
-
-          {/* ASIGNAR LOTES */}
-          <div className="mb-6">
-            <label className="block text-sm text-foreground mb-3">
-              1. Asignar Lotes a esta Mezcla *
-            </label>
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-3">
-              {configuracion.lotes_seleccionados.map((lote) => {
-                const yaAsignado = (mezcla_en_edicion.lotes_asignados || []).includes(lote.lote_id);
-
-                return (
-                  <button
-                    key={lote.lote_id}
-                    onClick={() => toggleLoteAsignado(lote.lote_id)}
-                    className={`
-                      p-4 rounded-xl border-2 text-left transition-all
-                      ${
-                        yaAsignado
-                          ? 'border-primary bg-primary/5'
-                          : 'border-gray-200 hover:border-gray-300'
-                      }
-                    `}
-                  >
-                    <div className="flex items-start justify-between">
-                      <div className="flex-1">
-                        <p className="text-foreground mb-1">{lote.nombre}</p>
-                        <p className="text-xs text-brand-brown/70">
-                          {lote.conteo_arboles.total} árboles
+      {/* AGREGAR PRODUCTO — un solo combobox (Command en Popover), no buscador + <select> */}
+      <div>
+        <p className="text-xs font-bold text-foreground mb-1.5">Agregar producto</p>
+        <Popover open={comboAbierto} onOpenChange={setComboAbierto}>
+          <PopoverTrigger asChild>
+            <button
+              type="button"
+              disabled={cargandoProductos}
+              className="w-full flex items-center gap-2 px-3 py-2.5 border border-input rounded-md text-sm text-muted-foreground hover:border-ring transition-colors disabled:opacity-50 disabled:cursor-not-allowed"
+            >
+              <Search className="w-4 h-4 flex-shrink-0" />
+              {cargandoProductos ? 'Cargando productos…' : 'Buscar producto por nombre o categoría…'}
+            </button>
+          </PopoverTrigger>
+          <PopoverContent align="start" className="p-0 w-[--radix-popover-trigger-width]" style={{ width: 'var(--radix-popover-trigger-width)' }}>
+            <Command>
+              <CommandInput placeholder="Buscar producto..." value={busqueda} onValueChange={setBusqueda} />
+              <CommandList>
+                <CommandEmpty>Ningún producto coincide con "{busqueda}".</CommandEmpty>
+                <CommandGroup>
+                  {productosDisponibles.map((producto) => (
+                    <CommandItem
+                      key={producto.id}
+                      value={producto.display_nombre}
+                      onSelect={() => {
+                        onAgregarProducto(producto.id);
+                        setBusqueda('');
+                        setComboAbierto(false);
+                      }}
+                    >
+                      <div className="flex-1 min-w-0">
+                        <p className="text-sm font-medium truncate">{producto.display_nombre}</p>
+                        <p className="text-xs text-muted-foreground">
+                          Stock: {formatearNumero(producto.cantidad_actual)} {producto.unidad_medida}
                         </p>
                       </div>
-                      {yaAsignado && (
-                        <div className="w-6 h-6 bg-primary rounded-full flex items-center justify-center text-white flex-shrink-0">
-                          <Check className="w-4 h-4" />
-                        </div>
+                      {producto.permitido_gerencia === false && (
+                        <Badge variant="destructive" className="flex-shrink-0">
+                          Restringido
+                        </Badge>
                       )}
-                    </div>
-                  </button>
-                );
-              })}
-            </div>
-          </div>
-
-          {/* AGREGAR PRODUCTOS */}
-          <div className="mb-6">
-            <label className="block text-sm text-foreground mb-3">
-              2. Agregar Productos *
-            </label>
-
-            <div className="flex gap-3 mb-4">
-              <input
-                type="text"
-                value={busquedaProducto}
-                onChange={(e) => setBusquedaProducto(e.target.value)}
-                className="flex-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                placeholder="Buscar producto..."
-                disabled={cargandoProductos}
-              />
-
-              <select
-                value={productoSeleccionado}
-                onChange={(e) => setProductoSeleccionado(e.target.value)}
-                className="flex-1 px-4 py-3 border border-gray-300 rounded-xl focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                disabled={cargandoProductos}
-              >
-                <option value="">
-                  {cargandoProductos ? 'Cargando productos...' : 'Seleccionar producto'}
-                </option>
-                {productosCatalogo
-                  .filter((producto) =>
-                    (producto.display_nombre ?? '').toLowerCase().includes(busquedaProducto.toLowerCase())
-                  )
-                  .map((producto) => (
-                    <option key={producto.id} value={producto.id}>
-                      {producto.display_nombre}
-                    </option>
+                    </CommandItem>
                   ))}
-              </select>
-
-              <button
-                onClick={agregarProducto}
-                disabled={!productoSeleccionado}
-                className="px-6 py-3 bg-primary text-white rounded-xl hover:bg-primary-dark transition-all flex items-center gap-2 disabled:opacity-50 disabled:cursor-not-allowed"
-              >
-                <Plus className="w-5 h-5" />
-                <span>Agregar</span>
-              </button>
-            </div>
-
-            {/* Lista de productos en la mezcla */}
-            {mezcla_en_edicion.productos.length > 0 && (
-              <div className="space-y-3">
-                {mezcla_en_edicion.productos.map((producto) => (
-                  <div
-                    key={producto.producto_id}
-                    className="border border-gray-200 rounded-xl p-4"
-                  >
-                    <div className="flex items-start justify-between mb-3">
-                      <div className="flex-1">
-                        <h4 className={`mb-1 ${productosCatalogo.find(p => p.id === producto.producto_id)?.permitido_gerencia === false ? 'text-red-600 font-bold' : 'text-foreground'}`}>
-                          {producto.producto_nombre}
-                        </h4>
-                        <p className="text-xs text-brand-brown/70">
-                          {producto.producto_categoria} • Stock: {formatearNumero(producto.inventario_disponible ?? 0)} {producto.producto_unidad}
-                        </p>
-                      </div>
-
-                      <button
-                        onClick={() => quitarProducto(producto.producto_id)}
-                        className="p-2 text-red-600 hover:bg-red-50 rounded-lg transition-colors"
-                        aria-label={`Quitar ${producto.producto_nombre}`}
-                      >
-                        <X className="w-5 h-5" />
-                      </button>
-                    </div>
-
-                    {/* Dosis - Fumigación */}
-                    {configuracion.tipo === 'fumigacion' && (
-                      <div className="grid grid-cols-2 gap-3">
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">
-                            Dosis por caneca *
-                          </label>
-                          <input
-                            type="number"
-                            onWheel={(e) => e.currentTarget.blur()}
-                            value={producto.dosis_por_caneca || ''}
-                            onChange={(e) =>
-                              actualizarDosis(
-                                producto.producto_id,
-                                'dosis_por_caneca',
-                                parseFloat(e.target.value) || 0
-                              )
-                            }
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                            placeholder="0"
-                            step="0.01"
-                            min="0"
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">Unidad</label>
-                          <div className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 text-foreground">
-                            {producto.unidad_dosis === 'cc' ? 'cc (líquido)' : 'gramos (sólido)'}
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Dosis - Drench (igual a fumigación) */}
-                    {configuracion.tipo === 'drench' && (
-                      <div className="grid grid-cols-2 gap-3">
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">
-                            Dosis por caneca *
-                          </label>
-                          <input
-                            type="number"
-                            onWheel={(e) => e.currentTarget.blur()}
-                            value={producto.dosis_por_caneca || ''}
-                            onChange={(e) =>
-                              actualizarDosis(
-                                producto.producto_id,
-                                'dosis_por_caneca',
-                                parseFloat(e.target.value) || 0
-                              )
-                            }
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                            placeholder="0"
-                            step="0.01"
-                            min="0"
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">Unidad</label>
-                          <div className="w-full px-3 py-2 border border-gray-300 rounded-lg bg-gray-50 text-foreground">
-                            {producto.unidad_dosis === 'cc' ? 'cc (líquido)' : 'gramos (sólido)'}
-                          </div>
-                        </div>
-                      </div>
-                    )}
-
-                    {/* Dosis - Fertilización (g para sólidos, cc para líquidos) */}
-                    {configuracion.tipo === 'fertilizacion' && (() => {
-                      const unidadDosis = producto.producto_unidad === 'Litros' ? 'cc' : 'g';
-                      return (
-                      <div className="grid grid-cols-2 md:grid-cols-4 gap-3">
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">
-                            Grandes ({unidadDosis})
-                          </label>
-                          <input
-                            type="number"
-                            onWheel={(e) => e.currentTarget.blur()}
-                            value={producto.dosis_grandes || ''}
-                            onChange={(e) =>
-                              actualizarDosis(
-                                producto.producto_id,
-                                'dosis_grandes',
-                                parseFloat(e.target.value) || 0
-                              )
-                            }
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                            placeholder="0"
-                            step="0.01"
-                            min="0"
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">
-                            Medianos ({unidadDosis})
-                          </label>
-                          <input
-                            type="number"
-                            onWheel={(e) => e.currentTarget.blur()}
-                            value={producto.dosis_medianos || ''}
-                            onChange={(e) =>
-                              actualizarDosis(
-                                producto.producto_id,
-                                'dosis_medianos',
-                                parseFloat(e.target.value) || 0
-                              )
-                            }
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                            placeholder="0"
-                            step="0.01"
-                            min="0"
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">
-                            Pequeños ({unidadDosis})
-                          </label>
-                          <input
-                            type="number"
-                            onWheel={(e) => e.currentTarget.blur()}
-                            value={producto.dosis_pequenos || ''}
-                            onChange={(e) =>
-                              actualizarDosis(
-                                producto.producto_id,
-                                'dosis_pequenos',
-                                parseFloat(e.target.value) || 0
-                              )
-                            }
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                            placeholder="0"
-                            step="0.01"
-                            min="0"
-                          />
-                        </div>
-
-                        <div>
-                          <label className="block text-xs text-brand-brown/70 mb-1">
-                            Clonales ({unidadDosis})
-                          </label>
-                          <input
-                            type="number"
-                            onWheel={(e) => e.currentTarget.blur()}
-                            value={producto.dosis_clonales || ''}
-                            onChange={(e) =>
-                              actualizarDosis(
-                                producto.producto_id,
-                                'dosis_clonales',
-                                parseFloat(e.target.value) || 0
-                              )
-                            }
-                            className="w-full px-3 py-2 border border-gray-300 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary focus:border-transparent"
-                            placeholder="0"
-                            step="0.01"
-                            min="0"
-                          />
-                        </div>
-                      </div>
-                      );
-                    })()}
-                  </div>
-                ))}
-              </div>
-            )}
-          </div>
-
-          {/* BOTONES DE ACCIÓN */}
-          <div className="flex items-center justify-end gap-3 pt-4 border-t border-gray-200">
-            <button
-              onClick={cancelarEdicion}
-              className="px-6 py-3 text-brand-brown hover:bg-gray-100 rounded-xl transition-all"
-            >
-              Cancelar
-            </button>
-
-            <button
-              onClick={confirmarMezcla}
-              className="px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:from-primary-dark hover:to-secondary-dark transition-all flex items-center gap-2"
-            >
-              <Check className="w-5 h-5" />
-              <span>{modo_edicion === 'crear' ? 'Confirmar Mezcla' : 'Guardar Cambios'}</span>
-            </button>
-          </div>
-        </div>
-      )}
-
-      {/* MENSAJE INICIAL */}
-      {!mezcla_en_edicion && mezclas_guardadas.length === 0 && (
-        <div className="text-center py-12 bg-background rounded-2xl border-2 border-dashed border-gray-300">
-          <div className="w-16 h-16 bg-gradient-to-br from-primary to-secondary rounded-2xl flex items-center justify-center text-white mx-auto mb-4">
-            <Beaker className="w-8 h-8" />
-          </div>
-          <h3 className="text-lg text-foreground mb-2">No hay mezclas creadas</h3>
-          <p className="text-brand-brown/70 mb-6">
-            Crea tu primera mezcla para comenzar
-          </p>
-          <button
-            onClick={crearNuevaMezcla}
-            className="inline-flex items-center gap-2 px-6 py-3 bg-gradient-to-r from-primary to-secondary text-white rounded-xl hover:from-primary-dark hover:to-secondary-dark transition-all"
-          >
-            <Plus className="w-5 h-5" />
-            <span>Crear Primera Mezcla</span>
-          </button>
-        </div>
-      )}
-
-      {/* CONFIRM DIALOG — ELIMINAR MEZCLA */}
-      <ConfirmDialog
-        open={confirmEliminarId !== null}
-        onOpenChange={(open) => { if (!open) setConfirmEliminarId(null); }}
-        title="¿Estás seguro de eliminar esta mezcla?"
-        description="Esta acción no se puede deshacer."
-        confirmLabel="Eliminar"
-        onConfirm={confirmarEliminarMezcla}
-        destructive
-      />
-
-      {/* RESUMEN DE CÁLCULOS */}
-      {mezclas_guardadas.length > 0 && calculos.length > 0 && !mezcla_en_edicion && (
-        <div className="bg-background rounded-2xl p-6 border border-gray-200">
-          <div className="flex items-center gap-3 mb-4">
-            <div className="w-10 h-10 bg-gradient-to-br from-primary to-secondary rounded-xl flex items-center justify-center text-white">
-              <Calculator className="w-5 h-5" />
-            </div>
-            <div>
-              <h3 className="text-foreground">Resumen de Cálculos</h3>
-              <p className="text-sm text-brand-brown/70">
-                {calculos.length} lotes calculados
-              </p>
-            </div>
-          </div>
-
-          <div className="space-y-3">
-            {calculos.map((calculo) => (
-              <div
-                key={`${calculo.lote_id}-${calculo.lote_nombre}`}
-                className="bg-white rounded-xl p-4 border border-gray-200"
-              >
-                <h4 className="text-foreground mb-3">{calculo.lote_nombre}</h4>
-                
-                <div className="grid grid-cols-2 md:grid-cols-4 gap-4 text-sm">
-                  <div>
-                    <p className="text-brand-brown/70 text-xs mb-1">Total Árboles</p>
-                    <p className="text-foreground">{formatearNumero(calculo.total_arboles)}</p>
-                  </div>
-
-                  {(configuracion.tipo === 'fumigacion' || configuracion.tipo === 'drench') && (
-                    <>
-                      <div>
-                        <p className="text-brand-brown/70 text-xs mb-1">Litros Mezcla</p>
-                        <p className="text-primary">{formatearNumero(calculo.litros_mezcla ?? 0)} L</p>
-                      </div>
-                      <div>
-                        <p className="text-brand-brown/70 text-xs mb-1">Canecas</p>
-                        <p className="text-primary">{formatearNumero(calculo.numero_canecas ?? 0)}</p>
-                      </div>
-                    </>
-                  )}
-
-                  {configuracion.tipo === 'fertilizacion' && (
-                    <>
-                      <div>
-                        <p className="text-brand-brown/70 text-xs mb-1">Kilos Totales</p>
-                        <p className="text-primary">{formatearNumero(calculo.kilos_totales ?? 0)} kg</p>
-                      </div>
-                      <div>
-                        <p className="text-brand-brown/70 text-xs mb-1">Bultos (50kg)</p>
-                        <p className="text-primary">{calculo.numero_bultos}</p>
-                      </div>
-                    </>
-                  )}
-                </div>
-              </div>
-            ))}
-          </div>
-        </div>
-      )}
+                </CommandGroup>
+              </CommandList>
+            </Command>
+          </PopoverContent>
+        </Popover>
+        <FieldDescription className="mt-1.5">
+          Filtra por nombre, categoría o estado físico. Un producto ya agregado no vuelve a aparecer en la lista.
+        </FieldDescription>
+      </div>
     </div>
   );
 }

--- a/src/components/aplicaciones/SeccionConfirmarCierre.tsx
+++ b/src/components/aplicaciones/SeccionConfirmarCierre.tsx
@@ -1,0 +1,84 @@
+import { AlertTriangle, Download } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Button } from '@/components/ui/button';
+import { Alert, AlertDescription } from '@/components/ui/alert';
+import { formatearMoneda } from '@/utils/format';
+import { SeccionHeader } from './SeccionInsumosCierre';
+
+interface SeccionConfirmarCierreProps {
+  costoInsumos: number;
+  costoManoObra: number;
+  costoTotal: number;
+  costoPorArbol: number;
+  onDescargarPDF: () => void;
+}
+
+/**
+ * Sección ③ del Cierre (`W03-cierre-v2.md` §1/§4) — el Resumen de Costos aparece UNA sola vez
+ * acá (antes se repetía entre el paso de Labores y el de Confirmación); el recap completo de
+ * "Información General"/"Ejecución" del antiguo Paso 3 se elimina por completo: esos datos ya
+ * están visibles arriba, en la misma página con scroll continuo.
+ */
+export function SeccionConfirmarCierre({
+  costoInsumos,
+  costoManoObra,
+  costoTotal,
+  costoPorArbol,
+  onDescargarPDF,
+}: SeccionConfirmarCierreProps) {
+  return (
+    <div className="space-y-4">
+      <SeccionHeader
+        numero={3}
+        titulo="Confirmar cierre"
+        descripcion="Los números de arriba ya se vieron una vez — no se repiten aquí."
+      />
+
+      <Card className="grid grid-cols-2 gap-4 bg-gradient-to-br from-primary/5 to-secondary/10 p-5 sm:grid-cols-4">
+        <CeldaCosto label="Insumos" valor={formatearMoneda(costoInsumos)} />
+        <CeldaCosto label="Mano de Obra" valor={formatearMoneda(costoManoObra)} />
+        <CeldaCosto label="Total" valor={formatearMoneda(costoTotal)} destacado />
+        <CeldaCosto label="Costo/Árbol" valor={formatearMoneda(costoPorArbol)} />
+      </Card>
+
+      <Alert variant="warning">
+        <AlertTriangle />
+        <AlertDescription>
+          <b className="font-semibold">Importante:</b> cerrar esta aplicación descuenta el
+          inventario, completa la tarea de labor y congela el registro. No podrás deshacerlo —
+          revisa el resumen antes de confirmar.
+        </AlertDescription>
+      </Alert>
+
+      <Button type="button" variant="outline" className="w-full" onClick={onDescargarPDF}>
+        <Download className="size-4" />
+        Descargar Reporte de Cierre (PDF)
+      </Button>
+    </div>
+  );
+}
+
+function CeldaCosto({
+  label,
+  valor,
+  destacado = false,
+}: {
+  label: string;
+  valor: string;
+  destacado?: boolean;
+}) {
+  return (
+    <div>
+      <p className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p
+        className={
+          destacado
+            ? 'text-lg font-bold tabular-nums text-primary-dark'
+            : 'text-base font-semibold tabular-nums text-foreground'
+        }
+      >
+        {valor}
+      </p>
+    </div>
+  );
+}

--- a/src/components/aplicaciones/SeccionInsumosCierre.tsx
+++ b/src/components/aplicaciones/SeccionInsumosCierre.tsx
@@ -1,0 +1,247 @@
+import { CheckCircle2, AlertTriangle } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Badge } from '@/components/ui/badge';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import { cn } from '@/components/ui/utils';
+import { formatearNumero } from '@/utils/format';
+import { calcularInsumosConDesviacion, type InsumoInput } from '@/utils/calculosCierreAplicacion';
+import type { TipoAplicacion } from '@/types/aplicaciones';
+
+interface SeccionInsumosCierreProps {
+  tipoAplicacion: TipoAplicacion;
+  totalLotes: number;
+  totalArboles: number;
+  proposito: string | null | undefined;
+  resumenInsumos: InsumoInput[];
+  canecasPlaneadas: number;
+  canecasAplicadas: number;
+}
+
+const ETIQUETA_TIPO: Record<string, string> = {
+  Fumigación: 'Fumigación',
+  Fertilización: 'Fertilización',
+};
+
+/**
+ * Sección ① del Cierre (`W03-cierre-v2.md` §1/§5) — Resumen + Insumos + Canecas fusionados en
+ * UNA tarjeta (antes 3 separadas). Corta: 4 filas como máximo, así que no se colapsa como Labores
+ * — se resume con una línea de rollup arriba de la tabla en vez de esconderse.
+ */
+export function SeccionInsumosCierre({
+  tipoAplicacion,
+  totalLotes,
+  totalArboles,
+  proposito,
+  resumenInsumos,
+  canecasPlaneadas,
+  canecasAplicadas,
+}: SeccionInsumosCierreProps) {
+  const insumosConDesviacion = calcularInsumosConDesviacion(resumenInsumos);
+  const criticos = insumosConDesviacion.filter((i) => i.esCritico);
+  const diferenciaCanecas = canecasAplicadas - canecasPlaneadas;
+
+  return (
+    <div className="space-y-4">
+      <SeccionHeader numero={1} titulo="Insumos" />
+
+      <Card className="overflow-hidden gap-0 py-0">
+        <dl className="grid grid-cols-2 gap-4 border-b bg-gradient-to-br from-primary/5 to-secondary/10 p-5 sm:grid-cols-4">
+          <div>
+            <dt className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">Tipo</dt>
+            <dd className="text-sm font-medium text-foreground">
+              {ETIQUETA_TIPO[tipoAplicacion] ?? 'Drench'}
+            </dd>
+          </div>
+          <div>
+            <dt className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">Lotes</dt>
+            <dd className="text-sm font-medium text-foreground">{totalLotes} lotes</dd>
+          </div>
+          <div>
+            <dt className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">
+              Total Árboles
+            </dt>
+            <dd className="text-sm font-medium text-foreground tabular-nums">
+              {formatearNumero(totalArboles, 0)}
+            </dd>
+          </div>
+          <div>
+            <dt className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">
+              Propósito
+            </dt>
+            <dd className="truncate text-sm font-medium text-foreground" title={proposito ?? undefined}>
+              {proposito || 'No especificado'}
+            </dd>
+          </div>
+        </dl>
+
+        {insumosConDesviacion.length === 0 ? (
+          <p className="p-6 text-center text-sm text-muted-foreground">
+            No hay insumos registrados
+          </p>
+        ) : (
+          <>
+            <RollupInsumos criticos={criticos} insumos={insumosConDesviacion} />
+
+            <Table>
+              <TableHeader>
+                <TableRow>
+                  <TableHead>Producto</TableHead>
+                  <TableHead className="text-right">Planeado</TableHead>
+                  <TableHead className="text-right">Aplicado</TableHead>
+                  <TableHead className="text-right">Diferencia</TableHead>
+                  <TableHead className="text-center">Estado</TableHead>
+                </TableRow>
+              </TableHeader>
+              <TableBody>
+                {insumosConDesviacion.map((insumo) => (
+                  <TableRow key={insumo.nombre}>
+                    <TableCell className="whitespace-normal font-medium text-foreground">
+                      {insumo.nombre}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums text-muted-foreground">
+                      {formatearNumero(insumo.planeado, 2)} {insumo.unidad}
+                    </TableCell>
+                    <TableCell className="text-right tabular-nums font-medium text-foreground">
+                      {formatearNumero(insumo.aplicado, 2)} {insumo.unidad}
+                    </TableCell>
+                    <TableCell
+                      className={cn(
+                        'text-right tabular-nums',
+                        insumo.diferencia > 0 && 'text-orange-600',
+                        insumo.diferencia < 0 && 'text-blue-600',
+                      )}
+                    >
+                      {insumo.diferencia > 0 ? '+' : ''}
+                      {formatearNumero(insumo.diferencia, 2)} {insumo.unidad}
+                    </TableCell>
+                    <TableCell className="text-center">
+                      <Badge
+                        variant="outline"
+                        className={
+                          insumo.esCritico
+                            ? 'border-destructive/30 bg-destructive/10 text-destructive'
+                            : 'border-success/30 bg-success/10 text-success'
+                        }
+                      >
+                        {insumo.esCritico ? 'Desviado' : 'OK'}
+                      </Badge>
+                    </TableCell>
+                  </TableRow>
+                ))}
+              </TableBody>
+            </Table>
+          </>
+        )}
+
+        {tipoAplicacion === 'Fumigación' && (
+          <div className="grid grid-cols-3 gap-4 border-t p-5">
+            {/* 2 decimales, no 1, en las TRES celdas. Con 1 decimal se lee
+                "76,0 − 75,8 = +0,17", que no cierra y hace dudar del número: el planeado real es
+                75,83 y la diferencia real es 0,17. Redondear los operandos pero no el resultado es
+                justo lo que hace que la cifra parezca un error de la app. */}
+            <CeldaCaneca label="Canecas Planeadas" valor={formatearNumero(canecasPlaneadas, 2)} />
+            <CeldaCaneca
+              label="Canecas Aplicadas"
+              valor={formatearNumero(canecasAplicadas, 2)}
+              className="text-primary"
+            />
+            <CeldaCaneca
+              label="Diferencia"
+              valor={`${diferenciaCanecas > 0 ? '+' : ''}${formatearNumero(diferenciaCanecas, 2)}`}
+              className={cn(
+                diferenciaCanecas > 0 && 'text-orange-600',
+                diferenciaCanecas < 0 && 'text-blue-600',
+              )}
+            />
+          </div>
+        )}
+      </Card>
+    </div>
+  );
+}
+
+function RollupInsumos({
+  criticos,
+  insumos,
+}: {
+  criticos: ReturnType<typeof calcularInsumosConDesviacion>;
+  insumos: ReturnType<typeof calcularInsumosConDesviacion>;
+}) {
+  if (criticos.length > 0) {
+    const nombres = criticos.map((i) => i.nombre).join(', ');
+    return (
+      <div className="flex items-center gap-2 border-b bg-destructive/5 px-5 py-3 text-sm text-destructive">
+        <AlertTriangle className="size-4 shrink-0" aria-hidden="true" />
+        <span>
+          {criticos.length === 1 ? '1 insumo con' : `${criticos.length} insumos con`} desviación
+          crítica (&gt;15%): <b className="font-semibold">{nombres}</b>.
+        </span>
+      </div>
+    );
+  }
+
+  const mayor = insumos.reduce((max, i) =>
+    Math.abs(i.diferencia) > Math.abs(max.diferencia) ? i : max,
+  );
+  const signo = mayor.diferencia > 0 ? '+' : '';
+
+  return (
+    <div className="flex items-center gap-2 border-b bg-success/5 px-5 py-3 text-sm text-primary-dark">
+      <CheckCircle2 className="size-4 shrink-0 text-primary" aria-hidden="true" />
+      <span>
+        {insumos.length} {insumos.length === 1 ? 'insumo aplicado' : 'insumos aplicados'}, dentro
+        de rango — mayor variación: {mayor.nombre} {signo}
+        {formatearNumero(mayor.diferencia, 2)} {mayor.unidad}.
+      </span>
+    </div>
+  );
+}
+
+function CeldaCaneca({
+  label,
+  valor,
+  className,
+}: {
+  label: string;
+  valor: string;
+  className?: string;
+}) {
+  return (
+    <div className="text-center">
+      <p className="mb-1 text-xs uppercase tracking-wide text-muted-foreground">{label}</p>
+      <p className={cn('text-2xl font-semibold tabular-nums text-foreground', className)}>{valor}</p>
+    </div>
+  );
+}
+
+/** Encabezado numerado no interactivo — reemplaza a `AplicacionStepper` en esta pantalla (una
+ * página de revisión de 3 secciones simultáneas, no un wizard secuencial). Sin `aria-current`,
+ * sin done/active/pending: es un ancla de lectura, no un control. Ver `W03-cierre-v2.md` §2. */
+export function SeccionHeader({
+  numero,
+  titulo,
+  descripcion,
+}: {
+  numero: number;
+  titulo: string;
+  descripcion?: string;
+}) {
+  return (
+    <div className="flex items-center gap-3">
+      <span className="flex size-7 shrink-0 items-center justify-center rounded-full border border-primary/35 bg-primary/10 text-sm font-bold text-primary-dark">
+        {numero}
+      </span>
+      <div>
+        <h2 className="text-lg font-semibold text-foreground">{titulo}</h2>
+        {descripcion && <p className="mt-0.5 text-sm text-muted-foreground">{descripcion}</p>}
+      </div>
+    </div>
+  );
+}

--- a/src/components/aplicaciones/SeccionLaboresCierre.tsx
+++ b/src/components/aplicaciones/SeccionLaboresCierre.tsx
@@ -1,0 +1,556 @@
+import { useId } from 'react';
+import {
+  Users,
+  Calendar as CalendarIcon,
+  ChevronDown,
+  Edit3,
+  Trash2,
+  Plus,
+  AlertTriangle,
+  CheckCircle2,
+} from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Collapsible, CollapsibleTrigger, CollapsibleContent } from '@/components/ui/collapsible';
+import {
+  Table,
+  TableHeader,
+  TableBody,
+  TableRow,
+  TableHead,
+  TableCell,
+} from '@/components/ui/table';
+import {
+  Select,
+  SelectTrigger,
+  SelectContent,
+  SelectItem,
+  SelectValue,
+  SelectGroup,
+  SelectLabel,
+} from '@/components/ui/select';
+import { Field, FieldLabel, FieldGroup } from '@/components/ui/field';
+import { DateInput } from '@/components/ui/date-input';
+import { Textarea } from '@/components/ui/textarea';
+import { Alert, AlertTitle, AlertDescription } from '@/components/ui/alert';
+import { cn } from '@/components/ui/utils';
+import { KPICard } from './shared/KPICard';
+import { AtencionRequeridaPanel } from './AtencionRequeridaPanel';
+import { SeccionHeader } from './SeccionInsumosCierre';
+import { formatearFecha } from '@/utils/fechas';
+import { formatearMoneda, formatearNumero } from '@/utils/format';
+import {
+  FRACCION_OPTIONS,
+  type ExcepcionesCierre,
+  type FuenteFechasEjecucion,
+  type KPIsLabores,
+  type RegistroPorLote,
+} from '@/utils/calculosCierreAplicacion';
+import type { RegistroTrabajoCierre } from '@/types/aplicaciones';
+
+export interface LoteOpcion {
+  lote_id: string;
+  nombre: string;
+  arboles: number;
+}
+
+export interface TrabajadorDisponible {
+  id: string;
+  nombre: string;
+  tipo: 'empleado' | 'contratista';
+  salario?: number;
+  prestaciones?: number;
+  auxilios?: number;
+  horas_semanales?: number;
+  tarifa_jornal?: number;
+}
+
+export interface NuevoRegistroForm {
+  trabajador_id: string;
+  trabajador_tipo: 'empleado' | 'contratista';
+  lote_id: string;
+  fecha_trabajo: string;
+  fraccion_jornal: number;
+}
+
+interface SeccionLaboresCierreProps {
+  lotes: LoteOpcion[];
+  tieneTarea: boolean;
+  registrosPorLote: Map<string, RegistroPorLote>;
+  kpis: KPIsLabores;
+  excepciones: ExcepcionesCierre;
+  editandoRegistro: string | null;
+  onIniciarEdicion: (regKey: string) => void;
+  onCancelarEdicion: () => void;
+  onEditarFraccion: (registroId: string, nuevaFraccion: number) => void;
+  onEliminarRegistro: (index: number) => void;
+  mostrarAgregarRegistro: boolean;
+  onAbrirAgregarRegistro: () => void;
+  onCancelarAgregarRegistro: () => void;
+  nuevoRegistro: NuevoRegistroForm;
+  onCambiarNuevoRegistro: (patch: Partial<NuevoRegistroForm>) => void;
+  onConfirmarAgregarRegistro: () => void;
+  trabajadoresDisponibles: TrabajadorDisponible[];
+  fechaInicioReal: string;
+  fechaFinReal: string;
+  fuenteFechas: FuenteFechasEjecucion;
+  onCambiarFechaInicio: (v: string) => void;
+  onCambiarFechaFin: (v: string) => void;
+  observaciones: string;
+  onCambiarObservaciones: (v: string) => void;
+}
+
+/**
+ * Sección ② del Cierre (`W03-cierre-v2.md` §2/§4) — donde vive el volumen real (jornales, N
+ * lotes). Cada lote colapsa por defecto y se abre solo si tiene una excepción real o es el único
+ * lote de la aplicación (la conveniencia que el módulo ya tenía para ese caso trivial). El panel
+ * "Atención requerida" agrega las 3 señales que antes solo se veían abriendo cada lote a ciegas.
+ */
+export function SeccionLaboresCierre({
+  lotes,
+  tieneTarea,
+  registrosPorLote,
+  kpis,
+  excepciones,
+  editandoRegistro,
+  onIniciarEdicion,
+  onCancelarEdicion,
+  onEditarFraccion,
+  onEliminarRegistro,
+  mostrarAgregarRegistro,
+  onAbrirAgregarRegistro,
+  onCancelarAgregarRegistro,
+  nuevoRegistro,
+  onCambiarNuevoRegistro,
+  onConfirmarAgregarRegistro,
+  trabajadoresDisponibles,
+  fechaInicioReal,
+  fechaFinReal,
+  fuenteFechas,
+  onCambiarFechaInicio,
+  onCambiarFechaFin,
+  observaciones,
+  onCambiarObservaciones,
+}: SeccionLaboresCierreProps) {
+  const loteIdsConExcepcion = new Set(excepciones.registrosSinTarifa.map((r) => r.lote_id));
+  const sinNovedades =
+    excepciones.registrosSinTarifa.length === 0 && excepciones.lotesSinLabor.length === 0;
+  const totalLotesConRegistro = registrosPorLote.size;
+
+  return (
+    <div className="space-y-4">
+      <SeccionHeader
+        numero={2}
+        titulo="Labores"
+        descripcion="Revisa los jornales registrados durante la ejecución. Los lotes sin novedades quedan colapsados — ábrelos si quieres verificar de todas formas."
+      />
+
+      <div className="grid grid-cols-2 gap-3 lg:grid-cols-4">
+        <KPICard titulo="Jornales" valor={formatearNumero(kpis.totalJornales, 1)} icon={Users} tono="neutro" />
+        <KPICard
+          titulo="Costo Mano de Obra"
+          valor={formatearMoneda(kpis.costoManoObra)}
+          icon={Users}
+          tono="neutro"
+        />
+        <KPICard titulo="Trabajadores" valor={String(kpis.trabajadoresUnicos)} icon={Users} tono="neutro" />
+        <KPICard
+          titulo="Días trabajados"
+          valor={String(kpis.diasTrabajados)}
+          icon={CalendarIcon}
+          tono="neutro"
+        />
+      </div>
+
+      {!tieneTarea && (
+        <Alert variant="warning">
+          <AlertTriangle />
+          <AlertTitle>Esta aplicación no tiene tarea de labor vinculada</AlertTitle>
+          <AlertDescription>
+            Los jornales se registraron antes de implementar la vinculación automática. Puedes
+            agregar registros manualmente usando el botón de abajo.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {tieneTarea && totalLotesConRegistro === 0 && (
+        <Alert variant="warning">
+          <AlertTriangle />
+          <AlertTitle>No hay jornales registrados para esta aplicación</AlertTitle>
+          <AlertDescription>
+            Puedes agregar registros de trabajo manualmente o volver al módulo de Labores para
+            registrarlos antes de cerrar.
+          </AlertDescription>
+        </Alert>
+      )}
+
+      {totalLotesConRegistro > 0 && sinNovedades && (
+        <div className="flex items-center gap-2 rounded-lg border border-success/30 bg-success/10 px-4 py-3 text-sm text-primary-dark">
+          <CheckCircle2 className="size-4 shrink-0 text-primary" aria-hidden="true" />
+          <span>
+            Sin novedades — los {totalLotesConRegistro}{' '}
+            {totalLotesConRegistro === 1 ? 'lote tiene' : 'lotes tienen'} jornales registrados y
+            ningún costo quedó en $0.
+          </span>
+        </div>
+      )}
+
+      <AtencionRequeridaPanel excepciones={excepciones} />
+
+      {totalLotesConRegistro > 0 && (
+        <div className="flex flex-col gap-2.5">
+          {Array.from(registrosPorLote.entries()).map(([loteId, { lote_nombre, registros: regsLote }]) => {
+            const totalLote = regsLote.reduce((s, r) => s + r.fraccion_jornal, 0);
+            const costoLote = regsLote.reduce((s, r) => s + r.costo_jornal, 0);
+            const tieneExcepcion = loteIdsConExcepcion.has(loteId);
+            const defaultOpen = totalLotesConRegistro === 1 || tieneExcepcion;
+            const arboles = lotes.find((l) => l.lote_id === loteId)?.arboles ?? 0;
+
+            return (
+              <LoteCollapsible
+                key={loteId}
+                loteNombre={lote_nombre}
+                arboles={arboles}
+                totalJornales={totalLote}
+                costo={costoLote}
+                defaultOpen={defaultOpen}
+                registros={regsLote}
+                editandoRegistro={editandoRegistro}
+                onIniciarEdicion={onIniciarEdicion}
+                onCancelarEdicion={onCancelarEdicion}
+                onEditarFraccion={onEditarFraccion}
+                onEliminarRegistro={onEliminarRegistro}
+              />
+            );
+          })}
+        </div>
+      )}
+
+      {!mostrarAgregarRegistro ? (
+        <button
+          type="button"
+          onClick={onAbrirAgregarRegistro}
+          className="flex w-full items-center justify-center gap-2 rounded-lg border-[1.5px] border-dashed border-primary/45 bg-primary/[0.03] py-3 text-sm font-medium text-primary-dark transition-colors hover:bg-primary/[0.07]"
+        >
+          <Plus className="size-4" aria-hidden="true" />
+          Agregar registro de trabajo faltante
+        </button>
+      ) : (
+        <FormularioNuevoRegistro
+          lotes={lotes}
+          trabajadoresDisponibles={trabajadoresDisponibles}
+          nuevoRegistro={nuevoRegistro}
+          onCambiarNuevoRegistro={onCambiarNuevoRegistro}
+          onConfirmar={onConfirmarAgregarRegistro}
+          onCancelar={onCancelarAgregarRegistro}
+        />
+      )}
+
+      <div className="grid grid-cols-1 gap-4 sm:grid-cols-2">
+        <Field>
+          <FieldLabel>Fecha Inicio Real</FieldLabel>
+          <DateInput value={fechaInicioReal} onChange={onCambiarFechaInicio} />
+          {fuenteFechas !== 'ninguna' && (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <CheckCircle2 className="size-3 shrink-0 text-primary" aria-hidden="true" />
+              Detectado de los registros de labor y movimientos — corrígelo si no coincide con lo
+              ejecutado.
+            </p>
+          )}
+        </Field>
+        <Field>
+          <FieldLabel>Fecha Fin Real</FieldLabel>
+          <DateInput value={fechaFinReal} onChange={onCambiarFechaFin} />
+          {fuenteFechas !== 'ninguna' && (
+            <p className="flex items-center gap-1.5 text-xs text-muted-foreground">
+              <CheckCircle2 className="size-3 shrink-0 text-primary" aria-hidden="true" />
+              Detectado de los registros de labor y movimientos — corrígelo si no coincide con lo
+              ejecutado.
+            </p>
+          )}
+        </Field>
+      </div>
+
+      <Field>
+        <FieldLabel>Observaciones de Cierre</FieldLabel>
+        <Textarea
+          rows={3}
+          value={observaciones}
+          onChange={(e) => onCambiarObservaciones(e.target.value)}
+          placeholder="Describe cualquier incidencia, clima, rendimiento del personal, etc..."
+        />
+        <p className="text-xs text-muted-foreground">
+          Único campo genuinamente irreducible de la pantalla — nadie más sabe si hubo lluvia o un
+          problema de personal.
+        </p>
+      </Field>
+    </div>
+  );
+}
+
+function LoteCollapsible({
+  loteNombre,
+  arboles,
+  totalJornales,
+  costo,
+  defaultOpen,
+  registros,
+  editandoRegistro,
+  onIniciarEdicion,
+  onCancelarEdicion,
+  onEditarFraccion,
+  onEliminarRegistro,
+}: {
+  loteNombre: string;
+  arboles: number;
+  totalJornales: number;
+  costo: number;
+  defaultOpen: boolean;
+  registros: Array<RegistroTrabajoCierre & { _index: number }>;
+  editandoRegistro: string | null;
+  onIniciarEdicion: (regKey: string) => void;
+  onCancelarEdicion: () => void;
+  onEditarFraccion: (registroId: string, nuevaFraccion: number) => void;
+  onEliminarRegistro: (index: number) => void;
+}) {
+  return (
+    <Collapsible defaultOpen={defaultOpen} className="overflow-hidden rounded-lg border bg-card">
+      <CollapsibleTrigger className="group flex w-full items-center justify-between gap-3 bg-muted px-4 py-3 text-left transition-colors hover:bg-muted/70">
+        <span className="flex items-center gap-2.5 min-w-0">
+          <ChevronDown className="size-4 shrink-0 text-muted-foreground transition-transform group-data-[state=open]:rotate-180" />
+          <span className="truncate text-sm font-medium text-foreground">{loteNombre}</span>
+          <span className="hidden shrink-0 text-xs text-muted-foreground sm:inline">
+            {formatearNumero(arboles, 0)} árboles
+          </span>
+        </span>
+        <span className="flex shrink-0 items-center gap-4 text-sm">
+          <span className="hidden font-medium text-foreground sm:inline">
+            {formatearNumero(totalJornales, 1)} jornales
+          </span>
+          <span className="font-semibold text-primary-dark">{formatearMoneda(costo)}</span>
+        </span>
+      </CollapsibleTrigger>
+      <CollapsibleContent>
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Fecha</TableHead>
+              <TableHead>Trabajador</TableHead>
+              <TableHead className="text-center">Tipo</TableHead>
+              <TableHead className="text-center">Fracción</TableHead>
+              <TableHead className="text-right">Costo</TableHead>
+              <TableHead className="text-center">Acciones</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
+            {registros.map((reg) => {
+              const regKey = reg.id || `new-${reg._index}`;
+              const editando = editandoRegistro === regKey;
+              return (
+                <TableRow key={regKey} className={cn(reg._isNew && 'bg-success/5')}>
+                  <TableCell className="text-foreground">{formatearFecha(reg.fecha_trabajo)}</TableCell>
+                  <TableCell className="text-foreground">{reg.trabajador_nombre}</TableCell>
+                  <TableCell className="text-center">
+                    <span
+                      className={cn(
+                        'inline-flex rounded-full px-2 py-0.5 text-[10.5px] font-semibold',
+                        reg.trabajador_tipo === 'empleado'
+                          ? 'border border-border text-muted-foreground'
+                          : 'bg-muted text-foreground',
+                      )}
+                    >
+                      {reg.trabajador_tipo === 'empleado' ? 'Emp' : 'Cont'}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    {editando ? (
+                      <Select
+                        defaultOpen
+                        value={String(reg.fraccion_jornal)}
+                        onValueChange={(v) => onEditarFraccion(regKey, parseFloat(v))}
+                        onOpenChange={(open) => {
+                          if (!open) onCancelarEdicion();
+                        }}
+                      >
+                        <SelectTrigger size="sm" className="mx-auto h-8 w-20">
+                          <SelectValue />
+                        </SelectTrigger>
+                        <SelectContent>
+                          {FRACCION_OPTIONS.map((f) => (
+                            <SelectItem key={f} value={String(f)}>
+                              {f}
+                            </SelectItem>
+                          ))}
+                        </SelectContent>
+                      </Select>
+                    ) : (
+                      <button
+                        type="button"
+                        onClick={() => onIniciarEdicion(regKey)}
+                        className="border-b border-dashed border-border text-sm font-medium text-foreground hover:text-primary"
+                        title="Clic para editar"
+                      >
+                        {reg.fraccion_jornal}
+                      </button>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right text-foreground">
+                    <span className="inline-flex items-center gap-1">
+                      {formatearMoneda(reg.costo_jornal)}
+                      {reg.costo_jornal === 0 && (
+                        <AlertTriangle className="size-3 text-warning-foreground" aria-hidden="true" />
+                      )}
+                    </span>
+                  </TableCell>
+                  <TableCell className="text-center">
+                    <div className="flex items-center justify-center gap-1">
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 text-muted-foreground hover:text-primary"
+                        onClick={() => onIniciarEdicion(regKey)}
+                        aria-label="Editar fracción de jornal"
+                      >
+                        <Edit3 className="size-3.5" />
+                      </Button>
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="icon"
+                        className="size-7 text-muted-foreground hover:text-destructive"
+                        onClick={() => onEliminarRegistro(reg._index)}
+                        aria-label="Eliminar registro de jornal"
+                      >
+                        <Trash2 className="size-3.5" />
+                      </Button>
+                    </div>
+                  </TableCell>
+                </TableRow>
+              );
+            })}
+          </TableBody>
+        </Table>
+      </CollapsibleContent>
+    </Collapsible>
+  );
+}
+
+function FormularioNuevoRegistro({
+  lotes,
+  trabajadoresDisponibles,
+  nuevoRegistro,
+  onCambiarNuevoRegistro,
+  onConfirmar,
+  onCancelar,
+}: {
+  lotes: LoteOpcion[];
+  trabajadoresDisponibles: TrabajadorDisponible[];
+  nuevoRegistro: NuevoRegistroForm;
+  onCambiarNuevoRegistro: (patch: Partial<NuevoRegistroForm>) => void;
+  onConfirmar: () => void;
+  onCancelar: () => void;
+}) {
+  const empleados = trabajadoresDisponibles.filter((t) => t.tipo === 'empleado');
+  const contratistas = trabajadoresDisponibles.filter((t) => t.tipo === 'contratista');
+  const formId = useId();
+
+  return (
+    <div className="rounded-lg border-2 border-primary/30 bg-card p-4">
+      <h4 className="mb-3 text-sm font-medium text-foreground">Nuevo Registro de Trabajo</h4>
+      <FieldGroup className="grid grid-cols-1 gap-3 sm:grid-cols-2 lg:grid-cols-5">
+        <Field>
+          <FieldLabel htmlFor={`${formId}-trabajador`}>Trabajador</FieldLabel>
+          <Select
+            value={nuevoRegistro.trabajador_id}
+            onValueChange={(id) => {
+              const t = trabajadoresDisponibles.find((t) => t.id === id);
+              onCambiarNuevoRegistro({ trabajador_id: id, trabajador_tipo: t?.tipo || 'empleado' });
+            }}
+          >
+            <SelectTrigger id={`${formId}-trabajador`} size="sm">
+              <SelectValue placeholder="Seleccionar..." />
+            </SelectTrigger>
+            <SelectContent>
+              <SelectGroup>
+                <SelectLabel>Empleados</SelectLabel>
+                {empleados.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.nombre}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+              <SelectGroup>
+                <SelectLabel>Contratistas</SelectLabel>
+                {contratistas.map((t) => (
+                  <SelectItem key={t.id} value={t.id}>
+                    {t.nombre}
+                  </SelectItem>
+                ))}
+              </SelectGroup>
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor={`${formId}-lote`}>Lote</FieldLabel>
+          <Select
+            value={nuevoRegistro.lote_id}
+            onValueChange={(id) => onCambiarNuevoRegistro({ lote_id: id })}
+          >
+            <SelectTrigger id={`${formId}-lote`} size="sm">
+              <SelectValue placeholder="Seleccionar..." />
+            </SelectTrigger>
+            <SelectContent>
+              {lotes.map((l) => (
+                <SelectItem key={l.lote_id} value={l.lote_id}>
+                  {l.nombre}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <Field>
+          <FieldLabel>Fecha</FieldLabel>
+          <DateInput
+            value={nuevoRegistro.fecha_trabajo}
+            onChange={(v) => onCambiarNuevoRegistro({ fecha_trabajo: v })}
+          />
+        </Field>
+
+        <Field>
+          <FieldLabel htmlFor={`${formId}-fraccion`}>Fracción</FieldLabel>
+          <Select
+            value={String(nuevoRegistro.fraccion_jornal)}
+            onValueChange={(v) => onCambiarNuevoRegistro({ fraccion_jornal: parseFloat(v) })}
+          >
+            <SelectTrigger id={`${formId}-fraccion`} size="sm">
+              <SelectValue />
+            </SelectTrigger>
+            <SelectContent>
+              {FRACCION_OPTIONS.map((f) => (
+                <SelectItem key={f} value={String(f)}>
+                  {f}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
+        </Field>
+
+        <div className="flex items-end gap-2">
+          <Button
+            type="button"
+            size="sm"
+            onClick={onConfirmar}
+            disabled={!nuevoRegistro.trabajador_id || !nuevoRegistro.lote_id}
+          >
+            Agregar
+          </Button>
+          <Button type="button" size="sm" variant="ghost" onClick={onCancelar}>
+            Cancelar
+          </Button>
+        </div>
+      </FieldGroup>
+    </div>
+  );
+}

--- a/src/components/aplicaciones/report/ApplicationResultsDashboard.tsx
+++ b/src/components/aplicaciones/report/ApplicationResultsDashboard.tsx
@@ -1,14 +1,15 @@
 import { useState } from 'react';
 import { useNavigate } from 'react-router-dom';
-import {
-  ArrowLeft, Calendar, FileText, Loader2,
-  Droplet, Leaf, Target, ChevronDown, ChevronUp,
-} from 'lucide-react';
-import { Button } from '../../ui/button';
-import { useReporteAplicacion } from '../../../hooks/useReporteAplicacion';
-import { generarPDFReporteCierre } from '../../../utils/generarPDFReporteCierre';
-import { fetchDatosReporteCierre } from '../../../utils/fetchDatosReporteCierre';
-import { formatearMoneda, formatearNumero } from '../../../utils/calculosReporteAplicacion';
+import { ChevronDown, ChevronUp, FileText, Loader2 } from 'lucide-react';
+import { Button } from '@/components/ui/button';
+import { Card } from '@/components/ui/card';
+import { Collapsible, CollapsibleContent, CollapsibleTrigger } from '@/components/ui/collapsible';
+import { Select, SelectContent, SelectItem, SelectTrigger, SelectValue } from '@/components/ui/select';
+import { AplicacionShell } from '@/components/aplicaciones/shared/AplicacionShell';
+import { useReporteAplicacion } from '@/hooks/useReporteAplicacion';
+import { generarPDFReporteCierre } from '@/utils/generarPDFReporteCierre';
+import { fetchDatosReporteCierre } from '@/utils/fetchDatosReporteCierre';
+import { formatearMoneda, formatearNumero, formatDateRange, formatShortDate } from '@/utils/format';
 import { HeroKPICards } from './HeroKPICards';
 import { TechnicalSection } from './TechnicalSection';
 import { EconomicSection } from './EconomicSection';
@@ -18,18 +19,11 @@ interface ApplicationResultsDashboardProps {
   aplicacionId: string;
 }
 
-function formatFechaCorta(fecha?: string): string {
-  if (!fecha) return '-';
-  const [year, month, day] = fecha.split('T')[0].split('-');
-  const meses = ['ene', 'feb', 'mar', 'abr', 'may', 'jun', 'jul', 'ago', 'sep', 'oct', 'nov', 'dic'];
-  return `${parseInt(day)} ${meses[parseInt(month) - 1]} ${year}`;
-}
-
-function getTipoIcon(tipo: string | null) {
-  const t = (tipo || '').toLowerCase();
-  if (t.includes('fumig')) return <Droplet className="w-4 h-4" />;
-  if (t.includes('fertil')) return <Leaf className="w-4 h-4" />;
-  return <Target className="w-4 h-4" />;
+/** Envoltorio nulo-seguro sobre `formatDateRange` (format.ts) — un reporte cuya aplicación no
+ * registró fecha de inicio/fin real muestra "—", nunca "Invalid Date". */
+function rangoFechas(inicio?: string | null, fin?: string | null): string {
+  if (!inicio || !fin) return '—';
+  return formatDateRange(inicio, fin);
 }
 
 export function ApplicationResultsDashboard({ aplicacionId }: ApplicationResultsDashboardProps) {
@@ -58,6 +52,8 @@ export function ApplicationResultsDashboard({ aplicacionId }: ApplicationResults
     }
   };
 
+  // Loading / error: sin rediseño propio — funcionan, no están en la lista de defectos
+  // (spec §4, "Estado que no diseñé a propósito").
   if (loading) {
     return (
       <div className="flex items-center justify-center min-h-[400px]">
@@ -86,194 +82,155 @@ export function ApplicationResultsDashboard({ aplicacionId }: ApplicationResults
 
   const esFertilizacion = (reporte.tipo_aplicacion || '').includes('Fertil');
   const containerLabel = esFertilizacion ? 'Bultos' : 'Canecas';
+  const titulo = reporte.nombre_aplicacion || reporte.codigo_aplicacion || 'Reporte';
+  const subtitulo = [
+    reporte.tipo_aplicacion || null,
+    rangoFechas(reporte.fecha_inicio, reporte.fecha_fin),
+    reporte.dias_aplicacion > 0 ? `${reporte.dias_aplicacion} día${reporte.dias_aplicacion === 1 ? '' : 's'}` : null,
+  ].filter(Boolean).join(' · ');
 
   return (
-    <div className="space-y-6 pb-8">
-      {/* ============================================================ */}
-      {/* [A] HEADER */}
-      {/* ============================================================ */}
-      <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
-        <div className="flex items-center gap-4">
-          <button onClick={handleClose} className="p-2 hover:bg-gray-100 rounded-lg transition-colors" aria-label="Volver">
-            <ArrowLeft className="w-5 h-5 text-brand-brown" />
-          </button>
-          <div>
-            <div className="flex items-center gap-3">
-              <h1 className="text-2xl font-bold text-foreground">
-                {reporte.nombre_aplicacion || reporte.codigo_aplicacion || 'Reporte'}
-              </h1>
-              <span className="px-3 py-1 bg-primary/10 text-primary rounded-lg text-sm font-medium flex items-center gap-1.5">
-                {getTipoIcon(reporte.tipo_aplicacion)}
-                {reporte.tipo_aplicacion}
-              </span>
-            </div>
-            <div className="flex items-center gap-3 text-sm text-brand-brown/70 mt-1">
-              <span className="flex items-center gap-1">
-                <Calendar className="w-4 h-4" />
-                {formatFechaCorta(reporte.fecha_inicio)} - {formatFechaCorta(reporte.fecha_fin)}
-              </span>
-              {reporte.dias_aplicacion > 0 && (
-                <>
-                  <span className="text-brand-brown/30">|</span>
-                  <span>{reporte.dias_aplicacion} dias</span>
-                </>
-              )}
-            </div>
-          </div>
-        </div>
-
-        <div className="flex items-center gap-3">
-          {/* Comparison selector */}
-          <select
-            onChange={(e) => seleccionarAnterior(e.target.value || null)}
-            defaultValue=""
-            className="px-4 py-2 pr-8 border border-gray-200 rounded-lg focus:outline-none focus:ring-2 focus:ring-primary/20 focus:border-primary text-sm bg-white min-w-[200px] appearance-none"
+    <AplicacionShell
+      titulo={titulo}
+      subtitulo={subtitulo}
+      estado="Cerrada"
+      acciones={(
+        <>
+          <Select
+            value={reporte.aplicacion_anterior_id ?? undefined}
+            onValueChange={(id) => seleccionarAnterior(id)}
           >
-            <option value="">Comparar con...</option>
-            {aplicacionesComparables.map((app) => (
-              <option key={app.id} value={app.id}>
-                {app.nombre || app.codigo} ({formatFechaCorta(app.fecha_cierre)})
-              </option>
-            ))}
-          </select>
+            <SelectTrigger className="min-w-[220px]" aria-label="Comparar con una aplicación anterior">
+              <SelectValue placeholder="Comparar con…" />
+            </SelectTrigger>
+            <SelectContent>
+              {aplicacionesComparables.map((app) => (
+                <SelectItem key={app.id} value={app.id}>
+                  {app.nombre || app.codigo}{app.fecha_cierre ? ` (${formatShortDate(app.fecha_cierre)})` : ''}
+                </SelectItem>
+              ))}
+            </SelectContent>
+          </Select>
 
-          {/* PDF export */}
-          <Button
-            onClick={descargarPDF}
-            disabled={generandoPDF}
-            className="bg-primary hover:bg-primary-dark text-white"
-          >
+          <Button onClick={descargarPDF} disabled={generandoPDF}>
             {generandoPDF ? (
-              <Loader2 className="w-4 h-4 mr-2 animate-spin" />
+              <Loader2 className="w-4 h-4 mr-2 animate-spin" aria-hidden="true" />
             ) : (
-              <FileText className="w-4 h-4 mr-2" />
+              <FileText className="w-4 h-4 mr-2" aria-hidden="true" />
             )}
             Exportar PDF
           </Button>
-        </div>
-      </div>
-
-      {/* Anterior banner */}
-      {reporte.aplicacion_anterior_nombre && (
-        <div className="bg-primary/5 border border-primary/20 rounded-xl px-4 py-3 flex items-center justify-between">
-          <p className="text-sm text-foreground">
-            Comparando con: <strong>{reporte.aplicacion_anterior_nombre}</strong>
-          </p>
-          <button
-            onClick={() => seleccionarAnterior(null)}
-            className="text-sm text-primary hover:text-primary-dark font-medium"
-          >
-            Quitar comparacion
-          </button>
-        </div>
+        </>
       )}
-
-      {/* ============================================================ */}
-      {/* [B] HERO KPIs */}
-      {/* ============================================================ */}
-      <HeroKPICards
-        financiero={reporte.financiero}
-        canecasTotales={reporte.detalle_canecas.totales.canecas}
-        totalArboles={reporte.total_arboles}
-        totalJornales={reporte.detalle_jornales.totales.jornales_total?.real || 0}
-        containerLabel={containerLabel}
-        anterior={reporte.anterior}
-      />
-
-      {/* ============================================================ */}
-      {/* [C] TECHNICAL SECTION */}
-      {/* ============================================================ */}
-      <TechnicalSection
-        canecasPorLote={reporte.detalle_canecas.por_lote}
-        canecasTotales={reporte.detalle_canecas.totales}
-        jornalesPorLote={reporte.detalle_jornales.por_lote}
-        jornalesTotales={reporte.detalle_jornales.totales}
-        graficoCanecas={reporte.grafico_canecas_por_lote}
-        graficoJornales={reporte.grafico_jornales_por_lote}
-        containerLabel={containerLabel}
-        detalle_productos_por_lote={reporte.detalle_productos.por_lote}
-      />
-
-      {/* ============================================================ */}
-      {/* [D] ECONOMIC SECTION */}
-      {/* ============================================================ */}
-      <EconomicSection
-        financiero={reporte.financiero}
-        detalle_productos_por_lote={reporte.detalle_productos.por_lote}
-        jornalesPorLote={reporte.detalle_jornales.por_lote}
-        valorJornal={reporte.detalle_jornales.valor_jornal}
-      />
-
-      {/* ============================================================ */}
-      {/* [E] PRODUCT COMPARISON */}
-      {/* ============================================================ */}
-      <ProductComparisonTable productos={reporte.detalle_productos.totales} />
-
-      {/* ============================================================ */}
-      {/* [F] METADATA (collapsible) */}
-      {/* ============================================================ */}
-      <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
-        <button
-          onClick={() => setMetadataOpen(!metadataOpen)}
-          className="w-full px-6 py-4 flex items-center justify-between hover:bg-gray-50 transition-colors"
-        >
-          <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
-            <FileText className="w-5 h-5 text-primary" />
-            Observaciones y Metadata
-          </h3>
-          {metadataOpen ? <ChevronUp className="w-5 h-5 text-gray-400" /> : <ChevronDown className="w-5 h-5 text-gray-400" />}
-        </button>
-
-        {metadataOpen && (
-          <div className="px-6 pb-5 border-t border-gray-100 pt-4">
-            {reporte.alertas.length > 0 && (
-              <div className="mb-4 p-3 bg-amber-50 border border-amber-200 rounded-lg">
-                <p className="text-sm font-medium text-amber-800 mb-1">Alertas</p>
-                <ul className="text-sm text-amber-700 list-disc list-inside">
-                  {reporte.alertas.map((a, i) => <li key={i}>{a}</li>)}
-                </ul>
-              </div>
-            )}
-
-            <div className="grid grid-cols-1 md:grid-cols-2 gap-6">
-              <div className="space-y-3">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-brand-brown/60">Fecha inicio real</span>
-                  <span className="text-foreground">{formatFechaCorta(reporte.fecha_inicio)}</span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-brand-brown/60">Fecha fin real</span>
-                  <span className="text-foreground">{formatFechaCorta(reporte.fecha_fin)}</span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-brand-brown/60">Dias de ejecucion</span>
-                  <span className="text-foreground">{reporte.dias_aplicacion} dias</span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-brand-brown/60">Arboles totales</span>
-                  <span className="text-foreground">{formatearNumero(reporte.total_arboles, 0)}</span>
-                </div>
-              </div>
-              <div className="space-y-3">
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-brand-brown/60">Valor jornal</span>
-                  <span className="text-foreground">{formatearMoneda(reporte.detalle_jornales.valor_jornal)}</span>
-                </div>
-                <div className="flex items-center justify-between text-sm">
-                  <span className="text-brand-brown/60">Tamano caneca</span>
-                  <span className="text-foreground">{reporte.tamano_caneca}L</span>
-                </div>
-                {reporte.codigo_aplicacion && (
-                  <div className="flex items-center justify-between text-sm">
-                    <span className="text-brand-brown/60">Codigo</span>
-                    <span className="text-foreground">{reporte.codigo_aplicacion}</span>
-                  </div>
-                )}
-              </div>
-            </div>
+    >
+      <div className="space-y-6 pb-8">
+        {reporte.aplicacion_anterior_nombre && (
+          <div className="flex items-center justify-between gap-3 rounded-xl border border-primary/25 bg-primary/5 px-4 py-3 flex-wrap">
+            <p className="text-sm text-foreground">
+              Comparando con: <strong>{reporte.aplicacion_anterior_nombre}</strong>
+            </p>
+            <button
+              onClick={() => seleccionarAnterior(null)}
+              className="text-sm font-medium text-primary hover:text-primary-dark"
+            >
+              Quitar comparación
+            </button>
           </div>
         )}
+
+        <HeroKPICards
+          financiero={reporte.financiero}
+          canecasTotales={reporte.detalle_canecas.totales.canecas}
+          totalArboles={reporte.total_arboles}
+          totalJornales={reporte.detalle_jornales.totales.jornales_total?.real || 0}
+          containerLabel={containerLabel}
+          anterior={reporte.anterior}
+        />
+
+        <TechnicalSection
+          canecasPorLote={reporte.detalle_canecas.por_lote}
+          canecasTotales={reporte.detalle_canecas.totales}
+          jornalesPorLote={reporte.detalle_jornales.por_lote}
+          jornalesTotales={reporte.detalle_jornales.totales}
+          graficoCanecas={reporte.grafico_canecas_por_lote}
+          graficoJornales={reporte.grafico_jornales_por_lote}
+          containerLabel={containerLabel}
+          detalle_productos_por_lote={reporte.detalle_productos.por_lote}
+        />
+
+        <EconomicSection
+          financiero={reporte.financiero}
+          detalle_productos_por_lote={reporte.detalle_productos.por_lote}
+          jornalesPorLote={reporte.detalle_jornales.por_lote}
+          valorJornal={reporte.detalle_jornales.valor_jornal}
+        />
+
+        <ProductComparisonTable productos={reporte.detalle_productos.totales} />
+
+        <Collapsible open={metadataOpen} onOpenChange={setMetadataOpen}>
+          <Card className="gap-0 overflow-hidden py-0">
+            <CollapsibleTrigger className="flex w-full items-center justify-between gap-2 px-6 py-4 text-left transition-colors hover:bg-gray-50">
+              <span className="flex items-center gap-2 text-lg font-semibold text-foreground">
+                <FileText className="size-[18px] text-primary" aria-hidden="true" />
+                Observaciones y Metadata
+              </span>
+              {metadataOpen ? (
+                <ChevronUp className="size-4 text-gray-400" aria-hidden="true" />
+              ) : (
+                <ChevronDown className="size-4 text-gray-400" aria-hidden="true" />
+              )}
+            </CollapsibleTrigger>
+
+            <CollapsibleContent className="border-t border-gray-100 px-6 pb-5 pt-4">
+              {reporte.alertas.length > 0 && (
+                <div className="mb-4 rounded-lg border border-amber-200 bg-amber-50 p-3">
+                  <p className="mb-1 text-sm font-medium text-amber-800">Alertas</p>
+                  <ul className="list-inside list-disc text-sm text-amber-700">
+                    {reporte.alertas.map((a, i) => <li key={i}>{a}</li>)}
+                  </ul>
+                </div>
+              )}
+
+              <div className="grid grid-cols-1 gap-6 md:grid-cols-2">
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Fecha inicio real</span>
+                    <span className="tabular-nums text-foreground">{reporte.fecha_inicio ? formatShortDate(reporte.fecha_inicio) : '—'}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Fecha fin real</span>
+                    <span className="tabular-nums text-foreground">{reporte.fecha_fin ? formatShortDate(reporte.fecha_fin) : '—'}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Días de ejecución</span>
+                    <span className="tabular-nums text-foreground">{reporte.dias_aplicacion} día{reporte.dias_aplicacion === 1 ? '' : 's'}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Árboles totales</span>
+                    <span className="tabular-nums text-foreground">{formatearNumero(reporte.total_arboles, 0)}</span>
+                  </div>
+                </div>
+                <div className="space-y-3">
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Valor jornal</span>
+                    <span className="tabular-nums text-foreground">{formatearMoneda(reporte.detalle_jornales.valor_jornal)}</span>
+                  </div>
+                  <div className="flex items-center justify-between text-sm">
+                    <span className="text-muted-foreground">Tamaño caneca</span>
+                    <span className="tabular-nums text-foreground">{reporte.tamano_caneca}L</span>
+                  </div>
+                  {reporte.codigo_aplicacion && (
+                    <div className="flex items-center justify-between text-sm">
+                      <span className="text-muted-foreground">Código</span>
+                      <span className="tabular-nums text-foreground">{reporte.codigo_aplicacion}</span>
+                    </div>
+                  )}
+                </div>
+              </div>
+            </CollapsibleContent>
+          </Card>
+        </Collapsible>
       </div>
-    </div>
+    </AplicacionShell>
   );
 }

--- a/src/components/aplicaciones/report/ApplicationResultsDashboard.tsx
+++ b/src/components/aplicaciones/report/ApplicationResultsDashboard.tsx
@@ -8,6 +8,7 @@ import { Button } from '../../ui/button';
 import { useReporteAplicacion } from '../../../hooks/useReporteAplicacion';
 import { generarPDFReporteCierre } from '../../../utils/generarPDFReporteCierre';
 import { fetchDatosReporteCierre } from '../../../utils/fetchDatosReporteCierre';
+import { formatearMoneda, formatearNumero } from '../../../utils/calculosReporteAplicacion';
 import { HeroKPICards } from './HeroKPICards';
 import { TechnicalSection } from './TechnicalSection';
 import { EconomicSection } from './EconomicSection';
@@ -93,7 +94,7 @@ export function ApplicationResultsDashboard({ aplicacionId }: ApplicationResults
       {/* ============================================================ */}
       <div className="flex flex-col md:flex-row items-start md:items-center justify-between gap-4">
         <div className="flex items-center gap-4">
-          <button onClick={handleClose} className="p-2 hover:bg-gray-100 rounded-lg transition-colors">
+          <button onClick={handleClose} className="p-2 hover:bg-gray-100 rounded-lg transition-colors" aria-label="Volver">
             <ArrowLeft className="w-5 h-5 text-brand-brown" />
           </button>
           <div>
@@ -250,13 +251,13 @@ export function ApplicationResultsDashboard({ aplicacionId }: ApplicationResults
                 </div>
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-brand-brown/60">Arboles totales</span>
-                  <span className="text-foreground">{reporte.total_arboles.toLocaleString('es-CO')}</span>
+                  <span className="text-foreground">{formatearNumero(reporte.total_arboles, 0)}</span>
                 </div>
               </div>
               <div className="space-y-3">
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-brand-brown/60">Valor jornal</span>
-                  <span className="text-foreground">${reporte.detalle_jornales.valor_jornal.toLocaleString('es-CO')}</span>
+                  <span className="text-foreground">{formatearMoneda(reporte.detalle_jornales.valor_jornal)}</span>
                 </div>
                 <div className="flex items-center justify-between text-sm">
                   <span className="text-brand-brown/60">Tamano caneca</span>

--- a/src/components/aplicaciones/report/EconomicSection.tsx
+++ b/src/components/aplicaciones/report/EconomicSection.tsx
@@ -2,7 +2,7 @@ import {
   BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
   Legend, ResponsiveContainer,
 } from 'recharts';
-import { formatearMoneda } from '../../../utils/calculosReporteAplicacion';
+import { formatearMoneda, formatearNumero } from '../../../utils/calculosReporteAplicacion';
 
 interface ComparisonField {
   real: number;
@@ -38,9 +38,9 @@ function deviationColor(desviacion: number, invertCost = true): string {
 }
 
 function formatCompact(value: number): string {
-  if (value >= 1_000_000) return `$${(value / 1_000_000).toFixed(1)}M`;
-  if (value >= 1_000) return `$${(value / 1_000).toFixed(0)}K`;
-  return `$${value.toFixed(0)}`;
+  if (value >= 1_000_000) return `$${formatearNumero(value / 1_000_000, 1)}M`;
+  if (value >= 1_000) return `$${formatearNumero(value / 1_000, 0)}K`;
+  return `$${formatearNumero(value, 0)}`;
 }
 
 interface CostCell {
@@ -59,7 +59,7 @@ function CostComparisonCell({ field }: { field: CostCell }) {
         )}
         {field.planeado > 0 && (
           <span className={`text-xs font-medium ${deviationColor(field.desviacion)}`}>
-            {field.desviacion > 0 ? '+' : ''}{field.desviacion.toFixed(1)}%
+            {field.desviacion > 0 ? '+' : ''}{formatearNumero(field.desviacion, 1)}%
           </span>
         )}
       </div>

--- a/src/components/aplicaciones/report/EconomicSection.tsx
+++ b/src/components/aplicaciones/report/EconomicSection.tsx
@@ -1,19 +1,25 @@
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
-  Legend, ResponsiveContainer,
+  Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis,
 } from 'recharts';
-import { formatearMoneda, formatearNumero } from '../../../utils/calculosReporteAplicacion';
+import { BarChart3 } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { formatearMoneda, formatearNumero } from '@/utils/format';
+import { cn } from '@/components/ui/utils';
 
 interface ComparisonField {
   real: number;
   planeado: number;
-  desviacion: number;
+  desviacion: number | undefined;
 }
 
 interface FinancieroField {
   real: number;
   planeado: number;
-  desviacion: number;
+  desviacion: number | undefined;
   cambio: number;
 }
 
@@ -29,12 +35,13 @@ interface EconomicSectionProps {
   valorJornal: number;
 }
 
-function deviationColor(desviacion: number, invertCost = true): string {
+const EPSILON_SERIE_CERO = 0.05;
+
+function deviationColor(desviacion: number): string {
   const abs = Math.abs(desviacion);
-  const isOver = desviacion > 0;
-  if (abs <= 5) return 'text-green-600';
-  if (abs <= 20) return 'text-amber-600';
-  return invertCost && isOver ? 'text-red-600' : invertCost && !isOver ? 'text-green-600' : 'text-red-600';
+  if (abs <= 5) return 'text-success';
+  if (abs <= 20) return 'text-warning';
+  return 'text-destructive';
 }
 
 function formatCompact(value: number): string {
@@ -43,27 +50,22 @@ function formatCompact(value: number): string {
   return `$${formatearNumero(value, 0)}`;
 }
 
-interface CostCell {
-  real: number;
-  planeado: number;
-  desviacion: number;
-}
-
-function CostComparisonCell({ field }: { field: CostCell }) {
+function CostComparisonCell({ field }: { field: ComparisonField }) {
+  const tieneDesviacion = field.planeado > 0 && field.desviacion !== undefined;
   return (
-    <td className="py-2.5 px-3 text-right text-sm">
+    <TableCell className="text-right tabular-nums">
       <div className="flex flex-col items-end gap-0.5">
-        <span className="text-foreground font-medium">{formatearMoneda(field.real)}</span>
+        <span className="font-medium text-foreground">{formatearMoneda(field.real)}</span>
         {field.planeado > 0 && (
-          <span className="text-gray-400 text-xs">Plan: {formatearMoneda(field.planeado)}</span>
+          <span className="text-xs text-muted-foreground">Plan: {formatearMoneda(field.planeado)}</span>
         )}
-        {field.planeado > 0 && (
-          <span className={`text-xs font-medium ${deviationColor(field.desviacion)}`}>
-            {field.desviacion > 0 ? '+' : ''}{formatearNumero(field.desviacion, 1)}%
+        {tieneDesviacion && (
+          <span className={cn('text-xs font-semibold', deviationColor(field.desviacion as number))}>
+            {(field.desviacion as number) > 0 ? '+' : ''}{formatearNumero(field.desviacion as number, 1)}%
           </span>
         )}
       </div>
-    </td>
+    </TableCell>
   );
 }
 
@@ -73,20 +75,25 @@ export function EconomicSection({
   jornalesPorLote,
   valorJornal,
 }: EconomicSectionProps) {
-  // Build per-lot economic rows
+  // Mismo criterio que TechnicalSection: "sin mapeo" se detecta por AUSENCIA de filas de
+  // producto (real Y plan), no porque la suma dé 0 — evita confundir "no se rastreó" con
+  // "se aplicaron cero insumos". Costo M.O. es independiente (sale de jornales × valor_jornal,
+  // una fuente distinta) y por eso NO se apaga junto con Insumos.
+  const sinMapeoInsumos = Object.values(detalle_productos_por_lote).every((filas) => (filas?.length ?? 0) === 0);
+
   const lotRows = jornalesPorLote.map((jl) => {
     const prods = detalle_productos_por_lote[jl.lote_id] || [];
     const costoInsumosReal = prods.reduce((s, p) => s + p.costo.real, 0);
     const costoInsumosPlan = prods.reduce((s, p) => s + p.costo.planeado, 0);
-    const costoInsumosDesv = costoInsumosPlan > 0 ? ((costoInsumosReal - costoInsumosPlan) / costoInsumosPlan) * 100 : 0;
+    const costoInsumosDesv = costoInsumosPlan > 0 ? ((costoInsumosReal - costoInsumosPlan) / costoInsumosPlan) * 100 : undefined;
 
     const costoMOReal = jl.jornales_total.real * valorJornal;
     const costoMOPlan = jl.jornales_total.planeado * valorJornal;
-    const costoMODesv = costoMOPlan > 0 ? ((costoMOReal - costoMOPlan) / costoMOPlan) * 100 : 0;
+    const costoMODesv = costoMOPlan > 0 ? ((costoMOReal - costoMOPlan) / costoMOPlan) * 100 : undefined;
 
     const totalReal = costoInsumosReal + costoMOReal;
     const totalPlan = costoInsumosPlan + costoMOPlan;
-    const totalDesv = totalPlan > 0 ? ((totalReal - totalPlan) / totalPlan) * 100 : 0;
+    const totalDesv = totalPlan > 0 ? ((totalReal - totalPlan) / totalPlan) * 100 : undefined;
 
     return {
       lote_id: jl.lote_id,
@@ -97,85 +104,105 @@ export function EconomicSection({
     };
   });
 
-  // Chart data: stacked horizontal bar (Insumos + M.O.)
-  const chartData = lotRows.map((r) => ({
-    lote: r.lote_nombre,
-    insumos: r.insumos.real,
-    mano_obra: r.mano_obra.real,
-  }));
+  const chartData = lotRows.map((r) => ({ lote: r.lote_nombre, insumos: r.insumos.real, mano_obra: r.mano_obra.real }));
+  const hayInsumos = chartData.some((d) => Math.abs(d.insumos) > EPSILON_SERIE_CERO);
+  const hayManoObra = chartData.some((d) => Math.abs(d.mano_obra) > EPSILON_SERIE_CERO);
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
-      <div className="px-6 py-4 border-b border-gray-200">
-        <h3 className="text-lg font-semibold text-foreground">Detalle Economico por Lote</h3>
+    <Card className="gap-0 overflow-hidden py-0">
+      <div className="border-b border-gray-200 px-6 py-4">
+        <h3 className="text-lg font-semibold text-foreground">
+          Detalle Económico por Lote
+        </h3>
       </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
-        <table className="w-full min-w-[700px]">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="text-left py-2.5 px-4 text-xs text-gray-500 font-medium sticky left-0 bg-gray-50 z-10">Lote</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Costo Insumos</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Costo M.O.</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Total</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {lotRows.map((row) => (
-              <tr key={row.lote_id} className="hover:bg-gray-50 transition-colors">
-                <td className="py-2.5 px-4 text-sm text-foreground font-medium sticky left-0 bg-white z-10">{row.lote_nombre}</td>
+      <Table>
+        <TableHeader>
+          <TableRow>
+            <TableHead>Lote</TableHead>
+            <TableHead className="text-right">Costo Insumos</TableHead>
+            <TableHead className="text-right">Costo M.O.</TableHead>
+            <TableHead className="text-right">Total</TableHead>
+          </TableRow>
+        </TableHeader>
+        <TableBody>
+          {lotRows.map((row) => (
+            <TableRow key={row.lote_id}>
+              <TableCell className="font-medium text-foreground">{row.lote_nombre}</TableCell>
+              {sinMapeoInsumos ? (
+                <TableCell className="text-right font-normal text-muted-foreground">—</TableCell>
+              ) : (
                 <CostComparisonCell field={row.insumos} />
-                <CostComparisonCell field={row.mano_obra} />
+              )}
+              <CostComparisonCell field={row.mano_obra} />
+              {sinMapeoInsumos ? (
+                <TableCell className="text-right font-normal text-muted-foreground">—</TableCell>
+              ) : (
                 <CostComparisonCell field={row.total} />
-              </tr>
-            ))}
-          </tbody>
-          <tfoot className="bg-gray-50 border-t border-gray-200">
-            <tr>
-              <td className="py-2.5 px-4 text-sm font-semibold text-foreground sticky left-0 bg-gray-50 z-10">Total</td>
-              <CostComparisonCell field={{
-                real: financiero.costo_productos.real,
-                planeado: financiero.costo_productos.planeado,
-                desviacion: financiero.costo_productos.desviacion,
-              }} />
-              <CostComparisonCell field={{
-                real: financiero.costo_jornales.real,
-                planeado: financiero.costo_jornales.planeado,
-                desviacion: financiero.costo_jornales.desviacion,
-              }} />
-              <CostComparisonCell field={{
-                real: financiero.costo_total.real,
-                planeado: financiero.costo_total.planeado,
-                desviacion: financiero.costo_total.desviacion,
-              }} />
-            </tr>
-          </tfoot>
-        </table>
-      </div>
+              )}
+            </TableRow>
+          ))}
+        </TableBody>
+        <TableFooter>
+          <TableRow>
+            <TableCell>Total</TableCell>
+            {sinMapeoInsumos ? (
+              <TableCell className="text-right font-normal text-muted-foreground">—</TableCell>
+            ) : (
+              <CostComparisonCell field={financiero.costo_productos} />
+            )}
+            <CostComparisonCell field={financiero.costo_jornales} />
+            <CostComparisonCell field={financiero.costo_total} />
+          </TableRow>
+        </TableFooter>
+      </Table>
 
-      {/* Stacked horizontal bar chart */}
-      {chartData.length > 0 && (
-        <div className="px-6 py-4 border-t border-gray-100">
+      {sinMapeoInsumos && (
+        <p className="border-t border-gray-100 px-6 py-3 text-xs text-muted-foreground">
+          Costo Insumos sin dato por lote — esta aplicación no registró productos por movimiento
+          (<code>movimientos_diarios_productos</code>). El Costo M.O. y el Total sí son reales.
+        </p>
+      )}
+
+      {(hayInsumos || hayManoObra) ? (
+        <div className="border-t border-gray-100 px-6 py-4">
           <div style={{ height: 224 }}>
             <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                layout="vertical"
-                margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
-              >
-                <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" />
-                <XAxis type="number" tickFormatter={(v) => formatCompact(v)} tick={{ fill: '#6B7280', fontSize: 12 }} />
-                <YAxis type="category" dataKey="lote" tick={{ fill: '#6B7280', fontSize: 12 }} width={100} />
+              <BarChart data={chartData} layout="vertical" margin={{ top: 5, right: 24, left: 10, bottom: 5 }}>
+                <defs>
+                  <pattern id="economico-mo-hatch" patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
+                    <rect width="6" height="6" fill="var(--chart-4)" />
+                    <line x1="0" y1="0" x2="0" y2="6" stroke="#ffffff" strokeOpacity={0.35} strokeWidth={2} />
+                  </pattern>
+                </defs>
+                <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+                <XAxis type="number" tickFormatter={formatCompact} tick={{ fill: '#6B7280', fontSize: 12 }} />
+                <YAxis type="category" dataKey="lote" tick={{ fill: '#6B7280', fontSize: 12 }} width={110} />
                 <Tooltip formatter={(v: number) => formatearMoneda(v)} />
-                <Legend />
-                <Bar dataKey="insumos" stackId="cost" fill="#3B82F6" name="Insumos" />
-                <Bar dataKey="mano_obra" stackId="cost" fill="#8B5CF6" name="Mano de Obra" radius={[0, 4, 4, 0]} />
+                <Legend wrapperStyle={{ fontSize: 12 }} />
+                {hayInsumos && (
+                  <Bar dataKey="insumos" stackId="cost" name="Insumos" fill="var(--chart-1)" stroke="var(--chart-1)" strokeWidth={1} />
+                )}
+                {hayManoObra && (
+                  <Bar dataKey="mano_obra" stackId="cost" name="Mano de Obra" fill="url(#economico-mo-hatch)" stroke="var(--chart-4)" strokeWidth={1} radius={[0, 4, 4, 0]} />
+                )}
               </BarChart>
             </ResponsiveContainer>
           </div>
         </div>
+      ) : (
+        <div className="border-t border-gray-100 px-6 py-8">
+          <Empty className="p-0">
+            <EmptyHeader>
+              <EmptyMedia variant="icon">
+                <BarChart3 />
+              </EmptyMedia>
+              <EmptyTitle>Sin datos para graficar</EmptyTitle>
+              <EmptyDescription>Ningún lote tiene costo de insumos ni de mano de obra mayor a cero.</EmptyDescription>
+            </EmptyHeader>
+          </Empty>
+        </div>
       )}
-    </div>
+    </Card>
   );
 }

--- a/src/components/aplicaciones/report/HeroKPICards.tsx
+++ b/src/components/aplicaciones/report/HeroKPICards.tsx
@@ -52,7 +52,7 @@ function DeviationBadge({ desviacion, invertCost = false }: { desviacion: number
   const color = deviationColor(desviacion, invertCost);
   return (
     <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
-      {desviacion > 0 ? '+' : ''}{abs.toFixed(1)}%
+      {desviacion > 0 ? '+' : ''}{formatearNumero(abs, 1)}%
     </span>
   );
 }
@@ -66,7 +66,7 @@ function DeltaBadge({ current, previous, inverted = false }: { current: number; 
   return (
     <div className={`flex items-center gap-1 text-xs font-medium ${isGood ? 'text-green-600' : 'text-red-600'}`}>
       {isPositive ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
-      <span>{delta > 0 ? '+' : ''}{delta.toFixed(1)}%</span>
+      <span>{delta > 0 ? '+' : ''}{formatearNumero(delta, 1)}%</span>
     </div>
   );
 }

--- a/src/components/aplicaciones/report/HeroKPICards.tsx
+++ b/src/components/aplicaciones/report/HeroKPICards.tsx
@@ -1,18 +1,20 @@
-import {
-  DollarSign, Package, TreePine, Users, TrendingUp, TrendingDown,
-} from 'lucide-react';
-import { formatearMoneda, formatearNumero } from '../../../utils/calculosReporteAplicacion';
+import { DollarSign, Package, TreePine, Users } from 'lucide-react';
+import { KPICard, type KPIComparacion } from '@/components/aplicaciones/shared/KPICard';
+import { calcularCambio } from '@/utils/calculosReporteAplicacion';
+import { formatearMoneda, formatearNumero } from '@/utils/format';
 
 interface ComparisonField {
   real: number;
   planeado: number;
-  desviacion: number;
+  // D2: `undefined` = sin plan (planeado 0/ausente). Ya viene resuelto desde
+  // useReporteAplicacion.ts (calcularCambio) — esta tarjeta solo lo traduce a un badge o nada.
+  desviacion: number | undefined;
 }
 
 interface FinancieroField {
   real: number;
   planeado: number;
-  desviacion: number;
+  desviacion: number | undefined;
   cambio: number;
 }
 
@@ -38,127 +40,105 @@ interface HeroKPICardsProps {
   anterior?: AnteriorData;
 }
 
-function deviationColor(desviacion: number, invertCost = false): string {
-  const abs = Math.abs(desviacion);
-  const isOver = invertCost ? desviacion > 0 : desviacion > 0;
-  if (abs <= 5) return 'text-green-600 bg-green-50';
-  if (abs <= 20) return 'text-amber-600 bg-amber-50';
-  return isOver ? 'text-red-600 bg-red-50' : 'text-green-600 bg-green-50';
-}
+/**
+ * Arma el arreglo `comparaciones` de una tarjeta: Plan (si hay base > 0) + Anterior (si se
+ * seleccionó una aplicación anterior y su valor es > 0). Un `delta` ausente no entra al arreglo
+ * — `KPICard` ya sabe no pintar nada en ese caso (contrato §3 del spec, cierra D2).
+ */
+function construirComparaciones(params: {
+  real: number;
+  planeado: number;
+  deltaPlan: number | undefined;
+  anteriorValor: number | undefined;
+  formatear: (v: number) => string;
+  invertido: boolean;
+}): KPIComparacion[] {
+  const { real, planeado, deltaPlan, anteriorValor, formatear, invertido } = params;
+  const comparaciones: KPIComparacion[] = [];
 
-function DeviationBadge({ desviacion, invertCost = false }: { desviacion: number; invertCost?: boolean }) {
-  if (desviacion === 0 && invertCost) return null;
-  const abs = Math.abs(desviacion);
-  const color = deviationColor(desviacion, invertCost);
-  return (
-    <span className={`inline-flex items-center px-2 py-0.5 rounded-full text-xs font-medium ${color}`}>
-      {desviacion > 0 ? '+' : ''}{formatearNumero(abs, 1)}%
-    </span>
-  );
-}
+  if (planeado > 0 && deltaPlan !== undefined) {
+    comparaciones.push({
+      tipo: 'plan',
+      etiqueta: 'Plan',
+      valorFormateado: `Plan: ${formatear(planeado)}`,
+      delta: deltaPlan,
+      invertido,
+    });
+  }
 
-function DeltaBadge({ current, previous, inverted = false }: { current: number; previous: number; inverted?: boolean }) {
-  if (previous === 0) return null;
-  const delta = ((current - previous) / previous) * 100;
-  const isPositive = delta > 0;
-  const isGood = inverted ? !isPositive : isPositive;
+  if (anteriorValor !== undefined && anteriorValor > 0) {
+    comparaciones.push({
+      tipo: 'anterior',
+      etiqueta: 'Anterior',
+      valorFormateado: `Anterior: ${formatear(anteriorValor)}`,
+      delta: calcularCambio(real, anteriorValor),
+      invertido,
+    });
+  }
 
-  return (
-    <div className={`flex items-center gap-1 text-xs font-medium ${isGood ? 'text-green-600' : 'text-red-600'}`}>
-      {isPositive ? <TrendingUp className="w-3 h-3" /> : <TrendingDown className="w-3 h-3" />}
-      <span>{delta > 0 ? '+' : ''}{formatearNumero(delta, 1)}%</span>
-    </div>
-  );
+  return comparaciones;
 }
 
 export function HeroKPICards({ financiero, canecasTotales, totalArboles, totalJornales, containerLabel, anterior }: HeroKPICardsProps) {
-  const arbolesPorJornal = totalJornales > 0 ? totalArboles / totalJornales : 0;
-
-  const cards = [
-    {
-      titulo: 'Costo Total',
-      valor: formatearMoneda(financiero.costo_total.real),
-      plan: financiero.costo_total.planeado > 0 ? `Plan: ${formatearMoneda(financiero.costo_total.planeado)}` : null,
-      desviacion: financiero.costo_total.desviacion,
-      invertCost: true,
-      icon: DollarSign,
-      iconBg: 'bg-gradient-to-br from-primary to-primary-dark',
-      anteriorValue: anterior?.costo_total,
-      anteriorLabel: anterior ? formatearMoneda(anterior.costo_total) : undefined,
-      currentValue: financiero.costo_total.real,
-      deltaInverted: true,
-    },
-    {
-      titulo: 'Costo/Arbol',
-      valor: formatearMoneda(financiero.costo_por_arbol.real),
-      plan: financiero.costo_por_arbol.planeado > 0 ? `Plan: ${formatearMoneda(financiero.costo_por_arbol.planeado)}` : null,
-      desviacion: financiero.costo_por_arbol.desviacion,
-      invertCost: true,
-      icon: TreePine,
-      iconBg: 'bg-gradient-to-br from-orange-500 to-orange-600',
-      anteriorValue: anterior?.costo_por_arbol,
-      anteriorLabel: anterior ? formatearMoneda(anterior.costo_por_arbol) : undefined,
-      currentValue: financiero.costo_por_arbol.real,
-      deltaInverted: true,
-    },
-    {
-      titulo: containerLabel,
-      valor: formatearNumero(canecasTotales.real, 1),
-      plan: canecasTotales.planeado > 0 ? `Plan: ${formatearNumero(canecasTotales.planeado, 1)}` : null,
-      desviacion: canecasTotales.desviacion,
-      invertCost: false,
-      icon: Package,
-      iconBg: 'bg-gradient-to-br from-blue-500 to-blue-600',
-      anteriorValue: anterior?.canecas,
-      anteriorLabel: anterior ? formatearNumero(anterior.canecas, 1) : undefined,
-      currentValue: canecasTotales.real,
-      deltaInverted: false,
-    },
-    {
-      titulo: 'Arboles/Jornal',
-      valor: formatearNumero(arbolesPorJornal, 0),
-      plan: null,
-      desviacion: 0,
-      invertCost: false,
-      icon: Users,
-      iconBg: 'bg-gradient-to-br from-teal-500 to-teal-600',
-      anteriorValue: anterior?.arboles_por_jornal,
-      anteriorLabel: anterior ? formatearNumero(anterior.arboles_por_jornal, 0) : undefined,
-      currentValue: arbolesPorJornal,
-      deltaInverted: false,
-    },
-  ];
+  const sinJornales = totalJornales <= 0;
+  const arbolesPorJornal = sinJornales ? 0 : totalArboles / totalJornales;
 
   return (
-    <div className="grid grid-cols-1 sm:grid-cols-2 lg:grid-cols-4 gap-4">
-      {cards.map((card) => {
-        const Icon = card.icon;
-        return (
-          <div key={card.titulo} className="bg-white rounded-2xl p-5 border border-gray-200">
-            <div className="flex items-center justify-between mb-3">
-              <div className={`w-10 h-10 ${card.iconBg} rounded-xl flex items-center justify-center`}>
-                <Icon className="w-5 h-5 text-white" />
-              </div>
-              <div className="flex items-center gap-2">
-                {anterior && card.anteriorValue != null && card.anteriorValue > 0 && (
-                  <DeltaBadge current={card.currentValue} previous={card.anteriorValue} inverted={card.deltaInverted} />
-                )}
-                {card.desviacion !== 0 && (
-                  <DeviationBadge desviacion={card.desviacion} invertCost={card.invertCost} />
-                )}
-              </div>
-            </div>
-            <h3 className="text-xl font-bold text-gray-900">{card.valor}</h3>
-            <p className="text-sm text-gray-600 font-medium mt-0.5">{card.titulo}</p>
-            {card.plan && (
-              <p className="text-xs text-gray-400 mt-1">{card.plan}</p>
-            )}
-            {anterior && card.anteriorLabel && (
-              <p className="text-xs text-gray-400 mt-0.5">Anterior: {card.anteriorLabel}</p>
-            )}
-          </div>
-        );
-      })}
+    <div className="grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
+      <KPICard
+        titulo="Costo Total"
+        valor={formatearMoneda(financiero.costo_total.real)}
+        icon={DollarSign}
+        comparaciones={construirComparaciones({
+          real: financiero.costo_total.real,
+          planeado: financiero.costo_total.planeado,
+          deltaPlan: financiero.costo_total.desviacion,
+          anteriorValor: anterior?.costo_total,
+          formatear: formatearMoneda,
+          invertido: true,
+        })}
+      />
+      <KPICard
+        titulo="Costo/Árbol"
+        valor={formatearMoneda(financiero.costo_por_arbol.real)}
+        icon={TreePine}
+        comparaciones={construirComparaciones({
+          real: financiero.costo_por_arbol.real,
+          planeado: financiero.costo_por_arbol.planeado,
+          deltaPlan: financiero.costo_por_arbol.desviacion,
+          anteriorValor: anterior?.costo_por_arbol,
+          formatear: formatearMoneda,
+          invertido: true,
+        })}
+      />
+      <KPICard
+        titulo={containerLabel}
+        valor={formatearNumero(canecasTotales.real, 1)}
+        icon={Package}
+        comparaciones={construirComparaciones({
+          real: canecasTotales.real,
+          planeado: canecasTotales.planeado,
+          deltaPlan: canecasTotales.desviacion,
+          anteriorValor: anterior?.canecas,
+          formatear: (v) => formatearNumero(v, 1),
+          invertido: false,
+        })}
+      />
+      <KPICard
+        titulo="Árboles/Jornal"
+        valor={formatearNumero(arbolesPorJornal, 0)}
+        icon={Users}
+        sinDato={sinJornales}
+        notaSinDato={sinJornales ? 'Sin jornales registrados' : undefined}
+        comparaciones={sinJornales ? [] : construirComparaciones({
+          real: arbolesPorJornal,
+          planeado: 0,
+          deltaPlan: undefined,
+          anteriorValor: anterior?.arboles_por_jornal,
+          formatear: (v) => formatearNumero(v, 0),
+          invertido: false,
+        })}
+      />
     </div>
   );
 }

--- a/src/components/aplicaciones/report/ProductComparisonTable.tsx
+++ b/src/components/aplicaciones/report/ProductComparisonTable.tsx
@@ -90,7 +90,7 @@ export function ProductComparisonTable({ productos }: ProductComparisonTableProp
                   </td>
                   <td className="py-2.5 px-3 text-right text-sm">
                     <span className={`font-medium ${deviationColor(prod.cantidad.desviacion)}`}>
-                      {prod.cantidad.desviacion > 0 ? '+' : ''}{prod.cantidad.desviacion.toFixed(1)}%
+                      {prod.cantidad.desviacion > 0 ? '+' : ''}{formatearNumero(prod.cantidad.desviacion, 1)}%
                     </span>
                   </td>
                   <td className="py-2.5 px-3 text-right text-sm text-foreground">

--- a/src/components/aplicaciones/report/ProductComparisonTable.tsx
+++ b/src/components/aplicaciones/report/ProductComparisonTable.tsx
@@ -1,10 +1,16 @@
 import { Package } from 'lucide-react';
-import { formatearMoneda, formatearNumero } from '../../../utils/calculosReporteAplicacion';
+import { Card } from '@/components/ui/card';
+import {
+  Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { Badge } from '@/components/ui/badge';
+import { formatearMoneda, formatearNumero } from '@/utils/format';
+import { cn } from '@/components/ui/utils';
 
 interface ComparisonField {
   real: number;
   planeado: number;
-  desviacion: number;
+  desviacion: number | undefined;
 }
 
 interface ProductoDetalle {
@@ -21,102 +27,149 @@ interface ProductComparisonTableProps {
 
 function deviationColor(desviacion: number): string {
   const abs = Math.abs(desviacion);
-  if (abs <= 5) return 'text-green-600';
-  if (abs <= 20) return 'text-amber-600';
-  return 'text-red-600';
+  if (abs <= 5) return 'text-success';
+  if (abs <= 20) return 'text-warning';
+  return 'text-destructive';
+}
+
+function deviationBadgeClass(desviacion: number): string {
+  const abs = Math.abs(desviacion);
+  if (abs <= 5) return 'bg-green-50 text-green-700';
+  if (abs <= 20) return 'bg-amber-50 text-amber-700';
+  return 'bg-red-50 text-red-700';
 }
 
 export function ProductComparisonTable({ productos }: ProductComparisonTableProps) {
   if (productos.length === 0) return null;
 
-  const highDeviationCount = productos.filter((p) => Math.abs(p.cantidad.desviacion) > 20).length;
+  // "Alta desviación" solo tiene sentido cuando hay un plan contra el cual desviarse — un
+  // producto sin plan (desviacion undefined, D2) no cuenta, aunque su cantidad real sea grande.
+  const conAltaDesviacion = productos.filter((p) => p.cantidad.planeado > 0 && p.cantidad.desviacion !== undefined && Math.abs(p.cantidad.desviacion) > 20);
 
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
-      <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between flex-wrap gap-2">
-        <h3 className="text-lg font-semibold text-foreground flex items-center gap-2">
-          <Package className="w-5 h-5 text-primary" />
-          Comparacion de Productos
+    <Card className="gap-0 overflow-hidden py-0">
+      <div className="flex flex-row flex-wrap items-center justify-between gap-2 border-b border-gray-200 px-6 py-4">
+        <h3 className="flex items-center gap-2 text-lg font-semibold text-foreground">
+          <Package className="size-[18px] text-primary" aria-hidden="true" />
+          Comparación de Productos
         </h3>
-        {highDeviationCount > 0 && (
-          <span className="text-sm text-brand-brown/60">
-            {highDeviationCount} producto(s) con alta desviacion
+        {conAltaDesviacion.length > 0 && (
+          <span className="text-sm text-muted-foreground">
+            {conAltaDesviacion.length} producto{conAltaDesviacion.length === 1 ? '' : 's'} con alta desviación
           </span>
         )}
       </div>
 
-      <div className="overflow-x-auto">
-        <table className="w-full min-w-[650px]">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="text-left py-2.5 px-4 text-xs text-gray-500 font-medium sticky left-0 bg-gray-50 z-10">Producto</th>
-              <th className="text-left py-2.5 px-3 text-xs text-gray-500 font-medium">Unidad</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Plan</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Real</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Diferencia</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Desv%</th>
-              <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Costo</th>
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
+      {/* Desktop / tablet (≥640px): tabla completa. */}
+      <div className="hidden sm:block">
+        <Table>
+          <TableHeader>
+            <TableRow>
+              <TableHead>Producto</TableHead>
+              <TableHead>Unidad</TableHead>
+              <TableHead className="text-right">Plan</TableHead>
+              <TableHead className="text-right">Real</TableHead>
+              <TableHead className="text-right">Diferencia</TableHead>
+              <TableHead className="text-right">Desv%</TableHead>
+              <TableHead className="text-right">Costo</TableHead>
+            </TableRow>
+          </TableHeader>
+          <TableBody>
             {productos.map((prod) => {
-              const highDev = Math.abs(prod.cantidad.desviacion) > 20;
+              const tienePlan = prod.cantidad.planeado > 0 && prod.cantidad.desviacion !== undefined;
+              const altaDesv = tienePlan && Math.abs(prod.cantidad.desviacion as number) > 20;
               const diferencia = prod.cantidad.real - prod.cantidad.planeado;
               return (
-                <tr key={prod.producto_id} className={`hover:bg-gray-50 transition-colors ${highDev ? 'bg-red-50/40' : ''}`}>
-                  <td className="py-2.5 px-4 text-sm text-foreground font-medium sticky left-0 bg-white z-10">
+                <TableRow key={prod.producto_id} className={cn(altaDesv && 'bg-red-50/40')}>
+                  <TableCell className="font-medium text-foreground">
                     <div className="flex items-center gap-2">
                       {prod.producto_nombre}
-                      {highDev && (
-                        <span className="px-1.5 py-0.5 text-xs bg-red-100 text-red-700 rounded">Alta desv.</span>
-                      )}
+                      {altaDesv && <Badge variant="destructive" className="text-xs">Alta desv.</Badge>}
                     </div>
-                  </td>
-                  <td className="py-2.5 px-3 text-sm text-gray-500">{prod.unidad}</td>
-                  <td className="py-2.5 px-3 text-right text-sm text-foreground">
-                    {formatearNumero(prod.cantidad.planeado, 1)}
-                  </td>
-                  <td className="py-2.5 px-3 text-right text-sm text-primary font-medium">
+                  </TableCell>
+                  <TableCell className="text-muted-foreground">{prod.unidad}</TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {tienePlan ? formatearNumero(prod.cantidad.planeado, 1) : <span className="text-muted-foreground">—</span>}
+                  </TableCell>
+                  <TableCell className="text-right font-medium text-primary tabular-nums">
                     {formatearNumero(prod.cantidad.real, 1)}
-                  </td>
-                  <td className="py-2.5 px-3 text-right text-sm">
-                    <span className={`inline-flex items-center px-2 py-0.5 rounded-lg ${
-                      diferencia > 0.1 ? 'bg-red-50 text-red-700' :
-                      diferencia < -0.1 ? 'bg-amber-50 text-amber-700' :
-                      'bg-gray-50 text-gray-700'
-                    }`}>
-                      {diferencia > 0 ? '+' : ''}{formatearNumero(diferencia, 1)}
-                    </span>
-                  </td>
-                  <td className="py-2.5 px-3 text-right text-sm">
-                    <span className={`font-medium ${deviationColor(prod.cantidad.desviacion)}`}>
-                      {prod.cantidad.desviacion > 0 ? '+' : ''}{formatearNumero(prod.cantidad.desviacion, 1)}%
-                    </span>
-                  </td>
-                  <td className="py-2.5 px-3 text-right text-sm text-foreground">
-                    {formatearMoneda(prod.costo.real)}
-                  </td>
-                </tr>
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {tienePlan ? (
+                      <span className={cn(
+                        'inline-flex items-center rounded-lg px-2 py-0.5 text-xs',
+                        diferencia > 0.1 ? 'bg-red-50 text-red-700' : diferencia < -0.1 ? 'bg-amber-50 text-amber-700' : 'bg-gray-50 text-gray-700',
+                      )}>
+                        {diferencia > 0 ? '+' : ''}{formatearNumero(diferencia, 1)}
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right tabular-nums">
+                    {tienePlan ? (
+                      <span className={cn('font-medium', deviationColor(prod.cantidad.desviacion as number))}>
+                        {(prod.cantidad.desviacion as number) > 0 ? '+' : ''}{formatearNumero(prod.cantidad.desviacion as number, 1)}%
+                      </span>
+                    ) : (
+                      <span className="text-muted-foreground">—</span>
+                    )}
+                  </TableCell>
+                  <TableCell className="text-right text-foreground tabular-nums">{formatearMoneda(prod.costo.real)}</TableCell>
+                </TableRow>
               );
             })}
-          </tbody>
-          <tfoot className="bg-gray-50 border-t border-gray-200">
-            <tr>
-              <td className="py-2.5 px-4 text-sm font-semibold text-foreground sticky left-0 bg-gray-50 z-10" colSpan={2}>Total</td>
-              <td className="py-2.5 px-3 text-right text-sm font-semibold text-foreground">
+          </TableBody>
+          <TableFooter>
+            <TableRow>
+              <TableCell colSpan={2}>Total</TableCell>
+              <TableCell className="text-right tabular-nums">
                 {formatearNumero(productos.reduce((s, p) => s + p.cantidad.planeado, 0), 1)}
-              </td>
-              <td className="py-2.5 px-3 text-right text-sm font-semibold text-primary">
+              </TableCell>
+              <TableCell className="text-right text-primary tabular-nums">
                 {formatearNumero(productos.reduce((s, p) => s + p.cantidad.real, 0), 1)}
-              </td>
-              <td className="py-2.5 px-3" colSpan={2}></td>
-              <td className="py-2.5 px-3 text-right text-sm font-semibold text-foreground">
+              </TableCell>
+              <TableCell colSpan={2} />
+              <TableCell className="text-right tabular-nums">
                 {formatearMoneda(productos.reduce((s, p) => s + p.costo.real, 0))}
-              </td>
-            </tr>
-          </tfoot>
-        </table>
+              </TableCell>
+            </TableRow>
+          </TableFooter>
+        </Table>
       </div>
-    </div>
+
+      {/* Móvil (<640px): lista de tarjetas — Patrón A (docs/sistema-visual.md §3-bis). 7
+          columnas no caben en 375px sin desplazar en dos ejes a la vez; una tarjeta por
+          producto evita el scroll horizontal por completo. */}
+      <div className="flex flex-col gap-2 p-4 sm:hidden">
+        {productos.map((prod) => {
+          const tienePlan = prod.cantidad.planeado > 0 && prod.cantidad.desviacion !== undefined;
+          const altaDesv = tienePlan && Math.abs(prod.cantidad.desviacion as number) > 20;
+          const diferencia = prod.cantidad.real - prod.cantidad.planeado;
+          return (
+            <div key={prod.producto_id} className="rounded-xl border border-gray-200 bg-white p-3.5 shadow-sm">
+              <div className="flex items-start justify-between gap-2">
+                <h4 className="min-w-0 text-sm font-semibold text-foreground">{prod.producto_nombre}</h4>
+                {tienePlan && (
+                  <span className={cn('shrink-0 rounded-md px-1.5 py-0.5 text-xs font-bold', deviationBadgeClass(prod.cantidad.desviacion as number))}>
+                    {(prod.cantidad.desviacion as number) > 0 ? '+' : ''}{formatearNumero(prod.cantidad.desviacion as number, 1)}%
+                  </span>
+                )}
+                {altaDesv && <Badge variant="destructive" className="shrink-0 text-xs">Alta desv.</Badge>}
+              </div>
+              <div className="mt-1.5 flex items-baseline gap-1.5">
+                <span className="text-xl font-bold tabular-nums">{formatearNumero(prod.cantidad.real, 1)}</span>
+                <span className="text-xs text-muted-foreground">{prod.unidad} reales</span>
+              </div>
+              <div className="mt-2 flex flex-wrap gap-x-3 gap-y-1 text-xs text-gray-500">
+                <span>Plan <b className="font-medium text-foreground">{tienePlan ? `${formatearNumero(prod.cantidad.planeado, 1)} ${prod.unidad}` : '—'}</b></span>
+                <span>Dif <b className="font-medium text-foreground">{tienePlan ? `${diferencia > 0 ? '+' : ''}${formatearNumero(diferencia, 1)}` : '—'}</b></span>
+                <span>Costo <b className="font-medium text-foreground">{formatearMoneda(prod.costo.real)}</b></span>
+              </div>
+            </div>
+          );
+        })}
+      </div>
+    </Card>
   );
 }

--- a/src/components/aplicaciones/report/TechnicalSection.tsx
+++ b/src/components/aplicaciones/report/TechnicalSection.tsx
@@ -1,14 +1,22 @@
 import { useState } from 'react';
 import {
-  BarChart, Bar, XAxis, YAxis, CartesianGrid, Tooltip,
-  Legend, ResponsiveContainer,
+  Bar, BarChart, CartesianGrid, Legend, ResponsiveContainer, Tooltip, XAxis, YAxis,
 } from 'recharts';
-import { formatearNumero } from '../../../utils/calculosReporteAplicacion';
+import { BarChart3, PackageX } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { Tabs, TabsContent, TabsList, TabsTrigger } from '@/components/ui/tabs';
+import {
+  Table, TableBody, TableCell, TableFooter, TableHead, TableHeader, TableRow,
+} from '@/components/ui/table';
+import { Empty, EmptyDescription, EmptyHeader, EmptyMedia, EmptyTitle } from '@/components/ui/empty';
+import { formatearNumero } from '@/utils/format';
+import { cn } from '@/components/ui/utils';
 
 interface ComparisonField {
   real: number;
   planeado: number;
-  desviacion: number;
+  // D2: `undefined` = sin base de comparación (planeado 0/ausente) — nunca un +100% fabricado.
+  desviacion: number | undefined;
 }
 
 interface CanecasPorLote {
@@ -45,28 +53,113 @@ interface TechnicalSectionProps {
 
 type TabKey = 'canecas' | 'insumos' | 'jornales';
 
+/** Umbral para tratar una serie como "en cero" — tolera el ruido de punto flotante que llega
+ * agregado desde Supabase (mismo problema de familia que D1: aritmética sin redondear antes de
+ * comparar). No es 0 estricto a propósito. */
+const EPSILON_SERIE_CERO = 0.05;
+
 function deviationColor(desviacion: number): string {
   const abs = Math.abs(desviacion);
-  if (abs <= 5) return 'text-green-600';
-  if (abs <= 20) return 'text-amber-600';
-  return 'text-red-600';
+  if (abs <= 5) return 'text-success';
+  if (abs <= 20) return 'text-warning';
+  return 'text-destructive';
 }
 
+/** Celda "valor real / Plan: X / ±X%" apilada — 3 usos en el módulo, no amerita un
+ * sub-componente compartido (decisión del spec, §8). */
 function ComparisonCell({ field, decimals = 1 }: { field: ComparisonField; decimals?: number }) {
+  const tieneDesviacion = field.planeado > 0 && field.desviacion !== undefined;
   return (
-    <td className="py-2.5 px-3 text-right text-sm">
+    <TableCell className="text-right tabular-nums">
       <div className="flex flex-col items-end gap-0.5">
-        <span className="text-foreground font-medium">{formatearNumero(field.real, decimals)}</span>
+        <span className="font-medium text-foreground">{formatearNumero(field.real, decimals)}</span>
         {field.planeado > 0 && (
-          <span className="text-gray-400 text-xs">Plan: {formatearNumero(field.planeado, decimals)}</span>
+          <span className="text-xs text-muted-foreground">Plan: {formatearNumero(field.planeado, decimals)}</span>
         )}
-        {field.planeado > 0 && (
-          <span className={`text-xs font-medium ${deviationColor(field.desviacion)}`}>
-            {field.desviacion > 0 ? '+' : ''}{formatearNumero(field.desviacion, 1)}%
+        {tieneDesviacion && (
+          <span className={cn('text-xs font-semibold', deviationColor(field.desviacion as number))}>
+            {(field.desviacion as number) > 0 ? '+' : ''}{formatearNumero(field.desviacion as number, 1)}%
           </span>
         )}
       </div>
-    </td>
+    </TableCell>
+  );
+}
+
+/** Serie de un gráfico Real/Plan/Anterior por lote — omitida entera (barra + leyenda) cuando
+ * ningún lote tiene valor. Cierra D2/D7: antes la leyenda mostraba "Plan" sin ninguna barra
+ * visible porque `aplicaciones_lotes_planificado` está vacía y `planeado` es 0 en todos lados. */
+function seriesConDatos(
+  datos: DatosGraficoBarrasLote[],
+  patternId: string,
+): Array<{ key: 'real' | 'planeado' | 'anterior'; nombre: string; fill: string; stroke: string; strokeDasharray?: string; radioFinal: boolean }> {
+  const tieneValores = (key: 'real' | 'planeado' | 'anterior') =>
+    datos.some((d) => Math.abs(d[key]) > EPSILON_SERIE_CERO);
+
+  const todas = [
+    { key: 'real' as const, nombre: 'Real', fill: 'var(--chart-1)', stroke: 'var(--chart-1)', radioFinal: false },
+    { key: 'planeado' as const, nombre: 'Plan', fill: `url(#${patternId})`, stroke: 'var(--chart-2)', radioFinal: false },
+    { key: 'anterior' as const, nombre: 'Anterior', fill: 'var(--chart-5)', stroke: 'var(--muted-foreground)', strokeDasharray: '3 3', radioFinal: true },
+  ];
+
+  return todas.filter((s) => tieneValores(s.key));
+}
+
+function GraficoBarrasLote({ datos, patternId, formatearValor }: {
+  datos: DatosGraficoBarrasLote[];
+  patternId: string;
+  formatearValor: (v: number) => string;
+}) {
+  const series = seriesConDatos(datos, patternId);
+
+  if (datos.length === 0 || series.length === 0) {
+    return (
+      <div className="border-t border-gray-100 px-6 py-8">
+        <Empty className="p-0">
+          <EmptyHeader>
+            <EmptyMedia variant="icon">
+              <BarChart3 />
+            </EmptyMedia>
+            <EmptyTitle>Sin datos para graficar</EmptyTitle>
+            <EmptyDescription>Ningún lote tiene un valor mayor a cero en esta pestaña.</EmptyDescription>
+          </EmptyHeader>
+        </Empty>
+      </div>
+    );
+  }
+
+  return (
+    <div className="border-t border-gray-100 px-6 py-4">
+      <div style={{ height: 224 }}>
+        <ResponsiveContainer width="100%" height="100%">
+          <BarChart data={datos} layout="vertical" margin={{ top: 5, right: 24, left: 10, bottom: 5 }}>
+            <defs>
+              <pattern id={patternId} patternUnits="userSpaceOnUse" width="6" height="6" patternTransform="rotate(45)">
+                <rect width="6" height="6" fill="var(--chart-2)" />
+                <line x1="0" y1="0" x2="0" y2="6" stroke="var(--primary)" strokeOpacity={0.3} strokeWidth={2} />
+              </pattern>
+            </defs>
+            <CartesianGrid strokeDasharray="3 3" stroke="var(--border)" />
+            <XAxis type="number" tick={{ fill: 'var(--gray-500, #6B7280)', fontSize: 12 }} />
+            <YAxis type="category" dataKey="lote" tick={{ fill: 'var(--gray-500, #6B7280)', fontSize: 12 }} width={110} />
+            <Tooltip formatter={(v: number) => formatearValor(v)} />
+            <Legend wrapperStyle={{ fontSize: 12 }} />
+            {series.map((s) => (
+              <Bar
+                key={s.key}
+                dataKey={s.key}
+                name={s.nombre}
+                fill={s.fill}
+                stroke={s.stroke}
+                strokeWidth={1}
+                strokeDasharray={s.strokeDasharray}
+                radius={s.radioFinal ? [0, 4, 4, 0] : [0, 2, 2, 0]}
+              />
+            ))}
+          </BarChart>
+        </ResponsiveContainer>
+      </div>
+    </div>
   );
 }
 
@@ -82,30 +175,28 @@ export function TechnicalSection({
 }: TechnicalSectionProps) {
   const [activeTab, setActiveTab] = useState<TabKey>('canecas');
 
-  const tabs: { key: TabKey; label: string }[] = [
-    { key: 'canecas', label: containerLabel },
-    { key: 'insumos', label: 'Insumos' },
-    { key: 'jornales', label: 'Jornales' },
-  ];
-
-  // Build insumos per lote aggregation for the table
+  // Insumos: agregación por lote para la tabla + gráfico de esta pestaña.
   const insumosPorLote = canecasPorLote.map((loteCaneca) => {
     const prods = detalle_productos_por_lote[loteCaneca.lote_id] || [];
     const totalReal = prods.reduce((s, p) => s + p.cantidad.real, 0);
     const totalPlan = prods.reduce((s, p) => s + p.cantidad.planeado, 0);
-    const desviacion = totalPlan > 0 ? ((totalReal - totalPlan) / totalPlan) * 100 : 0;
+    const desviacion = totalPlan > 0 ? ((totalReal - totalPlan) / totalPlan) * 100 : undefined;
     return {
       lote_id: loteCaneca.lote_id,
       lote_nombre: loteCaneca.lote_nombre,
       insumos: { real: totalReal, planeado: totalPlan, desviacion } as ComparisonField,
     };
   });
-
   const insumosTotalReal = insumosPorLote.reduce((s, l) => s + l.insumos.real, 0);
   const insumosTotalPlan = insumosPorLote.reduce((s, l) => s + l.insumos.planeado, 0);
-  const insumosTotalDesv = insumosTotalPlan > 0 ? ((insumosTotalReal - insumosTotalPlan) / insumosTotalPlan) * 100 : 0;
+  const insumosTotalDesv = insumosTotalPlan > 0 ? ((insumosTotalReal - insumosTotalPlan) / insumosTotalPlan) * 100 : undefined;
 
-  // Build chart data for insumos tab
+  // "Sin mapeo mezcla→lote" — condición estructural (CLAUDE.md, Applications Data Architecture:
+  // 4 de 20 aplicaciones cerradas no tienen ese mapeo), no una lectura real de 0. Se detecta por
+  // AUSENCIA de filas de producto, no por que la suma dé 0 — una suma en 0 con filas presentes
+  // sí sería un "0" real y se muestra como tal.
+  const sinMapeoInsumos = Object.values(detalle_productos_por_lote).every((filas) => (filas?.length ?? 0) === 0);
+
   const graficoInsumos: DatosGraficoBarrasLote[] = insumosPorLote.map((l) => ({
     lote: l.lote_nombre,
     planeado: l.insumos.planeado,
@@ -113,121 +204,125 @@ export function TechnicalSection({
     anterior: 0,
   }));
 
-  const chartData = activeTab === 'canecas' ? graficoCanecas
-    : activeTab === 'insumos' ? graficoInsumos
-    : graficoJornales;
-
   return (
-    <div className="bg-white rounded-2xl border border-gray-200 overflow-hidden">
-      <div className="px-6 py-4 border-b border-gray-200 flex items-center justify-between flex-wrap gap-3">
-        <h3 className="text-lg font-semibold text-foreground">Detalle Tecnico por Lote</h3>
-        <div className="flex bg-gray-100 rounded-lg p-0.5">
-          {tabs.map((tab) => (
-            <button
-              key={tab.key}
-              onClick={() => setActiveTab(tab.key)}
-              className={`px-3 py-1.5 text-sm rounded-md transition-colors ${
-                activeTab === tab.key
-                  ? 'bg-white text-foreground font-medium shadow-sm'
-                  : 'text-gray-500 hover:text-gray-700'
-              }`}
-            >
-              {tab.label}
-            </button>
-          ))}
+    <Tabs value={activeTab} onValueChange={(v) => setActiveTab(v as TabKey)}>
+      <Card className="gap-0 overflow-hidden py-0">
+        <div className="flex flex-row flex-wrap items-center justify-between gap-3 border-b border-gray-200 px-6 py-4">
+          <h3 className="text-lg font-semibold text-foreground">
+            Detalle Técnico por Lote
+          </h3>
+          <TabsList>
+            <TabsTrigger value="canecas" className="text-sm">{containerLabel}</TabsTrigger>
+            <TabsTrigger value="insumos" className="text-sm">Insumos</TabsTrigger>
+            <TabsTrigger value="jornales" className="text-sm">Jornales</TabsTrigger>
+          </TabsList>
         </div>
-      </div>
 
-      {/* Table */}
-      <div className="overflow-x-auto">
-        <table className="w-full min-w-[600px]">
-          <thead className="bg-gray-50">
-            <tr>
-              <th className="text-left py-2.5 px-4 text-xs text-gray-500 font-medium sticky left-0 bg-gray-50 z-10">Lote</th>
-              {activeTab === 'canecas' && (
-                <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">{containerLabel}</th>
-              )}
-              {activeTab === 'insumos' && (
-                <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Insumos (kg)</th>
-              )}
-              {activeTab === 'jornales' && (
-                <>
-                  <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Jornales</th>
-                  <th className="text-right py-2.5 px-3 text-xs text-gray-500 font-medium">Arb/Jornal</th>
-                </>
-              )}
-            </tr>
-          </thead>
-          <tbody className="divide-y divide-gray-100">
-            {activeTab === 'canecas' && canecasPorLote.map((lote) => (
-              <tr key={lote.lote_id} className="hover:bg-gray-50 transition-colors">
-                <td className="py-2.5 px-4 text-sm text-foreground font-medium sticky left-0 bg-white z-10">{lote.lote_nombre}</td>
-                <ComparisonCell field={lote.canecas} />
-              </tr>
-            ))}
-            {activeTab === 'insumos' && insumosPorLote.map((lote) => (
-              <tr key={lote.lote_id} className="hover:bg-gray-50 transition-colors">
-                <td className="py-2.5 px-4 text-sm text-foreground font-medium sticky left-0 bg-white z-10">{lote.lote_nombre}</td>
-                <ComparisonCell field={lote.insumos} />
-              </tr>
-            ))}
-            {activeTab === 'jornales' && jornalesPorLote.map((lote) => (
-              <tr key={lote.lote_id} className="hover:bg-gray-50 transition-colors">
-                <td className="py-2.5 px-4 text-sm text-foreground font-medium sticky left-0 bg-white z-10">{lote.lote_nombre}</td>
-                <ComparisonCell field={lote.jornales_total} />
-                <ComparisonCell field={lote.arboles_por_jornal} decimals={0} />
-              </tr>
-            ))}
-          </tbody>
-          <tfoot className="bg-gray-50 border-t border-gray-200">
-            {activeTab === 'canecas' && (
-              <tr>
-                <td className="py-2.5 px-4 text-sm font-semibold text-foreground sticky left-0 bg-gray-50 z-10">Total</td>
+        <TabsContent value="canecas" className="mt-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Lote</TableHead>
+                <TableHead className="text-right">{containerLabel}</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {canecasPorLote.map((lote) => (
+                <TableRow key={lote.lote_id}>
+                  <TableCell className="font-medium text-foreground">{lote.lote_nombre}</TableCell>
+                  <ComparisonCell field={lote.canecas} />
+                </TableRow>
+              ))}
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell>Total</TableCell>
                 <ComparisonCell field={canecasTotales.canecas} />
-              </tr>
+              </TableRow>
+            </TableFooter>
+          </Table>
+          <GraficoBarrasLote datos={graficoCanecas} patternId="tecnico-plan-hatch-canecas" formatearValor={(v) => formatearNumero(v, 1)} />
+        </TabsContent>
+
+        <TabsContent value="insumos" className="mt-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Lote</TableHead>
+                <TableHead className="text-right">Insumos (kg)</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {insumosPorLote.map((lote) => (
+                <TableRow key={lote.lote_id}>
+                  <TableCell className="font-medium text-foreground">{lote.lote_nombre}</TableCell>
+                  {sinMapeoInsumos ? (
+                    <TableCell className="text-right font-normal text-muted-foreground">—</TableCell>
+                  ) : (
+                    <ComparisonCell field={lote.insumos} />
+                  )}
+                </TableRow>
+              ))}
+            </TableBody>
+            {!sinMapeoInsumos && (
+              <TableFooter>
+                <TableRow>
+                  <TableCell>Total</TableCell>
+                  <ComparisonCell field={{ real: insumosTotalReal, planeado: insumosTotalPlan, desviacion: insumosTotalDesv }} />
+                </TableRow>
+              </TableFooter>
             )}
-            {activeTab === 'insumos' && (
-              <tr>
-                <td className="py-2.5 px-4 text-sm font-semibold text-foreground sticky left-0 bg-gray-50 z-10">Total</td>
-                <ComparisonCell field={{ real: insumosTotalReal, planeado: insumosTotalPlan, desviacion: insumosTotalDesv }} />
-              </tr>
-            )}
-            {activeTab === 'jornales' && (
-              <tr>
-                <td className="py-2.5 px-4 text-sm font-semibold text-foreground sticky left-0 bg-gray-50 z-10">Total</td>
+          </Table>
+          {sinMapeoInsumos ? (
+            <div className="border-t border-gray-100 px-6 py-8">
+              <Empty className="p-0">
+                <EmptyHeader>
+                  <EmptyMedia variant="icon">
+                    <PackageX />
+                  </EmptyMedia>
+                  <EmptyTitle>Sin datos de insumos por lote</EmptyTitle>
+                  <EmptyDescription>
+                    Esta aplicación no tiene mapeo mezcla→lote en <code>aplicaciones_calculos.mezcla_id</code>
+                    {' '}(ausente en 4 de 20 aplicaciones cerradas). No es una barra que no cargó — es una
+                    lectura real de "sin dato", y se muestra como tal.
+                  </EmptyDescription>
+                </EmptyHeader>
+              </Empty>
+            </div>
+          ) : (
+            <GraficoBarrasLote datos={graficoInsumos} patternId="tecnico-plan-hatch-insumos" formatearValor={(v) => formatearNumero(v, 1)} />
+          )}
+        </TabsContent>
+
+        <TabsContent value="jornales" className="mt-0">
+          <Table>
+            <TableHeader>
+              <TableRow>
+                <TableHead>Lote</TableHead>
+                <TableHead className="text-right">Jornales</TableHead>
+                <TableHead className="text-right">Arb/Jornal</TableHead>
+              </TableRow>
+            </TableHeader>
+            <TableBody>
+              {jornalesPorLote.map((lote) => (
+                <TableRow key={lote.lote_id}>
+                  <TableCell className="font-medium text-foreground">{lote.lote_nombre}</TableCell>
+                  <ComparisonCell field={lote.jornales_total} />
+                  <ComparisonCell field={lote.arboles_por_jornal} decimals={0} />
+                </TableRow>
+              ))}
+            </TableBody>
+            <TableFooter>
+              <TableRow>
+                <TableCell>Total</TableCell>
                 <ComparisonCell field={jornalesTotales.jornales_total} />
                 <ComparisonCell field={jornalesTotales.arboles_por_jornal} decimals={0} />
-              </tr>
-            )}
-          </tfoot>
-        </table>
-      </div>
-
-      {/* Chart */}
-      {chartData.length > 0 && (
-        <div className="px-6 py-4 border-t border-gray-100">
-          <div style={{ height: 224 }}>
-            <ResponsiveContainer width="100%" height="100%">
-              <BarChart
-                data={chartData}
-                layout="vertical"
-                margin={{ top: 5, right: 20, left: 10, bottom: 5 }}
-              >
-                <CartesianGrid strokeDasharray="3 3" stroke="#E5E7EB" />
-                <XAxis type="number" tick={{ fill: '#6B7280', fontSize: 12 }} />
-                <YAxis type="category" dataKey="lote" tick={{ fill: '#6B7280', fontSize: 12 }} width={100} />
-                <Tooltip formatter={(v: number) => formatearNumero(v, 1)} />
-                <Legend />
-                <Bar dataKey="planeado" fill="#BFD97D" name="Plan" radius={[0, 2, 2, 0]} />
-                <Bar dataKey="real" fill="#73991C" name="Real" radius={[0, 4, 4, 0]} />
-                {chartData.some(d => d.anterior > 0) && (
-                  <Bar dataKey="anterior" fill="#E5E7EB" name="Anterior" radius={[0, 2, 2, 0]} />
-                )}
-              </BarChart>
-            </ResponsiveContainer>
-          </div>
-        </div>
-      )}
-    </div>
+              </TableRow>
+            </TableFooter>
+          </Table>
+          <GraficoBarrasLote datos={graficoJornales} patternId="tecnico-plan-hatch-jornales" formatearValor={(v) => formatearNumero(v, 1)} />
+        </TabsContent>
+      </Card>
+    </Tabs>
   );
 }

--- a/src/components/aplicaciones/report/TechnicalSection.tsx
+++ b/src/components/aplicaciones/report/TechnicalSection.tsx
@@ -62,7 +62,7 @@ function ComparisonCell({ field, decimals = 1 }: { field: ComparisonField; decim
         )}
         {field.planeado > 0 && (
           <span className={`text-xs font-medium ${deviationColor(field.desviacion)}`}>
-            {field.desviacion > 0 ? '+' : ''}{field.desviacion.toFixed(1)}%
+            {field.desviacion > 0 ? '+' : ''}{formatearNumero(field.desviacion, 1)}%
           </span>
         )}
       </div>

--- a/src/components/aplicaciones/shared/AplicacionShell.tsx
+++ b/src/components/aplicaciones/shared/AplicacionShell.tsx
@@ -1,0 +1,77 @@
+import { Link } from 'react-router-dom';
+import {
+  Breadcrumb,
+  BreadcrumbItem,
+  BreadcrumbLink,
+  BreadcrumbList,
+  BreadcrumbPage,
+  BreadcrumbSeparator,
+} from '@/components/ui/breadcrumb';
+import type { EstadoAplicacion } from '@/types/aplicaciones';
+import { EstadoAplicacionBadge } from './EstadoAplicacionBadge';
+
+interface AplicacionShellProps {
+  titulo: string;
+  subtitulo?: string;
+  estado?: EstadoAplicacion | null;
+  /** default '/aplicaciones' */
+  volverA?: string;
+  acciones?: React.ReactNode;
+  children: React.ReactNode;
+}
+
+/**
+ * Marco de página compartido para las pantallas del módulo de Aplicaciones (Calculadora,
+ * Movimientos, Cierre y Reporte): breadcrumb de vuelta a Aplicaciones, título + estado,
+ * slot de acciones y slot de contenido.
+ *
+ * Cierre pasa de modal falso (`fixed inset-0` sobre la app en gris) a página completa
+ * construida con este componente — un refresh de página no debe perder el trabajo en curso
+ * porque ya no depende de un modal montado en memoria (ver decisión 1 del contrato de Fase 0).
+ */
+export function AplicacionShell({
+  titulo,
+  subtitulo,
+  estado,
+  volverA = '/aplicaciones',
+  acciones,
+  children,
+}: AplicacionShellProps) {
+  return (
+    <div className="min-h-screen bg-background py-8 px-4 sm:px-6 lg:px-8">
+      <div className="max-w-[1200px] mx-auto space-y-6">
+        <Breadcrumb>
+          <BreadcrumbList>
+            <BreadcrumbItem>
+              <BreadcrumbLink asChild>
+                <Link to={volverA}>Aplicaciones</Link>
+              </BreadcrumbLink>
+            </BreadcrumbItem>
+            <BreadcrumbSeparator />
+            <BreadcrumbItem>
+              <BreadcrumbPage>{titulo}</BreadcrumbPage>
+            </BreadcrumbItem>
+          </BreadcrumbList>
+        </Breadcrumb>
+
+        <div className="bg-white rounded-2xl shadow-sm border border-gray-200 p-6 sm:p-8">
+          <div className="flex flex-col sm:flex-row sm:items-start sm:justify-between gap-4">
+            <div className="flex items-start gap-3">
+              <div>
+                <div className="flex items-center gap-3 flex-wrap">
+                  <h1 className="text-foreground">{titulo}</h1>
+                  {estado !== undefined && <EstadoAplicacionBadge estado={estado ?? null} />}
+                </div>
+                {subtitulo && <p className="text-brand-brown/70 mt-1">{subtitulo}</p>}
+              </div>
+            </div>
+
+            {acciones && <div className="flex items-center gap-3 flex-wrap">{acciones}</div>}
+          </div>
+        </div>
+
+        {children}
+      </div>
+    </div>
+  );
+}

--- a/src/components/aplicaciones/shared/AplicacionStepper.tsx
+++ b/src/components/aplicaciones/shared/AplicacionStepper.tsx
@@ -34,7 +34,13 @@ export function AplicacionStepper({ pasos, pasoActual, onIrAPaso, className }: A
   return (
     <nav aria-label="Progreso de la aplicación" className={cn('w-full', className)}>
       {/* Desktop */}
-      <ol className="hidden md:flex items-start justify-between">
+      {/* `justify-between` + `flex-1` empujaba los pasos a los extremos: con 3 se veía bien y con
+          2 quedaba un conector enorme y todo descentrado. Ahora el <ol> se centra y se topa el
+          ancho en función de cuántos pasos hay, así 2 y 3 se ven igual de deliberados. */}
+      <ol
+        className="mx-auto hidden md:flex items-start justify-center"
+        style={{ maxWidth: `${pasos.length * 15}rem` }}
+      >
         {pasos.map((paso, index) => {
           const numero = index + 1;
           const isActive = pasoActual === numero;
@@ -45,20 +51,23 @@ export function AplicacionStepper({ pasos, pasoActual, onIrAPaso, className }: A
           const Circulo = (
             <div
               className={cn(
-                'w-16 h-16 rounded-2xl flex items-center justify-center mb-3 transition-all duration-300',
+                'size-12 rounded-xl flex items-center justify-center mb-3 transition-colors',
                 isActive
-                  ? 'bg-gradient-to-br from-primary to-secondary text-white shadow-lg scale-110'
+                  // Un solo acento: el paso activo es olivo sólido, no un degradado
+                  // primary→secondary. El `scale-110` además desalineaba el nodo activo
+                  // respecto de los otros y del conector.
+                  ? 'bg-primary text-primary-foreground ring-4 ring-primary/15'
                   : isCompleted
-                    ? 'bg-primary text-white'
+                    ? 'bg-primary/12 text-primary border border-primary'
                     : 'bg-muted text-muted-foreground',
               )}
             >
-              {isCompleted ? <Check className="w-8 h-8" /> : <span className="text-lg">{numero}</span>}
+              {isCompleted ? <Check className="size-5" /> : <span className="text-base font-semibold">{numero}</span>}
             </div>
           );
 
           return (
-            <li key={paso.id} className="flex items-start flex-1" aria-current={isActive ? 'step' : undefined}>
+            <li key={paso.id} className="flex items-start" aria-current={isActive ? 'step' : undefined}>
               <div className="flex flex-col items-center">
                 {isNavegable ? (
                   <button
@@ -89,7 +98,7 @@ export function AplicacionStepper({ pasos, pasoActual, onIrAPaso, className }: A
               </div>
 
               {!isLast && (
-                <div className="flex-1 h-1 mx-4 mt-8">
+                <div className="w-16 lg:w-24 h-0.5 mx-3 mt-6 shrink-0">
                   <div
                     className={cn(
                       'h-full rounded-full transition-all duration-300',

--- a/src/components/aplicaciones/shared/AplicacionStepper.tsx
+++ b/src/components/aplicaciones/shared/AplicacionStepper.tsx
@@ -1,0 +1,138 @@
+import { Check } from 'lucide-react';
+import { cn } from '@/components/ui/utils';
+
+export interface PasoStepper {
+  id: string;
+  titulo: string;
+  descripcion?: string;
+}
+
+interface AplicacionStepperProps {
+  pasos: PasoStepper[];
+  /** 1-based */
+  pasoActual: number;
+  /** undefined = no navegable */
+  onIrAPaso?: (n: number) => void;
+  className?: string;
+}
+
+/**
+ * Stepper único para el módulo de Aplicaciones — reemplaza los DOS steppers a mano que hoy
+ * existen (uno en CalculadoraAplicaciones.tsx con círculos numerados + descripción, otro en
+ * CierreAplicacion.tsx con círculos chicos + chevrons) y que hoy se ven distintos entre sí.
+ *
+ * Una sola implementación responsive: en escritorio muestra los pasos completos con
+ * título/descripción y línea conectora; en móvil colapsa a una barra de progreso con el
+ * título del paso actual (mismo patrón que ya usaba CalculadoraApliaciones.tsx en móvil).
+ *
+ * Solo los pasos completados son navegables cuando se provee `onIrAPaso` — no tiene sentido
+ * saltar a un paso futuro que aún no fue validado.
+ */
+export function AplicacionStepper({ pasos, pasoActual, onIrAPaso, className }: AplicacionStepperProps) {
+  const pasoActualInfo = pasos[pasoActual - 1];
+
+  return (
+    <nav aria-label="Progreso de la aplicación" className={cn('w-full', className)}>
+      {/* Desktop */}
+      <ol className="hidden md:flex items-start justify-between">
+        {pasos.map((paso, index) => {
+          const numero = index + 1;
+          const isActive = pasoActual === numero;
+          const isCompleted = pasoActual > numero;
+          const isLast = index === pasos.length - 1;
+          const isNavegable = isCompleted && !!onIrAPaso;
+
+          const Circulo = (
+            <div
+              className={cn(
+                'w-16 h-16 rounded-2xl flex items-center justify-center mb-3 transition-all duration-300',
+                isActive
+                  ? 'bg-gradient-to-br from-primary to-secondary text-white shadow-lg scale-110'
+                  : isCompleted
+                    ? 'bg-primary text-white'
+                    : 'bg-muted text-muted-foreground',
+              )}
+            >
+              {isCompleted ? <Check className="w-8 h-8" /> : <span className="text-lg">{numero}</span>}
+            </div>
+          );
+
+          return (
+            <li key={paso.id} className="flex items-start flex-1" aria-current={isActive ? 'step' : undefined}>
+              <div className="flex flex-col items-center">
+                {isNavegable ? (
+                  <button
+                    type="button"
+                    onClick={() => onIrAPaso?.(numero)}
+                    aria-label={`Ir al paso ${numero}: ${paso.titulo}`}
+                    className="flex flex-col items-center cursor-pointer"
+                  >
+                    {Circulo}
+                  </button>
+                ) : (
+                  Circulo
+                )}
+
+                <div className="text-center">
+                  <p
+                    className={cn(
+                      'text-sm mb-1 transition-colors',
+                      isActive || isCompleted ? 'text-foreground' : 'text-muted-foreground',
+                    )}
+                  >
+                    {paso.titulo}
+                  </p>
+                  {paso.descripcion && (
+                    <p className="text-xs text-brand-brown/50 max-w-[140px]">{paso.descripcion}</p>
+                  )}
+                </div>
+              </div>
+
+              {!isLast && (
+                <div className="flex-1 h-1 mx-4 mt-8">
+                  <div
+                    className={cn(
+                      'h-full rounded-full transition-all duration-300',
+                      isCompleted ? 'bg-primary' : 'bg-muted',
+                    )}
+                  />
+                </div>
+              )}
+            </li>
+          );
+        })}
+      </ol>
+
+      {/* Mobile */}
+      <div className="md:hidden">
+        <ol className="flex items-center justify-center gap-2 mb-4">
+          {pasos.map((paso, index) => {
+            const numero = index + 1;
+            const isActive = pasoActual === numero;
+            const isCompleted = pasoActual > numero;
+
+            return (
+              <li
+                key={paso.id}
+                aria-current={isActive ? 'step' : undefined}
+                className={cn(
+                  'h-2 flex-1 rounded-full transition-all duration-300',
+                  isActive || isCompleted ? 'bg-primary' : 'bg-muted',
+                )}
+              />
+            );
+          })}
+        </ol>
+
+        {pasoActualInfo && (
+          <div className="text-center">
+            <p className="text-lg text-foreground mb-1">{pasoActualInfo.titulo}</p>
+            <p className="text-sm text-brand-brown/70">
+              Paso {pasoActual} de {pasos.length}
+            </p>
+          </div>
+        )}
+      </div>
+    </nav>
+  );
+}

--- a/src/components/aplicaciones/shared/EstadoAplicacionBadge.tsx
+++ b/src/components/aplicaciones/shared/EstadoAplicacionBadge.tsx
@@ -1,0 +1,40 @@
+import { Badge } from '@/components/ui/badge';
+import { cn } from '@/components/ui/utils';
+import type { EstadoAplicacion } from '@/types/aplicaciones';
+
+interface EstadoAplicacionBadgeProps {
+  estado: EstadoAplicacion | null;
+  className?: string;
+}
+
+/**
+ * Único mapa estado→estilo para las 5 pantallas del módulo de Aplicaciones.
+ *
+ * Antes de este componente, cada pantalla traía su propio mapa y no coincidían entre sí
+ * (AplicacionesList.tsx tenía "En ejecución" en verde y "Cerrada" en gris; DetalleAplicacion.tsx
+ * tenía "En ejecución" en ámbar y "Cerrada" en verde). Esta paleta es la que ya usa la mayoría
+ * — coincide con DetalleAplicacion.tsx y con el mapa independiente de
+ * `src/components/inventory/dashboard/components/ConsumoAplicacionesTable.tsx` — y pasa a ser
+ * la única fuente de verdad.
+ */
+const ESTADO_ESTILOS: Record<EstadoAplicacion, string> = {
+  Calculada: 'bg-blue-50 text-blue-700 border-blue-200',
+  'En ejecución': 'bg-amber-50 text-amber-700 border-amber-200',
+  Cerrada: 'bg-green-50 text-green-700 border-green-200',
+};
+
+/**
+ * Badge de estado de una aplicación. `estado === null` renderiza "—", nunca un estado
+ * inventado (regla 2 de CLAUDE.md: "sin dato" nunca es 0 ni un valor por defecto).
+ */
+export function EstadoAplicacionBadge({ estado, className }: EstadoAplicacionBadgeProps) {
+  if (!estado) {
+    return <span className={cn('text-sm text-muted-foreground', className)}>—</span>;
+  }
+
+  return (
+    <Badge variant="outline" className={cn(ESTADO_ESTILOS[estado], className)}>
+      {estado}
+    </Badge>
+  );
+}

--- a/src/components/aplicaciones/shared/EstadoAplicacionBadge.tsx
+++ b/src/components/aplicaciones/shared/EstadoAplicacionBadge.tsx
@@ -10,17 +10,39 @@ interface EstadoAplicacionBadgeProps {
 /**
  * Único mapa estado→estilo para las 5 pantallas del módulo de Aplicaciones.
  *
- * Antes de este componente, cada pantalla traía su propio mapa y no coincidían entre sí
+ * Antes de este componente cada pantalla traía su propio mapa y no coincidían entre sí
  * (AplicacionesList.tsx tenía "En ejecución" en verde y "Cerrada" en gris; DetalleAplicacion.tsx
- * tenía "En ejecución" en ámbar y "Cerrada" en verde). Esta paleta es la que ya usa la mayoría
- * — coincide con DetalleAplicacion.tsx y con el mapa independiente de
- * `src/components/inventory/dashboard/components/ConsumoAplicacionesTable.tsx` — y pasa a ser
- * la única fuente de verdad.
+ * tenía "En ejecución" en ámbar y "Cerrada" en verde; ConsumoAplicacionesTable.tsx traía un tercero
+ * en azul/ámbar/verde). Este es ahora la única fuente de verdad.
+ *
+ * **Un solo acento — decisión del dueño, 2026-08-20.** La primera versión de este archivo copió el
+ * azul/ámbar/verde de ConsumoAplicacionesTable. Se descartó: tres hues compitiendo con el olivo de
+ * marca en una lista de 20 filas convierten el color en ruido, y el semáforo sugiere que "Cerrada"
+ * es bueno y "Calculada" es información, cuando en realidad son solo posiciones de un flujo.
+ *
+ * La jerarquía la carga la INTENSIDAD del mismo olivo, no el tono:
+ * - `En ejecución` — olivo sólido. Es el único estado que pide acción del usuario hoy.
+ * - `Calculada` — tinte de secondary. Planificada, todavía no arranca.
+ * - `Cerrada` — neutro con borde. Archivo; 17 de 20 filas son esto y deben quedarse calladas.
  */
 const ESTADO_ESTILOS: Record<EstadoAplicacion, string> = {
-  Calculada: 'bg-blue-50 text-blue-700 border-blue-200',
-  'En ejecución': 'bg-amber-50 text-amber-700 border-amber-200',
-  Cerrada: 'bg-green-50 text-green-700 border-green-200',
+  Calculada: 'bg-secondary/40 text-secondary-foreground border-secondary',
+  'En ejecución': 'bg-primary text-primary-foreground border-primary',
+  Cerrada: 'bg-transparent text-muted-foreground border-border',
+};
+
+/**
+ * El valor guardado NO es el que ve la usuaria. `AplicacionesList.tsx` viene mapeando
+ * `Calculada` → "Planificada" desde siempre (su `ESTADO_LABELS`), y el filtro de estado usa esa
+ * misma etiqueta. La primera versión de este componente renderizaba `{estado}` crudo, así que al
+ * cablearlo habría cambiado en silencio la palabra que la gente lleva meses leyendo — sin tocar la
+ * base de datos y sin que ningún test lo notara. El mapa vive acá para que las 5 pantallas digan
+ * lo mismo.
+ */
+const ESTADO_ETIQUETAS: Record<EstadoAplicacion, string> = {
+  Calculada: 'Planificada',
+  'En ejecución': 'En Ejecución',
+  Cerrada: 'Cerrada',
 };
 
 /**
@@ -34,7 +56,7 @@ export function EstadoAplicacionBadge({ estado, className }: EstadoAplicacionBad
 
   return (
     <Badge variant="outline" className={cn(ESTADO_ESTILOS[estado], className)}>
-      {estado}
+      {ESTADO_ETIQUETAS[estado]}
     </Badge>
   );
 }

--- a/src/components/aplicaciones/shared/KPICard.tsx
+++ b/src/components/aplicaciones/shared/KPICard.tsx
@@ -1,0 +1,157 @@
+import type { LucideIcon } from 'lucide-react';
+import { TrendingUp, TrendingDown } from 'lucide-react';
+import { Card } from '@/components/ui/card';
+import { cn } from '@/components/ui/utils';
+import { formatearNumero } from '@/utils/format';
+
+/**
+ * `formatPercentage()` de `format.ts` NO sirve acá: usa `toFixed`, que imprime el punto decimal
+ * anglosajón (`6.7%`). El resto del módulo ya formatea porcentajes con
+ * `formatearNumero(v, 1)` — es decir `es-CO`, con coma (`6,7%`). Se usa el mismo camino para que
+ * la misma cifra no se vea distinta en dos pantallas.
+ */
+function formatearPorcentajeConSigno(valor: number): string {
+  const signo = valor > 0 ? '+' : '';
+  return `${signo}${formatearNumero(valor, 1)}%`;
+}
+
+/**
+ * Una comparación que la tarjeta puede mostrar como badge.
+ *
+ * **`delta` se OMITE por completo cuando no hay base de comparación** — no `null`, no `0`.
+ * Quien arma los props ya decidió que no hay nada que mostrar; la tarjeta no vuelve a decidirlo.
+ */
+export interface KPIComparacion {
+  tipo: 'plan' | 'anterior';
+  /** "Plan" | "Anterior" */
+  etiqueta: string;
+  /** Ya formateado por format.ts. Ej: "Plan: $9.200.000" */
+  valorFormateado: string;
+  /** Porcentaje. Omitir el campo entero cuando la base es 0 o ausente. */
+  delta?: number;
+  /** Costo: subir es malo. Eficiencia/cantidad: subir es bueno. */
+  invertido?: boolean;
+}
+
+export interface KPICardProps {
+  titulo: string;
+  /** Ya formateado — `formatearMoneda`/`formatearNumero`, nunca inline. */
+  valor: string;
+  icon: LucideIcon;
+  /**
+   * `primary` = ícono en olivo (Reporte). `neutro` = ícono apagado (Lista, donde la tarjeta
+   * describe un estado y no un logro). Dos tratamientos, no un color por tarjeta.
+   */
+  tono?: 'primary' | 'neutro';
+  /** 0, 1 (solo Plan o solo Anterior) o 2 (ambas). */
+  comparaciones?: KPIComparacion[];
+  /** `true` → el valor renderiza "—". Nunca 0, nunca cadena vacía. */
+  sinDato?: boolean;
+  /** Texto corto bajo el valor cuando `sinDato` — explica POR QUÉ no hay dato. */
+  notaSinDato?: string;
+  className?: string;
+}
+
+/**
+ * Tarjeta KPI compartida por el Reporte de Aplicación (W04) y la Lista de Aplicaciones (W00).
+ *
+ * **Por qué existe y qué defecto cierra (D2).** Hoy las 4 tarjetas del Reporte muestran `+100,0%`
+ * en TODAS las aplicaciones cerradas, siempre. La causa no es "no se eligió comparación": es que
+ * `calcularDesviacion(planeado, real)` devuelve literalmente `100` cuando `planeado === 0`
+ * (`calculosReporteAplicacion.ts:15`), y `aplicaciones_lotes_planificado` está vacía, así que el
+ * plan es 0 estructuralmente en las 20 aplicaciones.
+ *
+ * La corrección vive en el CONTRATO, no en un parche: esta tarjeta es tonta a propósito. Si el
+ * arreglo `comparaciones` trae un badge, lo pinta; si no lo trae, no pinta nada. La pregunta
+ * "¿hay base de comparación?" se responde UNA vez, en quien arma los props, y la respuesta correcta
+ * ya existe en el repo — `calcularCambio()` (mismo archivo) devuelve `undefined` cuando la base es
+ * nula o 0. El módulo simplemente no la llama todavía.
+ *
+ * **Un solo acento.** `HeroKPICards.tsx` traía cuatro gradientes distintos por tarjeta
+ * (`from-orange-500`, `from-blue-500`, `from-teal-500`, `from-primary`) sin criterio semántico.
+ * Se retiran: dos tonos, ambos derivados de la marca. El color semántico (verde/rojo del delta)
+ * es otra cosa y sí se conserva — mide bueno/malo, no decora.
+ */
+export function KPICard({
+  titulo,
+  valor,
+  icon: Icon,
+  tono = 'primary',
+  comparaciones,
+  sinDato = false,
+  notaSinDato,
+  className,
+}: KPICardProps) {
+  const badges = (comparaciones ?? []).filter((c) => c.delta !== undefined);
+
+  return (
+    <Card className={cn('flex flex-col gap-3 p-4', className)}>
+      <div className="flex items-start justify-between gap-2">
+        <div
+          className={cn(
+            'flex size-10 shrink-0 items-center justify-center rounded-lg',
+            tono === 'primary'
+              ? 'bg-primary text-primary-foreground'
+              : 'bg-muted text-muted-foreground',
+          )}
+        >
+          <Icon className="size-[18px]" aria-hidden="true" />
+        </div>
+
+        {badges.length > 0 && (
+          <div className="flex flex-col items-end gap-1">
+            {badges.map((c) => (
+              <DeltaBadge key={c.tipo} comparacion={c} />
+            ))}
+          </div>
+        )}
+      </div>
+
+      <div>
+        {sinDato ? (
+          <p className="text-xl font-semibold text-muted-foreground tabular-nums">—</p>
+        ) : (
+          <p className="text-xl font-bold tabular-nums tracking-tight">{valor}</p>
+        )}
+        <p className="mt-0.5 text-sm font-medium text-muted-foreground">{titulo}</p>
+
+        {sinDato && notaSinDato && (
+          <p className="mt-1 text-xs italic text-muted-foreground">{notaSinDato}</p>
+        )}
+
+        {!sinDato &&
+          (comparaciones ?? []).map((c) => (
+            <p key={`${c.tipo}-valor`} className="mt-1 text-xs text-muted-foreground">
+              {c.valorFormateado}
+            </p>
+          ))}
+      </div>
+    </Card>
+  );
+}
+
+/**
+ * El signo del delta no decide el color por sí solo: subir el costo es malo, subir la eficiencia
+ * es bueno. `invertido` lo dice explícitamente en vez de dejarlo a una heurística por título.
+ */
+function DeltaBadge({ comparacion }: { comparacion: KPIComparacion }) {
+  const { delta, invertido = false, etiqueta } = comparacion;
+  if (delta === undefined) return null;
+
+  const sube = delta > 0;
+  const esBueno = invertido ? !sube : sube;
+  const Icono = sube ? TrendingUp : TrendingDown;
+
+  return (
+    <span
+      className={cn(
+        'inline-flex items-center gap-1 text-xs font-semibold tabular-nums',
+        esBueno ? 'text-success' : 'text-destructive',
+      )}
+      title={`${etiqueta}: ${formatearPorcentajeConSigno(delta)}`}
+    >
+      <Icono className="size-3" aria-hidden="true" />
+      {formatearPorcentajeConSigno(delta)}
+    </span>
+  );
+}

--- a/src/components/shared/FormDraftBanner.tsx
+++ b/src/components/shared/FormDraftBanner.tsx
@@ -39,7 +39,7 @@ export function FormDraftBanner({ variant, onRestore, onDiscard, show }: FormDra
     <div className="mb-4 flex items-center gap-3 bg-amber-50 border border-amber-200 rounded-xl px-4 py-3">
       <AlertTriangle className="w-5 h-5 text-amber-600 flex-shrink-0" />
       <span className="text-sm text-amber-800 flex-1">
-        Tienes datos sin guardar de una sesion anterior.
+        Tienes datos sin guardar de una sesión anterior.
       </span>
       <Button
         size="sm"

--- a/src/components/ui/alert.tsx
+++ b/src/components/ui/alert.tsx
@@ -11,6 +11,8 @@ const alertVariants = cva(
         default: "bg-card text-card-foreground",
         destructive:
           "text-destructive bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-destructive/90",
+        warning:
+          "text-warning bg-card [&>svg]:text-current *:data-[slot=alert-description]:text-warning/90",
       },
     },
     defaultVariants: {

--- a/src/components/ui/button-group.tsx
+++ b/src/components/ui/button-group.tsx
@@ -1,0 +1,83 @@
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot"
+
+import { cn } from "./utils"
+import { Separator } from "./separator"
+
+const buttonGroupVariants = cva(
+  "flex w-fit items-stretch has-[>[data-slot=button-group]]:gap-2 [&>*]:focus-visible:relative [&>*]:focus-visible:z-10 has-[select[aria-hidden=true]:last-child]:[&>[data-slot=select-trigger]:last-of-type]:rounded-r-md [&>[data-slot=select-trigger]:not([class*='w-'])]:w-fit [&>input]:flex-1",
+  {
+    variants: {
+      orientation: {
+        horizontal:
+          "[&>*:not(:first-child)]:rounded-l-none [&>*:not(:first-child)]:border-l-0 [&>*:not(:last-child)]:rounded-r-none",
+        vertical:
+          "flex-col [&>*:not(:first-child)]:rounded-t-none [&>*:not(:first-child)]:border-t-0 [&>*:not(:last-child)]:rounded-b-none",
+      },
+    },
+    defaultVariants: {
+      orientation: "horizontal",
+    },
+  }
+)
+
+function ButtonGroup({
+  className,
+  orientation,
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof buttonGroupVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="button-group"
+      data-orientation={orientation}
+      className={cn(buttonGroupVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupText({
+  className,
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> & {
+  asChild?: boolean
+}) {
+  const Comp = asChild ? Slot : "div"
+
+  return (
+    <Comp
+      className={cn(
+        "flex items-center gap-2 rounded-md border bg-muted px-4 text-sm font-medium shadow-xs [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ButtonGroupSeparator({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="button-group-separator"
+      orientation={orientation}
+      className={cn(
+        "relative m-0! self-stretch bg-input data-[orientation=vertical]:h-auto",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  ButtonGroup,
+  ButtonGroupSeparator,
+  ButtonGroupText,
+  buttonGroupVariants,
+}

--- a/src/components/ui/empty.tsx
+++ b/src/components/ui/empty.tsx
@@ -1,0 +1,104 @@
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "./utils"
+
+function Empty({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty"
+      className={cn(
+        "flex min-w-0 flex-1 flex-col items-center justify-center gap-6 rounded-lg border-dashed p-6 text-center text-balance md:p-12",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-header"
+      className={cn(
+        "flex max-w-sm flex-col items-center gap-2 text-center",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const emptyMediaVariants = cva(
+  "mb-2 flex shrink-0 items-center justify-center [&_svg]:pointer-events-none [&_svg]:shrink-0",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "flex size-10 shrink-0 items-center justify-center rounded-lg bg-muted text-foreground [&_svg:not([class*='size-'])]:size-6",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function EmptyMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof emptyMediaVariants>) {
+  return (
+    <div
+      data-slot="empty-icon"
+      data-variant={variant}
+      className={cn(emptyMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function EmptyTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-title"
+      className={cn("text-lg font-medium tracking-tight", className)}
+      {...props}
+    />
+  )
+}
+
+function EmptyDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <div
+      data-slot="empty-description"
+      className={cn(
+        "text-sm/relaxed text-muted-foreground [&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function EmptyContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="empty-content"
+      className={cn(
+        "flex w-full max-w-sm min-w-0 flex-col items-center gap-4 text-sm text-balance",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Empty,
+  EmptyHeader,
+  EmptyTitle,
+  EmptyDescription,
+  EmptyContent,
+  EmptyMedia,
+}

--- a/src/components/ui/field.tsx
+++ b/src/components/ui/field.tsx
@@ -1,0 +1,248 @@
+"use client"
+
+import { useMemo } from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "./utils"
+import { Label } from "./label"
+import { Separator } from "./separator"
+
+function FieldSet({ className, ...props }: React.ComponentProps<"fieldset">) {
+  return (
+    <fieldset
+      data-slot="field-set"
+      className={cn(
+        "flex flex-col gap-6",
+        "has-[>[data-slot=checkbox-group]]:gap-3 has-[>[data-slot=radio-group]]:gap-3",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLegend({
+  className,
+  variant = "legend",
+  ...props
+}: React.ComponentProps<"legend"> & { variant?: "legend" | "label" }) {
+  return (
+    <legend
+      data-slot="field-legend"
+      data-variant={variant}
+      className={cn(
+        "mb-3 font-medium",
+        "data-[variant=legend]:text-base",
+        "data-[variant=label]:text-sm",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-group"
+      className={cn(
+        "group/field-group @container/field-group flex w-full flex-col gap-7 data-[slot=checkbox-group]:gap-3 [&>[data-slot=field-group]]:gap-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const fieldVariants = cva(
+  "group/field flex w-full gap-3 data-[invalid=true]:text-destructive",
+  {
+    variants: {
+      orientation: {
+        vertical: ["flex-col [&>*]:w-full [&>.sr-only]:w-auto"],
+        horizontal: [
+          "flex-row items-center",
+          "[&>[data-slot=field-label]]:flex-auto",
+          "has-[>[data-slot=field-content]]:items-start has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+        responsive: [
+          "flex-col @md/field-group:flex-row @md/field-group:items-center [&>*]:w-full @md/field-group:[&>*]:w-auto [&>.sr-only]:w-auto",
+          "@md/field-group:[&>[data-slot=field-label]]:flex-auto",
+          "@md/field-group:has-[>[data-slot=field-content]]:items-start @md/field-group:has-[>[data-slot=field-content]]:[&>[role=checkbox],[role=radio]]:mt-px",
+        ],
+      },
+    },
+    defaultVariants: {
+      orientation: "vertical",
+    },
+  }
+)
+
+function Field({
+  className,
+  orientation = "vertical",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof fieldVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="field"
+      data-orientation={orientation}
+      className={cn(fieldVariants({ orientation }), className)}
+      {...props}
+    />
+  )
+}
+
+function FieldContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-content"
+      className={cn(
+        "group/field-content flex flex-1 flex-col gap-1.5 leading-snug",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldLabel({
+  className,
+  ...props
+}: React.ComponentProps<typeof Label>) {
+  return (
+    <Label
+      data-slot="field-label"
+      className={cn(
+        "group/field-label peer/field-label flex w-fit gap-2 leading-snug group-data-[disabled=true]/field:opacity-50",
+        "has-[>[data-slot=field]]:w-full has-[>[data-slot=field]]:flex-col has-[>[data-slot=field]]:rounded-md has-[>[data-slot=field]]:border [&>*]:data-[slot=field]:p-4",
+        "has-data-[state=checked]:border-primary has-data-[state=checked]:bg-primary/5 dark:has-data-[state=checked]:bg-primary/10",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="field-label"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium group-data-[disabled=true]/field:opacity-50",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="field-description"
+      className={cn(
+        "text-sm leading-normal font-normal text-muted-foreground group-has-[[data-orientation=horizontal]]/field:text-balance",
+        "last:mt-0 nth-last-2:-mt-1 [[data-variant=legend]+&]:-mt-1.5",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function FieldSeparator({
+  children,
+  className,
+  ...props
+}: React.ComponentProps<"div"> & {
+  children?: React.ReactNode
+}) {
+  return (
+    <div
+      data-slot="field-separator"
+      data-content={!!children}
+      className={cn(
+        "relative -my-2 h-5 text-sm group-data-[variant=outline]/field-group:-mb-2",
+        className
+      )}
+      {...props}
+    >
+      <Separator className="absolute inset-0 top-1/2" />
+      {children && (
+        <span
+          className="relative mx-auto block w-fit bg-background px-2 text-muted-foreground"
+          data-slot="field-separator-content"
+        >
+          {children}
+        </span>
+      )}
+    </div>
+  )
+}
+
+function FieldError({
+  className,
+  children,
+  errors,
+  ...props
+}: React.ComponentProps<"div"> & {
+  errors?: Array<{ message?: string } | undefined>
+}) {
+  const content = useMemo(() => {
+    if (children) {
+      return children
+    }
+
+    if (!errors?.length) {
+      return null
+    }
+
+    const uniqueErrors = [
+      ...new Map(errors.map((error) => [error?.message, error])).values(),
+    ]
+
+    if (uniqueErrors?.length == 1) {
+      return uniqueErrors[0]?.message
+    }
+
+    return (
+      <ul className="ml-4 flex list-disc flex-col gap-1">
+        {uniqueErrors.map(
+          (error, index) =>
+            error?.message && <li key={index}>{error.message}</li>
+        )}
+      </ul>
+    )
+  }, [children, errors])
+
+  if (!content) {
+    return null
+  }
+
+  return (
+    <div
+      role="alert"
+      data-slot="field-error"
+      className={cn("text-sm font-normal text-destructive", className)}
+      {...props}
+    >
+      {content}
+    </div>
+  )
+}
+
+export {
+  Field,
+  FieldLabel,
+  FieldDescription,
+  FieldError,
+  FieldGroup,
+  FieldLegend,
+  FieldSeparator,
+  FieldSet,
+  FieldContent,
+  FieldTitle,
+}

--- a/src/components/ui/input-group.tsx
+++ b/src/components/ui/input-group.tsx
@@ -1,0 +1,170 @@
+"use client"
+
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+
+import { cn } from "./utils"
+import { Button } from "./button"
+import { Input } from "./input"
+import { Textarea } from "./textarea"
+
+function InputGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="input-group"
+      role="group"
+      className={cn(
+        "group/input-group relative flex w-full items-center rounded-md border border-input shadow-xs transition-[color,box-shadow] outline-none dark:bg-input/30",
+        "h-9 min-w-0 has-[>textarea]:h-auto",
+
+        // Variants based on alignment.
+        "has-[>[data-align=inline-start]]:[&>input]:pl-2",
+        "has-[>[data-align=inline-end]]:[&>input]:pr-2",
+        "has-[>[data-align=block-start]]:h-auto has-[>[data-align=block-start]]:flex-col has-[>[data-align=block-start]]:[&>input]:pb-3",
+        "has-[>[data-align=block-end]]:h-auto has-[>[data-align=block-end]]:flex-col has-[>[data-align=block-end]]:[&>input]:pt-3",
+
+        // Focus state.
+        "has-[[data-slot=input-group-control]:focus-visible]:border-ring has-[[data-slot=input-group-control]:focus-visible]:ring-[3px] has-[[data-slot=input-group-control]:focus-visible]:ring-ring/50",
+
+        // Error state.
+        "has-[[data-slot][aria-invalid=true]]:border-destructive has-[[data-slot][aria-invalid=true]]:ring-destructive/20 dark:has-[[data-slot][aria-invalid=true]]:ring-destructive/40",
+
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+const inputGroupAddonVariants = cva(
+  "flex h-auto cursor-text items-center justify-center gap-2 py-1.5 text-sm font-medium text-muted-foreground select-none group-data-[disabled=true]/input-group:opacity-50 [&>kbd]:rounded-[calc(var(--radius)-5px)] [&>svg:not([class*='size-'])]:size-4",
+  {
+    variants: {
+      align: {
+        "inline-start":
+          "order-first pl-3 has-[>button]:ml-[-0.45rem] has-[>kbd]:ml-[-0.35rem]",
+        "inline-end":
+          "order-last pr-3 has-[>button]:mr-[-0.45rem] has-[>kbd]:mr-[-0.35rem]",
+        "block-start":
+          "order-first w-full justify-start px-3 pt-3 group-has-[>input]/input-group:pt-2.5 [.border-b]:pb-3",
+        "block-end":
+          "order-last w-full justify-start px-3 pb-3 group-has-[>input]/input-group:pb-2.5 [.border-t]:pt-3",
+      },
+    },
+    defaultVariants: {
+      align: "inline-start",
+    },
+  }
+)
+
+function InputGroupAddon({
+  className,
+  align = "inline-start",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof inputGroupAddonVariants>) {
+  return (
+    <div
+      role="group"
+      data-slot="input-group-addon"
+      data-align={align}
+      className={cn(inputGroupAddonVariants({ align }), className)}
+      onClick={(e) => {
+        if ((e.target as HTMLElement).closest("button")) {
+          return
+        }
+        e.currentTarget.parentElement?.querySelector("input")?.focus()
+      }}
+      {...props}
+    />
+  )
+}
+
+const inputGroupButtonVariants = cva(
+  "flex items-center gap-2 text-sm shadow-none",
+  {
+    variants: {
+      size: {
+        xs: "h-6 gap-1 rounded-[calc(var(--radius)-5px)] px-2 has-[>svg]:px-2 [&>svg:not([class*='size-'])]:size-3.5",
+        sm: "h-8 gap-1.5 rounded-md px-2.5 has-[>svg]:px-2.5",
+        "icon-xs":
+          "size-6 rounded-[calc(var(--radius)-5px)] p-0 has-[>svg]:p-0",
+        "icon-sm": "size-8 p-0 has-[>svg]:p-0",
+      },
+    },
+    defaultVariants: {
+      size: "xs",
+    },
+  }
+)
+
+function InputGroupButton({
+  className,
+  type = "button",
+  variant = "ghost",
+  size = "xs",
+  ...props
+}: Omit<React.ComponentProps<typeof Button>, "size"> &
+  VariantProps<typeof inputGroupButtonVariants>) {
+  return (
+    <Button
+      type={type}
+      data-size={size}
+      variant={variant}
+      className={cn(inputGroupButtonVariants({ size }), className)}
+      {...props}
+    />
+  )
+}
+
+function InputGroupText({ className, ...props }: React.ComponentProps<"span">) {
+  return (
+    <span
+      className={cn(
+        "flex items-center gap-2 text-sm text-muted-foreground [&_svg]:pointer-events-none [&_svg:not([class*='size-'])]:size-4",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupInput({
+  className,
+  ...props
+}: React.ComponentProps<"input">) {
+  return (
+    <Input
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 rounded-none border-0 bg-transparent shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function InputGroupTextarea({
+  className,
+  ...props
+}: React.ComponentProps<"textarea">) {
+  return (
+    <Textarea
+      data-slot="input-group-control"
+      className={cn(
+        "flex-1 resize-none rounded-none border-0 bg-transparent py-3 shadow-none focus-visible:ring-0 dark:bg-transparent",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  InputGroup,
+  InputGroupAddon,
+  InputGroupButton,
+  InputGroupText,
+  InputGroupInput,
+  InputGroupTextarea,
+}

--- a/src/components/ui/item.tsx
+++ b/src/components/ui/item.tsx
@@ -1,0 +1,193 @@
+import * as React from "react"
+import { cva, type VariantProps } from "class-variance-authority"
+import { Slot } from "@radix-ui/react-slot"
+
+import { cn } from "./utils"
+import { Separator } from "./separator"
+
+function ItemGroup({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      role="list"
+      data-slot="item-group"
+      className={cn("group/item-group flex flex-col", className)}
+      {...props}
+    />
+  )
+}
+
+function ItemSeparator({
+  className,
+  ...props
+}: React.ComponentProps<typeof Separator>) {
+  return (
+    <Separator
+      data-slot="item-separator"
+      orientation="horizontal"
+      className={cn("my-0", className)}
+      {...props}
+    />
+  )
+}
+
+const itemVariants = cva(
+  "group/item flex flex-wrap items-center rounded-md border border-transparent text-sm transition-colors duration-100 outline-none focus-visible:border-ring focus-visible:ring-[3px] focus-visible:ring-ring/50 [a]:transition-colors [a]:hover:bg-accent/50",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        outline: "border-border",
+        muted: "bg-muted/50",
+      },
+      size: {
+        default: "gap-4 p-4",
+        sm: "gap-2.5 px-4 py-3",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+      size: "default",
+    },
+  }
+)
+
+function Item({
+  className,
+  variant = "default",
+  size = "default",
+  asChild = false,
+  ...props
+}: React.ComponentProps<"div"> &
+  VariantProps<typeof itemVariants> & { asChild?: boolean }) {
+  const Comp = asChild ? Slot : "div"
+  return (
+    <Comp
+      data-slot="item"
+      data-variant={variant}
+      data-size={size}
+      className={cn(itemVariants({ variant, size, className }))}
+      {...props}
+    />
+  )
+}
+
+const itemMediaVariants = cva(
+  "flex shrink-0 items-center justify-center gap-2 group-has-[[data-slot=item-description]]/item:translate-y-0.5 group-has-[[data-slot=item-description]]/item:self-start [&_svg]:pointer-events-none",
+  {
+    variants: {
+      variant: {
+        default: "bg-transparent",
+        icon: "size-8 rounded-sm border bg-muted [&_svg:not([class*='size-'])]:size-4",
+        image:
+          "size-10 overflow-hidden rounded-sm [&_img]:size-full [&_img]:object-cover",
+      },
+    },
+    defaultVariants: {
+      variant: "default",
+    },
+  }
+)
+
+function ItemMedia({
+  className,
+  variant = "default",
+  ...props
+}: React.ComponentProps<"div"> & VariantProps<typeof itemMediaVariants>) {
+  return (
+    <div
+      data-slot="item-media"
+      data-variant={variant}
+      className={cn(itemMediaVariants({ variant, className }))}
+      {...props}
+    />
+  )
+}
+
+function ItemContent({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-content"
+      className={cn(
+        "flex flex-1 flex-col gap-1 [&+[data-slot=item-content]]:flex-none",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemTitle({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-title"
+      className={cn(
+        "flex w-fit items-center gap-2 text-sm leading-snug font-medium",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemDescription({ className, ...props }: React.ComponentProps<"p">) {
+  return (
+    <p
+      data-slot="item-description"
+      className={cn(
+        "line-clamp-2 text-sm leading-normal font-normal text-balance text-muted-foreground",
+        "[&>a]:underline [&>a]:underline-offset-4 [&>a:hover]:text-primary",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemActions({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-actions"
+      className={cn("flex items-center gap-2", className)}
+      {...props}
+    />
+  )
+}
+
+function ItemHeader({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-header"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+function ItemFooter({ className, ...props }: React.ComponentProps<"div">) {
+  return (
+    <div
+      data-slot="item-footer"
+      className={cn(
+        "flex basis-full items-center justify-between gap-2",
+        className
+      )}
+      {...props}
+    />
+  )
+}
+
+export {
+  Item,
+  ItemMedia,
+  ItemContent,
+  ItemActions,
+  ItemGroup,
+  ItemSeparator,
+  ItemTitle,
+  ItemDescription,
+  ItemHeader,
+  ItemFooter,
+}

--- a/src/components/ui/spinner.tsx
+++ b/src/components/ui/spinner.tsx
@@ -1,0 +1,16 @@
+import { Loader2Icon } from "lucide-react"
+
+import { cn } from "./utils"
+
+function Spinner({ className, ...props }: React.ComponentProps<"svg">) {
+  return (
+    <Loader2Icon
+      role="status"
+      aria-label="Cargando"
+      className={cn("size-4 animate-spin", className)}
+      {...props}
+    />
+  )
+}
+
+export { Spinner }

--- a/src/hooks/useReporteAplicacion.ts
+++ b/src/hooks/useReporteAplicacion.ts
@@ -544,6 +544,82 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                 });
             });
 
+            // Real plan source: `aplicaciones_lotes_planificado` has 0 rows and always has (see
+            // CLAUDE.md, "Applications Data Architecture" / D6) — the loop above never runs.
+            // `aplicaciones_calculos` is the actual snapshot the Calculadora wrote per lote when
+            // the application was planned (`numero_canecas`/`litros_mezcla`, or
+            // `numero_bultos`/`kilos_totales` for Fertilización — same field split the real-data
+            // aggregation above uses), and this hook already fetches it. 4 of 20 closed
+            // applications have no `aplicaciones_calculos` rows (the calculator was never run for
+            // them); those fall straight through to Fallback A/B below with plan left at 0/absent
+            // — never fabricated.
+            const calculosRows: any[] = appData.aplicaciones_calculos || [];
+            if (lotesPlanMap.size === 0 && calculosRows.length > 0) {
+                const esFertilizacionCalc = appData.tipo_aplicacion === 'Fertilización';
+
+                calculosRows.forEach((calc: any) => {
+                    const loteId = calc.lote_id;
+                    const canecas = esFertilizacionCalc
+                        ? Number(calc.numero_bultos || 0)
+                        : Number(calc.numero_canecas || 0);
+                    const litros = esFertilizacionCalc
+                        ? Number(calc.kilos_totales || 0)
+                        : Number(calc.litros_mezcla || 0);
+
+                    lotesPlanMap.set(loteId, {
+                        lote_id: loteId,
+                        canecas_plan: canecas,
+                        litros_plan: litros,
+                        jornales_plan: jornalesPlanLote(calc.total_arboles)
+                    });
+                });
+
+                // Per-product plan: `aplicaciones_productos.cantidad_total_necesaria` is a total
+                // for the MEZCLA, not per lote — when 2+ lotes share the same `mezcla_id` (via
+                // `aplicaciones_calculos.mezcla_id`, the canonical mezcla↔lote mapping — see
+                // CalculadoraAplicaciones.tsx step 5b), split it across those lotes proportionally
+                // to each lote's planned canecas/bultos share (the same real per-lote weight just
+                // computed above), so the totals still sum to `cantidad_total_necesaria` exactly
+                // and nothing is double-counted. Falls back to an equal split only if every lote
+                // sharing that mezcla reads 0 canecas, so a product never silently disappears.
+                const lotesPorMezcla = new Map<string, { lote_id: string; peso: number }[]>();
+                calculosRows.forEach((calc: any) => {
+                    if (!calc.mezcla_id) return;
+                    const arr = lotesPorMezcla.get(calc.mezcla_id) || [];
+                    arr.push({ lote_id: calc.lote_id, peso: lotesPlanMap.get(calc.lote_id)?.canecas_plan || 0 });
+                    lotesPorMezcla.set(calc.mezcla_id, arr);
+                });
+
+                lotesPorMezcla.forEach((lotesDeEstaMezcla, mezclaId) => {
+                    const prods = mezclasProductos.filter((mp: any) => mp.mezcla_id === mezclaId);
+                    if (prods.length === 0) return;
+
+                    const pesoTotal = lotesDeEstaMezcla.reduce((sum, l) => sum + l.peso, 0);
+
+                    prods.forEach((mp: any) => {
+                        const cantidadTotal = Number(mp.cantidad_total_necesaria || 0);
+                        const precio = Number(mp.precio_unitario || 0);
+
+                        lotesDeEstaMezcla.forEach(({ lote_id: loteId, peso }) => {
+                            const fraccion = pesoTotal > 0 ? peso / pesoTotal : 1 / lotesDeEstaMezcla.length;
+                            const cantidad = cantidadTotal * fraccion;
+                            const costo = cantidad * precio;
+
+                            costoProductosPlanTotal += costo;
+
+                            const key = `${loteId}-${mp.producto_id}`;
+                            productosPlanMap.set(key, {
+                                lote_id: loteId,
+                                producto_id: mp.producto_id,
+                                nombre: mp.producto_nombre,
+                                cantidad_plan: cantidad,
+                                costo_plan: costo
+                            });
+                        });
+                    });
+                });
+            }
+
             // Fallback A: when lotesPlanMap is empty but mezclas exist,
             // compute per-lote planned bultos from mezcla product dosis × tree sizes
             if (lotesPlanMap.size === 0 && mezclasProductos.length > 0) {
@@ -962,19 +1038,34 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                         desviacion: 0,
                         cambio: 0
                     },
+                    // `costo_total` y `costo_por_arbol` NO llevan plan, a propósito.
+                    //
+                    // `totalCostoReal` es insumos + mano de obra, pero el único plan que existe es
+                    // el de insumos (`costoProductosPlanTotal`); no hay plan de jornales guardado
+                    // en ninguna parte — `costo_jornales.planeado` es 0 justo arriba. Compararlos
+                    // es un error de categoría: da "+138,1%" para una aplicación cuyo consumo de
+                    // insumos se desvió +0,4%. El código venía marcando esa línea como
+                    // "// Rough comparison" desde antes.
+                    //
+                    // Mientras `aplicaciones_lotes_planificado` estuvo vacía esto no se notaba: el
+                    // plan era 0 y salía el +100% falso de D2. Al traer el plan real desde
+                    // `aplicaciones_calculos`, la cifra pasó a ser plausible y equivocada, que es
+                    // peor. Sin plan de mano de obra no hay plan de costo total — y la regla del
+                    // proyecto es no inventar la comparación: `planeado: 0` hace que KPICard omita
+                    // el badge y la tabla muestre "—".
+                    // `costo_productos` sí conserva su plan: ahí sí se comparan insumos con insumos.
                     costo_total: {
                         real: totalCostoReal,
-                        planeado: costoProductosPlanTotal,
-                        desviacion: calcularCambio(totalCostoReal, costoProductosPlanTotal),
+                        planeado: 0,
+                        desviacion: undefined,
                         cambio: 0
                     },
                     costo_por_arbol: (() => {
                         const real = safeDivide(totalCostoReal, totalArbolesApp);
-                        const planeado = safeDivide(costoProductosPlanTotal, totalArbolesApp);
                         return {
                             real,
-                            planeado,
-                            desviacion: calcularCambio(real, planeado),
+                            planeado: 0,
+                            desviacion: undefined,
                             cambio: 0
                         };
                     })()

--- a/src/hooks/useReporteAplicacion.ts
+++ b/src/hooks/useReporteAplicacion.ts
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { getSupabase } from '../utils/supabase/client';
 import {
+    calcularCambio,
     calcularDesviacion,
     convertirCanecasALitros,
     formatearDesviacion,
@@ -20,7 +21,11 @@ interface KPICardData {
 interface ComparisonField {
     real: number;
     planeado: number;
-    desviacion: number;
+    // D2 fix (5 call sites, see below): `undefined` = no hay base de comparación
+    // (planeado ausente o 0) — nunca se fabrica un +100%. Los sitios que todavía
+    // usan `calcularDesviacion` (per-lote / per-producto) siguen devolviendo
+    // `number`, que es un subtipo válido de `number | undefined`.
+    desviacion: number | undefined;
 }
 
 interface CanecasPorLote {
@@ -58,7 +63,8 @@ interface DatosGraficoCostos {
 interface FinancieroField {
     real: number;
     planeado: number;
-    desviacion: number;
+    // D2 fix — ver la misma nota en ComparisonField.
+    desviacion: number | undefined;
     cambio: number;
 }
 
@@ -792,8 +798,11 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                 totales: {
                     lote_id: '',
                     lote_nombre: 'Total',
-                    canecas: { real: totalCanecasReal, planeado: totalCanecasPlan, desviacion: calcularDesviacion(totalCanecasPlan, totalCanecasReal) },
-                    litros_totales: { real: totalLitrosReal, planeado: totalLitrosPlan, desviacion: calcularDesviacion(totalLitrosPlan, totalLitrosReal) }
+                    // D2 fix (1/5, 2/5): calcularCambio devuelve undefined cuando planeado es 0/ausente
+                    // — nunca un +100% fabricado. aplicaciones_lotes_planificado está vacía hoy, así que
+                    // esto es el caso normal, no la excepción (decisión 4 del contrato, CLAUDE.md D2).
+                    canecas: { real: totalCanecasReal, planeado: totalCanecasPlan, desviacion: calcularCambio(totalCanecasReal, totalCanecasPlan) },
+                    litros_totales: { real: totalLitrosReal, planeado: totalLitrosPlan, desviacion: calcularCambio(totalLitrosReal, totalLitrosPlan) }
                 } as CanecasPorLote,
                 por_lote: Array.from(lotesRealMap.values()).map(l => {
                     const planLote = lotesPlanMap.get(l.lote_id);
@@ -938,11 +947,13 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                     };
                 })(),
                 alertas: [],
+                // D2 fix (3/5, 4/5, 5/5): mismo cambio que arriba, aplicado a los totales
+                // financieros que alimentan directamente las 4 tarjetas KPI del Reporte.
                 financiero: {
                     costo_productos: {
                         real: totalCostoProductosReal,
                         planeado: costoProductosPlanTotal,
-                        desviacion: calcularDesviacion(costoProductosPlanTotal, totalCostoProductosReal),
+                        desviacion: calcularCambio(totalCostoProductosReal, costoProductosPlanTotal),
                         cambio: 0
                     },
                     costo_jornales: {
@@ -954,7 +965,7 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                     costo_total: {
                         real: totalCostoReal,
                         planeado: costoProductosPlanTotal,
-                        desviacion: calcularDesviacion(costoProductosPlanTotal, totalCostoReal),
+                        desviacion: calcularCambio(totalCostoReal, costoProductosPlanTotal),
                         cambio: 0
                     },
                     costo_por_arbol: (() => {
@@ -963,7 +974,7 @@ export function useReporteAplicacion(aplicacionId: string): UseReporteAplicacion
                         return {
                             real,
                             planeado,
-                            desviacion: calcularDesviacion(planeado, real),
+                            desviacion: calcularCambio(real, planeado),
                             cambio: 0
                         };
                     })()

--- a/src/styles/globals.css
+++ b/src/styles/globals.css
@@ -64,7 +64,14 @@
   --success: #73991C;
   --success-foreground: #ffffff;
   --border: rgba(115, 153, 28, 0.1);
-  --input: transparent;
+  /* Antes: `transparent`. `input.tsx` pinta `border-input` sobre `bg-input-background` (#ffffff),
+     así que todo Input quedaba blanco con borde invisible: se lee como campo sobre el fondo
+     off-white de la página (#F8FAF5), pero desaparece dentro de una Card blanca — que es donde
+     viven casi todos los formularios. En la misma pantalla, DateInput sí trae su propio borde
+     (`border-primary/20`), así que dos campos vecinos se veían distintos sin motivo.
+     Se le da el olivo de marca con algo más de peso que --border, que está calibrado para
+     separadores, no para bordes de campo. */
+  --input: rgba(115, 153, 28, 0.22);
   --input-background: #ffffff;
   --switch-background: #BFD97D;
   --font-weight-medium: 500;

--- a/src/types/aplicaciones.ts
+++ b/src/types/aplicaciones.ts
@@ -130,8 +130,11 @@ export interface ListaCompras {
 }
 
 // Estado completo de la calculadora
+// W01 v2 (2026-08-20): 3 pasos -> 2 ("Plan" fusiona Configuración+Mezcla, "Lista de
+// Compras" se mantiene). Único consumidor de este campo fuera de este archivo es
+// CalculadoraAplicaciones.tsx — verificado antes de reducir el tipo.
 export interface EstadoCalculadora {
-  paso_actual: 1 | 2 | 3;
+  paso_actual: 1 | 2;
   configuracion: ConfiguracionAplicacion | null;
   mezclas: Mezcla[];
   calculos: CalculosPorLote[];

--- a/src/utils/calculadoraAplicacionesHelpers.ts
+++ b/src/utils/calculadoraAplicacionesHelpers.ts
@@ -1,0 +1,85 @@
+// utils/calculadoraAplicacionesHelpers.ts
+// Ayudas puras del rediseño estructural W01 v2 de la Calculadora de Aplicaciones
+// (docs/../W01-calculadora-v2.md, campos #1 y #4). No toca calculosAplicaciones.ts —
+// esa es la lógica de dominio de dosis/canecas/bultos; esto es únicamente texto/fecha
+// de conveniencia para el "Plan" de una aplicación.
+
+import type { TipoAplicacionLocal } from '../types/aplicaciones';
+
+const MESES_CORTOS = [
+  'ene', 'feb', 'mar', 'abr', 'may', 'jun',
+  'jul', 'ago', 'sep', 'oct', 'nov', 'dic',
+];
+
+const ETIQUETA_TIPO: Record<TipoAplicacionLocal, string> = {
+  fumigacion: 'Fumigación',
+  fertilizacion: 'Fertilización',
+  drench: 'Drench',
+};
+
+/**
+ * Sugiere un nombre para la aplicación a partir de lo que ya se decidió arriba en el
+ * formulario (tipo, cuántos lotes, mes/año de inicio) — campo #1 de la auditoría de W01 v2.
+ * Nunca lanza ni asume: cualquier segmento sin dato todavía se omite en vez de mostrar un
+ * placeholder inventado ("undefined lotes", "Invalid Date", etc.).
+ *
+ * Ejemplo real: sugerirNombreAplicacion('fertilizacion', 4, '2026-08-18')
+ *   -> "Fertilización · 4 lotes · ago 2026"
+ */
+export function sugerirNombreAplicacion(
+  tipo: TipoAplicacionLocal | undefined,
+  numLotes: number,
+  fechaInicioISO: string,
+): string {
+  const partes: string[] = [];
+
+  if (tipo) {
+    partes.push(ETIQUETA_TIPO[tipo]);
+  }
+
+  if (numLotes > 0) {
+    partes.push(numLotes === 1 ? '1 lote' : `${numLotes} lotes`);
+  }
+
+  if (fechaInicioISO && /^\d{4}-\d{2}-\d{2}$/.test(fechaInicioISO)) {
+    const [anio, mesStr] = fechaInicioISO.split('-');
+    const mesIndex = parseInt(mesStr, 10) - 1;
+    if (mesIndex >= 0 && mesIndex < 12) {
+      partes.push(`${MESES_CORTOS[mesIndex]} ${anio}`);
+    }
+  }
+
+  return partes.join(' · ');
+}
+
+/**
+ * Sugiere `fecha_fin_planeada` como `fecha_inicio_planeada` + 1 mes calendario, en hora
+ * LOCAL (nunca UTC — ver la regla de CLAUDE.md sobre `obtenerFechaHoy()`). Heurística
+ * marcada como "a confirmar con el dueño" en el diseño (campo #4 de la auditoría); coincide
+ * con el único dato real disponible (18/08 -> 18/09, 31 días exactos).
+ *
+ * Si el día de inicio no existe en el mes destino (ej. 31 de enero -> febrero), cae al
+ * último día de ese mes en vez de desbordar a marzo — mismo comportamiento que la mayoría
+ * de calendarios, y evita que "fin" caiga después del mes siguiente por sorpresa.
+ */
+export function sugerirFechaFin(fechaInicioISO: string): string {
+  if (!fechaInicioISO || !/^\d{4}-\d{2}-\d{2}$/.test(fechaInicioISO)) return '';
+
+  const [anioStr, mesStr, diaStr] = fechaInicioISO.split('-');
+  const anio = parseInt(anioStr, 10);
+  const mes = parseInt(mesStr, 10) - 1; // 0-indexed
+  const dia = parseInt(diaStr, 10);
+
+  // Día 0 del mes siguiente-siguiente = último día del mes destino. Construir la fecha
+  // objetivo primero y comparar contra ese tope evita el desborde de `new Date(y, m, d)`
+  // cuando `d` no existe en el mes destino (JS normaliza en vez de fallar).
+  const ultimoDiaMesDestino = new Date(anio, mes + 2, 0).getDate();
+  const diaFinal = Math.min(dia, ultimoDiaMesDestino);
+
+  const fechaFin = new Date(anio, mes + 1, diaFinal);
+
+  const y = fechaFin.getFullYear();
+  const m = String(fechaFin.getMonth() + 1).padStart(2, '0');
+  const d = String(fechaFin.getDate()).padStart(2, '0');
+  return `${y}-${m}-${d}`;
+}

--- a/src/utils/calculosCierreAplicacion.ts
+++ b/src/utils/calculosCierreAplicacion.ts
@@ -1,0 +1,237 @@
+/**
+ * Lógica pura del rediseño W03 v2 (Cierre de Aplicación) — `docs/…/W03-cierre-v2.md`.
+ *
+ * Ninguna de estas funciones toca Supabase ni JSX: reciben datos ya cargados por
+ * `cargarDatos()`/`fetchRegistrosTrabajoParaCierre` (en `CierreAplicacion.tsx` y
+ * `laborCosts.ts`, ninguno de los dos tocado aquí) y devuelven derivaciones puras,
+ * siguiendo la regla de CLAUDE.md de que la lógica de negocio vive en `src/utils/calculos*.ts`,
+ * no inline en el componente.
+ */
+
+import type { RegistroTrabajoCierre } from '@/types/aplicaciones';
+
+/** Opciones de fracción de jornal — sin cambios respecto a la pantalla original, solo movida
+ * aquí para que el `Select` de la tabla y el del formulario "Agregar registro" (dos archivos
+ * distintos tras el split) compartan una única fuente. */
+export const FRACCION_OPTIONS = [0.25, 0.5, 0.75, 1.0, 1.5, 2.0] as const;
+
+// ---------------------------------------------------------------------------------------------
+// Insumos — desviación planeado vs. aplicado
+// ---------------------------------------------------------------------------------------------
+
+export interface InsumoInput {
+  nombre: string;
+  unidad: string;
+  planeado: number;
+  aplicado: number;
+}
+
+export interface InsumoConDesviacion extends InsumoInput {
+  diferencia: number;
+  /** Mismo criterio que el módulo ya usaba antes de v2: no se cambia. */
+  esCritico: boolean;
+}
+
+/**
+ * `planeado === 0` nunca es "crítico" — regla heredada intacta de la pantalla original
+ * (`CierreAplicacion.tsx` antes de este rediseño). Cambiarla sería una decisión de negocio,
+ * no de superficie, y está fuera del alcance de W03 v2.
+ */
+export function calcularDesviacionInsumo(
+  insumo: Pick<InsumoInput, 'planeado' | 'aplicado'>,
+): { diferencia: number; esCritico: boolean } {
+  const diferencia = insumo.aplicado - insumo.planeado;
+  const esCritico = insumo.planeado > 0 && Math.abs(diferencia / insumo.planeado) > 0.15;
+  return { diferencia, esCritico };
+}
+
+export function calcularInsumosConDesviacion(insumos: InsumoInput[]): InsumoConDesviacion[] {
+  return insumos.map((insumo) => ({ ...insumo, ...calcularDesviacionInsumo(insumo) }));
+}
+
+// ---------------------------------------------------------------------------------------------
+// Fechas de ejecución real — deriva Fecha Inicio/Fin Real de los registros reales
+// ---------------------------------------------------------------------------------------------
+
+export type FuenteFechasEjecucion = 'registros' | 'movimientos' | 'combinado' | 'ninguna';
+
+export interface FechasEjecucionReal {
+  fechaInicio: string | null;
+  fechaFin: string | null;
+  fuente: FuenteFechasEjecucion;
+}
+
+/**
+ * Reemplaza la lógica ad hoc que antes vivía inline en `cargarDatos()`: Fecha Fin caía en
+ * `obtenerFechaHoy()` (el día en que se hace el papeleo, no el día en que terminó el trabajo) y
+ * Fecha Inicio solo se corregía si el campo estaba vacío, así que casi siempre se quedaba en la
+ * fecha PLANEADA. Acá se deriva siempre, de forma simétrica, de la unión de
+ * `registros_trabajo.fecha_trabajo` y `movimientos_diarios.fecha_movimiento` (recomendación de
+ * W03-cierre-v2.md §8.1 cuando no hay una opinión más fuerte: unión — nunca angosta lo que el
+ * usuario ya capturó).
+ *
+ * Nota de verificación (no de este código, del reporte de implementación): en producción 14 de
+ * 15 aplicaciones cerradas ya coinciden exactamente con el último movimiento — esto es una
+ * mejora de robustez hacia adelante, no una corrección de datos corruptos.
+ */
+export function derivarFechasEjecucionReal(
+  fechasRegistros: Array<string | null | undefined>,
+  fechasMovimientos: Array<string | null | undefined>,
+): FechasEjecucionReal {
+  const registrosValidas = fechasRegistros.filter((f): f is string => !!f).sort();
+  const movimientosValidas = fechasMovimientos.filter((f): f is string => !!f).sort();
+  const todas = [...registrosValidas, ...movimientosValidas].sort();
+
+  if (todas.length === 0) {
+    return { fechaInicio: null, fechaFin: null, fuente: 'ninguna' };
+  }
+
+  const fuente: FuenteFechasEjecucion =
+    registrosValidas.length > 0 && movimientosValidas.length > 0
+      ? 'combinado'
+      : registrosValidas.length > 0
+        ? 'registros'
+        : 'movimientos';
+
+  return {
+    fechaInicio: todas[0],
+    fechaFin: todas[todas.length - 1],
+    fuente,
+  };
+}
+
+// ---------------------------------------------------------------------------------------------
+// Agrupación de registros por lote y KPIs de labor — antes recalculados inline en cada render
+// ---------------------------------------------------------------------------------------------
+
+export interface RegistroPorLote {
+  lote_nombre: string;
+  registros: Array<RegistroTrabajoCierre & { _index: number }>;
+}
+
+/** Agrupa los registros ACTIVOS (no marcados `_deleted`) por `lote_id`, preservando el índice
+ * original de `registrosEditados` para que editar/eliminar por fila siga funcionando igual. */
+export function agruparRegistrosPorLote(
+  registrosEditados: RegistroTrabajoCierre[],
+): Map<string, RegistroPorLote> {
+  const porLote = new Map<string, RegistroPorLote>();
+  registrosEditados.forEach((r, index) => {
+    if (r._deleted) return;
+    const key = r.lote_id;
+    if (!porLote.has(key)) {
+      porLote.set(key, { lote_nombre: r.lote_nombre, registros: [] });
+    }
+    porLote.get(key)!.registros.push({ ...r, _index: index });
+  });
+  return porLote;
+}
+
+export interface KPIsLabores {
+  totalJornales: number;
+  costoManoObra: number;
+  trabajadoresUnicos: number;
+  diasTrabajados: number;
+}
+
+export function calcularKPIsLabores(registrosActivos: RegistroTrabajoCierre[]): KPIsLabores {
+  return {
+    totalJornales: registrosActivos.reduce((s, r) => s + r.fraccion_jornal, 0),
+    costoManoObra: registrosActivos.reduce((s, r) => s + r.costo_jornal, 0),
+    trabajadoresUnicos: new Set(registrosActivos.map((r) => r.empleado_id || r.contratista_id)).size,
+    diasTrabajados: new Set(registrosActivos.map((r) => r.fecha_trabajo)).size,
+  };
+}
+
+/**
+ * Une una lista de textos con coma, "y" antes del último — el formato de la lista de insumos
+ * del `AlertDialog` de confirmación ("Producto A, Producto B y Producto C"). Copia exacta que el
+ * dueño aprobó en v1 (`W03-cierre.md` §3), sin cambios en v2.
+ */
+export function formatearListaConY(items: string[]): string {
+  if (items.length === 0) return '';
+  if (items.length === 1) return items[0];
+  return `${items.slice(0, -1).join(', ')} y ${items[items.length - 1]}`;
+}
+
+// ---------------------------------------------------------------------------------------------
+// Panel "Atención requerida" — 3 señales que el sistema ya calculaba pero dejaba enterradas
+// ---------------------------------------------------------------------------------------------
+
+export interface LoteInput {
+  lote_id: string;
+  nombre: string;
+}
+
+export interface RegistroConLote {
+  lote_id: string;
+  lote_nombre: string;
+  trabajador_nombre: string;
+  costo_jornal: number;
+}
+
+export interface InsumoCriticoExcepcion {
+  nombre: string;
+  diferencia: number;
+  unidad: string;
+}
+
+export interface RegistroSinTarifaExcepcion {
+  lote_id: string;
+  lote_nombre: string;
+  trabajador_nombre: string;
+}
+
+export interface LoteSinLaborExcepcion {
+  lote_id: string;
+  nombre: string;
+}
+
+export interface ExcepcionesCierre {
+  insumosCriticos: InsumoCriticoExcepcion[];
+  registrosSinTarifa: RegistroSinTarifaExcepcion[];
+  lotesSinLabor: LoteSinLaborExcepcion[];
+}
+
+/**
+ * Las 3 señales de `W03-cierre-v2.md` §1.1 — ninguna requiere un fetch nuevo, las 3 se derivan
+ * de datos que `cargarDatos()` ya trae hoy:
+ *
+ * 1. Insumo con desviación crítica (>15%, mismo criterio que `calcularDesviacionInsumo`).
+ * 2. Registro de labor con `costo_jornal === 0` (falta tarifa asignada al trabajador).
+ * 3. Lote de la aplicación sin NINGÚN jornal registrado — antes invisible por omisión: si un
+ *    lote no tiene registros simplemente no aparece en `agruparRegistrosPorLote`.
+ *
+ * Dos guardas explícitas (riesgo #8 del documento de diseño), ambas para no inventar una
+ * excepción a partir de la ausencia de datos:
+ * - `tieneTarea === false` → NO se calcula `lotesSinLabor`. Sin tarea vinculada no hay
+ *   registros_trabajo por diseño (aplicaciones anteriores a la vinculación automática), y esa
+ *   ausencia ya tiene su propio aviso separado en la pantalla — repetirla lote por lote sería
+ *   ruido, no señal.
+ * - `lotes.length === 0` → NO se calcula `lotesSinLabor`. Si el fetch de lotes falló o llegó
+ *   vacío, todos los lotes se verían "sin labor" por falta de catálogo, no porque de verdad
+ *   falten jornales.
+ */
+export function calcularExcepcionesCierre(
+  insumos: InsumoInput[],
+  registrosActivos: RegistroConLote[],
+  lotes: LoteInput[],
+  tieneTarea: boolean,
+): ExcepcionesCierre {
+  const insumosCriticos: InsumoCriticoExcepcion[] = calcularInsumosConDesviacion(insumos)
+    .filter((i) => i.esCritico)
+    .map((i) => ({ nombre: i.nombre, diferencia: i.diferencia, unidad: i.unidad }));
+
+  const registrosSinTarifa: RegistroSinTarifaExcepcion[] = registrosActivos
+    .filter((r) => r.costo_jornal === 0)
+    .map((r) => ({ lote_id: r.lote_id, lote_nombre: r.lote_nombre, trabajador_nombre: r.trabajador_nombre }));
+
+  let lotesSinLabor: LoteSinLaborExcepcion[] = [];
+  if (tieneTarea && lotes.length > 0) {
+    const loteIdsConRegistro = new Set(registrosActivos.map((r) => r.lote_id));
+    lotesSinLabor = lotes
+      .filter((l) => !loteIdsConRegistro.has(l.lote_id))
+      .map((l) => ({ lote_id: l.lote_id, nombre: l.nombre }));
+  }
+
+  return { insumosCriticos, registrosSinTarifa, lotesSinLabor };
+}


### PR DESCRIPTION
Rediseño de los 5 workflows del módulo Aplicaciones sobre los primitivos de `src/components/ui/`, con los diseños aprobados uno por uno por el dueño. 44 archivos, +8.484 / −6.229.

## Los workflows

| | Cambio |
|---|---|
| **Lista** | Badge/botón/⋮ en un solo grupo alineado · `DropdownMenu` en vez de posicionar a mano · estados de vacío, carga y **error** (antes solo había `console.error`) |
| **Calculadora** | 3 pasos → 2 · 23 → 15 decisiones · con una sola mezcla los lotes se heredan en vez de pedirse dos veces |
| **Movimientos** | 11 movimientos colapsados en `Accordion` · **nunca un "100%" pelado cuando se excede** · `Sheet`/`Drawer` en vez de reemplazar el tablero |
| **Cierre** | De modal falso a página real · 3 pasos con compuerta → 1 página · ~10 → ~2 acciones forzadas · archivo de 1.500 líneas partido en secciones + lógica pura con 22 tests |
| **Reporte** | Escala tipográfica de 10 tamaños arbitrarios → 6 reales · columna Plan recuperada |

Los 5 modales `fixed inset-0` quedaron en **0**, con guarda estática y lista de excepciones vacía.

## Defectos de producción encontrados (ajenos al rediseño)

1. **El filtro de Tipo vaciaba la lista.** `<option value="fumigacion">` contra `'Fumigación'`: el `===` nunca daba true. El cast `as TipoAplicacion` impedía que TypeScript lo viera. El filtro de Estado, en el markup de al lado, sí estaba bien.
2. **Todas las fechas de la lista salían un día antes.** `new Date('2026-02-01')` se parsea como medianoche UTC y en Bogotá cae en enero 31. Verificado contra producción en las 4 filas visibles.
3. **`+100,0%` en las 4 tarjetas de TODAS las aplicaciones cerradas.** `calcularDesviacion` devuelve literalmente `100` cuando el planeado es 0, y `aplicaciones_lotes_planificado` está vacía. `calcularCambio()` ya existía en el mismo archivo y devuelve `undefined` sin base — el módulo no la llamaba.
4. **`Costo Total` comparaba insumos+mano de obra contra un plan de solo insumos.** Escondido tras el +100% falso; al recuperar el plan real pasó a mostrar "+138,1%" en una aplicación cuyos insumos se desviaron +0,4%. Queda sin plan: sin plan de jornales no hay plan de costo total.
5. **La cuadrilla no se mostraba.** 6 trabajadores por movimiento en `movimientos_diarios_trabajadores` (926 filas); el tablero pintaba solo `responsable`, texto libre.
6. **El Reporte leía la tabla vacía** teniendo `aplicaciones_calculos(*)` ya en el query sin usar.
7. **`--input: transparent`** hacía que todo `Input` de la app fuera una caja blanca con borde invisible dentro de una `Card` blanca.

## Verificación

`tsc` 0 errores · `lint` 0 errores (896 warnings, línea base 942) · **123 archivos / 2.863 tests** · `npm run build` OK · revisión visual de las 5 pantallas contra datos reales de producción, en escritorio y 375px.

## Queda abierto, a propósito

- `cerrarAplicacion()` son 6+ escrituras sin transacción. Se preservó el orden exacto y no se tocó.
- `aplicaciones_lotes_planificado` sigue vacía pero con lectores (`useReporteAplicacion`, Esco). Decisión del dueño: no borrarla.
- `movimientos_diarios.responsable` es texto libre y está sucio ("Felipe García" / "Felipe Garcia").

Contrato del módulo: `src/components/aplicaciones/CLAUDE.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)