### PR TITLE
chore(ci): detect edge-function deployment drift

### DIFF
--- a/.github/workflows/deteccion-deriva-despliegue.yml
+++ b/.github/workflows/deteccion-deriva-despliegue.yml
@@ -1,0 +1,50 @@
+# Detecta codigo mezclado a `main` que nunca llego a produccion.
+#
+# El 2026-08-20 se mezclo el arreglo de seguridad ESCO-1 y se dio por cerrado.
+# Cuatro dias despues seguia sin desplegarse, con cinco rutas de escritura
+# abiertas anonimamente en internet. Nada lo detectaba, porque nada comparaba
+# el despliegue vivo contra el repositorio.
+name: Deteccion de deriva de despliegue
+
+on:
+  schedule:
+    # 12:30 UTC = 07:30 Bogota, todos los dias. Un cron de GitHub Actions puede
+    # atrasarse; para este chequeo diario da igual.
+    - cron: '30 12 * * *'
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  deriva:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          # OBLIGATORIO: con el checkout superficial por defecto (fetch-depth: 1)
+          # el ultimo commit que toca el arbol desplegado puede no estar en el
+          # historial, y `git log -- <ruta>` devuelve vacio. El script falla
+          # explicitamente en ese caso en vez de reportar "sin deriva".
+          fetch-depth: 0
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      # Sin dependencias: el script usa solo `fetch` y `git`, ambos ya presentes.
+      - name: Comprobar deriva
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+        # Sin tuberia a `tee`: el shell por defecto de Actions es `bash -e`, SIN
+        # pipefail, asi que el codigo de salida de una tuberia es el de `tee` (0)
+        # y un fallo del script no tumbaria el job. Se guarda la salida, se
+        # publica en el resumen y se sale con el codigo real.
+        run: |
+          set +e
+          node scripts/check-deploy-drift.mjs > salida-deriva.txt 2>&1
+          estado=$?
+          { echo '```'; cat salida-deriva.txt; echo '```'; } >> "$GITHUB_STEP_SUMMARY"
+          cat salida-deriva.txt
+          exit $estado

