### PR TITLE
fix: align jornal divisor in calculosCierreAplicacion with DIAS_LABORALES_MES

### DIFF
--- a/src/__tests__/calculosCierreAplicacion.test.ts
+++ b/src/__tests__/calculosCierreAplicacion.test.ts
@@ -397,7 +397,7 @@ describe('construirPayloadCierreAplicacion', () => {
       lotes: [],
       movimientos: [],
     });
-    const esperado = Math.round(((1300000 + 200000 + 50000) / (48 * 4.33)) * 8);
+    const esperado = Math.round((1300000 + 200000 + 50000) / 22);
     expect(payload.registros_trabajo[0].valor_jornal_empleado).toBe(esperado);
   });
 

--- a/src/__tests__/jornalDivisorContract.test.ts
+++ b/src/__tests__/jornalDivisorContract.test.ts
@@ -91,9 +91,17 @@ describe('divisor del jornal — decisión del dueño: 22', () => {
 });
 
 describe('guard estático — un solo divisor, en los tres árboles', () => {
-  /** Ficheros que calculan el costo de un jornal de empleado. */
+  /**
+   * Ficheros que calculan el costo de un jornal de empleado.
+   *
+   * `calculosCierreAplicacion.ts` NO estaba en esta lista, y por eso se escapó del PR #144:
+   * quedó como el único sitio del proyecto con la fórmula vieja (`horas_semanales * 4.33 / 8`)
+   * mientras los otros cinco ya dividían por 22. Un fichero que deriva un jornal y no está
+   * listado acá es un fichero que puede divergir en silencio — si aparece otro, va acá.
+   */
   const FICHEROS_COSTO_JORNAL = [
     'src/utils/laborCosts.ts',
+    'src/utils/calculosCierreAplicacion.ts',
     'src/supabase/functions/server/chat.tsx',
     'src/supabase/functions/server/telegram/conversations/jornal.ts',
     'supabase/functions/make-server-1ccce916/chat.tsx',
@@ -106,10 +114,19 @@ describe('guard estático — un solo divisor, en los tres árboles', () => {
     expect(contenido, `${rel} volvió a declarar WEEKS_PER_MONTH`).not.toMatch(/WEEKS_PER_MONTH/);
   });
 
-  it.each(FICHEROS_COSTO_JORNAL)('%s declara el divisor 22 y ningún otro', (rel) => {
+  it.each(FICHEROS_COSTO_JORNAL)('%s usa el divisor 22 y ningún otro', (rel) => {
     const contenido = leer(rel);
     const declaraciones = [...contenido.matchAll(/DIAS_LABORALES_MES\s*(?::\s*number\s*)?=\s*([0-9.]+)/g)];
-    expect(declaraciones.length, `${rel} no declara DIAS_LABORALES_MES`).toBeGreaterThan(0);
+    // Importar la constante es la forma PREFERIDA — sólo hay una copia del número. Los tres
+    // árboles de edge function no pueden importar desde `src/utils/`, así que ahí (y sólo ahí)
+    // la declaración local es legítima; en el navegador lo correcto es el import.
+    const importa = /import\s*\{[^}]*\bDIAS_LABORALES_MES\b[^}]*\}\s*from\s*['"][^'"]*laborCosts['"]/.test(
+      contenido,
+    );
+    expect(
+      declaraciones.length > 0 || importa,
+      `${rel} no declara NI importa DIAS_LABORALES_MES`,
+    ).toBe(true);
     for (const d of declaraciones) {
       expect(d[1], `${rel} declara un divisor distinto de 22`).toBe('22');
     }

--- a/src/utils/calculosCierreAplicacion.ts
+++ b/src/utils/calculosCierreAplicacion.ts
@@ -8,6 +8,7 @@
  * no inline en el componente.
  */
 
+import { DIAS_LABORALES_MES } from '@/utils/laborCosts';
 import type { RegistroTrabajoCierre } from '@/types/aplicaciones';
 
 /**
@@ -328,19 +329,21 @@ export interface PayloadCierreAplicacion {
 }
 
 /**
- * Reproduce exactamente `reg.tarifa_jornal || (reg.salario ? Math.round(...) : 0)` — la fórmula
- * que `cerrarAplicacion()` (versión no transaccional) usaba inline para
- * `registros_trabajo.valor_jornal_empleado` de un registro NUEVO. Copia literal, no una
- * reinterpretación: `||` es truthy-check de JS (un `tarifa_jornal` de 0 cae al fallback), no
- * `??`.
+ * `reg.tarifa_jornal || (reg.salario ? salario mensual / DIAS_LABORALES_MES : 0)` para
+ * `registros_trabajo.valor_jornal_empleado` de un registro NUEVO. El `||` se conserva literal
+ * del original: es truthy-check de JS (un `tarifa_jornal` de 0 cae al fallback), no `??`.
+ *
+ * **El divisor NO se declara acá: se importa de `laborCosts.ts`.** Hay UN divisor del jornal en
+ * todo el proyecto —22 días laborales, decisión del dueño del 2026-08-20— y este fichero fue el
+ * único que se quedó con la fórmula vieja por horas semanales, cuyo divisor efectivo con las 44 h
+ * de la nómina real es 23,815: subvaluaba cada jornal nuevo del cierre un 7,6 %.
+ * `__tests__/jornalDivisorContract.test.ts` es la guarda que impide que vuelva a divergir.
  */
 function calcularValorJornalEmpleadoNuevo(reg: RegistroTrabajoCierre): number {
   if (reg.tarifa_jornal) return reg.tarifa_jornal;
   if (reg.salario) {
     return Math.round(
-      ((reg.salario + (reg.prestaciones || 0) + (reg.auxilios || 0)) /
-        ((reg.horas_semanales || 48) * 4.33)) *
-        8,
+      (reg.salario + (reg.prestaciones || 0) + (reg.auxilios || 0)) / DIAS_LABORALES_MES,
     );
   }
   return 0;


### PR DESCRIPTION
Hallazgo **#45b** de la operación de mantenimiento.

## El defecto

El 2026-08-20 Santiago decidió que **el divisor del jornal es 22 días laborales**. El PR #144 alineó `laborCosts.ts` y las dos copias de `telegram/conversations/jornal.ts`, y `main` ya exporta `DIAS_LABORALES_MES = 22`.

**`src/utils/calculosCierreAplicacion.ts` quedó como el único sitio del proyecto que seguía derivando un jornal con la fórmula vieja.** `calcularValorJornalEmpleadoNuevo()` dividía por `horas_semanales × 4,33` y multiplicaba por 8 — la fórmula que el PR #144 vino a eliminar.

La función alimenta `registros_trabajo.valor_jornal_empleado` de los registros **nuevos** que se crean al cerrar una aplicación (`CierreAplicacion.tsx` → `construirPayloadCierreAplicacion` → RPC `fn_cerrar_aplicacion`, migración 106).

## Evidencia

Verificado contra producción (solo lectura): **los 18 empleados asalariados tienen `horas_semanales = 44`**, sin excepción. Así que el divisor efectivo era uniformemente `44 × 4,33 ÷ 8 = 23,815` en vez de 22.

## Cifra que cambia, y en cuánto

Un jornal completo de empleado nuevo registrado al cerrar una aplicación sube **+8,25 %**. Es uniforme para toda la nómina, porque todos comparten las 44 h:

| Empleado | Total mensual | Antes | Ahora | Δ |
|---|---|---|---|---|
| Menor de la nómina | $1.950.905 | $81.919 | $88.678 | **+$6.759** |
| Jornalero tipo (mayor) | $2.508.098 | $105.316 | $114.004 | **+$8.688** |

Es un **cálculo de costo que ve Gerencia**: entra al costo de mano de obra por lote y, por ahí, al costo/kg de `/produccion`. Antes de este PR, el mismo trabajo valía distinto según si se registraba desde Labores (22) o desde el cierre de una aplicación (23,815).

**No toca la historia.** Solo aplica a registros nuevos; las 2.550 filas de `registros_trabajo` ya escritas conservan el costo vigente al momento de registrarse, que sigue siendo el histórico correcto.

## Qué cambié

1. **`src/utils/calculosCierreAplicacion.ts`** — la fórmula pasa a `(salario + prestaciones + auxilios) / DIAS_LABORALES_MES`, **importando** la constante desde `@/utils/laborCosts` en vez de declarar un número propio. El `||` de `tarifa_jornal` se conserva literal (truthy-check, no `??`): un contratista sigue cobrando su tarifa plana y un `tarifa_jornal` de 0 sigue cayendo al fallback. `horas_semanales` deja de influir en el costo, igual que en `laborCosts.ts`.
2. **`src/__tests__/calculosCierreAplicacion.test.ts`** — el esperado pasa a `Math.round((1300000 + 200000 + 50000) / 22)`, o sea 59.661 → 70.455. (Estaba en la línea 400, no 399.)
3. **`src/__tests__/jornalDivisorContract.test.ts`** — `src/utils/calculosCierreAplicacion.ts` entra a `FICHEROS_COSTO_JORNAL`. **No estar en esa lista es exactamente por qué el defecto sobrevivió al PR #144.**

### Un ajuste necesario en el guard

El guard exigía que cada fichero **declarara** `DIAS_LABORALES_MES = 22`. Ese contrato solo tiene sentido para los tres árboles de edge function, que no pueden importar desde `src/utils/`. Para un fichero del navegador lo correcto es **importar** la constante: así hay una sola copia del número. El guard acepta ahora declaración-con-valor-22 **o** import desde `laborCosts`, y sigue rechazando cualquier declaración con un valor distinto de 22.

El guard además funcionó en vivo durante este PR: mi primera versión del comentario explicativo mencionaba el literal `4.33` y la regla `not.toMatch(/4\.33/)` la rechazó. Reescribí el comentario sin el literal en vez de debilitar la regla.

## Cómo lo verifiqué

Worktree aislado sobre `origin/main` (`6369352`), `npm ci` limpio. El checkout compartido no se tocó.

- `npx tsc --noEmit` — **limpio**
- `npm run lint` — **0 errores / 904 warnings**, idéntico a la línea base
- `npx vitest run` — **129 ficheros / 2953 tests, todos verdes**

Comprobado a mano que `4.33` y `WEEKS_PER_MONTH` ya no aparecen en el fichero, ni en el código ni en los comentarios.

## Rollback

`git revert` del commit. El cambio es puramente de cálculo en una función pura, sin migración, sin cambio de esquema y sin efecto sobre filas ya escritas — revertir devuelve el divisor viejo y nada más. Si se revierte, hay que sacar también el fichero de `FICHEROS_COSTO_JORNAL` o el guard queda rojo, que es el comportamiento deseado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyDuV9zQppKCmTRcWuCWaJ)_