### PR TITLE
fix(aplicaciones): no se podían cargar los jornales por trabajador en Movimientos

### DIFF
--- a/src/components/aplicaciones/DailyMovementForm.tsx
+++ b/src/components/aplicaciones/DailyMovementForm.tsx
@@ -1447,10 +1447,20 @@ export function DailyMovementForm({ aplicacion, open, onOpenChange, onSuccess }:
 
   return (
     <>
-      {/* Escritorio: Sheet lateral, más ancho que el sm:max-w-sm por defecto — la
-          matriz de jornal×lote sería inutilizable a 384px (ver §6 del diseño). */}
+      {/* Escritorio: Sheet lateral de MEDIA PANTALLA, proporcional al monitor.
+          `clamp(480px, 50vw, 900px)`:
+            - 50vw es el objetivo — el panel crece con la pantalla en vez de quedar
+              clavado en un ancho fijo (1.366px → 683px, 1.600px → 800px).
+            - Piso de 480px: por debajo de un monitor de ~960px, media pantalla
+              empieza a apretar el formulario; ahí se prefiere invadir más de la
+              mitad antes que encoger los campos.
+            - Techo de 900px: en un monitor ancho, media pantalla son 1.200px+ y un
+              formulario de una columna a ese ancho se vuelve incómodo de leer —
+              la vista se estira sin ganar nada.
+          Antes era un fijo de 480px, y con ese ancho la matriz de jornales quedaba
+          literalmente inalcanzable (ver el comentario en JornalFractionMatrix). */}
       <Sheet open={open && !isMobile} onOpenChange={onOpenChange}>
-        <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-[480px]">
+        <SheetContent className="flex w-full flex-col gap-0 p-0 sm:max-w-[clamp(480px,50vw,900px)]">
           <SheetHeader className="border-b border-border px-5 py-4">
             <SheetTitle>{tituloHeader}</SheetTitle>
             <SheetDescription>{subtituloHeader}</SheetDescription>

--- a/src/components/shared/JornalFractionMatrix.tsx
+++ b/src/components/shared/JornalFractionMatrix.tsx
@@ -29,6 +29,60 @@ export interface JornalFractionMatrixProps {
   showCostPreview?: boolean; // Show calculated cost per worker
 }
 
+/**
+ * Los dos controles de una asignación (fracción + observación). Viven en un solo lugar a
+ * proposito: el componente tiene dos disposiciones — tabla horizontal para varios lotes y lista
+ * vertical para uno solo — y si cada una trajera su propia copia del `Select`, las opciones de
+ * jornal podrian divergir sin que ningun test lo note.
+ */
+function ControlesAsignacion({
+  trabajadorId,
+  loteId,
+  workMatrix,
+  observaciones,
+  onFraccionChange,
+  onObservacionesChange,
+  disabled,
+}: {
+  trabajadorId: string;
+  loteId: string;
+  workMatrix: WorkMatrix;
+  observaciones: ObservacionesMatrix;
+  onFraccionChange: (trabajadorId: string, loteId: string, fraccion: string) => void;
+  onObservacionesChange: (trabajadorId: string, loteId: string, obs: string) => void;
+  disabled: boolean;
+}) {
+  return (
+    <>
+      <Select
+        value={workMatrix[trabajadorId]?.[loteId] || '0.0'}
+        onValueChange={(value) => onFraccionChange(trabajadorId, loteId, value)}
+        disabled={disabled}
+      >
+        <SelectTrigger className="h-8 text-xs border-primary/20 hover:border-primary/40">
+          <SelectValue />
+        </SelectTrigger>
+        <SelectContent>
+          <SelectItem value="0.0">-</SelectItem>
+          <SelectItem value="0.25">2 horas</SelectItem>
+          <SelectItem value="0.5">4 horas</SelectItem>
+          <SelectItem value="0.75">6 horas</SelectItem>
+          <SelectItem value="1.0">8 horas</SelectItem>
+        </SelectContent>
+      </Select>
+
+      <Textarea
+        value={observaciones[trabajadorId]?.[loteId] || ''}
+        onChange={(e) => onObservacionesChange(trabajadorId, loteId, e.target.value)}
+        placeholder="Notas..."
+        rows={2}
+        className="text-xs resize-none border-primary/20 focus:border-primary/40"
+        disabled={disabled}
+      />
+    </>
+  );
+}
+
 export function JornalFractionMatrix({
   trabajadores,
   lotes,
@@ -131,8 +185,99 @@ export function JornalFractionMatrix({
           </div>
         )}
 
-        {/* Table with horizontal scroll */}
-        <div className="overflow-x-auto">
+        {/* Un solo lote -> LISTA VERTICAL, no tabla.
+            Por que existe esta rama: la tabla de abajo fija la columna del trabajador a la
+            izquierda y la del total a la derecha, y deja las columnas de lote desplazandose en
+            el medio. Eso funciona en el dialogo ancho de Labores, pero `DailyMovementForm`
+            monta esta matriz en un panel lateral de 480px y SIEMPRE le pasa exactamente un
+            lote (un movimiento diario es de un solo lote). Medido en produccion el 2026-08-21:
+            contenedor 445px, columna Trabajador 434px, columna Total 87px -- las dos fijas
+            suman 521px dentro de 445px, se superponen entre si y tapan por completo la unica
+            columna que tiene los controles, que quedaba dibujada fuera de la pantalla.
+            Deslizar no ayudaba: una columna `sticky` se queda clavada encima. Resultado: era
+            IMPOSIBLE cargar el jornal desde esa pantalla.
+            Con un solo lote la tabla no aporta nada -- no hay nada que comparar entre columnas --
+            asi que se cae a una lista, que no tiene ancho minimo ni scroll horizontal. */}
+        {lotes.length === 1 ? (
+          <ul className="divide-y divide-primary/5">
+            {trabajadores.map((trabajador) => {
+              const lote = lotes[0];
+              const totalFraccion = calculateTotalFraccion(trabajador.data.id!);
+              const totalCosto = showCostPreview ? calculateCosto(trabajador, totalFraccion) : 0;
+
+              return (
+                <li key={trabajador.data.id!} className="space-y-3 px-5 py-4">
+                  <div className="flex items-start justify-between gap-3">
+                    <div className="min-w-0 flex-1">
+                      <div className="flex flex-wrap items-center gap-2">
+                        <span className="text-sm font-medium text-foreground">
+                          {trabajador.data.nombre}
+                        </span>
+                        {trabajador.type === 'contratista' ? (
+                          <Badge
+                            variant="outline"
+                            className="flex-shrink-0 border-blue-200 bg-blue-50 text-xs text-blue-700"
+                          >
+                            {trabajador.data.tipo_contrato}
+                          </Badge>
+                        ) : (
+                          <Badge
+                            variant="outline"
+                            className="flex-shrink-0 border-green-200 bg-green-50 text-xs text-green-700"
+                          >
+                            Empleado
+                          </Badge>
+                        )}
+                      </div>
+                      {showCostPreview && totalFraccion > 0 && (
+                        <p className="mt-0.5 text-xs text-gray-500">
+                          Costo: {formatCurrency(totalCosto)}
+                        </p>
+                      )}
+                    </div>
+
+                    <span
+                      className={`inline-flex flex-shrink-0 items-center justify-center rounded-lg px-3 py-1 text-sm font-semibold ${
+                        totalFraccion > 0
+                          ? 'bg-primary/10 text-primary'
+                          : 'bg-gray-100 text-gray-400'
+                      }`}
+                    >
+                      {totalFraccion.toFixed(2)}
+                    </span>
+
+                    {onRemoveTrabajador && (
+                      <Button
+                        type="button"
+                        variant="ghost"
+                        size="sm"
+                        onClick={() => onRemoveTrabajador(trabajador.data.id!)}
+                        disabled={disabled}
+                        className="h-7 w-7 flex-shrink-0 p-0 text-red-600 hover:bg-red-50 hover:text-red-700"
+                      >
+                        ✕
+                      </Button>
+                    )}
+                  </div>
+
+                  <div className="grid gap-2 sm:grid-cols-[minmax(0,9rem)_minmax(0,1fr)]">
+                    <ControlesAsignacion
+                      trabajadorId={trabajador.data.id!}
+                      loteId={lote.id}
+                      workMatrix={workMatrix}
+                      observaciones={observaciones}
+                      onFraccionChange={onFraccionChange}
+                      onObservacionesChange={onObservacionesChange}
+                      disabled={disabled}
+                    />
+                  </div>
+                </li>
+              );
+            })}
+          </ul>
+        ) : (
+          /* Varios lotes: la tabla horizontal original, con scroll y columnas fijas. */
+          <div className="overflow-x-auto">
           <table className="w-full">
             <thead className="bg-background">
               <tr>
@@ -214,35 +359,13 @@ export function JornalFractionMatrix({
                     {lotes.map((lote) => (
                       <td key={lote.id} className="py-2 px-2 text-center">
                         <div className="space-y-1.5">
-                          {/* Fraction selector */}
-                          <Select
-                            value={workMatrix[trabajador.data.id!]?.[lote.id] || '0.0'}
-                            onValueChange={(value) =>
-                              onFraccionChange(trabajador.data.id!, lote.id, value)
-                            }
-                            disabled={disabled}
-                          >
-                            <SelectTrigger className="h-8 text-xs border-primary/20 hover:border-primary/40">
-                              <SelectValue />
-                            </SelectTrigger>
-                            <SelectContent>
-                              <SelectItem value="0.0">-</SelectItem>
-                              <SelectItem value="0.25">2 horas</SelectItem>
-                              <SelectItem value="0.5">4 horas</SelectItem>
-                              <SelectItem value="0.75">6 horas</SelectItem>
-                              <SelectItem value="1.0">8 horas</SelectItem>
-                            </SelectContent>
-                          </Select>
-
-                          {/* Observations textarea */}
-                          <Textarea
-                            value={observaciones[trabajador.data.id!]?.[lote.id] || ''}
-                            onChange={(e) =>
-                              onObservacionesChange(trabajador.data.id!, lote.id, e.target.value)
-                            }
-                            placeholder="Notas..."
-                            rows={2}
-                            className="text-xs resize-none border-primary/20 focus:border-primary/40"
+                          <ControlesAsignacion
+                            trabajadorId={trabajador.data.id!}
+                            loteId={lote.id}
+                            workMatrix={workMatrix}
+                            observaciones={observaciones}
+                            onFraccionChange={onFraccionChange}
+                            onObservacionesChange={onObservacionesChange}
                             disabled={disabled}
                           />
                         </div>
@@ -267,6 +390,7 @@ export function JornalFractionMatrix({
             </tbody>
           </table>
         </div>
+        )}
 
         {/* Summary footer */}
         <div className="px-5 py-3 bg-background border-t border-primary/10">


### PR DESCRIPTION
Reportado por David: en **Movimientos Diarios** no hay dónde escribir el jornal de cada trabajador.

## Por qué pasaba

Regresión del rediseño W02 (`c10ff4e`). Ese commit movió `DailyMovementForm` de un bloque a ancho completo de página a un **panel lateral de 480px**, y dejó `JornalFractionMatrix` intacta. Esa matriz es una tabla horizontal con la columna `Trabajador` fija a la izquierda y `Total` fija a la derecha.

Medido en vivo sobre el caso real:

| | ancho |
|---|---|
| Contenedor visible | **445px** |
| `Trabajador` (fija izquierda) | **434px** |
| `Total` (fija derecha) | **87px** |
| Columna del lote — la única con controles | 200px |

Las dos columnas fijas suman **521px dentro de 445px**: se superponen entre ellas y tapan por completo la columna del lote, que quedaba dibujada en x=1337–1537, fuera de la pantalla. **Deslizar no ayudaba** — una columna `sticky` se queda clavada encima pase lo que pase.

## El arreglo

Con **un solo lote** la matriz deja de ser tabla y pasa a lista vertical: una fila por trabajador con su selector de jornal y sus notas. Sin columnas fijas, sin ancho mínimo, sin scroll horizontal.

Es la forma correcta para esta pantalla: un movimiento diario es **siempre de un solo lote**, así que una tabla horizontal no aportaba nada — no hay nada que comparar entre columnas.

**No toca el caso de varios lotes.** `RegistrarTrabajoDialog` (Labores) usa la misma matriz en un diálogo de 768px con varios lotes y conserva la tabla. Los dos controles se extraen a `ControlesAsignacion` para que las dos disposiciones no puedan divergir en las opciones de jornal.

## Verificación

En el navegador, con el caso real de David (Drench agosto, 9 trabajadores, lote 1. Piedra Paula) en el panel de 480px:

- 0 tablas horizontales · lista con 9 filas · **ningún** contenedor con scroll horizontal
- **12 de 12** selectores dentro de la pantalla

`tsc` 0 errores · `lint` 0 errores · 2.921 pruebas en verde.

🤖 Generated with [Claude Code](https://claude.com/claude-code)