--- a/scripts/check-deploy-drift.mjs
+++ b/scripts/check-deploy-drift.mjs
@@ -1,0 +1,171 @@
+#!/usr/bin/env node
+// Detecta DERIVA DE DESPLIEGUE de la edge function: codigo mezclado a `main`
+// que nunca llego a produccion.
+//
+// Por que existe: el arreglo de seguridad ESCO-1 se mezclo el 2026-08-20 y se
+// dio por cerrado. Cuatro dias despues seguia sin desplegarse, con cinco rutas
+// de escritura abiertas anonimamente en internet. "Mezclado" no es prueba de
+// que este desplegado, y hasta hoy nada lo comprobaba.
+//
+// El chequeo: comparar el `updated_at` del despliegue vivo contra la fecha del
+// ultimo commit que toca el arbol desplegado. Si el commit es POSTERIOR al
+// despliegue, hay deriva.
+//
+// Uso:
+//   SUPABASE_ACCESS_TOKEN=sbp_... node scripts/check-deploy-drift.mjs
+//
+// Salida: 0 = sin deriva. 1 = hay deriva, o no se pudo comprobar.
+
+import { execFileSync } from 'node:child_process';
+
+// --- Configuracion (todo sobreescribible por entorno) ---------------------
+export const PROYECTO_POR_DEFECTO = 'ywhtjwawnkeqlwxbvgup';
+export const FUNCION_POR_DEFECTO = 'make-server-1ccce916';
+export const RUTA_DESPLEGADA_POR_DEFECTO = 'supabase/functions/make-server-1ccce916';
+
+// -------------------------------------------------------------------------
+// Logica pura (probada en check-deploy-drift.test.mjs)
+// -------------------------------------------------------------------------
+
+/**
+ * `updated_at` de la Management API viene en EPOCH MILISEGUNDOS
+ * (ej. 1787016998919 -> 2026-08-18T01:36:38Z). Tratarlo como segundos da 1970
+ * y el chequeo diria "sin deriva" para siempre: es el modo de fallo silencioso
+ * que hay que evitar, asi que se valida el rango en vez de confiar.
+ * @param {unknown} valor
+ * @returns {Date}
+ */
+export function parsearUpdatedAt(valor) {
+  const ms = typeof valor === 'string' ? Number(valor) : valor;
+  if (typeof ms !== 'number' || !Number.isFinite(ms)) {
+    throw new Error(`updated_at no es un numero: ${JSON.stringify(valor)}`);
+  }
+  // Un despliegue plausible cae entre 2020 y 2100. Un valor en segundos
+  // (~1.8e9) queda por debajo del piso y revienta aqui, en vez de mentir.
+  const PISO_MS = Date.UTC(2020, 0, 1);
+  const TECHO_MS = Date.UTC(2100, 0, 1);
+  if (ms < PISO_MS || ms > TECHO_MS) {
+    throw new Error(
+      `updated_at fuera de rango: ${ms}. Se esperan epoch MILISEGUNDOS ` +
+        `(${PISO_MS}..${TECHO_MS}); un valor en segundos cae aca.`,
+    );
+  }
+  return new Date(ms);
+}
+
+/**
+ * @param {{ desplegadoEnMs: number|string, commitISO: string }} entrada
+ * @returns {{ hayDeriva: boolean, desplegado: Date, commit: Date, horasDeDeriva: number }}
+ */
+export function evaluarDeriva({ desplegadoEnMs, commitISO }) {
+  const desplegado = parsearUpdatedAt(desplegadoEnMs);
+  const commit = new Date(commitISO);
+  if (Number.isNaN(commit.getTime())) {
+    throw new Error(`fecha de commit invalida: ${JSON.stringify(commitISO)}`);
+  }
+  const diffMs = commit.getTime() - desplegado.getTime();
+  return {
+    hayDeriva: diffMs > 0,
+    desplegado,
+    commit,
+    horasDeDeriva: Math.round((diffMs / 3_600_000) * 10) / 10,
+  };
+}
+
+// -------------------------------------------------------------------------
+// Entrada/salida
+// -------------------------------------------------------------------------
+
+/**
+ * Fecha del ultimo commit que toca el arbol desplegado.
+ *
+ * Se usa `%cI` (committer date) y no `%aI` (author date) a proposito: la fecha
+ * de autor es cuando se ESCRIBIO el commit, que puede ser dias anterior a
+ * cuando aterrizo en `main`. Usarla solo puede ESCONDER deriva, nunca
+ * inventarla, y esconder deriva es el defecto que este chequeo persigue.
+ *
+ * @param {string} ruta
+ */
+export function fechaUltimoCommit(ruta) {
+  const salida = execFileSync('git', ['log', '-1', '--format=%cI', '--', ruta], {
+    encoding: 'utf8',
+  }).trim();
+  if (!salida) {
+    throw new Error(
+      `git log no devolvio ningun commit para "${ruta}". En GitHub Actions esto ` +
+        `casi siempre significa checkout superficial: hace falta fetch-depth: 0.`,
+    );
+  }
+  return salida;
+}
+
+/**
+ * @param {{ proyecto: string, funcion: string, token: string }} opciones
+ */
+export async function updatedAtDelDespliegue({ proyecto, funcion, token }) {
+  const url = `https://api.supabase.com/v1/projects/${proyecto}/functions`;
+  const respuesta = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}` },
+  });
+  if (!respuesta.ok) {
+    throw new Error(
+      `Management API respondio ${respuesta.status} ${respuesta.statusText} en ${url}`,
+    );
+  }
+  const funciones = await respuesta.json();
+  const encontrada = Array.isArray(funciones)
+    ? funciones.find((f) => f?.slug === funcion)
+    : undefined;
+  if (!encontrada) {
+    throw new Error(`la edge function "${funcion}" no existe en el proyecto ${proyecto}`);
+  }
+  return encontrada.updated_at;
+}
+
+async function main() {
+  const proyecto = process.env.SUPABASE_PROJECT_REF || PROYECTO_POR_DEFECTO;
+  const funcion = process.env.EDGE_FUNCTION_SLUG || FUNCION_POR_DEFECTO;
+  const ruta = process.env.EDGE_FUNCTION_PATH || RUTA_DESPLEGADA_POR_DEFECTO;
+  const token = process.env.SUPABASE_ACCESS_TOKEN;
+
+  // Falla cerrado, igual que CLIMA_SYNC_SECRET en la edge function: un
+  // detector que no hace nada cuando le falta configuracion es exactamente el
+  // "se dio por cerrado" que este chequeo existe para impedir.
+  if (!token) {
+    console.error(
+      'ERROR: falta SUPABASE_ACCESS_TOKEN (personal access token de Supabase).\n' +
+        'En GitHub Actions se configura como secreto del repositorio.',
+    );
+    process.exit(1);
+  }
+
+  const updatedAt = await updatedAtDelDespliegue({ proyecto, funcion, token });
+  const commitISO = fechaUltimoCommit(ruta);
+  const { hayDeriva, desplegado, commit, horasDeDeriva } = evaluarDeriva({
+    desplegadoEnMs: updatedAt,
+    commitISO,
+  });
+
+  console.log(`edge function : ${funcion} (proyecto ${proyecto})`);
+  console.log(`desplegada    : ${desplegado.toISOString()}`);
+  console.log(`ultimo commit : ${commit.toISOString()}  (${ruta})`);
+
+  if (!hayDeriva) {
+    console.log('\nOK: el despliegue vivo es posterior al ultimo commit del arbol desplegado.');
+    return;
+  }
+
+  console.error(
+    `\nDERIVA DE DESPLIEGUE: hay codigo en main desde hace ${horasDeDeriva} h que no esta ` +
+      `en produccion.\nDesplegar con:  npx supabase functions deploy ${funcion}`,
+  );
+  process.exit(1);
+}
+
+// Solo corre si se invoca como programa; importarlo desde el test no ejecuta nada.
+if (process.argv[1] && import.meta.url === `file://${process.argv[1]}`) {
+  main().catch((error) => {
+    console.error(`ERROR: ${error.message}`);
+    process.exit(1);
+  });
+}

