### PR TITLE
fix: use shared clasificarGravedad in monitoreo CargaMasiva (10% threshold, not 15%)

### DIFF
--- a/src/components/monitoreo/CargaMasiva.tsx
+++ b/src/components/monitoreo/CargaMasiva.tsx
@@ -4,6 +4,7 @@ import { MonitoreoSubNav } from './MonitoreoSubNav';
 import { useState } from 'react';
 import { getSupabase } from '../../utils/supabase/client';
 import { obtenerFechaHoy } from '@/utils/fechas';
+import { calcularIncidencia, clasificarGravedad } from '../../utils/calculosMonitoreo';
 
 interface ResultadoCarga {
   exito: boolean;
@@ -172,20 +173,12 @@ export function CargaMasiva() {
             continue;
           }
 
-          // Calcular incidencia para determinar gravedad
-          const incidencia = (arbolesAfectados / arbolesMonitoreados) * 100;
-
-          // Determinar gravedad basado en incidencia
-          let gravedadTexto: 'Baja' | 'Media' | 'Alta' = 'Baja';
-          let gravedadNumerica: 1 | 2 | 3 = 1;
-
-          if (incidencia >= 30) {
-            gravedadTexto = 'Alta';
-            gravedadNumerica = 3;
-          } else if (incidencia >= 15) {
-            gravedadTexto = 'Media';
-            gravedadNumerica = 2;
-          }
+          // Gravedad por el criterio COMPARTIDO del modulo (cortes 10 % / 30 %), el mismo que
+          // usan `RegistroMonitoreo` y todas las pantallas del dashboard. No se re-derivan los
+          // umbrales aca: duplicarlos es lo que hizo que esta carga escribiera 'Media' desde el
+          // 15 % mientras cualquier lector la clasifica desde el 10 %.
+          const incidencia = calcularIncidencia(arbolesAfectados, arbolesMonitoreados);
+          const gravedad = clasificarGravedad(incidencia);
 
           // Preparar registro para insertar
           // NOTA: incidencia y severidad son calculadas automáticamente por la BD
@@ -197,8 +190,8 @@ export function CargaMasiva() {
             arboles_monitoreados: arbolesMonitoreados,
             arboles_afectados: arbolesAfectados,
             individuos_encontrados: individuosEncontrados,
-            gravedad_texto: gravedadTexto,
-            gravedad_numerica: gravedadNumerica,
+            gravedad_texto: gravedad.texto,
+            gravedad_numerica: gravedad.numerica,
             monitor: fila['Monitor']?.trim() || null,
             observaciones: fila['Observaciones']?.trim() || null
           });


### PR DESCRIPTION
Hallazgo **#12a** de la operación de mantenimiento.

## El defecto

`clasificarGravedad()` (`src/utils/calculosMonitoreo.ts`) usa los buckets **10 % / 30 %** y es el criterio compartido de todo el módulo de monitoreo. `src/components/monitoreo/CargaMasiva.tsx` **no lo llamaba**: duplicaba los umbrales inline y usaba **15 %** como corte de «Media».

```ts
if (incidencia >= 30)      { gravedadTexto = 'Alta';  … }
else if (incidencia >= 15) { gravedadTexto = 'Media'; … }   // ← 15, no 10
```

`gravedad_texto` **se persiste** en `monitoreos`. Así que una fila cargada masivamente con 12 % de incidencia quedaba guardada como `Baja`, mientras cualquier pantalla que reclasifica esa misma incidencia con el criterio compartido la muestra `Media`. La base y la pantalla decían cosas distintas sobre la misma observación.

La divergencia nació de duplicar los umbrales en vez de llamar a la función — que es precisamente lo que el contrato del proyecto prohíbe: *«Weighted incidencia everywhere via `calcularIncidencia` and the shared `clasificarGravedad` color buckets (10 % / 30 %) — never re-derive inline or use a different color scale.»*

## Evidencia

El hallazgo es del 2026-08-03, así que verifiqué que siguiera vivo antes de tocar nada. Lo está: el bloque de 15 % está en `main` hoy (`6369352`).

Contado contra producción (solo lectura), hoy:

```sql
select count(*) from monitoreos
where incidencia >= 10 and incidencia < 15 and gravedad_texto = 'Baja';
-- 48
```

**48 filas subvaluadas, de 4.200.** Y son exactamente esas: no hay ninguna otra fila cuyo `gravedad_texto` discrepe del criterio compartido, lo que confirma que este era el único escritor divergente.

## Qué cambié

Un solo fichero, `src/components/monitoreo/CargaMasiva.tsx`: el bloque inline se reemplaza por las dos funciones compartidas, igual que `RegistroMonitoreo.tsx` (líneas 252-253), que es la referencia del módulo.

```ts
const incidencia = calcularIncidencia(arbolesAfectados, arbolesMonitoreados);
const gravedad = clasificarGravedad(incidencia);
```

Arreglé la causa (los umbrales duplicados), no el síntoma: ya no hay un segundo lugar donde el número 10 pueda desincronizarse.

Dos notas sobre equivalencia, para que la revisión sea corta:
- `calcularIncidencia` guarda contra división por cero devolviendo 0; acá no cambia nada porque la validación de la línea 155 ya rechaza `arbolesMonitoreados <= 0` antes de llegar. El cálculo es idéntico al inline que reemplaza.
- `clasificarGravedad` devuelve `{ texto, numerica }` con los mismos valores 1/2/3 que llevaba `gravedadNumerica`, y `registrosParaInsertar` está declarado `any[]`, así que no hay fricción de tipos. `tsc` lo confirma.

## Alcance: sólo el código

**Este PR arregla el defecto hacia adelante. Las 48 filas históricas siguen subvaluadas.**

Re-etiquetarlas es una operación de datos sobre producción, **necesita aprobación de Santiago y deliberadamente NO entra en este PR**. Queda anotada en el hallazgo #12 para una decisión aparte. Este PR no ejecuta ningún UPDATE.

Vale la pena decidirlo pronto, porque mientras tanto esas 48 filas son la única fuente de desacuerdo entre `gravedad_texto` y lo que muestran las pantallas.

## Cómo lo verifiqué

Worktree aislado sobre `origin/main` (`6369352`), `npm ci` limpio. El checkout compartido no se tocó.

- `npx tsc --noEmit` — **limpio**
- `npm run lint` — **0 errores / 904 warnings**, idéntico a la línea base
- `npx vitest run` — **129 ficheros / 2951 tests, todos verdes**

## Rollback

`git revert` del commit. Es un cambio de una sola expresión en un componente, sin migración, sin cambio de esquema y sin efecto retroactivo sobre filas ya escritas. Revertir devuelve el umbral de 15 % para cargas futuras y no altera nada de lo ya guardado.

---
_Generated by [Claude Code](https://claude.ai/code/session_01XyDuV9zQppKCmTRcWuCWaJ)_