### PR TITLE
fix(labores): use the owner-decided 22-day divisor for the employee jornal

### DIFF
--- a/src/__tests__/jornalDivisorContract.test.ts
+++ b/src/__tests__/jornalDivisorContract.test.ts
@@ -1,0 +1,124 @@
+// ARCHIVO: __tests__/jornalDivisorContract.test.ts
+// DESCRIPCIÓN: El costo de un jornal de empleado se deriva del salario MENSUAL
+// dividido por 22 días laborales. **22 es una decisión del dueño (Santiago,
+// 2026-08-20), no una fórmula legal** — cierra la ambigüedad del hallazgo #3
+// de la operación de mantenimiento.
+//
+// El defecto que cierra este contrato: la app dividía por
+// `horas_semanales * 4.33 / 8`. Con las 44 horas semanales que tiene TODA la
+// nómina de Escocia (20 de 21 empleados; el 21.º no tiene salario), eso da un
+// divisor de 23,815 y subvalúa cada jornal un 7,6 %:
+//
+//   Jornalero tipo (1.750.905 + 508.148 + 249.045 = 2.508.098):
+//     antes  2.508.098 / 23,815 = $105.316
+//     ahora  2.508.098 / 22     = $114.004   (+$8.688 por jornal, +8,25 %)
+//
+// Esco (`chat.tsx`) ya dividía por 22, así que la app y el asistente daban
+// cifras distintas para el mismo trabajo. Este guard existe para que no vuelvan
+// a divergir: hay UN divisor y vive en tres árboles que no pueden importarse
+// entre sí (navegador, edge function `src/supabase/...`, copia desplegada
+// `supabase/functions/make-server-1ccce916/...`).
+//
+// Lo que este guard NO hace: no toca la historia. `registros_trabajo.costo_jornal`
+// guarda el costo vigente al momento de registrar y sigue siendo el histórico
+// correcto (2.550 filas, $160M). El cambio aplica solo a jornales nuevos.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  DIAS_LABORALES_MES,
+  calculateLaborCost,
+  calculateContractorCost,
+} from '@/utils/laborCosts';
+
+const RAIZ = join(__dirname, '..', '..');
+const leer = (rel: string) => readFileSync(join(RAIZ, rel), 'utf-8');
+
+/** Nómina real de Escocia a 2026-08 (jornalero tipo, 44 h semanales). */
+const JORNALERO = { salario: 1_750_905, prestaciones: 508_148, auxilios: 249_045 };
+const TOTAL_MENSUAL = JORNALERO.salario + JORNALERO.prestaciones + JORNALERO.auxilios;
+
+describe('divisor del jornal — decisión del dueño: 22', () => {
+  it('DIAS_LABORALES_MES es exactamente 22', () => {
+    expect(DIAS_LABORALES_MES).toBe(22);
+  });
+
+  it('un jornal completo es salario mensual / 22', () => {
+    const { totalCost, dailyCost } = calculateLaborCost({
+      salary: JORNALERO.salario,
+      benefits: JORNALERO.prestaciones,
+      allowances: JORNALERO.auxilios,
+      weeklyHours: 44,
+      fractionWorked: 1,
+    });
+    expect(dailyCost).toBeCloseTo(TOTAL_MENSUAL / 22, 2);
+    expect(Math.round(totalCost)).toBe(114_004);
+  });
+
+  it('ya NO devuelve la cifra vieja del divisor 23,815 (44 h × 4,33 / 8)', () => {
+    const { totalCost } = calculateLaborCost({
+      salary: JORNALERO.salario,
+      benefits: JORNALERO.prestaciones,
+      allowances: JORNALERO.auxilios,
+      weeklyHours: 44,
+      fractionWorked: 1,
+    });
+    expect(Math.round(totalCost)).not.toBe(105_316);
+  });
+
+  it('horas_semanales NO cambia el costo del jornal', () => {
+    const base = { salary: JORNALERO.salario, benefits: JORNALERO.prestaciones, allowances: JORNALERO.auxilios, fractionWorked: 1 };
+    const h44 = calculateLaborCost({ ...base, weeklyHours: 44 }).totalCost;
+    const h48 = calculateLaborCost({ ...base, weeklyHours: 48 }).totalCost;
+    const sinDato = calculateLaborCost({ ...base }).totalCost;
+    expect(h44).toBe(h48);
+    expect(h44).toBe(sinDato);
+  });
+
+  it('las fracciones son proporcionales al jornal completo', () => {
+    const base = { salary: JORNALERO.salario, benefits: JORNALERO.prestaciones, allowances: JORNALERO.auxilios, weeklyHours: 44 };
+    const completo = calculateLaborCost({ ...base, fractionWorked: 1 }).totalCost;
+    for (const f of [0.25, 0.5, 0.75]) {
+      expect(calculateLaborCost({ ...base, fractionWorked: f }).totalCost).toBeCloseTo(completo * f, 1);
+    }
+  });
+
+  it('el contratista sigue cobrando su tarifa_jornal plana, sin divisor', () => {
+    expect(calculateContractorCost(90_000, 1).totalCost).toBe(90_000);
+    expect(calculateContractorCost(90_000, 0.5).totalCost).toBe(45_000);
+  });
+});
+
+describe('guard estático — un solo divisor, en los tres árboles', () => {
+  /** Ficheros que calculan el costo de un jornal de empleado. */
+  const FICHEROS_COSTO_JORNAL = [
+    'src/utils/laborCosts.ts',
+    'src/supabase/functions/server/chat.tsx',
+    'src/supabase/functions/server/telegram/conversations/jornal.ts',
+    'supabase/functions/make-server-1ccce916/chat.tsx',
+    'supabase/functions/make-server-1ccce916/telegram/conversations/jornal.ts',
+  ];
+
+  it.each(FICHEROS_COSTO_JORNAL)('%s no reintroduce el divisor por horas semanales', (rel) => {
+    const contenido = leer(rel);
+    expect(contenido, `${rel} volvió a usar 4.33 semanas/mes para el jornal`).not.toMatch(/4\.33/);
+    expect(contenido, `${rel} volvió a declarar WEEKS_PER_MONTH`).not.toMatch(/WEEKS_PER_MONTH/);
+  });
+
+  it.each(FICHEROS_COSTO_JORNAL)('%s declara el divisor 22 y ningún otro', (rel) => {
+    const contenido = leer(rel);
+    const declaraciones = [...contenido.matchAll(/DIAS_LABORALES_MES\s*(?::\s*number\s*)?=\s*([0-9.]+)/g)];
+    expect(declaraciones.length, `${rel} no declara DIAS_LABORALES_MES`).toBeGreaterThan(0);
+    for (const d of declaraciones) {
+      expect(d[1], `${rel} declara un divisor distinto de 22`).toBe('22');
+    }
+  });
+
+  it('las dos copias del árbol de edge function calculan igual', () => {
+    const sinCabecera = (rel: string) => leer(rel).split('\n').slice(1).join('\n').replace(/\s+/g, ' ');
+    expect(sinCabecera('src/supabase/functions/server/telegram/conversations/jornal.ts')).toBe(
+      sinCabecera('supabase/functions/make-server-1ccce916/telegram/conversations/jornal.ts'),
+    );
+  });
+});