--- a/scripts/check-deploy-drift.test.mjs
+++ b/scripts/check-deploy-drift.test.mjs
@@ -1,0 +1,69 @@
+import { describe, it, expect } from 'vitest';
+import { evaluarDeriva, parsearUpdatedAt } from './check-deploy-drift.mjs';
+
+// El caso real: `updated_at` de la Management API llega en epoch MILISEGUNDOS.
+const DESPLIEGUE_2026_08_18_MS = 1787016998919; // 2026-08-18T01:36:38.919Z
+
+describe('parsearUpdatedAt', () => {
+  it('interpreta epoch milisegundos', () => {
+    expect(parsearUpdatedAt(DESPLIEGUE_2026_08_18_MS).toISOString()).toBe(
+      '2026-08-18T01:36:38.919Z',
+    );
+  });
+
+  it('acepta el mismo valor como string', () => {
+    expect(parsearUpdatedAt(String(DESPLIEGUE_2026_08_18_MS)).getTime()).toBe(
+      DESPLIEGUE_2026_08_18_MS,
+    );
+  });
+
+  it('revienta ante epoch SEGUNDOS en vez de devolver una fecha de 1970', () => {
+    // Este es el modo de fallo silencioso: 1970 es anterior a cualquier commit,
+    // asi que el chequeo diria "sin deriva" para siempre.
+    expect(() => parsearUpdatedAt(Math.floor(DESPLIEGUE_2026_08_18_MS / 1000))).toThrow(
+      /fuera de rango/,
+    );
+  });
+
+  it('revienta ante un valor que no es numero', () => {
+    expect(() => parsearUpdatedAt(null)).toThrow(/no es un numero/);
+    expect(() => parsearUpdatedAt('2026-08-18T01:36:38Z')).toThrow(/no es un numero/);
+  });
+});
+
+describe('evaluarDeriva', () => {
+  it('detecta deriva cuando el commit es posterior al despliegue', () => {
+    // El fallo real: ESCO-1 se mezclo el 2026-08-20 y el despliegue vivo era del 18.
+    const r = evaluarDeriva({
+      desplegadoEnMs: DESPLIEGUE_2026_08_18_MS,
+      commitISO: '2026-08-20T13:03:24-05:00',
+    });
+    expect(r.hayDeriva).toBe(true);
+    expect(r.horasDeDeriva).toBeGreaterThan(40);
+  });
+
+  it('no reporta deriva cuando el despliegue es posterior al commit', () => {
+    const r = evaluarDeriva({
+      desplegadoEnMs: Date.UTC(2026, 7, 24, 15, 52, 43),
+      commitISO: '2026-08-24T11:24:59+00:00',
+    });
+    expect(r.hayDeriva).toBe(false);
+    expect(r.horasDeDeriva).toBeLessThan(0);
+  });
+
+  it('no reporta deriva cuando coinciden exactamente', () => {
+    const instante = Date.UTC(2026, 7, 24, 12, 0, 0);
+    const r = evaluarDeriva({
+      desplegadoEnMs: instante,
+      commitISO: new Date(instante).toISOString(),
+    });
+    expect(r.hayDeriva).toBe(false);
+  });
+
+  it('revienta ante una fecha de commit invalida en vez de asumir que no hay deriva', () => {
+    // git log sin commits devuelve cadena vacia; eso no puede leerse como "todo bien".
+    expect(() =>
+      evaluarDeriva({ desplegadoEnMs: DESPLIEGUE_2026_08_18_MS, commitISO: '' }),
+    ).toThrow(/fecha de commit invalida/);
+  });
+});


