### PR TITLE
fix(hato): reject pesaje photos that match no cow in the roster

### DIFF
--- a/src/__tests__/importHatoOcrPesaje.test.ts
+++ b/src/__tests__/importHatoOcrPesaje.test.ts
@@ -22,6 +22,7 @@ import {
   construirFilasPesajeInsertables,
   construirPromptOcrPesaje,
   construirRosterPesaje,
+  detectarRechazoLecturaPesaje,
   esCandidataRosterPesaje,
   esquemaJsonOcrPesaje,
   ETAPAS_ROSTER_PESAJE,
@@ -302,6 +303,74 @@ describe('procesarLecturaOcrPesaje', () => {
       roster,
     );
     expect(resultado.filasConfirmadas[0].celdasNoConfiables.sort()).toEqual(['s1_am', 's2_pm']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 4.b detectarRechazoLecturaPesaje -- finding #40 (2026-08-24): rechazar en
+//     vez de aceptar cuando la carga no reconoció NINGUNA vaca del roster.
+//     Caso real: la liquidación de El Pomar subida por error a esta ruta se
+//     "aceptaba" con un diff vacío y sin ninguna señal accionable.
+// ---------------------------------------------------------------------------
+
+describe('detectarRechazoLecturaPesaje', () => {
+  const roster = construirRosterPesaje(ROSTER_BASE);
+
+  it('no rechaza cuando al menos una fila ancló contra el roster', () => {
+    const ocr = procesarLecturaOcrPesaje(
+      [{ pagina: 1, filas: [filaOcr({ nombreImpreso: 'ALINA' })], avisos: [] }],
+      roster,
+    );
+    expect(detectarRechazoLecturaPesaje(ocr)).toBeNull();
+  });
+
+  it('rechaza cuando el modelo no reportó ninguna fila en ninguna foto (documento sin filas de vaca)', () => {
+    const ocr = procesarLecturaOcrPesaje([{ pagina: 1, filas: [], avisos: [] }], roster);
+    const rechazo = detectarRechazoLecturaPesaje(ocr);
+    expect(rechazo).not.toBeNull();
+    expect(rechazo?.nombresNoReconocidos).toEqual([]);
+    expect(rechazo?.detalle).toContain('No se reconoció ninguna vaca del hato');
+    expect(rechazo?.detalle).toContain('liquidación de El Pomar');
+    // Sin nombres leídos, el detalle no debe fingir haber leído algo.
+    expect(rechazo?.detalle).not.toContain('Se alcanzó a leer');
+  });
+
+  it('rechaza cuando SÍ se leyeron filas pero ninguna ancla contra el roster, y lista hasta 5 nombres sin duplicar', () => {
+    const ocr = procesarLecturaOcrPesaje(
+      [
+        {
+          pagina: 1,
+          filas: [
+            filaOcr({ nombreImpreso: 'PROVEEDOR', orden: 1 }),
+            filaOcr({ nombreImpreso: 'NIT', orden: 2 }),
+            filaOcr({ nombreImpreso: 'NIT', orden: 3 }), // duplicado -- no debe listarse dos veces
+            filaOcr({ nombreImpreso: 'SUBTOTAL', orden: 4 }),
+            filaOcr({ nombreImpreso: 'CANTIDAD', orden: 5 }),
+            filaOcr({ nombreImpreso: 'PRECIO', orden: 6 }),
+            filaOcr({ nombreImpreso: 'MES', orden: 7 }), // 6º nombre distinto -- se recorta a 5
+          ],
+          avisos: [],
+        },
+      ],
+      roster,
+    );
+    const rechazo = detectarRechazoLecturaPesaje(ocr);
+    expect(rechazo).not.toBeNull();
+    expect(rechazo?.nombresNoReconocidos).toHaveLength(5);
+    expect(rechazo?.nombresNoReconocidos).toEqual(['PROVEEDOR', 'NIT', 'SUBTOTAL', 'CANTIDAD', 'PRECIO']);
+    expect(rechazo?.detalle).toContain('Se alcanzó a leer: PROVEEDOR, NIT, SUBTOTAL, CANTIDAD, PRECIO');
+  });
+
+  it('agrega la carga de TODAS las fotos, no solo la primera -- cero filas confirmadas en toda la carga rechaza', () => {
+    const ocr = procesarLecturaOcrPesaje(
+      [
+        { pagina: 1, filas: [filaOcr({ nombreImpreso: 'DESCONOCIDA_1' })], avisos: [] },
+        { pagina: 2, filas: [filaOcr({ nombreImpreso: 'DESCONOCIDA_2' })], avisos: [] },
+      ],
+      roster,
+    );
+    expect(ocr.filasConfirmadas).toHaveLength(0);
+    expect(detectarRechazoLecturaPesaje(ocr)).not.toBeNull();
   });
 });
 

--- a/src/components/hato/components/SubirPesajeFoto.tsx
+++ b/src/components/hato/components/SubirPesajeFoto.tsx
@@ -89,8 +89,19 @@ export function SubirPesajeFoto({
   fotosIniciales?: File[];
   onCompletado?: () => void;
 }) {
-  const { subirFotos, iniciarManual, comprometer, limpiar, loading, error, resultado, comprometiendo, errorCommit, commitResultado } =
-    useSubirPesajeFoto();
+  const {
+    subirFotos,
+    iniciarManual,
+    comprometer,
+    limpiar,
+    loading,
+    error,
+    documentoRechazado,
+    resultado,
+    comprometiendo,
+    errorCommit,
+    commitResultado,
+  } = useSubirPesajeFoto();
   const produccion = useProduccionHato();
   const { profile } = useAuth();
   // Mismo conjunto de roles que la RLS de escritura de `hato_*` (migración 053).
@@ -339,7 +350,28 @@ export function SubirPesajeFoto({
             </div>
           )}
 
-          {error && (
+          {/* Finding #40: el servidor rechazó la carga EXPLÍCITAMENTE (422 --
+              ninguna vaca del roster ancló en ninguna foto) en vez de
+              "aceptar" con un diff vacío. La foto SIGUE guardada como capa
+              cruda (el mensaje del servidor ya lo dice); acá solo se ofrece
+              la salida: cerrar este diálogo y usar la tarjeta de al lado.
+              Ámbar, no rojo -- no es una falla técnica, es "revisa qué
+              subiste". */}
+          {error && documentoRechazado && (
+            <div className="flex items-start gap-2 rounded-xl border border-amber-300 bg-amber-50 px-4 py-3 text-sm text-amber-800">
+              <AlertTriangle className="w-4 h-4 flex-shrink-0 mt-0.5" />
+              <div>
+                <p className="font-medium">Esta foto no parece la planilla de pesaje</p>
+                <p className="mt-1">{error}</p>
+                <p className="mt-1">
+                  Si querías cargar la liquidación de El Pomar, cierra este diálogo y usa la tarjeta
+                  &quot;Venta quincenal al camión&quot; que está al lado, en esta misma pestaña.
+                </p>
+              </div>
+            </div>
+          )}
+
+          {error && !documentoRechazado && (
             <div className="flex items-center gap-2 rounded-xl border border-red-200 bg-red-50 px-4 py-3 text-sm text-red-700">
               <AlertTriangle className="w-4 h-4 flex-shrink-0" />
               {error}

--- a/src/components/hato/hooks/useSubirPesajeFoto.ts
+++ b/src/components/hato/hooks/useSubirPesajeFoto.ts
@@ -93,6 +93,13 @@ export interface CeldaParaCommit {
 export function useSubirPesajeFoto() {
   const [loading, setLoading] = useState(false);
   const [error, setError] = useState<string | null>(null);
+  // Finding #40 (2026-08-24): distingue el rechazo EXPLÍCITO del servidor
+  // (HTTP 422 -- ninguna vaca del roster ancló en ninguna foto, ver
+  // `detectarRechazoLecturaPesaje` en `ocrPesaje.ts`) de cualquier otro
+  // error (red, 500, 502...). `SubirPesajeFoto.tsx` lo usa para mostrar un
+  // panel accionable en vez del cajón de error genérico -- sin esta bandera
+  // tendría que adivinar el motivo comparando el TEXTO del mensaje.
+  const [documentoRechazado, setDocumentoRechazado] = useState(false);
   const [resultado, setResultado] = useState<PreviewPesajeRespuesta | null>(null);
   const [comprometiendo, setComprometiendo] = useState(false);
   const [errorCommit, setErrorCommit] = useState<string | null>(null);
@@ -110,6 +117,7 @@ export function useSubirPesajeFoto() {
   const subirFotos = useCallback(async (fotos: File[], anio: number, mes: number) => {
     setLoading(true);
     setError(null);
+    setDocumentoRechazado(false);
     setResultado(null);
     setCommitResultado(null);
     setErrorCommit(null);
@@ -133,6 +141,9 @@ export function useSubirPesajeFoto() {
       }
       const body = resultadoCuerpo.body;
       if (!res.ok || !body?.success) {
+        // 422 = rechazo explícito del servidor (ver `documentoRechazado`
+        // arriba), no un error de red/servidor genérico.
+        if (res.status === 422) setDocumentoRechazado(true);
         throw new Error(body?.error || `El servidor respondió ${res.status} al leer las fotos.`);
       }
 
@@ -233,6 +244,7 @@ export function useSubirPesajeFoto() {
   const limpiar = useCallback(() => {
     setResultado(null);
     setError(null);
+    setDocumentoRechazado(false);
     setCommitResultado(null);
     setErrorCommit(null);
   }, []);
@@ -244,6 +256,7 @@ export function useSubirPesajeFoto() {
     limpiar,
     loading,
     error,
+    documentoRechazado,
     resultado,
     comprometiendo,
     errorCommit,

--- a/src/supabase/functions/server/hato-pesaje-foto.ts
+++ b/src/supabase/functions/server/hato-pesaje-foto.ts
@@ -53,7 +53,7 @@ import {
 
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo set de escritura del módulo (053), igual que chequeo/foto.
 
-function respuestaError(c: Context, status: 400 | 401 | 403 | 500 | 502 | 503, error: string) {
+function respuestaError(c: Context, status: 400 | 401 | 403 | 422 | 500 | 502 | 503, error: string) {
   return c.json({ success: false, error }, status);
 }
 

--- a/src/supabase/functions/server/hato-pesaje-pipeline.ts
+++ b/src/supabase/functions/server/hato-pesaje-pipeline.ts
@@ -40,6 +40,7 @@ import { fechasPesajeMensuales } from './calculos-hato.ts';
 import {
   construirDiffPesaje,
   construirRosterPesaje,
+  detectarRechazoLecturaPesaje,
   esCandidataRosterPesaje,
   esquemaJsonOcrPesaje,
   construirPromptOcrPesaje,
@@ -163,7 +164,7 @@ export interface PipelinePesajeFotoResultado {
 
 export type ResultadoPipelinePesajeFoto =
   | { ok: true; resultado: PipelinePesajeFotoResultado }
-  | { ok: false; status: 500 | 502; error: string };
+  | { ok: false; status: 422 | 500 | 502; error: string };
 
 interface LlamadaModeloOk {
   ok: true;
@@ -353,6 +354,24 @@ export async function ejecutarPipelinePesajeFoto(params: {
 
   // --- 4. Anti-row-drift por nombre (lógica pura) ---------------------------
   const ocr = procesarLecturaOcrPesaje(lecturas, roster);
+
+  // --- 4.b Finding #40: RECHAZAR en vez de aceptar cuando ninguna fila de
+  //     NINGUNA foto ancló contra el roster -- ver `detectarRechazoLecturaPesaje`
+  //     (`ocrPesaje.ts`) para la regla completa. Antes de este chequeo el
+  //     pipeline seguía de largo con `filasConfirmadas` vacío, devolvía
+  //     `success: true` con un diff vacío, y la foto quedaba guardada en
+  //     Storage sin ninguna señal accionable -- exactamente lo que pasó con
+  //     la liquidación de El Pomar subida por error a esta ruta el
+  //     2026-08-19. La foto SIGUE guardándose (paso 1, arriba) -- este
+  //     rechazo nunca la descarta, solo evita fingir que hubo una lectura útil. ---
+  const rechazo = detectarRechazoLecturaPesaje(ocr);
+  if (rechazo) {
+    return {
+      ok: false,
+      status: 422,
+      error: `${rechazo.detalle}${rutasStorage.some((r) => r !== null) ? ' Las fotos sí quedaron guardadas.' : ''}`,
+    };
+  }
 
   // --- 5. Existentes en hato_pesajes_leche, para clasificar el diff --------
   const animalIdsLeidos = ocr.filasConfirmadas.map((f) => f.animalId);

--- a/src/supabase/functions/server/importHato/ocrPesaje.ts
+++ b/src/supabase/functions/server/importHato/ocrPesaje.ts
@@ -786,3 +786,60 @@ export function construirPromptOcrPesaje(): string {
     "Responde ÚNICAMENTE con el JSON del esquema pedido. Sin explicaciones, sin markdown.",
   ].join('\n');
 }
+
+// ---------------------------------------------------------------------------
+// 8. Rechazo cuando NINGUNA fila de la carga ancló contra el roster
+// ---------------------------------------------------------------------------
+
+export interface RechazoLecturaPesaje {
+  /** Mensaje completo, listo para mostrar al usuario o para viajar en el
+   * `error` de la respuesta HTTP. */
+  detalle: string;
+  /** Nombres impresos leídos (si el modelo alcanzó a leer alguno) que no
+   * coincidieron con ninguna vaca del roster -- hasta 5, sin duplicados.
+   * Útil para que el humano confirme si el documento es otra cosa (p. ej.
+   * la liquidación de El Pomar, que no trae nombres de vaca en absoluto). */
+  nombresNoReconocidos: string[];
+}
+
+/**
+ * Finding #40 (mantenimiento 2026-08-24): antes de este chequeo, una carga
+ * cuyas fotos NO eran de la planilla de pesaje (p. ej. la liquidación
+ * quincenal de El Pomar, subida por error a esta ruta) se "aceptaba" --
+ * `success: true`, diff vacío -- sin ninguna señal que el usuario pudiera
+ * accionar. La foto (3,2 MB en el incidente real) quedaba guardada como
+ * capa cruda sin que del otro lado saliera ningún pesaje, y nada en la
+ * respuesta decía "esto no parece lo que buscabas".
+ *
+ * Regla: si NINGUNA fila de NINGUNA foto de la carga ancló contra el
+ * roster (cero `filasConfirmadas`, agregado sobre TODAS las fotos juntas --
+ * `procesarLecturaOcrPesaje` ya las combina), la lectura se RECHAZA en vez
+ * de aceptarse. No importa si la causa real es "esta no es la planilla de
+ * pesaje" o "la foto salió ilegible/mal encuadrada": en los dos casos
+ * aceptar en silencio produce el mismo daño (cero pesajes, cero
+ * explicación), así que el mensaje cubre ambas sin afirmar cuál es.
+ *
+ * Un roster VACÍO (nadie activo en ordeño/novilla, `esCandidataRosterPesaje`)
+ * es un problema de DATOS, no de la foto, y se rechaza ANTES de llegar
+ * acá, con su propio mensaje (`ejecutarPipelinePesajeFoto`) -- esta función
+ * nunca ve ese caso.
+ */
+export function detectarRechazoLecturaPesaje(ocr: ResultadoOcrPesaje): RechazoLecturaPesaje | null {
+  if (ocr.filasConfirmadas.length > 0) return null;
+
+  const nombresNoReconocidos = [
+    ...new Set(ocr.filasNoLeidas.map((f) => f.nombreImpreso.trim()).filter((n) => n !== '')),
+  ].slice(0, 5);
+
+  const muestra =
+    nombresNoReconocidos.length > 0
+      ? ` Se alcanzó a leer: ${nombresNoReconocidos.join(', ')} -- ninguno coincide con una vaca activa del hato.`
+      : '';
+
+  return {
+    nombresNoReconocidos,
+    detalle:
+      `No se reconoció ninguna vaca del hato en la(s) foto(s) subida(s).${muestra} ` +
+      'Puede que la foto no sea de la planilla de pesaje -- ¿era la liquidación de El Pomar? -- o que la letra no se alcance a leer. Revisa la foto y vuelve a intentar.',
+  };
+}

--- a/src/utils/importHato/ocrPesaje.ts
+++ b/src/utils/importHato/ocrPesaje.ts
@@ -770,3 +770,60 @@ export function construirPromptOcrPesaje(): string {
     "Responde ÚNICAMENTE con el JSON del esquema pedido. Sin explicaciones, sin markdown.",
   ].join('\n');
 }
+
+// ---------------------------------------------------------------------------
+// 8. Rechazo cuando NINGUNA fila de la carga ancló contra el roster
+// ---------------------------------------------------------------------------
+
+export interface RechazoLecturaPesaje {
+  /** Mensaje completo, listo para mostrar al usuario o para viajar en el
+   * `error` de la respuesta HTTP. */
+  detalle: string;
+  /** Nombres impresos leídos (si el modelo alcanzó a leer alguno) que no
+   * coincidieron con ninguna vaca del roster -- hasta 5, sin duplicados.
+   * Útil para que el humano confirme si el documento es otra cosa (p. ej.
+   * la liquidación de El Pomar, que no trae nombres de vaca en absoluto). */
+  nombresNoReconocidos: string[];
+}
+
+/**
+ * Finding #40 (mantenimiento 2026-08-24): antes de este chequeo, una carga
+ * cuyas fotos NO eran de la planilla de pesaje (p. ej. la liquidación
+ * quincenal de El Pomar, subida por error a esta ruta) se "aceptaba" --
+ * `success: true`, diff vacío -- sin ninguna señal que el usuario pudiera
+ * accionar. La foto (3,2 MB en el incidente real) quedaba guardada como
+ * capa cruda sin que del otro lado saliera ningún pesaje, y nada en la
+ * respuesta decía "esto no parece lo que buscabas".
+ *
+ * Regla: si NINGUNA fila de NINGUNA foto de la carga ancló contra el
+ * roster (cero `filasConfirmadas`, agregado sobre TODAS las fotos juntas --
+ * `procesarLecturaOcrPesaje` ya las combina), la lectura se RECHAZA en vez
+ * de aceptarse. No importa si la causa real es "esta no es la planilla de
+ * pesaje" o "la foto salió ilegible/mal encuadrada": en los dos casos
+ * aceptar en silencio produce el mismo daño (cero pesajes, cero
+ * explicación), así que el mensaje cubre ambas sin afirmar cuál es.
+ *
+ * Un roster VACÍO (nadie activo en ordeño/novilla, `esCandidataRosterPesaje`)
+ * es un problema de DATOS, no de la foto, y se rechaza ANTES de llegar
+ * acá, con su propio mensaje (`ejecutarPipelinePesajeFoto`) -- esta función
+ * nunca ve ese caso.
+ */
+export function detectarRechazoLecturaPesaje(ocr: ResultadoOcrPesaje): RechazoLecturaPesaje | null {
+  if (ocr.filasConfirmadas.length > 0) return null;
+
+  const nombresNoReconocidos = [
+    ...new Set(ocr.filasNoLeidas.map((f) => f.nombreImpreso.trim()).filter((n) => n !== '')),
+  ].slice(0, 5);
+
+  const muestra =
+    nombresNoReconocidos.length > 0
+      ? ` Se alcanzó a leer: ${nombresNoReconocidos.join(', ')} -- ninguno coincide con una vaca activa del hato.`
+      : '';
+
+  return {
+    nombresNoReconocidos,
+    detalle:
+      `No se reconoció ninguna vaca del hato en la(s) foto(s) subida(s).${muestra} ` +
+      'Puede que la foto no sea de la planilla de pesaje -- ¿era la liquidación de El Pomar? -- o que la letra no se alcance a leer. Revisa la foto y vuelve a intentar.',
+  };
+}

--- a/supabase/functions/make-server-1ccce916/hato-pesaje-foto.ts
+++ b/supabase/functions/make-server-1ccce916/hato-pesaje-foto.ts
@@ -53,7 +53,7 @@ import {
 
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo set de escritura del módulo (053), igual que chequeo/foto.
 
-function respuestaError(c: Context, status: 400 | 401 | 403 | 500 | 502 | 503, error: string) {
+function respuestaError(c: Context, status: 400 | 401 | 403 | 422 | 500 | 502 | 503, error: string) {
   return c.json({ success: false, error }, status);
 }
 

--- a/supabase/functions/make-server-1ccce916/hato-pesaje-pipeline.ts
+++ b/supabase/functions/make-server-1ccce916/hato-pesaje-pipeline.ts
@@ -40,6 +40,7 @@ import { fechasPesajeMensuales } from './calculos-hato.ts';
 import {
   construirDiffPesaje,
   construirRosterPesaje,
+  detectarRechazoLecturaPesaje,
   esCandidataRosterPesaje,
   esquemaJsonOcrPesaje,
   construirPromptOcrPesaje,
@@ -163,7 +164,7 @@ export interface PipelinePesajeFotoResultado {
 
 export type ResultadoPipelinePesajeFoto =
   | { ok: true; resultado: PipelinePesajeFotoResultado }
-  | { ok: false; status: 500 | 502; error: string };
+  | { ok: false; status: 422 | 500 | 502; error: string };
 
 interface LlamadaModeloOk {
   ok: true;
@@ -353,6 +354,24 @@ export async function ejecutarPipelinePesajeFoto(params: {
 
   // --- 4. Anti-row-drift por nombre (lógica pura) ---------------------------
   const ocr = procesarLecturaOcrPesaje(lecturas, roster);
+
+  // --- 4.b Finding #40: RECHAZAR en vez de aceptar cuando ninguna fila de
+  //     NINGUNA foto ancló contra el roster -- ver `detectarRechazoLecturaPesaje`
+  //     (`ocrPesaje.ts`) para la regla completa. Antes de este chequeo el
+  //     pipeline seguía de largo con `filasConfirmadas` vacío, devolvía
+  //     `success: true` con un diff vacío, y la foto quedaba guardada en
+  //     Storage sin ninguna señal accionable -- exactamente lo que pasó con
+  //     la liquidación de El Pomar subida por error a esta ruta el
+  //     2026-08-19. La foto SIGUE guardándose (paso 1, arriba) -- este
+  //     rechazo nunca la descarta, solo evita fingir que hubo una lectura útil. ---
+  const rechazo = detectarRechazoLecturaPesaje(ocr);
+  if (rechazo) {
+    return {
+      ok: false,
+      status: 422,
+      error: `${rechazo.detalle}${rutasStorage.some((r) => r !== null) ? ' Las fotos sí quedaron guardadas.' : ''}`,
+    };
+  }
 
   // --- 5. Existentes en hato_pesajes_leche, para clasificar el diff --------
   const animalIdsLeidos = ocr.filasConfirmadas.map((f) => f.animalId);

--- a/supabase/functions/make-server-1ccce916/importHato/ocrPesaje.ts
+++ b/supabase/functions/make-server-1ccce916/importHato/ocrPesaje.ts
@@ -786,3 +786,60 @@ export function construirPromptOcrPesaje(): string {
     "Responde ÚNICAMENTE con el JSON del esquema pedido. Sin explicaciones, sin markdown.",
   ].join('\n');
 }
+
+// ---------------------------------------------------------------------------
+// 8. Rechazo cuando NINGUNA fila de la carga ancló contra el roster
+// ---------------------------------------------------------------------------
+
+export interface RechazoLecturaPesaje {
+  /** Mensaje completo, listo para mostrar al usuario o para viajar en el
+   * `error` de la respuesta HTTP. */
+  detalle: string;
+  /** Nombres impresos leídos (si el modelo alcanzó a leer alguno) que no
+   * coincidieron con ninguna vaca del roster -- hasta 5, sin duplicados.
+   * Útil para que el humano confirme si el documento es otra cosa (p. ej.
+   * la liquidación de El Pomar, que no trae nombres de vaca en absoluto). */
+  nombresNoReconocidos: string[];
+}
+
+/**
+ * Finding #40 (mantenimiento 2026-08-24): antes de este chequeo, una carga
+ * cuyas fotos NO eran de la planilla de pesaje (p. ej. la liquidación
+ * quincenal de El Pomar, subida por error a esta ruta) se "aceptaba" --
+ * `success: true`, diff vacío -- sin ninguna señal que el usuario pudiera
+ * accionar. La foto (3,2 MB en el incidente real) quedaba guardada como
+ * capa cruda sin que del otro lado saliera ningún pesaje, y nada en la
+ * respuesta decía "esto no parece lo que buscabas".
+ *
+ * Regla: si NINGUNA fila de NINGUNA foto de la carga ancló contra el
+ * roster (cero `filasConfirmadas`, agregado sobre TODAS las fotos juntas --
+ * `procesarLecturaOcrPesaje` ya las combina), la lectura se RECHAZA en vez
+ * de aceptarse. No importa si la causa real es "esta no es la planilla de
+ * pesaje" o "la foto salió ilegible/mal encuadrada": en los dos casos
+ * aceptar en silencio produce el mismo daño (cero pesajes, cero
+ * explicación), así que el mensaje cubre ambas sin afirmar cuál es.
+ *
+ * Un roster VACÍO (nadie activo en ordeño/novilla, `esCandidataRosterPesaje`)
+ * es un problema de DATOS, no de la foto, y se rechaza ANTES de llegar
+ * acá, con su propio mensaje (`ejecutarPipelinePesajeFoto`) -- esta función
+ * nunca ve ese caso.
+ */
+export function detectarRechazoLecturaPesaje(ocr: ResultadoOcrPesaje): RechazoLecturaPesaje | null {
+  if (ocr.filasConfirmadas.length > 0) return null;
+
+  const nombresNoReconocidos = [
+    ...new Set(ocr.filasNoLeidas.map((f) => f.nombreImpreso.trim()).filter((n) => n !== '')),
+  ].slice(0, 5);
+
+  const muestra =
+    nombresNoReconocidos.length > 0
+      ? ` Se alcanzó a leer: ${nombresNoReconocidos.join(', ')} -- ninguno coincide con una vaca activa del hato.`
+      : '';
+
+  return {
+    nombresNoReconocidos,
+    detalle:
+      `No se reconoció ninguna vaca del hato en la(s) foto(s) subida(s).${muestra} ` +
+      'Puede que la foto no sea de la planilla de pesaje -- ¿era la liquidación de El Pomar? -- o que la letra no se alcance a leer. Revisa la foto y vuelve a intentar.',
+  };
+}


### PR DESCRIPTION
## Summary

Finding #40 (maintenance sweep, 2026-08-19 incident): `POST /hato/pesaje/foto` silently "accepted" a photo of the wrong document (El Pomar's liquidación, uploaded to the pesaje route by mistake) — `success: true`, empty diff, the 3.2 MB photo stored in `hato-pesajes-fotos` matching zero records, and no signal the person could act on. No weighing has been captured since 2026-08-12.

- `detectarRechazoLecturaPesaje` (new, pure, `src/utils/importHato/ocrPesaje.ts`): rejects when **zero rows across all uploaded photos** anchored against the active-cow roster (`ocr.filasConfirmadas.length === 0`). Doesn't try to distinguish "wrong document" from "unreadable photo" — both produce the same damage if accepted silently, so the message covers both and lists up to 5 unrecognized names read from the photo(s) as a diagnostic (mirrored to both edge-function trees by `docs/hato/regenerar-copias-importhato.py`).
- `ejecutarPipelinePesajeFoto` (`hato-pesaje-pipeline.ts`, hand-synced pair) now returns `{ ok: false, status: 422 }` when that predicate fires, **after** the raw-layer photo upload (step 1) — the photo is still stored, and the rejection message says so explicitly, same pattern already used for the "couldn't read any photo" (502) case.
- `hato-pesaje-foto.ts`'s `respuestaError` status union extended to accept 422.
- Telegram's `/pesaje` conversation (`telegram/conversations/pesajeLeche.ts`) shares `ejecutarPipelinePesajeFoto` and already surfaces `lectura.error` verbatim on `!lectura.ok` — it gets the same protection with **no code change needed there**.
- `SubirPesajeFoto.tsx` / `useSubirPesajeFoto.ts`: the hook now exposes `documentoRechazado` (set on HTTP 422, distinct from generic errors) so the dialog renders this specific rejection as an amber, actionable panel — "esta foto no parece la planilla de pesaje", the server message, and a pointer to the sibling "Venta quincenal al camión" card that's already visible on the same "Registrar" tab (no new navigation/state-lifting needed — both cards already sit side by side).

## Twin route (liquidación/quincena photo) — reported, NOT fixed here

`hato-produccion-quincena-foto.ts` / `hato-liquidacion-pomar.ts` share the same underlying defect: a photo that isn't the liquidación document comes back with all 8 fields `ilegible`/`null` and `success: true` — no rejection path exists there either. Per the brief, this is flagged for a separate fix, not bundled into this PR.

## Test plan
- [x] `npm run typecheck` — clean (0 errors)
- [x] `npm run lint` — 0 errors, 902 warnings (all pre-existing `no-explicit-any`, none introduced by this change)
- [x] `npm test` — 133 files / 3010 tests pass, including 4 new tests for `detectarRechazoLecturaPesaje` (`src/__tests__/importHatoOcrPesaje.test.ts`) and the existing parity guard (`importHatoParidadServidor.test.ts`, `--check` mode)
- [x] TDD sanity check: temporarily reverted the predicate to a no-op, confirmed the 3 new rejection tests fail for the right reason, restored, confirmed green again
- [x] Diffed both mirror trees after every edit (`src/supabase/functions/server/` vs `supabase/functions/make-server-1ccce916/`) — byte-identical except the generator's own per-path header comment in `importHato/ocrPesaje.ts`

## Deployment

**This needs `npx supabase functions deploy make-server-1ccce916` after merge** — the backend fix (the actual `POST /hato/pesaje/foto` and Telegram `/pesaje` behavior change) lives in the edge function and has no effect until redeployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)