### PR TITLE
Fix: hato chequeo roster uses calculated etapa, not raw column (finding #23)

### DIFF
--- a/src/__tests__/useAnimalesParaPlanillaChequeoRoster.test.ts
+++ b/src/__tests__/useAnimalesParaPlanillaChequeoRoster.test.ts
@@ -1,0 +1,83 @@
+// ARCHIVO: __tests__/useAnimalesParaPlanillaChequeoRoster.test.ts
+// DESCRIPCIÓN: Finding #23 (P2, Data Integrity, mantenimiento 2026-08-24).
+// `esCandidataAPlanilla` (`useAnimalesParaPlanillaChequeo.ts`) decidía el
+// roster de la planilla de chequeo comparando contra `fila.etapa` CRUDA --
+// el campo manual de `hato_animales` -- que nadie mantiene desde que las
+// migraciones 089/092 volvieron la categoría CALCULADA (`num_partos` /
+// `fecha_nacimiento`, con `etapa_forzada` como override explícito). Una
+// novilla recién parida es 'vaca' para el resto del sistema apenas se
+// registra el parto (`num_partos >= 1` siempre gana, ver
+// `hatoCategorias.test.ts`), pero seguía sin aparecer en esta planilla
+// porque `hato_animales.etapa` no se actualiza sola.
+//
+// Este archivo prueba SOLO la función de roster, no el hook completo (no
+// hay patrón de `renderHook` en este repo, y `esCandidataAPlanilla` ya es
+// pura una vez que recibe los umbrales y la fecha de referencia) -- debe
+// FALLAR si alguien vuelve a comparar contra `fila.etapa` sin pasar antes
+// por `calcularEtapaHato`.
+
+import { describe, it, expect } from 'vitest';
+import { esCandidataAPlanilla } from '@/components/hato/hooks/useAnimalesParaPlanillaChequeo';
+import type { UmbralesCategoriaHato } from '@/utils/hatoCategorias';
+import type { EstadoActualHatoViewRow } from '@/types/hato';
+
+const UMBRALES: UmbralesCategoriaHato = { meses_ternera_leche_max: 3, meses_ternera_max: 12 };
+const HOY = '2026-08-24';
+
+function filaBase(overrides: Partial<EstadoActualHatoViewRow> = {}): EstadoActualHatoViewRow {
+  return {
+    animal_id: 'animal-1',
+    numero: 200,
+    nombre: 'PRUEBA',
+    etapa: 'novilla',
+    raza: 'jersey',
+    estado: 'activa',
+    ultimo_chequeo_vaca_id: null,
+    ultimo_chequeo_fecha: null,
+    pl: null,
+    meses_prenez: null,
+    fecha_secar: null,
+    fecha_probable_parto: null,
+    ultimo_servicio_fecha: null,
+    ultimo_servicio_toro_id: null,
+    ultimo_tipo_servicio: null,
+    ultimo_parto_fecha: null,
+    num_partos: 0,
+    ultimo_secado_real_fecha: null,
+    ultima_confirmacion_prenez_fecha: null,
+    ultimo_evento_fecha: null,
+    ultimo_estado_chequeo: null,
+    fecha_nacimiento: null,
+    etapa_forzada: false,
+    ultima_confirmacion_prenez_metodo: null,
+    ultimo_aborto_fecha: null,
+    ...overrides,
+  };
+}
+
+describe('esCandidataAPlanilla (roster de la planilla de chequeo, finding #23)', () => {
+  it('una novilla que YA parió (num_partos >= 1) es candidata aunque `etapa` siga sin corregir a mano -- caso central del finding', () => {
+    const fila = filaBase({ etapa: 'novilla', etapa_forzada: false, num_partos: 1, estado: 'activa' });
+    expect(esCandidataAPlanilla(fila, UMBRALES, HOY)).toBe(true);
+  });
+
+  it('una novilla real (sin partos) NO es candidata -- el fix no debe empezar a incluir novillas de verdad', () => {
+    const fila = filaBase({ etapa: 'novilla', etapa_forzada: false, num_partos: 0, estado: 'activa' });
+    expect(esCandidataAPlanilla(fila, UMBRALES, HOY)).toBe(false);
+  });
+
+  it('una vaca ya marcada como tal (etapa cruda "vaca") sigue siendo candidata -- caso ya cubierto antes del fix', () => {
+    const fila = filaBase({ etapa: 'vaca', etapa_forzada: false, num_partos: 3, estado: 'activa' });
+    expect(esCandidataAPlanilla(fila, UMBRALES, HOY)).toBe(true);
+  });
+
+  it('etapa_forzada=true (override manual) gana SIEMPRE, incluso con num_partos >= 1: si Martha forzó "novilla" a mano, no entra a la planilla', () => {
+    const fila = filaBase({ etapa: 'novilla', etapa_forzada: true, num_partos: 2, estado: 'activa' });
+    expect(esCandidataAPlanilla(fila, UMBRALES, HOY)).toBe(false);
+  });
+
+  it('una vaca (calculada) pero ya vendida/muerta no entra al roster -- `estado` sigue siendo el segundo filtro', () => {
+    const fila = filaBase({ etapa: 'novilla', etapa_forzada: false, num_partos: 1, estado: 'vendida' });
+    expect(esCandidataAPlanilla(fila, UMBRALES, HOY)).toBe(false);
+  });
+});

--- a/src/components/hato/hooks/useAnimalesParaPlanillaChequeo.ts
+++ b/src/components/hato/hooks/useAnimalesParaPlanillaChequeo.ts
@@ -37,6 +37,11 @@ import {
   type SexoCria,
   type TipoEstado,
 } from '@/utils/calculosHato';
+import {
+  calcularEtapaHato,
+  construirUmbralesCategoriaHatoDesdeFilas,
+  type UmbralesCategoriaHato,
+} from '@/utils/hatoCategorias';
 import type { EstadoActualHatoViewRow, TipoServicioHato } from '@/types/hato';
 import { obtenerFechaHoy } from '@/utils/fechas';
 
@@ -186,12 +191,42 @@ function ordenarPorNombreDeVaca(a: AnimalParaPlanillaChequeo, b: AnimalParaPlani
   return a.nombre.localeCompare(b.nombre, 'es', { sensitivity: 'base' });
 }
 
-/** Solo vacas adultas activas (etapa `vaca`, estado `activa`) -- ordeño y
- * horro por igual, terneras/novillas quedan fuera: la planilla de chequeo
- * histórica es específicamente el ciclo reproductivo de vacas adultas
- * (esquema TERNERAS es una tabla aparte, ver CLAUDE.md "Hato Lechero"). */
-function esCandidataAPlanilla(fila: EstadoActualHatoViewRow): boolean {
-  return fila.etapa === 'vaca' && fila.estado === 'activa';
+/** Solo vacas adultas activas (etapa EFECTIVA `vaca`, estado `activa`) --
+ * ordeño y horro por igual, terneras/novillas quedan fuera: la planilla de
+ * chequeo histórica es específicamente el ciclo reproductivo de vacas
+ * adultas (esquema TERNERAS es una tabla aparte, ver CLAUDE.md "Hato
+ * Lechero").
+ *
+ * Corrección (finding #23, mantenimiento 2026-08-24): antes comparaba contra
+ * `fila.etapa` CRUDA (el campo manual de `hato_animales`), que nadie
+ * mantiene desde que la migración 089/092 volvió la categoría CALCULADA
+ * (`num_partos`/`fecha_nacimiento`, con `etapa_forzada` como override
+ * explícito -- ver `calcularEtapaHato`, `hatoCategorias.ts`). Una novilla
+ * recién parida ya es 'vaca' para el resto del sistema (Tablero, Animales,
+ * Esco) apenas se registra el parto, pero seguía sin aparecer en esta
+ * planilla porque `hato_animales.etapa` no se actualiza sola -- su próximo
+ * chequeo se perdía en silencio (peor aún en la ruta de foto: una fila cuyo
+ * animal no está en el roster queda `no leída`, sin error visible). Mismo
+ * criterio que `hato-chequeo-foto.ts` y `hato-chequeo-preview.ts` (server) --
+ * las tres copias deben coincidir.
+ *
+ * Exportada para que `useAnimalesParaPlanillaChequeoRoster.test.ts` pueda
+ * probarla directo, sin montar el hook completo.
+ */
+export function esCandidataAPlanilla(
+  fila: EstadoActualHatoViewRow,
+  umbrales: UmbralesCategoriaHato,
+  fechaReferencia: string,
+): boolean {
+  const etapaEfectiva = calcularEtapaHato(
+    fila.etapa,
+    fila.etapa_forzada,
+    fila.num_partos,
+    fila.fecha_nacimiento,
+    umbrales,
+    fechaReferencia,
+  );
+  return etapaEfectiva.etapa === 'vaca' && fila.estado === 'activa';
 }
 
 export function useAnimalesParaPlanillaChequeo() {
@@ -229,6 +264,9 @@ export function useAnimalesParaPlanillaChequeo() {
       if (toroError) throw toroError;
 
       const config = construirHatoConfigDesdeFilas((configRows ?? []) as FilaHatoConfig[]);
+      // Mismas filas crudas de `hato_config` que ya se pidieron arriba --
+      // sin una segunda consulta (mismo patrón que `useHatoAnimales.ts`).
+      const umbralesCategoria = construirUmbralesCategoriaHatoDesdeFilas((configRows ?? []) as FilaHatoConfig[]);
       const hoy = obtenerFechaHoy();
       const nombrePorToroId = new Map<string, string>(
         ((toroRows ?? []) as { id: string; nombre: string }[]).map((t) => [t.id, t.nombre]),
@@ -236,7 +274,7 @@ export function useAnimalesParaPlanillaChequeo() {
       const ultimoPartoPorAnimal = indexarUltimoParto(partosRes.filas);
 
       const filas: AnimalParaPlanillaChequeo[] = ((estadoRows ?? []) as EstadoActualHatoViewRow[])
-        .filter(esCandidataAPlanilla)
+        .filter((fila) => esCandidataAPlanilla(fila, umbralesCategoria, hoy))
         .map((fila) => {
           const derivado = derivarEstadoReproductivo(filaVistaAFactRow(fila), config, hoy);
 

--- a/src/supabase/functions/server/hato-chequeo-foto.ts
+++ b/src/supabase/functions/server/hato-chequeo-foto.ts
@@ -50,6 +50,13 @@ import {
   type LecturaOcrPagina,
 } from './importHato/ocrChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { derivarEstadoReproductivo } from './calculos-hato.ts';
+import {
+  categorizarAnimal,
+  construirUmbralesCategoriaHatoDesdeFilas,
+  resolverEtapaEfectiva,
+  type HatoEstadoActualRow,
+} from './hato-aggregation.ts';
 
 // --- Límites de entrada -----------------------------------------------------
 // La planilla real son ~2 páginas (35 vacas, carta horizontal, Fase 2). Se
@@ -375,8 +382,10 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
     supabase.from('hato_toros').select('nombre').order('nombre'),
     // El MISMO universo que exporta la planilla (D-A del plan): vacas adultas
     // activas de `v_hato_estado_actual`. De acá sale el roster contra el que
-    // se cotejan las anclas de cada fila.
-    supabase.from('v_hato_estado_actual').select('animal_id, numero, nombre, etapa, estado'),
+    // se cotejan las anclas de cada fila. `select('*')` -- ver más abajo por
+    // qué se necesita la fila completa (finding #23) y no solo
+    // animal_id/numero/nombre/etapa/estado.
+    supabase.from('v_hato_estado_actual').select('*'),
   ]);
 
   if (configRes.error) return respuestaError(c, 500, `No se pudo leer hato_config: ${configRes.error.message}`);
@@ -392,12 +401,40 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
     return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
   }
 
-  const animalesRoster: AnimalRosterPlanilla[] = ((rosterRes.data ?? []) as Array<Record<string, unknown>>)
-    .filter((f) => f.etapa === 'vaca' && f.estado === 'activa')
-    .map((f) => ({
-      id: String(f.animal_id),
-      numero: (f.numero as number | null) ?? null,
-      nombre: (f.nombre as string | null) ?? null,
+  let umbralesCategoria;
+  try {
+    umbralesCategoria = construirUmbralesCategoriaHatoDesdeFilas((configRes.data ?? []) as FilaHatoConfig[]);
+  } catch (err) {
+    return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
+  }
+
+  // Finding #23 (P2, mantenimiento 2026-08-24): el roster tiene que usar la
+  // etapa EFECTIVA (calculada, D-13/migración 092), nunca `hato_animales.etapa`
+  // cruda -- una novilla que ya parió es 'vaca' para el resto del sistema
+  // (Tablero, Animales, Esco) apenas se registra el parto, aunque nadie haya
+  // corregido a mano el campo manual. Antes de este fix esa vaca quedaba
+  // fuera del roster, su próxima fila de chequeo (por foto) no cotejaba
+  // contra ningún ancla válida y quedaba `no leída` sin error visible.
+  // `categorizarAnimal` (`hato-aggregation.ts`) solo devuelve
+  // 'hato_ordeno'/'horro' cuando `estado==='activa'` Y la etapa efectiva es
+  // 'vaca' (nunca 'ternera'/'novilla'/'toro') -- exactamente la condición
+  // que antes escribía `f.etapa === 'vaca' && f.estado === 'activa'`, ahora
+  // con la etapa calculada. Mismo criterio que
+  // `useAnimalesParaPlanillaChequeo.ts` (frontend) y `hato-chequeo-preview.ts`
+  // (endpoint gemelo) -- las tres copias deben coincidir.
+  const hoy = generadoEn.slice(0, 10);
+  const filasRoster = (rosterRes.data ?? []) as unknown as HatoEstadoActualRow[];
+  const animalesRoster: AnimalRosterPlanilla[] = filasRoster
+    .filter((fila) => {
+      const etapaEfectiva = resolverEtapaEfectiva(fila, umbralesCategoria, hoy);
+      const derivado = derivarEstadoReproductivo({ ...fila, etapa: etapaEfectiva.etapa }, config, hoy);
+      const categoria = categorizarAnimal(fila, etapaEfectiva.etapa, derivado.estado);
+      return categoria === 'hato_ordeno' || categoria === 'horro';
+    })
+    .map((fila) => ({
+      id: fila.animal_id,
+      numero: fila.numero,
+      nombre: fila.nombre,
     }));
   const roster = construirRosterPlanilla(animalesRoster);
 

--- a/src/supabase/functions/server/hato-chequeo-foto.ts
+++ b/src/supabase/functions/server/hato-chequeo-foto.ts
@@ -500,15 +500,35 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
 
   let animales: AnimalHatoActual[] = [];
   if (numerosEnHoja.length > 0) {
+    // Finding #23 (P2, mantenimiento 2026-08-24, seguimiento de la primera
+    // pasada de este mismo finding): esta consulta leía `hato_animales.etapa`
+    // cruda -- mismo defecto ya corregido acá arriba en el paso 3 (roster) y
+    // en el paso 4 de `hato-chequeo-preview.ts`. El campo en sí no gobierna
+    // ningún filtro en `construirDiffChequeo` (el match es solo por
+    // número), pero SÍ viaja en `AnimalHatoActual.etapa` -- ahora sale de
+    // `v_hato_estado_actual` (la MISMA vista que ya arma el roster del paso
+    // 3) y se calcula con `resolverEtapaEfectiva`, mismo criterio que
+    // `useAnimalesParaPlanillaChequeo.ts` (frontend) y
+    // `hato-chequeo-preview.ts` (endpoint gemelo, ver su paso 4) -- las tres
+    // copias deben coincidir. Sin este fix, una novilla recién parida
+    // viajaba como 'novilla' en el diff de la ruta de foto y como 'vaca' en
+    // la ruta .xlsx -- la misma vaca descrita distinto según por dónde
+    // entrara el chequeo.
     const { data, error } = await supabase
-      .from('hato_animales')
-      .select('id, numero, nombre, etapa, estado')
+      .from('v_hato_estado_actual')
+      .select('*')
       // Migración 066: `numero` solo es único entre animales `activa`. Un
       // chequeo describe el hato VIVO -- mismo filtro que el preview.
       .eq('estado', 'activa')
       .in('numero', numerosEnHoja);
-    if (error) return respuestaError(c, 500, `No se pudo leer hato_animales: ${error.message}`);
-    animales = (data ?? []) as AnimalHatoActual[];
+    if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
+    animales = ((data ?? []) as unknown as HatoEstadoActualRow[]).map((fila) => ({
+      id: fila.animal_id,
+      numero: fila.numero as number,
+      nombre: fila.nombre,
+      etapa: resolverEtapaEfectiva(fila, umbralesCategoria, hoy).etapa,
+      estado: fila.estado,
+    }));
   }
 
   const animalIds = animales.map((a) => a.id);

--- a/src/supabase/functions/server/hato-chequeo-preview.ts
+++ b/src/supabase/functions/server/hato-chequeo-preview.ts
@@ -34,6 +34,11 @@ import type {
 import type { HojaCruda } from './importHato/tipos.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
 import { derivarEstadoReproductivo, etiquetaEstadoReproductivo, type EstadoActualHatoRow } from './calculos-hato.ts';
+import {
+  construirUmbralesCategoriaHatoDesdeFilas,
+  resolverEtapaEfectiva,
+  type HatoEstadoActualRow,
+} from './hato-aggregation.ts';
 
 const TAMANO_MAXIMO_BYTES = 20 * 1024 * 1024; // 20 MB -- una planilla real pesa unos pocos cientos de KB.
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053).
@@ -188,6 +193,20 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
     return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
   }
 
+  let umbralesCategoria;
+  try {
+    umbralesCategoria = construirUmbralesCategoriaHatoDesdeFilas((filasConfig ?? []) as FilaHatoConfig[]);
+  } catch (err) {
+    return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
+  }
+
+  // Mismo criterio de "hoy" que `hato-alertas-tick.ts` (UTC) -- las edge
+  // functions quedan deliberadamente fuera del arreglo de "hoy en hora
+  // local" (CLAUDE.md, "Hoy siempre se toma en hora LOCAL"). Se calcula una
+  // sola vez y se reutiliza tanto para la etapa efectiva (paso 4) como para
+  // "Estado registrado" (paso 4b) -- antes cada paso tenía su propia fecha.
+  const hoy = new Date().toISOString().slice(0, 10);
+
   // --- 3. Extract + Normalize (motor compartido con el pipeline histórico) -
   const generadoEn = new Date().toISOString();
   const salida = normalizarHojas(hojas, generadoEn, config);
@@ -197,17 +216,34 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
 
   let animales: AnimalHatoActual[] = [];
   if (numerosEnHoja.length > 0) {
+    // Finding #23 (P2, mantenimiento 2026-08-24): esta consulta leía
+    // `hato_animales.etapa` cruda -- el campo manual, que nadie mantiene
+    // desde que las migraciones 089/092 volvieron la categoría CALCULADA
+    // (`num_partos`/`fecha_nacimiento`, con `etapa_forzada` como override
+    // explícito). El campo en sí no gobierna ningún filtro en
+    // `construirDiffChequeo` (el match es solo por número), pero SÍ viaja en
+    // `AnimalHatoActual.etapa` -- ahora sale de `v_hato_estado_actual` (la
+    // MISMA vista que ya se consulta en el paso 4b) y se calcula con
+    // `resolverEtapaEfectiva`, mismo criterio que
+    // `useAnimalesParaPlanillaChequeo.ts` (frontend) y `hato-chequeo-foto.ts`
+    // (endpoint gemelo) -- las tres copias deben coincidir.
     const { data, error } = await supabase
-      .from('hato_animales')
-      .select('id, numero, nombre, etapa, estado')
+      .from('v_hato_estado_actual')
+      .select('*')
       // Migración 066: `numero` ya no es UNIQUE global -- solo lo es entre
       // animales `activa`. Un chequeo describe el hato VIVO, así que se
       // filtra a `activa` para no traer dos filas con el mismo número
       // (una vendida/muerta + una activa) y perder una en el Map por número.
       .eq('estado', 'activa')
       .in('numero', numerosEnHoja);
-    if (error) return respuestaError(c, 500, `No se pudo leer hato_animales: ${error.message}`);
-    animales = (data ?? []) as AnimalHatoActual[];
+    if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
+    animales = ((data ?? []) as unknown as HatoEstadoActualRow[]).map((fila) => ({
+      id: fila.animal_id,
+      numero: fila.numero as number,
+      nombre: fila.nombre,
+      etapa: resolverEtapaEfectiva(fila, umbralesCategoria, hoy).etapa,
+      estado: fila.estado,
+    }));
   }
 
   const animalIds = animales.map((a) => a.id);
@@ -253,13 +289,12 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
       )
       .in('animal_id', animalIds);
     if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
-    // Mismo criterio de "hoy" que `hato-alertas-tick.ts` (UTC) -- las edge
-    // functions quedan deliberadamente fuera del arreglo de "hoy en hora
-    // local" (CLAUDE.md, "Hoy siempre se toma en hora LOCAL"): un desfase de
-    // un día en esta comparación de referencia no cambia la CLASIFICACIÓN
-    // reproductiva de una vaca de un día para otro salvo en el borde exacto
-    // de un umbral, y el conflicto que esto detecta ya es de días/semanas.
-    const hoy = new Date().toISOString().slice(0, 10);
+    // `hoy` (UTC) se calcula una sola vez, arriba, y se reutiliza acá -- ver
+    // esa definición para el criterio completo (mismo que
+    // `hato-alertas-tick.ts`): un desfase de un día en esta comparación de
+    // referencia no cambia la CLASIFICACIÓN reproductiva de una vaca de un
+    // día para otro salvo en el borde exacto de un umbral, y el conflicto
+    // que esto detecta ya es de días/semanas.
     estadosRegistrados = (data ?? []).map((fila: Record<string, unknown>) => {
       const derivado = derivarEstadoReproductivo(fila as unknown as EstadoActualHatoRow, config, hoy);
       return {

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-foto.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-foto.ts
@@ -50,6 +50,13 @@ import {
   type LecturaOcrPagina,
 } from './importHato/ocrChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { derivarEstadoReproductivo } from './calculos-hato.ts';
+import {
+  categorizarAnimal,
+  construirUmbralesCategoriaHatoDesdeFilas,
+  resolverEtapaEfectiva,
+  type HatoEstadoActualRow,
+} from './hato-aggregation.ts';
 
 // --- Límites de entrada -----------------------------------------------------
 // La planilla real son ~2 páginas (35 vacas, carta horizontal, Fase 2). Se
@@ -375,8 +382,10 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
     supabase.from('hato_toros').select('nombre').order('nombre'),
     // El MISMO universo que exporta la planilla (D-A del plan): vacas adultas
     // activas de `v_hato_estado_actual`. De acá sale el roster contra el que
-    // se cotejan las anclas de cada fila.
-    supabase.from('v_hato_estado_actual').select('animal_id, numero, nombre, etapa, estado'),
+    // se cotejan las anclas de cada fila. `select('*')` -- ver más abajo por
+    // qué se necesita la fila completa (finding #23) y no solo
+    // animal_id/numero/nombre/etapa/estado.
+    supabase.from('v_hato_estado_actual').select('*'),
   ]);
 
   if (configRes.error) return respuestaError(c, 500, `No se pudo leer hato_config: ${configRes.error.message}`);
@@ -392,12 +401,40 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
     return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
   }
 
-  const animalesRoster: AnimalRosterPlanilla[] = ((rosterRes.data ?? []) as Array<Record<string, unknown>>)
-    .filter((f) => f.etapa === 'vaca' && f.estado === 'activa')
-    .map((f) => ({
-      id: String(f.animal_id),
-      numero: (f.numero as number | null) ?? null,
-      nombre: (f.nombre as string | null) ?? null,
+  let umbralesCategoria;
+  try {
+    umbralesCategoria = construirUmbralesCategoriaHatoDesdeFilas((configRes.data ?? []) as FilaHatoConfig[]);
+  } catch (err) {
+    return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
+  }
+
+  // Finding #23 (P2, mantenimiento 2026-08-24): el roster tiene que usar la
+  // etapa EFECTIVA (calculada, D-13/migración 092), nunca `hato_animales.etapa`
+  // cruda -- una novilla que ya parió es 'vaca' para el resto del sistema
+  // (Tablero, Animales, Esco) apenas se registra el parto, aunque nadie haya
+  // corregido a mano el campo manual. Antes de este fix esa vaca quedaba
+  // fuera del roster, su próxima fila de chequeo (por foto) no cotejaba
+  // contra ningún ancla válida y quedaba `no leída` sin error visible.
+  // `categorizarAnimal` (`hato-aggregation.ts`) solo devuelve
+  // 'hato_ordeno'/'horro' cuando `estado==='activa'` Y la etapa efectiva es
+  // 'vaca' (nunca 'ternera'/'novilla'/'toro') -- exactamente la condición
+  // que antes escribía `f.etapa === 'vaca' && f.estado === 'activa'`, ahora
+  // con la etapa calculada. Mismo criterio que
+  // `useAnimalesParaPlanillaChequeo.ts` (frontend) y `hato-chequeo-preview.ts`
+  // (endpoint gemelo) -- las tres copias deben coincidir.
+  const hoy = generadoEn.slice(0, 10);
+  const filasRoster = (rosterRes.data ?? []) as unknown as HatoEstadoActualRow[];
+  const animalesRoster: AnimalRosterPlanilla[] = filasRoster
+    .filter((fila) => {
+      const etapaEfectiva = resolverEtapaEfectiva(fila, umbralesCategoria, hoy);
+      const derivado = derivarEstadoReproductivo({ ...fila, etapa: etapaEfectiva.etapa }, config, hoy);
+      const categoria = categorizarAnimal(fila, etapaEfectiva.etapa, derivado.estado);
+      return categoria === 'hato_ordeno' || categoria === 'horro';
+    })
+    .map((fila) => ({
+      id: fila.animal_id,
+      numero: fila.numero,
+      nombre: fila.nombre,
     }));
   const roster = construirRosterPlanilla(animalesRoster);
 

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-foto.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-foto.ts
@@ -500,15 +500,35 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
 
   let animales: AnimalHatoActual[] = [];
   if (numerosEnHoja.length > 0) {
+    // Finding #23 (P2, mantenimiento 2026-08-24, seguimiento de la primera
+    // pasada de este mismo finding): esta consulta leía `hato_animales.etapa`
+    // cruda -- mismo defecto ya corregido acá arriba en el paso 3 (roster) y
+    // en el paso 4 de `hato-chequeo-preview.ts`. El campo en sí no gobierna
+    // ningún filtro en `construirDiffChequeo` (el match es solo por
+    // número), pero SÍ viaja en `AnimalHatoActual.etapa` -- ahora sale de
+    // `v_hato_estado_actual` (la MISMA vista que ya arma el roster del paso
+    // 3) y se calcula con `resolverEtapaEfectiva`, mismo criterio que
+    // `useAnimalesParaPlanillaChequeo.ts` (frontend) y
+    // `hato-chequeo-preview.ts` (endpoint gemelo, ver su paso 4) -- las tres
+    // copias deben coincidir. Sin este fix, una novilla recién parida
+    // viajaba como 'novilla' en el diff de la ruta de foto y como 'vaca' en
+    // la ruta .xlsx -- la misma vaca descrita distinto según por dónde
+    // entrara el chequeo.
     const { data, error } = await supabase
-      .from('hato_animales')
-      .select('id, numero, nombre, etapa, estado')
+      .from('v_hato_estado_actual')
+      .select('*')
       // Migración 066: `numero` solo es único entre animales `activa`. Un
       // chequeo describe el hato VIVO -- mismo filtro que el preview.
       .eq('estado', 'activa')
       .in('numero', numerosEnHoja);
-    if (error) return respuestaError(c, 500, `No se pudo leer hato_animales: ${error.message}`);
-    animales = (data ?? []) as AnimalHatoActual[];
+    if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
+    animales = ((data ?? []) as unknown as HatoEstadoActualRow[]).map((fila) => ({
+      id: fila.animal_id,
+      numero: fila.numero as number,
+      nombre: fila.nombre,
+      etapa: resolverEtapaEfectiva(fila, umbralesCategoria, hoy).etapa,
+      estado: fila.estado,
+    }));
   }
 
   const animalIds = animales.map((a) => a.id);

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-preview.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-preview.ts
@@ -34,6 +34,11 @@ import type {
 import type { HojaCruda } from './importHato/tipos.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
 import { derivarEstadoReproductivo, etiquetaEstadoReproductivo, type EstadoActualHatoRow } from './calculos-hato.ts';
+import {
+  construirUmbralesCategoriaHatoDesdeFilas,
+  resolverEtapaEfectiva,
+  type HatoEstadoActualRow,
+} from './hato-aggregation.ts';
 
 const TAMANO_MAXIMO_BYTES = 20 * 1024 * 1024; // 20 MB -- una planilla real pesa unos pocos cientos de KB.
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053).
@@ -188,6 +193,20 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
     return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
   }
 
+  let umbralesCategoria;
+  try {
+    umbralesCategoria = construirUmbralesCategoriaHatoDesdeFilas((filasConfig ?? []) as FilaHatoConfig[]);
+  } catch (err) {
+    return respuestaError(c, 500, err instanceof Error ? err.message : String(err));
+  }
+
+  // Mismo criterio de "hoy" que `hato-alertas-tick.ts` (UTC) -- las edge
+  // functions quedan deliberadamente fuera del arreglo de "hoy en hora
+  // local" (CLAUDE.md, "Hoy siempre se toma en hora LOCAL"). Se calcula una
+  // sola vez y se reutiliza tanto para la etapa efectiva (paso 4) como para
+  // "Estado registrado" (paso 4b) -- antes cada paso tenía su propia fecha.
+  const hoy = new Date().toISOString().slice(0, 10);
+
   // --- 3. Extract + Normalize (motor compartido con el pipeline histórico) -
   const generadoEn = new Date().toISOString();
   const salida = normalizarHojas(hojas, generadoEn, config);
@@ -197,17 +216,34 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
 
   let animales: AnimalHatoActual[] = [];
   if (numerosEnHoja.length > 0) {
+    // Finding #23 (P2, mantenimiento 2026-08-24): esta consulta leía
+    // `hato_animales.etapa` cruda -- el campo manual, que nadie mantiene
+    // desde que las migraciones 089/092 volvieron la categoría CALCULADA
+    // (`num_partos`/`fecha_nacimiento`, con `etapa_forzada` como override
+    // explícito). El campo en sí no gobierna ningún filtro en
+    // `construirDiffChequeo` (el match es solo por número), pero SÍ viaja en
+    // `AnimalHatoActual.etapa` -- ahora sale de `v_hato_estado_actual` (la
+    // MISMA vista que ya se consulta en el paso 4b) y se calcula con
+    // `resolverEtapaEfectiva`, mismo criterio que
+    // `useAnimalesParaPlanillaChequeo.ts` (frontend) y `hato-chequeo-foto.ts`
+    // (endpoint gemelo) -- las tres copias deben coincidir.
     const { data, error } = await supabase
-      .from('hato_animales')
-      .select('id, numero, nombre, etapa, estado')
+      .from('v_hato_estado_actual')
+      .select('*')
       // Migración 066: `numero` ya no es UNIQUE global -- solo lo es entre
       // animales `activa`. Un chequeo describe el hato VIVO, así que se
       // filtra a `activa` para no traer dos filas con el mismo número
       // (una vendida/muerta + una activa) y perder una en el Map por número.
       .eq('estado', 'activa')
       .in('numero', numerosEnHoja);
-    if (error) return respuestaError(c, 500, `No se pudo leer hato_animales: ${error.message}`);
-    animales = (data ?? []) as AnimalHatoActual[];
+    if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
+    animales = ((data ?? []) as unknown as HatoEstadoActualRow[]).map((fila) => ({
+      id: fila.animal_id,
+      numero: fila.numero as number,
+      nombre: fila.nombre,
+      etapa: resolverEtapaEfectiva(fila, umbralesCategoria, hoy).etapa,
+      estado: fila.estado,
+    }));
   }
 
   const animalIds = animales.map((a) => a.id);
@@ -253,13 +289,12 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
       )
       .in('animal_id', animalIds);
     if (error) return respuestaError(c, 500, `No se pudo leer v_hato_estado_actual: ${error.message}`);
-    // Mismo criterio de "hoy" que `hato-alertas-tick.ts` (UTC) -- las edge
-    // functions quedan deliberadamente fuera del arreglo de "hoy en hora
-    // local" (CLAUDE.md, "Hoy siempre se toma en hora LOCAL"): un desfase de
-    // un día en esta comparación de referencia no cambia la CLASIFICACIÓN
-    // reproductiva de una vaca de un día para otro salvo en el borde exacto
-    // de un umbral, y el conflicto que esto detecta ya es de días/semanas.
-    const hoy = new Date().toISOString().slice(0, 10);
+    // `hoy` (UTC) se calcula una sola vez, arriba, y se reutiliza acá -- ver
+    // esa definición para el criterio completo (mismo que
+    // `hato-alertas-tick.ts`): un desfase de un día en esta comparación de
+    // referencia no cambia la CLASIFICACIÓN reproductiva de una vaca de un
+    // día para otro salvo en el borde exacto de un umbral, y el conflicto
+    // que esto detecta ya es de días/semanas.
     estadosRegistrados = (data ?? []).map((fila: Record<string, unknown>) => {
       const derivado = derivarEstadoReproductivo(fila as unknown as EstadoActualHatoRow, config, hoy);
       return {


### PR DESCRIPTION
## Finding

**#23 (P2, Data Integrity)** — Chequeo and pesaje rosters still key on the raw `hato_animales.etapa` column that migrations 089/092 demoted to a manual override nothing maintains.

Since 089/092, animal category is **calculated** (`src/utils/hatoCategorias.ts::calcularEtapaHato`, mirrored server-side by `resolverEtapaEfectiva` in `hato-aggregation.ts`): `etapa_forzada = true` wins; else `num_partos >= 1` ⇒ `'vaca'`; else derived from `fecha_nacimiento`; else falls back to the stored `etapa`.

All three roster sites still read the RAW stored column:
- `src/components/hato/hooks/useAnimalesParaPlanillaChequeo.ts:194` — `fila.etapa === 'vaca' && fila.estado === 'activa'`
- `src/supabase/functions/server/hato-chequeo-foto.ts:396` — the same filter (roster used to validate OCR anchors)
- `src/supabase/functions/server/hato-chequeo-preview.ts:200-202` — sourced `id, numero, nombre, etapa, estado` straight from `hato_animales`

**Why it matters (hasn't fired yet):** it fires the first time any active novilla has a parto registered — `num_partos` becomes 1, so she instantly reads `'vaca'` everywhere else in the app (Tablero, Animales, Esco), but `hato_animales.etapa` doesn't update itself. From that moment she's silently absent from Martha's printed planilla, the `.xlsx` preview roster, and the photo-OCR roster. The OCR path is the worst case: a row whose `numero`+`nombre` doesn't match the roster is marked `no leída` and never shifted — the chequeo is dropped with no visible error, for exactly the animal whose next chequeo matters most.

Exposure measured at the time the finding was written: 35 vacas / 27 novillas active, 0 mis-rostered today (the bug is dormant until the next novilla-to-vaca transition).

## What changed

All three sites now resolve the **effective** etapa before filtering, using the existing (already paridad-protected) calculators — no new engine logic, no migration, no API contract change:

1. **`useAnimalesParaPlanillaChequeo.ts`** — `esCandidataAPlanilla` now takes `(fila, umbrales, fechaReferencia)` and computes the etapa via `calcularEtapaHato` (`hatoCategorias.ts`) before comparing to `'vaca'`. Exported so it's directly unit-testable.
2. **`hato-chequeo-foto.ts`** (both trees) — the roster query now selects `v_hato_estado_actual.*` (was a narrow 5-column select) and filters via `resolverEtapaEfectiva` + `derivarEstadoReproductivo` + `categorizarAnimal` (`hato-aggregation.ts`), keeping only `'hato_ordeno'`/`'horro'` — provably equivalent to the old `etapa==='vaca' && estado==='activa'` check, now computed from the calculated etapa.
3. **`hato-chequeo-preview.ts`** (both trees) — switched the animal-matching query from `hato_animales` to `v_hato_estado_actual`, computing `AnimalHatoActual.etapa` via `resolverEtapaEfectiva` instead of passing the raw column through. `hoy` is now computed once and shared with the existing "Estado registrado" (step 4b) computation instead of being redefined twice.

The `src/supabase/functions/server/` and `supabase/functions/make-server-1ccce916/` copies of both endpoint files are **byte-identical** after the change (verified with `diff`).

## How I verified

- `npm run lint` — 0 errors, 904 warnings (unchanged baseline).
- `npm run typecheck` — clean.
- `npm test` — 132 files / 2971 tests pass (was 131/2966; +1 file/+5 tests from the new roster test, everything else green, including the hato parity tests).
- Added `src/__tests__/useAnimalesParaPlanillaChequeoRoster.test.ts`, asserting (among other cases) that an animal with `num_partos >= 1` and stored `etapa = 'novilla'` **is** included in the roster — the exact regression this finding describes. Confirmed by construction that this fails against the pre-fix filter (`fila.etapa === 'vaca'` is false for a raw `'novilla'` row).
- Manually traced that `resolverEtapaEfectiva(fila).etapa === 'vaca' && fila.estado === 'activa'` is mathematically equivalent to `categorizarAnimal(fila, etapa, derivado.estado) ∈ {'hato_ordeno','horro'}` (both categories require `estado==='activa'` and etapa efectiva `'vaca'`), so `hato-chequeo-foto.ts` doesn't need to special-case the `derivado.estado` outcome for this filter to be correct.

## Rollback

Pure revert of this commit — no migration, no data change, no API contract change.

## Note for deploy

**`hato-chequeo-foto.ts` and `hato-chequeo-preview.ts` are Deno edge functions.** This PR does not deploy them. After merge, someone needs to run:

```
npx supabase functions deploy make-server-1ccce916
```

Until that deploy runs, the two server-side fixes are inert (repo-only) and the frontend fix (`useAnimalesParaPlanillaChequeo.ts`) is the only one live. I did not deploy this myself, per instructions.

## Things I found but did NOT fix (out of scope, flagging per SOP)

- `hato-chequeo-preview.ts` step 4b ("Estado registrado" / N23 conflict detection) still feeds `derivarEstadoReproductivo` with the raw `fila.etapa` from `v_hato_estado_actual` (line ~300), without going through `resolverEtapaEfectiva` first — the same class of bug already fixed elsewhere (frontend `hatoCategorias.ts`, Esco `hato-aggregation.ts::buildReproduccionSummary`), but not one of the three sites this finding named. A recently-calved novilla would get a wrong "estado registrado" conflict label in that specific N23 comparison. Flagging for a separate fix rather than bundling it here.