### PR DESCRIPTION
## El defecto

Nada comprueba que la edge function desplegada corresponda a lo que hay en `main`.

Es la causa raíz del peor fallo de la semana: el arreglo de seguridad **ESCO-1 se fusionó el 2026-08-20 y se dio por cerrado**. Cuatro días después seguía sin desplegarse — con cinco rutas de escritura abiertas anónimamente en internet todo ese tiempo. «Fusionado» dejó de ser prueba de nada, y no había ningún mecanismo que lo notara.

## La evidencia

El chequeo es una sola comparación. Corriendo la lógica de este PR contra los datos reales de hoy:

```
ultimo commit del arbol desplegado: 2026-08-24T11:24:59+00:00

vs despliegue vivo  1787586763349 -> 2026-08-24T15:52:43.349Z | deriva: false  (-4.5h)
vs despliegue viejo 1787016998919 -> 2026-08-18T01:36:38.919Z | deriva: true  (153.8h)
```

La segunda línea es el despliegue que estaba vivo **durante el incidente ESCO-1**: el chequeo lo habría marcado en rojo con **153,8 h de deriva**. La primera es el estado de hoy (alguien desplegó hace 4,5 h) y sale verde, así que el workflow no nace rojo por deriva.

## Qué cambié

Tres ficheros nuevos, ninguno tocado.

**`scripts/check-deploy-drift.mjs`** — sin dependencias, solo `fetch` y `git`.
1. Lee `updated_at` de la edge function en la Management API de Supabase.
2. `git log -1 --format=%cI -- supabase/functions/make-server-1ccce916`.
3. Commit posterior al despliegue → salida 1.

Tres decisiones que no se deducen del diff:

- **`updated_at` viene en epoch MILISEGUNDOS** (`1787016998919` → `2026-08-18T01:36:38Z`). Leerlo como segundos da **1970**, que es anterior a cualquier commit: el chequeo diría «sin deriva» para siempre. `parsearUpdatedAt` valida el rango 2020–2100 y **revienta** en vez de mentir. Es el test que más importa de los 8.
- **`%cI` (committer date), no `%aI`** (que es lo que proponía el hallazgo). La fecha de autor es cuándo se *escribió* el commit y puede ser días anterior a cuándo aterrizó en `main`; usarla solo puede **esconder** deriva, nunca inventarla — y esconder deriva es exactamente el defecto que esto persigue. Para el caso ESCO-1 ambas lo detectan; `%cI` es la conservadora de las dos.
- **Falla cerrado sin `SUPABASE_ACCESS_TOKEN`.** Mismo criterio que el proyecto ya aplica a `CLIMA_SYNC_SECRET` (sin secreto → 503, nunca abierto): un detector que no hace nada cuando le falta configuración es precisamente el «se dio por cerrado» que existe para impedir.

