### PR TITLE
fix(inventory): stop losing the ledger trace when deleting a compra

### DIFF
--- a/src/__tests__/eliminarCompraConReversion.test.ts
+++ b/src/__tests__/eliminarCompraConReversion.test.ts
@@ -1,0 +1,197 @@
+import { describe, it, expect, vi } from 'vitest';
+import { eliminarCompraConReversion } from '@/components/inventory/PurchaseHistory';
+
+/**
+ * Cubre el finding #28: eliminar una compra restaba stock sin dejar rastro en
+ * `movimientos_inventario` -- dos errores tragados en silencio:
+ *   1. Un `.delete().eq('compra_id', ...)` contra una tabla que no tiene esa columna.
+ *   2. Un `.insert()` con `tipo_movimiento: 'Salida'`, que no es una etiqueta válida
+ *      del ENUM (`Entrada` | `Salida por Aplicación` | `Salida Otros` | `Ajuste`).
+ *
+ * Estos tests no usan @testing-library/react (no está instalado en este repo, ver
+ * `accionesRecomendadasComponentes.test.tsx`) -- `eliminarCompraConReversion` recibe
+ * el cliente de Supabase por parámetro, así que se prueba directamente sin renderizar
+ * el componente, con un stub construido a mano por tabla (mismo espíritu que el
+ * `createChainableMock` de `aplicacionesReales.test.ts`).
+ */
+
+type PurchaseFixture = Parameters<typeof eliminarCompraConReversion>[1];
+
+function crearCompra(overrides: Partial<PurchaseFixture> = {}): PurchaseFixture {
+  return {
+    id: 'compra-1',
+    fecha_compra: '2026-08-01',
+    proveedor: 'Agroinsumos S.A.',
+    numero_factura: 'F-001',
+    producto_id: 'prod-1',
+    cantidad: 20,
+    unidad: 'Kilos',
+    numero_lote_producto: null,
+    fecha_vencimiento: null,
+    costo_unitario: 5000,
+    costo_total: 100000,
+    link_factura: null,
+    usuario_registro: 'consuelo@escocia.co',
+    created_at: '2026-08-01T10:00:00Z',
+    ...overrides,
+  };
+}
+
+interface StubOptions {
+  cantidadActualProducto?: number;
+  productoFetchError?: { message: string } | null;
+  movimientoInsertError?: { message: string } | null;
+  productoUpdateError?: { message: string } | null;
+  compraDeleteError?: { message: string } | null;
+  rpcError?: { message: string } | null;
+}
+
+/** Registro de llamadas por tabla/método, en el orden real en que ocurrieron. */
+function crearSupabaseStub(options: StubOptions = {}) {
+  const orden: string[] = [];
+
+  const productosMock = {
+    select: vi.fn(() => ({
+      eq: vi.fn(() => ({
+        single: vi.fn(() =>
+          Promise.resolve({
+            data: { cantidad_actual: options.cantidadActualProducto ?? 100 },
+            error: options.productoFetchError ?? null,
+          }),
+        ),
+      })),
+    })),
+    update: vi.fn((payload: Record<string, unknown>) => {
+      orden.push('productos.update');
+      return {
+        eq: vi.fn(() => Promise.resolve({ error: options.productoUpdateError ?? null })),
+        _payload: payload,
+      };
+    }),
+  };
+
+  const movimientosMock = {
+    insert: vi.fn((payload: Record<string, unknown>) => {
+      orden.push('movimientos_inventario.insert');
+      return Promise.resolve({ error: options.movimientoInsertError ?? null, _payload: payload });
+    }),
+    delete: vi.fn(() => {
+      orden.push('movimientos_inventario.delete');
+      return { eq: vi.fn(() => Promise.resolve({ error: null })) };
+    }),
+  };
+
+  const comprasMock = {
+    delete: vi.fn(() => {
+      orden.push('compras.delete');
+      return { eq: vi.fn(() => Promise.resolve({ error: options.compraDeleteError ?? null })) };
+    }),
+  };
+
+  const rpc = vi.fn(() => {
+    orden.push('rpc.fn_cleanup_compra_dependencies');
+    return Promise.resolve({ error: options.rpcError ?? null });
+  });
+
+  const storageRemove = vi.fn(() => Promise.resolve({ error: null }));
+
+  const from = vi.fn((table: string) => {
+    if (table === 'productos') return productosMock;
+    if (table === 'movimientos_inventario') return movimientosMock;
+    if (table === 'compras') return comprasMock;
+    throw new Error(`Tabla no mockeada en el stub: ${table}`);
+  });
+
+  return {
+    from,
+    rpc,
+    storage: { from: vi.fn(() => ({ remove: storageRemove })) },
+    // Expuestos para inspeccionar llamadas desde los tests
+    _spies: { productosMock, movimientosMock, comprasMock, rpc, storageRemove },
+    _orden: orden,
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  } as any;
+}
+
+describe('eliminarCompraConReversion', () => {
+  it('camino feliz: escribe el ajuste en el ledger ANTES de tocar el stock, con una etiqueta válida del ENUM', async () => {
+    const supabase = crearSupabaseStub({ cantidadActualProducto: 100 });
+    const compra = crearCompra({ cantidad: 20 });
+
+    await eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co');
+
+    // El ledger se escribe antes que el stock -- si el ledger falla, el stock nunca se toca.
+    expect(supabase._orden.indexOf('movimientos_inventario.insert')).toBeLessThan(
+      supabase._orden.indexOf('productos.update'),
+    );
+
+    const [payloadMovimiento] = supabase._spies.movimientosMock.insert.mock.calls[0];
+    expect(payloadMovimiento.tipo_movimiento).toBe('Salida Otros');
+    expect(payloadMovimiento.tipo_movimiento).not.toBe('Salida'); // etiqueta inválida del ENUM
+    expect(payloadMovimiento.cantidad).toBe(20);
+    expect(payloadMovimiento.saldo_anterior).toBe(100);
+    expect(payloadMovimiento.saldo_nuevo).toBe(80);
+
+    const [payloadProducto] = supabase._spies.productosMock.update.mock.calls[0];
+    expect(payloadProducto.cantidad_actual).toBe(80);
+
+    // Nunca se borra por compra_id -- movimientos_inventario no tiene esa columna.
+    expect(supabase._spies.movimientosMock.delete).not.toHaveBeenCalled();
+
+    expect(supabase._spies.comprasMock.delete).toHaveBeenCalledTimes(1);
+  });
+
+  it('si falla el insert del ledger (p.ej. etiqueta inválida), aborta y deja el stock intacto', async () => {
+    const supabase = crearSupabaseStub({
+      cantidadActualProducto: 100,
+      movimientoInsertError: { message: 'invalid input value for enum tipo_movimiento: "Salida"' },
+    });
+    const compra = crearCompra({ cantidad: 20 });
+
+    await expect(eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co')).rejects.toThrow(
+      /movimiento de ajuste/i,
+    );
+
+    expect(supabase._spies.productosMock.update).not.toHaveBeenCalled();
+    expect(supabase._spies.comprasMock.delete).not.toHaveBeenCalled();
+  });
+
+  it('no permite dejar el inventario en negativo, y no escribe nada si el guard dispara', async () => {
+    const supabase = crearSupabaseStub({ cantidadActualProducto: 10 });
+    const compra = crearCompra({ cantidad: 20 }); // 10 - 20 = -10
+
+    await expect(eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co')).rejects.toThrow(
+      /inventario negativo/i,
+    );
+
+    expect(supabase._spies.movimientosMock.insert).not.toHaveBeenCalled();
+    expect(supabase._spies.productosMock.update).not.toHaveBeenCalled();
+    expect(supabase._spies.comprasMock.delete).not.toHaveBeenCalled();
+  });
+
+  it('si falla la actualización de stock después del ledger, aborta antes de borrar la compra', async () => {
+    const supabase = crearSupabaseStub({
+      cantidadActualProducto: 100,
+      productoUpdateError: { message: 'timeout' },
+    });
+    const compra = crearCompra({ cantidad: 20 });
+
+    await expect(eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co')).rejects.toThrow(
+      /actualizar inventario/i,
+    );
+
+    expect(supabase._spies.comprasMock.delete).not.toHaveBeenCalled();
+  });
+
+  it('la limpieza de gasto pendiente y de la factura son no bloqueantes: un error ahí no impide eliminar la compra', async () => {
+    const supabase = crearSupabaseStub({
+      cantidadActualProducto: 100,
+      rpcError: { message: 'no permitido' },
+    });
+    const compra = crearCompra({ cantidad: 20, link_factura: 'facturas/f-001.pdf' });
+
+    await expect(eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co')).resolves.toBeUndefined();
+
+    expect(supabase._spies.comprasMock.delete).toHaveBeenCalledTimes(1);
+  });
+});

--- a/src/components/inventory/PurchaseHistory.tsx
+++ b/src/components/inventory/PurchaseHistory.tsx
@@ -1,8 +1,10 @@
 import { useState, useEffect } from 'react';
+import type { SupabaseClient } from '@supabase/supabase-js';
 import { getSupabase } from '../../utils/supabase/client';
 import { useAuth } from '../../contexts/AuthContext';
 import { useSafeMode } from '../../contexts/SafeModeContext';
 import { InventorySubNav } from './InventorySubNav';
+import type { Database } from '@/types/database';
 import {
   ShoppingCart,
   Calendar,
@@ -43,6 +45,108 @@ interface Purchase {
     categoria: string;
     permitido_gerencia?: boolean;
   };
+}
+
+/**
+ * Ejecuta la eliminación de una compra revirtiendo el stock del producto.
+ *
+ * `movimientos_inventario` es un log de eventos, no un dato que se corrige a mano:
+ * la compra sí ocurrió, así que su movimiento `Entrada` original NUNCA se borra
+ * (y no puede filtrarse por `compra_id` -- esa columna no existe en esta tabla).
+ * En su lugar se inserta un movimiento `Salida Otros` compensatorio (mismo criterio
+ * que la migración 108 para `gan_movimientos`: no se borra la historia, se compensa).
+ *
+ * Ese movimiento compensatorio se escribe ANTES de tocar `productos.cantidad_actual`
+ * y, si falla, la función lanza y aborta -- el stock queda intacto en vez de moverse
+ * sin dejar rastro. No es atómico (llamado desde el navegador, sin RPC), pero el
+ * orden garantiza que nunca se pierde la trazabilidad silenciosamente.
+ *
+ * Exportada (en vez de quedar inline en `handleDeletePurchase`) para poder probar esta
+ * secuencia sin renderizar el componente -- este repo no tiene @testing-library/react.
+ */
+export async function eliminarCompraConReversion(
+  supabase: SupabaseClient<Database>,
+  purchase: Purchase,
+  responsable: string | null,
+): Promise<void> {
+  // 1. Leer el stock actual del producto
+  const { data: currentProduct, error: productFetchError } = await supabase
+    .from('productos')
+    .select('cantidad_actual')
+    .eq('id', purchase.producto_id)
+    .single();
+
+  if (productFetchError) throw new Error('Error al obtener producto: ' + productFetchError.message);
+
+  const saldoAnterior = currentProduct.cantidad_actual ?? 0;
+  const nuevaCantidad = saldoAnterior - purchase.cantidad;
+
+  if (nuevaCantidad < 0) {
+    throw new Error('No se puede eliminar la compra porque resultaría en inventario negativo');
+  }
+
+  // 2. Dejar el rastro en el ledger ANTES de tocar el stock -- si esto falla, se
+  // aborta acá y el inventario queda intacto.
+  const { error: movementAjusteError } = await supabase
+    .from('movimientos_inventario')
+    .insert({
+      fecha_movimiento: obtenerFechaHoy(),
+      producto_id: purchase.producto_id,
+      tipo_movimiento: 'Salida Otros',
+      cantidad: purchase.cantidad,
+      unidad: purchase.unidad as Database['public']['Enums']['unidad_medida'],
+      factura: null,
+      saldo_anterior: saldoAnterior,
+      saldo_nuevo: nuevaCantidad,
+      valor_movimiento: purchase.costo_total,
+      responsable,
+      observaciones: `Ajuste por eliminación de compra - Factura: ${purchase.numero_factura || 'N/A'} - Proveedor: ${purchase.proveedor} - Fecha original: ${purchase.fecha_compra}`,
+      provisional: false,
+    });
+
+  if (movementAjusteError) {
+    throw new Error('Error al registrar el movimiento de ajuste de inventario: ' + movementAjusteError.message);
+  }
+
+  // 3. Revertir el stock del producto -- solo después de que el ledger quedó escrito.
+  const { error: inventoryError } = await supabase
+    .from('productos')
+    .update({
+      cantidad_actual: nuevaCantidad,
+      updated_at: new Date().toISOString(),
+    })
+    .eq('id', purchase.producto_id);
+
+  if (inventoryError) throw new Error('Error al actualizar inventario: ' + inventoryError.message);
+
+  // 4. Eliminar gasto pendiente asociado (si existe)
+  // Uses SECURITY DEFINER RPC to bypass fin_gastos RLS (Administrador can't delete directly)
+  const { error: gastoError } = await supabase
+    .rpc('fn_cleanup_compra_dependencies', { p_compra_id: purchase.id });
+
+  if (gastoError) {
+    console.error('Failed to cleanup compra dependencies:', gastoError);
+    // Non-blocking: FK is ON DELETE SET NULL as safety net
+  }
+
+  // 5. Eliminar factura de Storage (si existe)
+  if (purchase.link_factura) {
+    const { error: storageError } = await supabase.storage
+      .from('facturas')
+      .remove([purchase.link_factura]);
+
+    if (storageError) {
+      // No lanzar error, continuar con la eliminación
+    }
+  }
+
+  // 6. Eliminar la compra
+  const { error: deleteError } = await supabase
+    .from('compras')
+    .delete()
+    .eq('id', purchase.id);
+
+  if (deleteError) throw new Error('Error al eliminar compra: ' + deleteError.message);
 }
 
 /**
@@ -320,95 +424,7 @@ export function PurchaseHistory({ hideSubNav = false }: { hideSubNav?: boolean }
 
     try {
       setDeleting(true);
-      const supabase = getSupabase();
-
-      // 1. Revertir inventario (restar la cantidad de la compra del producto)
-      const { data: currentProduct, error: productFetchError } = await supabase
-        .from('productos')
-        .select('cantidad_actual')
-        .eq('id', purchaseToDelete.producto_id)
-        .single();
-
-      if (productFetchError) throw new Error('Error al obtener producto: ' + productFetchError.message);
-
-      const nuevaCantidad = (currentProduct.cantidad_actual ?? 0) - purchaseToDelete.cantidad;
-
-      if (nuevaCantidad < 0) {
-        toast.error('No se puede eliminar la compra porque resultaría en inventario negativo');
-        return;
-      }
-
-      const { error: inventoryError } = await supabase
-        .from('productos')
-        .update({
-          cantidad_actual: nuevaCantidad,
-          updated_at: new Date().toISOString()
-        })
-        .eq('id', purchaseToDelete.producto_id);
-
-      if (inventoryError) throw new Error('Error al actualizar inventario: ' + inventoryError.message);
-
-      // 2. Eliminar gasto pendiente asociado (si existe)
-      // Uses SECURITY DEFINER RPC to bypass fin_gastos RLS (Administrador can't delete directly)
-      const { error: gastoError } = await supabase
-        .rpc('fn_cleanup_compra_dependencies', { p_compra_id: purchaseToDelete.id });
-
-      if (gastoError) {
-        console.error('Failed to cleanup compra dependencies:', gastoError);
-        // Non-blocking: FK is ON DELETE SET NULL as safety net
-      }
-
-      // 3. Eliminar factura de Storage (si existe)
-      if (purchaseToDelete.link_factura) {
-        const { error: storageError } = await supabase.storage
-          .from('facturas')
-          .remove([purchaseToDelete.link_factura]);
-
-        if (storageError) {
-          // No lanzar error, continuar con la eliminación
-        }
-      }
-
-      // 4. Eliminar movimiento de compra original y crear movimiento de ajuste
-      // 4a. Eliminar el movimiento original de la compra
-      const { error: movementDeleteError } = await supabase
-        .from('movimientos_inventario')
-        .delete()
-        .eq('compra_id', purchaseToDelete.id);
-
-      if (movementDeleteError) {
-        console.error('Failed to delete purchase movement (non-blocking):', movementDeleteError);
-      }
-
-      // 4b. Crear nuevo movimiento de ajuste que documente la eliminación
-      const { error: movementAjusteError } = await supabase
-        .from('movimientos_inventario')
-        .insert({
-            fecha_movimiento: obtenerFechaHoy(),
-            producto_id: purchaseToDelete.producto_id,
-            tipo_movimiento: 'Salida' as any,
-            cantidad: purchaseToDelete.cantidad,
-            unidad: purchaseToDelete.unidad,
-            factura: null,
-            saldo_anterior: currentProduct.cantidad_actual,
-            saldo_nuevo: nuevaCantidad,
-            valor_movimiento: purchaseToDelete.costo_total,
-            responsable: user?.email || null,
-            observaciones: `Ajuste por eliminación de compra - Factura: ${purchaseToDelete.numero_factura || 'N/A'} - Proveedor: ${purchaseToDelete.proveedor} - Fecha original: ${purchaseToDelete.fecha_compra}`,
-            provisional: false,
-          } as any);
-
-      if (movementAjusteError) {
-        // No lanzar error, continuar con la eliminación
-      }
-
-      // 5. Eliminar la compra
-      const { error: deleteError } = await supabase
-        .from('compras')
-        .delete()
-        .eq('id', purchaseToDelete.id);
-
-      if (deleteError) throw new Error('Error al eliminar compra: ' + deleteError.message);
+      await eliminarCompraConReversion(getSupabase(), purchaseToDelete, user?.email || null);
 
       // Recargar lista de compras
       await loadPurchases();


### PR DESCRIPTION
## Finding (P2, Bug Triage #28)

Deleting a compra decremented product stock with zero ledger trace, because of two independent silent failures in `handleDeletePurchase` (`src/components/inventory/PurchaseHistory.tsx`):

1. `.from('movimientos_inventario').delete().eq('compra_id', purchaseToDelete.id)` — **`movimientos_inventario` has no `compra_id` column** (confirmed against `information_schema`). The query errored and the error was swallowed as "non-blocking", so the original `Entrada` movement survived as an orphan.
2. `.from('movimientos_inventario').insert({ tipo_movimiento: 'Salida' as any, ... })` — **`'Salida'` is not a valid label** of the `tipo_movimiento` enum (the four labels are `Entrada`, `Salida por Aplicación`, `Salida Otros`, `Ajuste`). That insert always failed, and the error was swallowed too.

Meanwhile the `productos.cantidad_actual` decrement succeeded unconditionally. Net effect: stock drops, the compra row disappears, and the ledger records nothing.

## What changed

Extracted the delete-and-revert sequence into an exported `eliminarCompraConReversion(supabase, purchase, responsable)` in the same file, and fixed the sequence itself:

- **Dropped the `.eq('compra_id', ...)` delete entirely.** It could never work, and deleting the original `Entrada` would have been the wrong semantics anyway — the purchase did happen. Same argument migration 108 makes for `gan_movimientos`: the ledger is an event log, you compensate, you don't erase history.
- **The compensating movement now uses a valid label: `'Salida Otros'`** (existing enum value, currently zero rows before this fix). Removed the `as any` casts (both the field-level one and the whole-object one on this insert — everything now typechecks against the generated `Database` type, no new dependency needed).
- **The ledger write now happens BEFORE the stock decrement, and its failure blocks the whole deletion** (throws instead of being swallowed). This can't be made atomic from the browser (no RPC — this fix does not add a migration), so the ordering + fail-loud is what guarantees stock is never moved without a trace.
- Left the gasto-cleanup RPC and factura-storage-delete steps as non-blocking, exactly as before — out of scope for this finding.

## How I verified it

- **Red → green**: wrote the test file first against the (still buggy) code, confirmed all 5 cases failed with `eliminarCompraConReversion is not a function` (the right reason — it didn't exist yet), then implemented the fix and re-ran to green.
- Added `src/__tests__/eliminarCompraConReversion.test.ts` (5 tests, no `@testing-library/react` needed since the function takes the Supabase client by parameter — pattern matches `aplicacionesReales.test.ts`'s `createChainableMock`):
  - happy path: ledger insert happens before the stock update, uses `'Salida Otros'` (not `'Salida'`), never calls `.delete()` on `movimientos_inventario`
  - ledger insert fails → deletion aborts, stock update is never called
  - negative-inventory guard → nothing gets written
  - stock update fails after a successful ledger write → compra is never deleted
  - non-blocking gasto/factura cleanup failures don't block the deletion
- Confirmed the pre-existing static guard `productoStockSinMovimiento.test.ts` (which already lists `PurchaseHistory.tsx` as an "authorized writer" of `productos.cantidad_actual` that must insert its movimiento alongside) still passes — it independently corroborates the ledger-before-stock ordering used here, matching the same pattern `NuevoMovimientoModal.tsx` already uses.

### Gates

```
npm run typecheck   # clean
npm run lint         # 0 errors, 902 warnings (was 904 -- this fix removes 2 pre-existing `any`s, adds none)
npm test             # 132 files / 2971 tests passed (was 131/2966; +1 file, +5 tests, 0 regressions)
```

## Rollback

Revert this commit. No migration, no schema change — purely a client-side logic fix plus one new test file.

## Contradicts the finding?

No — verified all cited facts independently (missing `compra_id` column via `information_schema`-derived `src/types/database.ts`, the 4-label enum, both swallowed errors). Followed the specified approach exactly (no new `compra_id` column, ledger-correct compensating-movement route, `'Salida Otros'`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)