--- a/src/supabase/functions/server/telegram/conversations/jornal.ts
+++ b/src/supabase/functions/server/telegram/conversations/jornal.ts
@@ -26,9 +26,9 @@ const FRACCIONES = ["0.25", "0.5", "0.75", "1.0"] as const;
 const TASKS_PER_PAGE = 6;
 const WORKERS_PER_PAGE = 8;
 
-// Standard 8-hour workday, ~4.33 weeks per month
-const STANDARD_WORKDAY_HOURS = 8;
-const WEEKS_PER_MONTH = 4.33;
+// Días laborales por mes: decisión del dueño (Santiago, 2026-08-20).
+// Debe coincidir con DIAS_LABORALES_MES en src/utils/laborCosts.ts y en chat.tsx.
+const DIAS_LABORALES_MES = 22;
 
 // ---------------------------------------------------------------------------
 // Supabase helper
@@ -50,13 +50,12 @@ function calcEmpleadoCost(
   salario: number,
   prestaciones: number,
   auxilios: number,
-  horasSemanales: number,
+  _horasSemanales: number,
   fraccion: number,
 ): number {
-  const hrs = horasSemanales > 0 ? horasSemanales : 48;
-  const monthlyHours = hrs * WEEKS_PER_MONTH;
-  const hourlyRate = (salario + prestaciones + auxilios) / monthlyHours;
-  return Math.round(hourlyRate * STANDARD_WORKDAY_HOURS * fraccion * 100) / 100;
+  // horasSemanales se ignora a propósito: el jornal es un día laboral completo.
+  const costoJornal = (salario + prestaciones + auxilios) / DIAS_LABORALES_MES;
+  return Math.round(costoJornal * fraccion * 100) / 100;
 }
 
 function calcContratistaCost(tarifaJornal: number, fraccion: number): number {

--- a/src/utils/laborCosts.ts
+++ b/src/utils/laborCosts.ts
@@ -10,7 +10,12 @@ export interface CostCalculationParams {
   salary: number;
   benefits: number;
   allowances: number;
-  weeklyHours: number;
+  /**
+   * @deprecated Ya NO participa en el cálculo. El jornal se deriva del salario
+   * mensual dividido por `DIAS_LABORALES_MES`, no de las horas semanales.
+   * Se conserva en la firma para no romper los call sites existentes.
+   */
+  weeklyHours?: number;
   fractionWorked: number;
 }
 
@@ -26,34 +31,42 @@ export interface CostCalculationResult {
 export const STANDARD_WORKDAY_HOURS = 8;
 
 /**
- * Average weeks per month for monthly salary calculations
+ * Días laborales por mes usados para derivar el costo de un jornal a partir del
+ * salario MENSUAL.
+ *
+ * **22 es una decisión del dueño (Santiago, 2026-08-20), no una fórmula legal.**
+ * Es el único divisor válido del proyecto y debe coincidir con el que usa Esco
+ * (`src/supabase/functions/server/chat.tsx`) y el bot de Telegram
+ * (`.../telegram/conversations/jornal.ts`). El guard estático
+ * `src/__tests__/jornalDivisorContract.test.ts` falla si alguno diverge.
+ *
+ * Antes de 2026-08 el jornal se derivaba de `horas_semanales × 4,33 ÷ 8`, que
+ * con las 44 horas semanales de toda la nómina daba un divisor de 23,815 y
+ * subvaluaba cada jornal un 7,6 %.
  */
-export const WEEKS_PER_MONTH = 4.33;
+export const DIAS_LABORALES_MES = 22;
 
 /**
  * Calculate labor costs using standardized formula
- * Formula: (salary + benefits + allowances) / (weeklyHours * WEEKS_PER_MONTH) * 8 * fractionWorked
+ * Formula: (salary + benefits + allowances) / DIAS_LABORALES_MES * fractionWorked
  * Note: Assumes salary is MONTHLY
+ *
+ * `weeklyHours` se ignora a propósito: el jornal es un día laboral completo,
+ * no un bloque de 8 horas prorrateado sobre la jornada semanal.
  */
 export function calculateLaborCost(params: CostCalculationParams): CostCalculationResult {
-  const { salary, benefits, allowances, weeklyHours, fractionWorked } = params;
+  const { salary, benefits, allowances, fractionWorked } = params;
 
   // Input validation
-  if (weeklyHours <= 0) {
-    throw new Error('Weekly hours must be greater than 0');
-  }
-
   if (fractionWorked < 0 || fractionWorked > 3) {
     throw new Error('Fraction worked must be between 0 and 3');
   }
 
-  // Calculate hourly rate from MONTHLY salary
-  // Convert weekly hours to monthly hours: weeklyHours * 4.33 (average weeks per month)
-  const monthlyHours = weeklyHours * WEEKS_PER_MONTH;
-  const hourlyRate = (salary + benefits + allowances) / monthlyHours;
+  // Costo de un jornal completo a partir del salario MENSUAL
+  const dailyCost = (salary + benefits + allowances) / DIAS_LABORALES_MES;
 
-  // Calculate daily cost (8 hours)
-  const dailyCost = hourlyRate * STANDARD_WORKDAY_HOURS;
+  // Tarifa horaria implícita (solo informativa)
+  const hourlyRate = dailyCost / STANDARD_WORKDAY_HOURS;
 
   // Calculate total cost for the fraction worked
   const totalCost = dailyCost * fractionWorked;

--- a/supabase/functions/make-server-1ccce916/telegram/conversations/jornal.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/conversations/jornal.ts
@@ -26,9 +26,9 @@ const FRACCIONES = ["0.25", "0.5", "0.75", "1.0"] as const;
 const TASKS_PER_PAGE = 6;
 const WORKERS_PER_PAGE = 8;
 
-// Standard 8-hour workday, ~4.33 weeks per month
-const STANDARD_WORKDAY_HOURS = 8;
-const WEEKS_PER_MONTH = 4.33;
+// Días laborales por mes: decisión del dueño (Santiago, 2026-08-20).
+// Debe coincidir con DIAS_LABORALES_MES en src/utils/laborCosts.ts y en chat.tsx.
+const DIAS_LABORALES_MES = 22;
 
 // ---------------------------------------------------------------------------
 // Supabase helper
@@ -50,13 +50,12 @@ function calcEmpleadoCost(
   salario: number,
   prestaciones: number,
   auxilios: number,
-  horasSemanales: number,
+  _horasSemanales: number,
   fraccion: number,
 ): number {
-  const hrs = horasSemanales > 0 ? horasSemanales : 48;
-  const monthlyHours = hrs * WEEKS_PER_MONTH;
-  const hourlyRate = (salario + prestaciones + auxilios) / monthlyHours;
-  return Math.round(hourlyRate * STANDARD_WORKDAY_HOURS * fraccion * 100) / 100;
+  // horasSemanales se ignora a propósito: el jornal es un día laboral completo.
+  const costoJornal = (salario + prestaciones + auxilios) / DIAS_LABORALES_MES;
+  return Math.round(costoJornal * fraccion * 100) / 100;
 }
 
 function calcContratistaCost(tarifaJornal: number, fraccion: number): number {


### PR DESCRIPTION
Closes maintenance finding **#3** (P1, open since 2026-08-06). Not a new finding.

## Bug

The app and Esco disagreed on what a jornal costs.

`src/utils/laborCosts.ts` derived the cost of a full jornal as
`(salario + prestaciones + auxilios) / (horas_semanales × 4,33) × 8`.
Every employee in `empleados` carries `horas_semanales = 44` (verified in production
2026-08-24: 20 of 21 rows; the 21st, EMILIANO GARCIA, has no salary by design —
migration 107). That makes the effective divisor **23,815**, not 22.

Esco (`src/supabase/functions/server/chat.tsx:755`) already divided by **22**, so the
same day of work was priced differently depending on who you asked.

**Before / after — the jornalero on the standard 2026 payroll**
(`1.750.905 + 508.148 + 249.045 = 2.508.098`):

| | divisor | costo por jornal |
|---|---|---|
| app (before) | 23,815 | **$105.316** |
| Esco / app (after) | 22 | **$114.004** |

That is **+$8.688 per jornal, +8,25 %** — the app was understating labor by 7,6 %.
It flows into `registros_trabajo.costo_jornal`, and from there into cost/kg
(`calculosCostoKg.ts`) and the application-closure cost sheet.

## Root cause

`src/utils/laborCosts.ts:29` `WEEKS_PER_MONTH = 4.33`, applied at `:52-55`
(`monthlyHours = weeklyHours * WEEKS_PER_MONTH`). The formula prorates a monthly
salary over the *weekly hour* schedule; a jornal is a whole working day, not an
8-hour slice of a 44-hour week. Mirrored verbatim in the Telegram bot
(`telegram/conversations/jornal.ts:29-31, 49-60`), in both edge-function trees.

## Fix

**The divisor is Santiago's decision (2026-08-20): 22.** This PR only aligns the
code to it — no accounting rule is being invented here.

- `src/utils/laborCosts.ts`: `WEEKS_PER_MONTH` → `DIAS_LABORALES_MES = 22`.
  `dailyCost = (salary + benefits + allowances) / 22`; `hourlyRate` is now derived
  from `dailyCost` and stays informational.
- `weeklyHours` becomes optional and documented as ignored, so the 6 existing call
  sites keep compiling unchanged. Its `<= 0` throw is removed — it guarded an input
  that no longer affects the result.
- Same change in **both** copies of `telegram/conversations/jornal.ts`.
- `chat.tsx` already used 22 and is untouched.

Nothing else changed. No refactor.

## What this does NOT touch

**History.** `registros_trabajo.costo_jornal` stores the cost that was in force when
the work was captured (2.550 rows, $160M since 2025-10-16) and remains the correct
historical figure. Only jornales captured from now on use 22. Recosting history is a
separate owner decision.

## Verification

New static + behavioural guard `src/__tests__/jornalDivisorContract.test.ts` (17 tests):
asserts `DIAS_LABORALES_MES === 22`, that a full jornal is exactly `$114.004` for the
real payroll row, that it is **not** the old `$105.316`, that `horas_semanales` no
longer moves the number, that contractors still bill their flat `tarifa_jornal`, and —
the static half — that none of the five files that price a jornal can reintroduce
`4.33` / `WEEKS_PER_MONTH` or declare a divisor other than 22. It also asserts the two
edge-function copies of `jornal.ts` stay byte-equal modulo the header comment.

```
npx tsc --noEmit   → clean
npm run lint       → 0 errors, 904 warnings (baseline)
npx vitest run     → 128 files / 2938 tests, all green
```

## Deploy note

`telegram/conversations/jornal.ts` changed in both trees, so the edge function needs
`npx supabase functions deploy make-server-1ccce916` for the Telegram `/jornal` flow to
price at 22. Until it is redeployed, Telegram-captured jornales keep the old figure —
the browser paths are correct as soon as this merges.

## Rollback

`git revert` the commit. It restores the previous divisor everywhere at once; no data
migration is involved, since only newly written `costo_jornal` values are affected.

## Follow-up (deliberately out of scope)

- Recosting the 2.550 historical `registros_trabajo` rows — owner decision, not a fix.
- `EMILIANO GARCIA` has `salario = NULL` by design, so any jornal registered against him
  costs $0 silently. That is a separate known gap, not touched here.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyDuV9zQppKCmTRcWuCWaJ)_