**`scripts/check-deploy-drift.test.mjs`** — 8 tests. `npm run lint` es `eslint src` y `tsconfig.json` incluye solo `src`, así que `scripts/` no se lintea ni se typechequea (convención existente del repo); vitest sí lo recoge con su patrón por defecto.

**`.github/workflows/deteccion-deriva-despliegue.yml`** — **es el primer workflow del repo**; no había `.github/`. Diario a las 12:30 UTC (07:30 Bogotá) + `workflow_dispatch`. Dos detalles que costarían un fallo silencioso:

- **`fetch-depth: 0` es obligatorio.** Con el checkout superficial por defecto, el último commit que toca el árbol desplegado puede no estar en el historial y `git log -1 -- <la ruta>` devuelve vacío. El script falla explícitamente en ese caso en vez de reportar «sin deriva».
- **Sin tubería a `tee`.** El shell por defecto de Actions es `bash -e`, **sin `pipefail`**, así que el código de salida de una tubería es el de `tee` (0) y un fallo del script no tumbaría el job. Se guarda la salida, se publica en `$GITHUB_STEP_SUMMARY` y se sale con el código real.

## ⚠️ Hace falta un secreto que esta sesión no puede configurar

Leer el `updated_at` del despliegue exige un **personal access token de Supabase**. No puedo crearlo ni cargarlo, así que queda como paso manual:

1. Supabase → Account → **Access Tokens** → generar uno (`Escociaos CI — deploy drift`).
2. GitHub → repo → Settings → Secrets and variables → Actions → New repository secret, nombre exacto **`SUPABASE_ACCESS_TOKEN`**.

**Hasta que ese secreto exista, la ejecución programada saldrá en rojo con el mensaje `ERROR: falta SUPABASE_ACCESS_TOKEN`.** Es deliberado (falla cerrado). Si se prefiere fusionar sin el secreto y configurarlo después, el workflow avisa exactamente qué falta; lo que no hará nunca es pasar en verde sin haber comprobado nada.

`SUPABASE_PROJECT_REF`, `EDGE_FUNCTION_SLUG` y `EDGE_FUNCTION_PATH` son sobreescribibles por entorno pero traen los valores del proyecto por defecto, así que no hay nada más que configurar.

## Por qué un workflow y no una nota en el runbook

El hallazgo pide que corra solo. Una nota en un runbook depende de que alguien la lea el día correcto, que es la misma clase de mecanismo que ya falló. El workflow corre sin que nadie se acuerde.

Mejora posible que **no** se hizo aquí, para no ampliar el alcance: que la deriva abra o actualice un issue en vez de solo tumbar el job. Requiere `permissions: issues: write` y lógica de deduplicación; el job rojo ya notifica por correo.

## Cómo lo verifiqué

Worktree limpio sobre `origin/main` (`6369352`), `npm ci`:

| Chequeo | Resultado |
|---|---|
| `npx tsc --noEmit` | exit 0 |
| `npm run lint` | **0 errores**, 904 warnings (línea base exacta) |
| `npx vitest run` | **130 ficheros / 2959 tests, todos verdes** (129/2951 + los 8 nuevos) |
| `node scripts/check-deploy-drift.mjs` sin token | sale 1 con el mensaje correcto |
| Lógica completa contra datos reales | ver el bloque de evidencia de arriba |
| YAML | parsea con `yaml.safe_load` |

El workflow en sí no se pudo ejecutar antes de fusionar (los `schedule` y `workflow_dispatch` solo existen una vez en `main`); lo que sí se ejecutó de punta a punta es el script que invoca.

## Rollback

`git revert` del único commit, o borrar el fichero del workflow. No toca código de aplicación, esquema, edge functions ni configuración de producción — solo agrega CI.