### PR TITLE
fix(clima): migration 103's row-count guard expired 24h after it was written

### DIFF
--- a/src/sql/migrations/103_clima_cobertura_parcial.sql
+++ b/src/sql/migrations/103_clima_cobertura_parcial.sql
@@ -149,6 +149,7 @@ DECLARE
   v_objetivo         integer;
   v_objetivo_viejos  integer;
   v_check_def        text;
+  v_total_pre        integer;
 BEGIN
   -- 0.1 Exactamente dos poblaciones. Si aparece una tercera estacion, la
   --     semantica de `lecturas_count` deja de estar establecida y el backfill
@@ -221,7 +222,15 @@ BEGIN
     RAISE EXCEPTION 'Migracion 103: el CHECK ya incluye cobertura_parcial -- la migracion ya se corrio. ABORTA.';
   END IF;
 
-  RAISE NOTICE 'Migracion 103: pre-condiciones OK -- 2 estaciones, 1.757 filas historicas intactas, % filas parciales por corregir.', v_objetivo;
+  -- 0.6 Conteo de partida. La invariante que importa NO es un total absoluto
+  --     sino que esta migracion no cree ni borre filas: el cron nocturno
+  --     inserta una fila por dia, asi que cualquier numero fijo caduca a las
+  --     24 horas de escribirlo. Se guarda transaction-local y se coteja al
+  --     final contra si mismo.
+  SELECT count(*) INTO v_total_pre FROM public.clima_resumen_diario;
+  PERFORM set_config('m103.total_pre', v_total_pre::text, true);
+
+  RAISE NOTICE 'Migracion 103: pre-condiciones OK -- 2 estaciones, 1.757 filas historicas intactas, % filas parciales por corregir, % filas en total al arrancar.', v_objetivo, v_total_pre;
 END $$;
 
 
@@ -387,6 +396,7 @@ DECLARE
   v_wu_parcial    integer;
   v_wu_nulos      integer;
   v_total         integer;
+  v_total_pre     text;
   v_check_def     text;
 BEGIN
   -- 4.1 Los dias parciales quedaron marcados, y TODOS con lluvia_total_mm NULL.
@@ -434,8 +444,12 @@ BEGIN
 
   -- 4.4 No se creo ni se borro ninguna fila: esto es un UPDATE, no una limpieza.
   SELECT count(*) INTO v_total FROM public.clima_resumen_diario;
-  IF v_total <> 1910 THEN
-    RAISE EXCEPTION 'Migracion 103: clima_resumen_diario quedo con % filas, se esperaban 1.910. Esta migracion no inserta ni borra filas.', v_total;
+  v_total_pre := current_setting('m103.total_pre', true);
+  IF v_total_pre IS NULL OR v_total_pre = '' THEN
+    RAISE EXCEPTION 'Migracion 103: no se encontro el conteo de partida. Esta migracion DEBE correrse como una sola transaccion -- el bloque de pre-condiciones y el de post-condiciones tienen que compartir transaccion.';
+  END IF;
+  IF v_total <> v_total_pre::integer THEN
+    RAISE EXCEPTION 'Migracion 103: clima_resumen_diario paso de % a % filas durante la migracion. Esta migracion solo ACTUALIZA: no inserta ni borra.', v_total_pre, v_total;
   END IF;
 
   -- 4.5 El CHECK admite el valor nuevo.
@@ -465,6 +479,11 @@ END $$;
 --
 --   fecha        lecturas_count  lluvia_total_mm  lluvia_confianza
 --   2026-08-19   167             0.00             ok
+--   2026-08-20   114             0.00             ok   <-- sellado por el cron
+--                                                       del 2026-08-21 05:15 UTC,
+--                                                       antes de aplicar esta
+--                                                       migracion. Es el segundo
+--                                                       dia del mismo corte de luz.
 --   2026-03-30   147             18.03            ok
 --   2026-03-27   225             3.30             ok
 --   2026-03-18   111             1.02             ok


### PR DESCRIPTION
**Migration 103 is currently unrunnable.** This makes it runnable again. Merge before applying it.

## What happened

103 did not get applied before the `2026-08-21 05:15 UTC` rollup. That rollup sealed **2026-08-20** — 114 of 288 readings, the second day of the same power outage — as `lluvia_confianza='ok'` with `lluvia_total_mm=0.00`. That is precisely the defect 103 exists to close, so there are now **two** fabricated dry days instead of one, and the table went 1.910 → 1.911 rows.

```
 fecha        lecturas_count  lluvia_total_mm  lluvia_confianza
 2026-08-18   288             NULL             contador_congelado
 2026-08-19   167             0.00             ok                  <-- known
 2026-08-20   114             0.00             ok                  <-- new
```

## The actual bug this fixes

Post-condition 4.4 compared against the literal `1910`:

```sql
IF v_total <> 1910 THEN
  RAISE EXCEPTION 'Migracion 103: clima_resumen_diario quedo con % filas, se esperaban 1.910...';
```

With 1.911 rows the migration would do **all** of its work — drop and re-add the CHECK, replace `fn_clima_rollup_diario`, run the backfill — and then abort on its own post-condition, rolling the whole transaction back. Nothing applied, no obvious explanation.

Worse, it degrades on its own: the nightly cron inserts one row per day, so **any fixed total written into a migration expires within 24 hours of being written**. This is a latent trap in the pattern, not a one-off typo.

The invariant that actually matters is not an absolute total — it is that *this migration creates and deletes nothing; it only updates*. So the starting count is now captured in the pre-condition block (`set_config`, transaction-local) and compared against itself at the end. If the setting is missing, the migration says so explicitly rather than failing confusingly: it must run as a single transaction, which its own header already required.

## Verified against production today (SELECT only)

All seven guards pass as things currently stand:

| Guard | Expected | Actual |
|---|---|---|
| 0.1 distinct stations | 2 | 2 |
| 0.2 wunderground rows | 1757 | 1757 |
| 0.2 wunderground `ok` | 1730 | 1730 |
| 0.3 target set | ≥ 4 | **5** |
| 0.3b unexpected old partials | 0 | 0 |
| 0.4 2026-08-19 in documented state | 1 | 1 |
| 4.3 wunderground NULL rain | 54 | 54 |

The target set is **5 rows, not 4** — 2026-08-20 joins it, which is correct and desirable. Guard 0.3 was deliberately written as "at least 4" to absorb exactly this, so it needed no change.

## Note on modifying a merged migration

Normally off-limits. Defensible here because **103 is not applied to production** — verified: the CHECK still carries only the three values from 068 — so there is no history to rewrite. The alternative, a `106` patching a migration that aborts, leaves two files for one change and neither is independently applicable.

The 2026-08-20 pre-state is recorded in the ROLLBACK block so the revert path stays complete.

## Still pending after this

Applying 103 and 104. Every further day of outage adds another fabricated row.

---
_Generated by [Claude Code](https://claude.ai/code/session_01QZt6WKuGeEfREknFNsn9d4)_