### PR TITLE
fix(monitoreo): group monitoreos by ISO week in UTC, not by a locally-shifted date

### DIFF
--- a/src/__tests__/hatoFechaLocalGuard.test.ts
+++ b/src/__tests__/hatoFechaLocalGuard.test.ts
@@ -87,15 +87,6 @@ const LISTA_BLANCA_UTC: { archivo: string; ocurrencias: number; razon: string }[
       'UTC; enumerarFechas() itera con cursor. Los tres son ida y vuelta UTC coherente.',
   },
   {
-    archivo: 'src/components/monitoreo/TablaMonitoreos.tsx',
-    ocurrencias: 2,
-    razon:
-      'agruparPorSemana() mezcla `new Date(fecha_monitoreo)` (UTC) con getDay()/getDate() ' +
-      'LOCALES. Está mal, pero el arreglo es la aritmética de semana entera, no el ' +
-      'recorte -- cambiar solo la lectura movería las etiquetas sin corregir el cálculo. ' +
-      'Congelado aquí a propósito para que no se cuele un sitio nuevo mientras tanto.',
-  },
-  {
     archivo: 'src/utils/accionesHechos.ts',
     ocurrencias: 1,
     razon:

--- a/src/__tests__/semanaISO.test.ts
+++ b/src/__tests__/semanaISO.test.ts
@@ -1,0 +1,106 @@
+// ARCHIVO: __tests__/semanaISO.test.ts
+// DESCRIPCIÓN: Contrato de `semanaISO()` (src/utils/fechas.ts) y del agrupador
+// semanal de `TablaMonitoreos`.
+//
+// Defecto que cierra (hallazgo #27 de la operación de mantenimiento):
+// `agruparPorSemana()` construía `new Date(m.fecha_monitoreo)` — que para un
+// `AAAA-MM-DD` es medianoche **UTC** — y luego lo leía con `getFullYear()`,
+// `getMonth()`, `getDate()`, `getDay()`, que son **locales**. En Bogotá (UTC-5)
+// esa Date es el día anterior a las 19:00, así que cada fecha se corría un día
+// hacia atrás. Consecuencia exacta: **un monitoreo hecho un lunes se archivaba
+// en la semana anterior**, porque lunes−1 = domingo, y el domingo cierra la
+// semana ISO precedente.
+//
+// Medido en producción 2026-08-24: **677 de 4.200 monitoreos (16,1 %)** caen en
+// lunes, sobre 14 fechas y 13 rondas — y esas 13 rondas quedaban **partidas en
+// dos grupos semanales**, con su mitad del lunes en la semana de antes.
+//
+// El segundo defecto era el año: la etiqueta usaba el año del CALENDARIO local.
+// Un monitoreo del 1 de enero se archivaba bajo el año anterior (31-dic local),
+// y aun sin el corrimiento, el año de calendario y el año ISO no coinciden en el
+// cambio de año — «Semana 53 · 2027» es una combinación que no existe.
+
+import { describe, it, expect } from 'vitest';
+import { semanaISO } from '@/utils/fechas';
+
+describe('semanaISO — casos canónicos ISO 8601', () => {
+  it.each([
+    // fecha        semana  añoISO  lunes         domingo
+    ['2026-01-05', 2, 2026, '2026-01-05', '2026-01-11'], // lunes
+    ['2026-01-01', 1, 2026, '2025-12-29', '2026-01-04'], // jueves: semana 1 de 2026
+    ['2025-12-29', 1, 2026, '2025-12-29', '2026-01-04'], // lunes que abre la semana 1 de 2026
+    ['2027-01-01', 53, 2026, '2026-12-28', '2027-01-03'], // viernes: semana 53 de 2026
+    ['2026-08-03', 32, 2026, '2026-08-03', '2026-08-09'], // último monitoreo real, un lunes
+    ['2025-01-03', 1, 2025, '2024-12-30', '2025-01-05'], // primer monitoreo real, un viernes
+  ])('%s → semana %i de %i (%s a %s)', (fecha, semana, anioISO, lunes, domingo) => {
+    expect(semanaISO(fecha as string)).toEqual({ semana, anioISO, lunes, domingo });
+  });
+
+  it('el lunes y el domingo de la misma semana caen en el mismo grupo', () => {
+    const lunes = semanaISO('2026-08-03');
+    const domingo = semanaISO('2026-08-09');
+    expect(`${lunes.anioISO}-S${lunes.semana}`).toBe(`${domingo.anioISO}-S${domingo.semana}`);
+  });
+
+  it('el domingo anterior pertenece a la semana anterior, no a la del lunes', () => {
+    expect(semanaISO('2026-08-02').semana).toBe(31);
+    expect(semanaISO('2026-08-03').semana).toBe(32);
+  });
+
+  it('ignora cualquier hora que traiga el string', () => {
+    expect(semanaISO('2026-08-03T23:45:00Z')).toEqual(semanaISO('2026-08-03'));
+  });
+
+  it('el lunes y el domingo devueltos están a exactamente 6 días', () => {
+    const { lunes, domingo } = semanaISO('2026-02-18');
+    const dias = (Date.parse(domingo) - Date.parse(lunes)) / 86400000;
+    expect(dias).toBe(6);
+  });
+});
+
+describe('regresión — el agrupador ya no corre las fechas un día hacia atrás', () => {
+  /**
+   * Reproduce la aritmética vieja de `TablaMonitoreos.agruparPorSemana()`
+   * **con el huso de Bogotá fijado a mano**, para que el test sea determinista
+   * en cualquier runner. `new Date('AAAA-MM-DD')` es medianoche UTC; en UTC-5
+   * los getters locales ven el día anterior a las 19:00, y eso es lo que
+   * simula el `- 5h`. Un runner en UTC no reproduce el bug por sí solo, así que
+   * un `it.runIf(offset > 0)` habría dejado el caso sin correr en CI.
+   */
+  const viejoAgrupadorEnBogota = (iso: string) => {
+    const utc = new Date(`${iso}T00:00:00Z`);
+    const local = new Date(utc.getTime() - 5 * 3600 * 1000); // UTC-5
+    const anio = local.getUTCFullYear();
+    const d = new Date(Date.UTC(anio, local.getUTCMonth(), local.getUTCDate()));
+    const dayNum = d.getUTCDay() || 7;
+    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
+    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
+    const semana = Math.ceil(((d.getTime() - yearStart.getTime()) / 86400000 + 1) / 7);
+    return { semana, anio };
+  };
+
+  it('las fechas de lunes con monitoreos reales ya no bajan una semana', () => {
+    const lunesReales = [
+      '2025-01-20', '2025-02-10', '2025-04-21', '2025-05-12', '2025-06-09',
+      '2025-07-21', '2025-09-08', '2025-09-29', '2026-08-03',
+    ];
+    for (const fecha of lunesReales) {
+      const nuevo = semanaISO(fecha);
+      const viejo = viejoAgrupadorEnBogota(fecha);
+      expect(viejo.semana, `${fecha}: la aritmética vieja debía quedar una semana atrás`).toBe(
+        nuevo.semana - 1,
+      );
+    }
+  });
+
+  it('los días que NO son lunes caían en la semana correcta por casualidad', () => {
+    for (const fecha of ['2026-08-04', '2026-08-05', '2026-08-06', '2026-08-07', '2026-08-08', '2026-08-09']) {
+      expect(viejoAgrupadorEnBogota(fecha).semana).toBe(semanaISO(fecha).semana);
+    }
+  });
+
+  it('un monitoreo del 1 de enero ya no se archiva bajo el año anterior', () => {
+    expect(viejoAgrupadorEnBogota('2026-01-01').anio).toBe(2025);
+    expect(semanaISO('2026-01-01').anioISO).toBe(2026);
+  });
+});

--- a/src/components/monitoreo/TablaMonitoreos.tsx
+++ b/src/components/monitoreo/TablaMonitoreos.tsx
@@ -6,7 +6,7 @@ import { Label } from '../ui/label';
 import { Button } from '../ui/button';
 import { Search, Calendar, MapPin, Bug, Filter, X, ArrowUpDown, ArrowUp, ArrowDown, ChevronDown, ChevronUp } from 'lucide-react';
 import { toast } from 'sonner';
-import { formatearFecha, formatearFechaCorta } from '../../utils/fechas';
+import { formatearFecha, formatearFechaCorta, semanaISO } from '../../utils/fechas';
 
 interface Monitoreo {
   id: string;
@@ -185,37 +185,25 @@ export function TablaMonitoreos() {
     return direccionOrden === 'asc' ? comparacion : -comparacion;
   });
 
-  // ✅ NUEVO: Función para obtener número de semana ISO 8601
-  const getNumeroSemana = (fecha: Date): number => {
-    const d = new Date(Date.UTC(fecha.getFullYear(), fecha.getMonth(), fecha.getDate()));
-    const dayNum = d.getUTCDay() || 7;
-    d.setUTCDate(d.getUTCDate() + 4 - dayNum);
-    const yearStart = new Date(Date.UTC(d.getUTCFullYear(), 0, 1));
-    return Math.ceil((((d.getTime() - yearStart.getTime()) / 86400000) + 1) / 7);
-  };
-
-  // ✅ NUEVO: Agrupar monitoreos por semana
+  // Agrupar monitoreos por semana ISO 8601.
+  // `semanaISO()` hace toda la aritmética en UTC a partir del string
+  // `AAAA-MM-DD` de la BD. Antes se mezclaba `new Date(fecha_monitoreo)`
+  // (medianoche UTC) con getDay()/getDate() LOCALES, y en UTC-5 eso corría cada
+  // fecha un día hacia atrás: todo monitoreo de un lunes caía en la semana
+  // anterior. El año de la etiqueta es el año ISO, no el del calendario.
   const agruparPorSemana = (monitoreos: Monitoreo[]): GrupoSemana[] => {
     const grupos = new Map<string, GrupoSemana>();
 
     monitoreos.forEach(m => {
-      const fecha = new Date(m.fecha_monitoreo);
-      const año = fecha.getFullYear();
-      const semana = getNumeroSemana(fecha);
-      const key = `${año}-S${semana}`;
+      const { semana, anioISO, lunes, domingo } = semanaISO(m.fecha_monitoreo);
+      const key = `${anioISO}-S${semana}`;
 
       if (!grupos.has(key)) {
-        // Calcular fechas de inicio y fin de la semana
-        const primerDia = new Date(fecha);
-        primerDia.setDate(fecha.getDate() - (fecha.getDay() || 7) + 1); // Lunes
-        const ultimoDia = new Date(primerDia);
-        ultimoDia.setDate(primerDia.getDate() + 6); // Domingo
-
         grupos.set(key, {
           semana,
-          año,
-          fechaInicio: primerDia.toISOString().split('T')[0],
-          fechaFin: ultimoDia.toISOString().split('T')[0],
+          año: anioISO,
+          fechaInicio: lunes,
+          fechaFin: domingo,
           registros: [],
           totalRegistros: 0
         });

--- a/src/utils/fechas.ts
+++ b/src/utils/fechas.ts
@@ -348,3 +348,58 @@ export function calcularRangoFechasPorPeriodo(periodo: string): { fecha_desde: s
       };
   }
 }
+// ---------------------------------------------------------------------------
+// Semana ISO 8601
+// ---------------------------------------------------------------------------
+
+/**
+ * Semana ISO 8601 de una fecha `AAAA-MM-DD`, con su año ISO y el lunes/domingo
+ * que la delimitan.
+ *
+ * **Toda la aritmética es UTC y arranca de los tres números del string**, nunca
+ * de `new Date(iso)` leído con getters locales. Ese cruce es el defecto que esta
+ * función reemplaza: en UTC-5, `new Date('2026-01-05')` es medianoche UTC pero
+ * `getDate()` devuelve **4**, así que todo monitoreo de un lunes se agrupaba en
+ * la semana anterior (677 de 4.200 filas en producción, 2026-08-24).
+ *
+ * El **año que devuelve es el año ISO, no el del calendario**. No son lo mismo
+ * en el cambio de año: el 2027-01-01 es viernes y pertenece a la semana 53 de
+ * 2026, y el 2024-12-30 es lunes y pertenece a la semana 1 de 2025. Etiquetar
+ * una semana con el año del calendario produce combinaciones que no existen
+ * («Semana 53 · 2027»).
+ *
+ * @param fechaISO - Fecha en formato `AAAA-MM-DD` (se ignora cualquier hora)
+ */
+export function semanaISO(fechaISO: string): {
+  semana: number;
+  anioISO: number;
+  lunes: string;
+  domingo: string;
+} {
+  const [a, m, d] = fechaISO.slice(0, 10).split('-').map(Number);
+  const base = new Date(Date.UTC(a, m - 1, d));
+
+  // Jueves de la misma semana ISO: define el año ISO y el número de semana.
+  const jueves = new Date(base.getTime());
+  const diaSemana = jueves.getUTCDay() || 7; // lunes = 1 … domingo = 7
+  jueves.setUTCDate(jueves.getUTCDate() + 4 - diaSemana);
+
+  const anioISO = jueves.getUTCFullYear();
+  const inicioAnio = Date.UTC(anioISO, 0, 1);
+  const semana = Math.ceil(((jueves.getTime() - inicioAnio) / 86400000 + 1) / 7);
+
+  const lunes = new Date(base.getTime());
+  lunes.setUTCDate(lunes.getUTCDate() - (diaSemana - 1));
+  const domingo = new Date(lunes.getTime());
+  domingo.setUTCDate(domingo.getUTCDate() + 6);
+
+  return { semana, anioISO, lunes: aISOUTC(lunes), domingo: aISOUTC(domingo) };
+}
+
+/** Formatea una Date como `AAAA-MM-DD` leyendo sus componentes UTC. */
+function aISOUTC(fecha: Date): string {
+  const anio = fecha.getUTCFullYear();
+  const mes = String(fecha.getUTCMonth() + 1).padStart(2, '0');
+  const dia = String(fecha.getUTCDate()).padStart(2, '0');
+  return `${anio}-${mes}-${dia}`;
+}


### PR DESCRIPTION
Closes maintenance finding **#27** (P2, open). Not a new finding.

## Bug

In `/monitoreo` → Historial, the week accordion files **every Monday's monitoreo under
the previous week**, and splits a round that spans a Monday into two week groups.

`agruparPorSemana()` built `new Date(m.fecha_monitoreo)` — for a bare `AAAA-MM-DD`
that is **midnight UTC** — and then read it back with `getFullYear()`, `getMonth()`,
`getDate()`, `getDay()`, which are **local**. In Bogotá (UTC-5) that Date is the
*previous* day at 19:00, so every date shifted one day backwards. Monday − 1 = Sunday,
and Sunday closes the preceding ISO week.

Measured against production 2026-08-24:

```sql
select count(*) total,
       count(*) filter (where extract(isodow from fecha_monitoreo)=1) lunes,
       count(distinct fecha_monitoreo) filter (where extract(isodow from fecha_monitoreo)=1) fechas,
       count(distinct ronda_id)        filter (where extract(isodow from fecha_monitoreo)=1) rondas
from monitoreos;
-- total = 4200 | lunes = 677 | fechas = 14 | rondas = 13
```

**677 of 4.200 observations (16,1 %)**, over 14 dates. All **13** rounds that touch a
Monday are split across two week groups:

```sql
with r as (select ronda_id, min(fecha_monitoreo) mn, max(fecha_monitoreo) mx, count(*) n,
                  count(*) filter (where extract(isodow from fecha_monitoreo)=1) lun
           from monitoreos where ronda_id is not null group by 1)
select count(*) from r where lun>0 and lun<n and mn<>mx;   -- 13
```

Second defect, latent: the group label used the **calendar** year of the shifted date,
so a 1-January monitoreo was filed under the previous year (`2026-01-01` → `2025`).
Even with the shift fixed, calendar year ≠ ISO week-year at the boundary — `2027-01-01`
is ISO week **53 of 2026**, and the old code would have labelled it "Semana 53 · 2027",
a combination that does not exist.

## Root cause

`src/components/monitoreo/TablaMonitoreos.tsx:189-217` — `getNumeroSemana()` normalised
through `Date.UTC(fecha.getFullYear(), fecha.getMonth(), fecha.getDate())`, i.e. it fed
*local* components into a UTC constructor; `agruparPorSemana()` did the same with
`fecha.getDay()` / `fecha.getDate()` for the Monday–Sunday range, then read the result
back out with `toISOString()`, shifting it a second time.

This is exactly the mixed-basis case that `hatoFechaLocalGuard.test.ts` had whitelisted
with the note *"Está mal, pero el arreglo es la aritmética de semana entera, no el
recorte"*. This PR is that fix, so the whitelist entry is removed.

## Fix

- New pure helper `semanaISO(fechaISO)` in `src/utils/fechas.ts`. It parses the three
  numbers out of the `AAAA-MM-DD` string and does **all** arithmetic in UTC — it never
  touches a local getter and never touches the clock. Returns `{ semana, anioISO, lunes,
  domingo }`, with dates formatted from UTC components (no `toISOString()` round trip).
- `TablaMonitoreos.tsx` now calls it. The group key and label use **`anioISO`**, not the
  calendar year.
- `getNumeroSemana()` and the inline Monday/Sunday arithmetic are deleted; the file now
  contains zero `toISOString()` calls, so its `hatoFechaLocalGuard` whitelist entry is
  gone rather than merely re-counted.

No other behaviour changed — sorting, filtering, expand/collapse and the rendered
columns are untouched.

## Verification

New `src/__tests__/semanaISO.test.ts` (13 tests): canonical ISO 8601 cases including the
two year-boundary traps (`2026-01-01` → week 1 of 2026, `2027-01-01` → week 53 of 2026,
`2025-12-29` → week 1 of 2026), Monday/Sunday landing in the same group, the preceding
Sunday landing in the previous one, and both real production endpoints
(`2025-01-03`, `2026-08-03`).

The regression half re-implements the **old** arithmetic with the Bogotá offset pinned
to `-5h` in the test itself, so it is deterministic on a UTC runner instead of silently
skipping: it asserts the old code lands one week early on all 9 real Monday dates, that
non-Mondays were right by accident, and that `2026-01-01` used to be filed under 2025.

```
npx tsc --noEmit   → clean
npm run lint       → 0 errors, 904 warnings (baseline)
npx vitest run     → 128 files / 2934 tests, all green
```

## Rollback

`git revert` the commit. Nothing is persisted — this is a display grouping only, no data
is written or migrated, so reverting restores the previous (wrong) grouping immediately
with no cleanup.

## Follow-up (deliberately out of scope)

`semanaISO()` is a general helper now. Other week-based views (weekly report,
`fetchDatosReporteSemanal.ts`) were **not** migrated onto it in this PR — they are
whitelisted as UTC-coherent today and changing them would move numbers Gerencia reads.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyDuV9zQppKCmTRcWuCWaJ)_