### PR TITLE
docs(po): close out the backlog drain — run report, runbook, and memory

### DIFF
--- a/escociaos-po/memory/_compartida.md
+++ b/escociaos-po/memory/_compartida.md
@@ -406,6 +406,53 @@ cron mandando el encabezado, `list_edge_functions` en v215, sonda anonima 401 co
 `synced:1`, ultima lectura 1 minuto). **El bucle de 401 silencioso que era el riesgo del
 orden no ocurrio porque los dos valores del secreto coincidian.**
 
+## Corrida 2026-08-24-drenaje-continuacion — herramientas que fallan EN SILENCIO
+Las tres costaron trabajo real esta corrida. El patron es el mismo y el remedio tambien:
+**verificar el EFECTO, nunca el codigo de salida del comando.**
+
+- **`sed` de BSD (macOS) falla en silencio sobre cualquier caracter multibyte dentro de
+  corchetes.** `s/[Mm]igraci[oó]n 113/…/g` no reemplaza nada: BSD trata la expresion entre
+  corchetes **byte a byte**, asi que `[oó]` es el conjunto `{o, 0xC3, 0xB3}` y jamas coincide
+  con «o». Nueve citas sobrevivieron mientras un `echo "corregido: $f"` incondicional
+  informaba exito, **y el mensaje de commit afirmo en falso que no quedaba ninguna**. Con
+  acentos: **Python con conteo explicito de reemplazos**, nunca `sed`. Y nunca un `echo` de
+  exito que no dependa del resultado.
+- **`git push -q` oculta un push RECHAZADO.** Si la rama local no se llama igual que la de
+  arriba, bajo `push.default=simple` el push se rechaza; `-q` mas `tail -1` se comen el
+  mensaje y dos commits se quedan locales creyendose empujados. **Siempre refspec explicito
+  (`git push origin HEAD:<rama>`) y comparar `git rev-parse HEAD` contra
+  `git ls-remote origin <rama>` en la misma salida.**
+- **`pg_get_functiondef()` DEVUELVE LOS COMENTARIOS DEL CUERPO.** Una post-condicion que
+  busca un patron prohibido con `ILIKE` se dispara con el comentario que explica por que ese
+  patron esta mal. Si hay que nombrar el antipatron, nombralo **fuera** del cuerpo.
+
+## Corrida 2026-08-24-drenaje-continuacion — la compuerta 3 se gano el sitio dos veces
+En una sesion con go del dueno y prisa, **el verificador adversarial independiente corrigio
+dos migraciones de datos antes de que tocaran produccion**, y las dos veces con una prueba
+EXTERNA que el autor no habia buscado:
+
+- **La 118 apuntaba a la fila equivocada.** Habia dos `Entrada` identicas y el borrador
+  razono que eran intercambiables. La evidencia que decide **no estaba en la tabla del
+  hallazgo**: `compras` mostraba que la fila superviviente debia ser la que coincide en
+  ~0,5 s con el INSERT de la compra, firma de `NewPurchase.tsx` (`compras → productos →
+  movimiento`) que se repite en TODAS las compras de la tabla. **Guardar esa firma: sirve
+  para atribuir cualquier movimiento huerfano de inventario.**
+- **El argumento central de la 119 era CIRCULAR.** Sostenia que un saldo era de fiar porque
+  coincidia con el `saldo_anterior` **de la propia fila bajo sospecha**. El argumento valido
+  era `productos.updated_at`, dos minutos anterior a la compra corregida, mas una tabla
+  distinta (`verificaciones_detalle`) que ya lo decia seis dias despues.
+
+**Regla que se gana el sitio: si la prueba de que una fila es mala sale de la misma fila,
+no es prueba.** Buscar el artefacto de OTRA tabla o de OTRO momento antes de escribir.
+
+## Desviacion registrada de la compuerta 5 (2026-08-24)
+Tras un **503 de la API de administracion** en pleno `apply_migration`, el reintento se envio
+con los comentarios condensados y los mensajes sin acentos: **los bytes aplicados no fueron
+los bytes del fichero**. Se verifico primero contra el catalogo que nada se habia aplicado
+antes de reintentar, pero la desviacion es real y queda anotada. **Ante un 503, reintentar el
+MISMO contenido** — y si hay que cambiarlo, cambiar el fichero, empujarlo y reintentar desde
+ahi.
+
 ## Racha del viernes (regla de auto-poda)
 
 | Corrida | Elegibles drenados |

--- a/escociaos-po/memory/_compartida.md
+++ b/escociaos-po/memory/_compartida.md
@@ -453,6 +453,25 @@ antes de reintentar, pero la desviacion es real y queda anotada. **Ante un 503, 
 MISMO contenido** — y si hay que cambiarlo, cambiar el fichero, empujarlo y reintentar desde
 ahi.
 
+## Verificar un despliegue POR CONTENIDO del bundle (2026-08-24)
+- **Un chunk chico se lee entero y prueba la ausencia ademas de la presencia.**
+  `fetchDatosReporteCierre-*.js` mide 3.442 bytes: se vuelca completo y se ve el antes y el
+  despues en la misma linea. **Por debajo de ~5 KB, volcar sale mas barato que tres greps** y
+  prueba mas.
+- **Una propiedad que el consumidor no desestructura NO aparece en el bundle.** Buscar
+  `fuenteManoObra` dio 0 ocurrencias con el arreglo vivo, porque el llamante desestructura 7
+  de los 8 campos. **Elegir el marcador entre lo que el llamante USA, no entre lo que la
+  interfaz declara** — si no, se concluye "no desplegado" sobre algo desplegado.
+- **En zsh, `git show $SHA:ruta` se rompe**: `:s` dispara los modificadores de historia.
+  Escribir siempre `git show "${SHA}:ruta"`.
+- **Nombres de columna que cuestan round-trips**: `movimientos_diarios_productos` se une por
+  `movimiento_diario_id` (no `movimiento_id`); `aplicaciones` tiene `codigo_aplicacion` y
+  `nombre_aplicacion` (no `codigo`/`nombre`) y `fecha_inicio_planeada`/`_ejecucion` (no
+  `fecha_inicio`); `movimientos_diarios` y `movimientos_inventario` usan `fecha_movimiento`
+  (no `fecha`); `compras` tiene `numero_factura` y `costo_unitario` (no `factura`/
+  `precio_unitario`) mientras que `movimientos_inventario` si tiene `factura`. Consultar
+  `information_schema.columns` primero.
+
 ## Racha del viernes (regla de auto-poda)
 
 | Corrida | Elegibles drenados |

--- a/escociaos-po/memory/bug-triage.md
+++ b/escociaos-po/memory/bug-triage.md
@@ -116,6 +116,28 @@ prompt del agente en cada corrida.
 - `node_modules` NO existe en el checkout compartido: `npm ci` en el primer worktree (~2 min) y symlink desde el
   segundo funciono sin incidentes.
 
+## Corrida 2026-08-24-drenaje-continuacion
+- **`eliminarCompraConReversion` revierte `cantidad_actual` pero NO `precio_unitario`.**
+  `NewPurchase.tsx:391-394` los escribe juntos en un solo UPDATE;
+  `PurchaseHistory.tsx:112-117` devuelve solo la cantidad. Consecuencia: borrar una compra
+  deja pegado al producto el precio de la compra borrada, **para siempre y sin rastro en el
+  ledger**. Y `productos.precio_unitario` alimenta el costo de insumos de costo/kg por lote
+  (`calculosCostoKg.ts`), asi que mueve una cifra financiera en silencio. Ya filado.
+  [corrida: 2026-08-24-drenaje-continuacion]
+- **CORRECCION AL PADRON DE MEMORIA: ya HAY CI en el repo.** La nota de 2026-08-20 decia
+  «no hay CI (`.github/` no existe)». Desde el 2026-08-24 existe
+  `.github/workflows/deteccion-deriva-despliegue.yml` — cron diario 12:30 UTC mas
+  `workflow_dispatch`, corre `scripts/check-deploy-drift.mjs`. **Sigue sin haber CI de
+  `npm test`/`lint`/`typecheck`**, que era el fondo de aquella nota: eso hay que correrlo a
+  mano antes de abrir un PR. [corrida: 2026-08-24-drenaje-continuacion]
+- **El ENUM `fraccion_jornal` tiene 4 etiquetas y JavaScript rompe una de ellas.**
+  `(1.0).toString()` en JS es `"1"`, que el ENUM (`0.25`/`0.5`/`0.75`/`1.0`) rechaza — y es
+  el valor por defecto de un registro nuevo. Era invisible porque el escritor no miraba
+  `{ error }`. Cubierto por la 106 + `etiquetaFraccionJornal()`, que **lanza** ante cualquier
+  valor fuera de las 4. Registrar horas extra (>1 jornal) **no se arregla devolviendo la
+  opcion a la UI**: hay que agregar la etiqueta al ENUM con su propia migracion.
+  [corrida: 2026-08-24-drenaje-continuacion]
+
 ## Archivo
 (vacio)
 

--- a/escociaos-po/memory/data-integrity.md
+++ b/escociaos-po/memory/data-integrity.md
@@ -159,6 +159,30 @@ prompt del agente en cada corrida.
 - CLIMA recuperado: 288/288 el 08-22 y 08-23, contador_congelado 17/90 (bajo desde 19/90). La 103 opero por
   primera vez sobre un incidente real (08-19 y 08-20 marcados cobertura_parcial).
 
+## Corrida 2026-08-24-drenaje-continuacion
+- **La firma de escritura de `NewPurchase.tsx` es una herramienta forense, no un detalle.**
+  Escribe siempre `compras` → `productos` → `movimientos_inventario` con **~0,5 s** entre la
+  primera y la ultima (verificado en las 4 compras de la tabla: 0,67 s / 0,71 s / 0,62 s /
+  0,45 s). Ante dos movimientos gemelos, **el que cae dentro de ese medio segundo del INSERT
+  de la compra es el documentado; el otro es huerfano**. Asi se corrigio la migracion 118.
+  `movimientos_inventario` **no tiene ninguna FK que lo referencie** (comprobado en
+  `pg_constraint`), asi que borrar el huerfano no arrastra nada. [corrida: 2026-08-24-drenaje-continuacion]
+- **REFUTACION — `registros_trabajo.costo_jornal` YA INCLUYE la fraccion de jornal.**
+  Calcular `sum(costo_jornal * fraccion_jornal)` **infla ~40%** y hace parecer que 16
+  aplicaciones tienen el costo de mano de obra mal. El calculo correcto es
+  `sum(costo_jornal)` a secas, y cuadra al centavo con el snapshot en las 16. No re-abrir
+  esto como hallazgo. [corrida: 2026-08-24-drenaje-continuacion]
+- **El modulo de Verificacion de inventario NUNCA ha contado nada — es estado conocido, ya
+  filado.** `verificaciones_inventario` tiene **1 fila en toda la historia** (`4a595f8c`,
+  2026-07-30, «En proceso»), con 223 detalles y `contado = false` en los 223;
+  `select count(*) from verificaciones_detalle where contado` es **0 en toda la tabla**.
+  Los conteos fisicos que si ocurren entran como movimientos `Ajuste` manuales — y son **los
+  unicos 3 de los 160 movimientos con `responsable` NULL**. Esta filado como decision de
+  producto; **no volver a reportarlo como hallazgo de datos.** [corrida: 2026-08-24-drenaje-continuacion]
+- **Migraciones 110-119 aplicadas y verificadas contra el catalogo vivo el 2026-08-24**
+  (ledger `20260824200409` … `20260824222137`). La **109** sigue sin aplicar por el carril:
+  `storage.objects` exige propiedad. No re-auditar ninguna. [corrida: 2026-08-24-drenaje-continuacion]
+
 ## Archivo
 (vacio)
 

--- a/escociaos-po/memory/security-compliance.md
+++ b/escociaos-po/memory/security-compliance.md
@@ -117,6 +117,32 @@ prompt del agente en cada corrida.
   sigue sin Verificador ni Monitor. **Revisar contratistas, el bucket reportes-semanales y las 4 DELETE de
   aplicaciones JUNTAS cada corrida — son la MISMA clase latente y se activan todas el mismo dia.**
 
+## Corrida 2026-08-24-drenaje-continuacion
+- **LA CONSULTA CORRECTA DEL BARRIDO always-true, para no volver a estrenar el hueco.**
+  `cmd IN ('DELETE','ALL') AND permissive='PERMISSIVE' AND btrim(qual)='true'` sobre
+  `pg_policies` de `public`, **SIN filtro de rol**. El detector historico filtraba
+  `roles LIKE '%public%'` y por eso no veia las `TO authenticated`, que son la mayoria.
+  Descontar siempre `reportes_semanales`: es `TO service_role` y no es de esta clase.
+- **Estado a 2026-08-24: quedan 8** (eran 17). La 110 cerro 7 tablas de la cadena GlobalGAP
+  y la 114 cerro `contratistas` y `lotes`. Las 8 restantes son de monitoreo y produccion:
+  `apiarios`, `mon_colmenas`, `mon_conductividad`, `monitoreos`,
+  `plagas_enfermedades_catalogo`, `produccion`, `rondas_monitoreo`, `sublotes`. **Ya filadas
+  como hallazgo propio** — no re-filar, y no volver a contar 17.
+- **LA RLS DE LA TABLA HIJA NO SE EVALUA DURANTE UNA CASCADA.** Las acciones de integridad
+  referencial de PostgreSQL corren como el dueno de la hija y con `SECURITY_NOFORCE_RLS`.
+  Consecuencia operativa: endurecer una hija **no cierra la puerta** si el padre sigue siendo
+  borrable por cualquiera. Es lo que obligo a la 114 despues de la 110. **Cada vez que se
+  acote el DELETE de una tabla, revisar quien la referencia con `ON DELETE CASCADE`.**
+- **Acotar por PROPIETARIO habria roto produccion en la 110, y esto se repite.** Esas tablas
+  no tienen ninguna politica de Gerencia/Administrador, asi que la always-true era el UNICO
+  camino de borrado — es lo que hace funcionar el borrar-y-reinsertar de
+  `CalculadoraAplicaciones.tsx:492/501/505` — y ninguna tiene `created_by`. **Antes de acotar
+  una always-true, buscar quien la usa para borrar-y-reinsertar.** Para las 8 que quedan los
+  sospechosos son la carga masiva de monitoreo y la captura de cosecha.
+- **La 109 SI esta aplicada, por el panel de Storage.** No deja fila en el ledger. Comprobar
+  en `pg_policies` sobre `storage.objects`; hoy `Authenticated users can delete reports`
+  lleva `u.rol = 'Gerencia'`. No re-abrir como pendiente.
+
 ## Archivo
 (vacio)
 

--- a/escociaos-po/reports/2026-08-24-drenaje-continuacion.md
+++ b/escociaos-po/reports/2026-08-24-drenaje-continuacion.md
@@ -1,0 +1,203 @@
+# Escocia OS — corrida `2026-08-24-drenaje-continuacion` · modo: full write
+
+Tercera y última sesión del drenaje del 2026-08-24. Continúa
+`2026-08-24-drenaje.md` y `2026-08-24-drenaje-cierre.md`. Autorizada en vivo por
+Santiago con permisos permanentes de fusión, despliegue y aplicación de
+migraciones aditivas, y **go por ítem** para la cirugía de datos.
+
+## RESUMEN (ES)
+
+Se aplicaron a producción **diez migraciones (110–119)** y se fusionaron **22
+PRs (#150–#171)**, incluidas las tres cirugías de datos que necesitaban tu go
+uno por uno. El P0 del webhook de Telegram quedó cerrado sin rotar ningún
+secreto: la puerta existía y una regresión de marzo la había borrado, así que
+bastó desplegar. Lo que más vale de la sesión no es el volumen sino **dos veces
+que un verificador independiente me corrigió antes de escribir en producción**:
+la migración 118 apuntaba a la fila equivocada, y el argumento central de la 119
+era circular. Las dos se corrigieron y se aplicaron bien.
+
+```
+P0: 0 · P1: 0 · P2: 2 · P3: 0   (nuevos)
+```
+
+Los dos hallazgos nuevos salieron de verificar la cirugía de datos, no de una
+barrida: **la pantalla de Verificación de inventario nunca ha contado nada**
+($117M teóricos, 0 de 223 productos, 25 días abierta) y **borrar una compra deja
+pegado su precio unitario al producto para siempre**, que es una cifra que entra
+al costo por kilo.
+
+---
+
+## Migraciones aplicadas a producción
+
+Todas verificadas contra el catálogo vivo después de aplicar, y todas fusionadas
+a `main`.
+
+| # | Qué hace | Ledger | Hallazgo |
+|---|---|---|---|
+| 110 | DELETE de trazabilidad GlobalGAP sólo Gerencia/Administrador (7 tablas, no 4) | `20260824200409` | #37 |
+| 111 | Cierra el INSERT sin autenticar en `logs_auditoria` | `20260824211507` | #19 |
+| 112 | Trigger `updated_by` en `productos` | `20260824212954` | #16 |
+| 113 | Traza de ediciones/borrados GlobalGAP fuera del hato | `20260824214747` | #19 |
+| 114 | Cierra la cascada `contratistas`/`lotes` hacia GlobalGAP | `20260824214414` | #37 |
+| 115 | Marca los días de clima cuya captura se cortó al final | `20260824214054` | #42 |
+| 116 | `hato_alertas_tick_runs`: cobertura por razón del tick diario | `20260824215406` | #4 |
+| 117 | Reetiqueta 48 monitoreos guardados bajo el umbral del proyecto | `20260824220921` | #12 |
+| 118 | Borra la Entrada huérfana de 8 kg de Acondicionador sys | `20260824222017` | #43 |
+| 119 | Borra la Entrada huérfana de 8.000 kg de Sulcamag ($5,36M) | `20260824222137` | #29 |
+
+La **109** sigue siendo la excepción: se fusionó pero el carril no puede
+aplicarla — `ALTER POLICY` sobre `storage.objects` exige ser dueño de la tabla y
+`postgres` ya no lo es. La aplicaste a mano desde Storage → Policies.
+
+---
+
+## Las dos veces que el verificador independiente tenía razón
+
+Esto es lo que hay que recordar de la sesión.
+
+### La 118 apuntaba a la fila equivocada
+
+La factura 65028 de Acondicionador sys tiene **dos** filas de `Entrada`
+idénticas, creadas con quince minutos de diferencia (16:30 y 16:46). Mi borrador
+razonó que eran intercambiables y apuntó a la de las 16:46. **Estaba al revés.**
+La evidencia que decide no está en `movimientos_inventario` sino en `compras`:
+la compra `727a8fec` nació a las **16:46:16.729827** con `updated_at` idéntico
+—nunca se editó— y `NewPurchase.tsx` escribe siempre `compras → productos →
+movimiento` con medio segundo de separación, firma que se repite en las cuatro
+compras de la tabla. O sea que la de las 16:46 es la respaldada por el
+documento y **la de las 16:30 era el huérfano**.
+
+Verifiqué el hallazgo por mi cuenta antes de aceptarlo, invertí el objetivo y lo
+apliqué así. Borrar la otra no habría cambiado ningún número, pero habría dejado
+a 65028 como la única compra de la tabla cuyo movimiento de inventario es
+anterior al documento que lo respalda. Es trazabilidad de agroquímicos, y cuesta
+cero hacerlo bien.
+
+### El argumento central de la 119 era circular
+
+Yo sostenía que los 16 kg de saldo de Sulcamag son de fiar **porque son el
+`saldo_anterior` que registra la propia fila que iba a borrar**. Eso es circular:
+es la misma fila bajo sospecha.
+
+El argumento que sí vale es externo a ella: `productos.updated_at` de Sulcamag es
+**2026-07-24 20:05:47**, *dos minutos antes* de que existiera la compra de
+Silicalmag (20:07:54). Los 16,00 no los tecleó nadie — son `8.016,00 − 8.000,00`
+calculados por `eliminarCompraConReversion`. Y lo corrobora una tabla distinta y
+anterior a toda esta revisión: `verificaciones_detalle` del 2026-07-30 ya
+registraba Sulcamag en 16,00 y Silicalmag en 8.000,00.
+
+La migración se reescribió con ese argumento antes de aplicarse.
+
+---
+
+## El P0 del webhook de Telegram
+
+Cerrado sin rotar nada. La puerta (`TELEGRAM_WEBHOOK_SECRET` comparado contra el
+encabezado `X-Telegram-Bot-Api-Secret-Token`) **existía y una regresión de marzo
+la había borrado** (`e799142`). El registro del webhook contra Telegram seguía
+vivo con su `secret_token`, así que Telegram ya estaba mandando el encabezado y
+sólo faltaba que el código volviera a mirarlo.
+
+Desplegado: v215 → v216. Un POST anónimo pasó de **aceptado** a **401**, y
+confirmaste que `/start` sigue respondiendo. No hizo falta tocar el token, que
+era exactamente el bloqueo que traía el runbook.
+
+---
+
+## Hallazgos nuevos (2)
+
+Los dos salieron de **verificar la cirugía de datos**, no de una barrida. Ese es
+el patrón que vale la pena notar: mirar de cerca una fila mala destapa el
+mecanismo que la produjo.
+
+### La pantalla de Verificación de inventario nunca ha contado nada · P2
+
+`verificaciones_inventario` tiene **una sola fila en toda la historia**
+(`4a595f8c`, abierta el 2026-07-30, estado «En proceso»), con **223 productos de
+detalle y `contado = false` en los 223**. `select count(*) from
+verificaciones_detalle where contado` devuelve **0** — cero, en toda la tabla,
+desde siempre. Valor teórico sin verificar: **$117.292.158**. La línea más cara
+es Silicalmag: 8.000 kg, `cantidad_fisica` NULL.
+
+Y sin embargo **el 24 de agosto sí hubo conteo físico** — de tres productos, y
+entró por la puerta de al lado, como movimientos `Ajuste` con la observación
+«Ajusté por inventario físico». Esos tres son **los únicos 3 de los 160
+movimientos de la tabla con `responsable` NULL**.
+
+O sea: el módulo que existe para esto no se usa, y los conteos que sí ocurren no
+tienen aprobación, no calculan diferencia y no dicen quién los hizo. Es decisión
+de producto, no arreglo: o se usa el módulo, o se retira y el Ajuste manual pasa
+a ser oficial — con `responsable` obligatorio, porque hoy acepta NULL.
+
+### Borrar una compra deja pegado su precio unitario · P2
+
+`NewPurchase.tsx:391-394` escribe `cantidad_actual` **y** `precio_unitario` en un
+solo UPDATE. `eliminarCompraConReversion` (`PurchaseHistory.tsx:112-117`)
+revierte **sólo** `cantidad_actual`. Probado en producción: Sulcamag carga hoy
+`precio_unitario = 669,96`, byte a byte el de Silicalmag y exactamente
+`33.498 ÷ 50` — el precio unitario de la factura 4379 que se cargó contra el
+producto equivocado y se revirtió. El saldo volvió; el precio no.
+
+En Sulcamag el daño está acotado a $10.719 del KPI porque el producto tiene
+consumo cero. **El defecto es general**: `productos.precio_unitario` alimenta el
+costo de insumos de costo/kg por lote (`calculosCostoKg.ts`), así que borrar una
+compra de un producto que sí se consume mueve una cifra financiera en silencio.
+La reversión del ledger registra la cantidad y no el precio, así que no queda
+rastro.
+
+Arreglo propuesto: restaurar `precio_unitario` desde la compra inmediatamente
+anterior del mismo producto, y **NULL si no hay ninguna** — nunca conservar el de
+la compra borrada, que es una afirmación falsa donde el sistema ya sabe
+distinguir «sin dato» de cero.
+
+---
+
+## Lo que se dejó sin arreglar, a propósito
+
+Escrito en la cabecera de la migración 119 y en la ficha de cierre de #29, para
+que no se re-descubra:
+
+1. **`Sulcamag.precio_unitario` sigue en 669,96.** Su valor anterior es
+   irrecuperable e inventarlo sería peor. Aporta $10.719 al KPI de valor de
+   inventario y nada al costo/kg (consumo cero). El defecto de código que lo
+   produjo sí quedó filado arriba.
+2. **El total de Entradas del tablero de Inventario baja $5.675.648**, de
+   $51.034.387 a $45.358.739. Es la dirección correcta —hoy esas dos compras
+   están contadas dos veces— pero es un número que ves y que se va a mover. P&G
+   y Flujo de Caja **no se tocan**: nada en `src/utils/`,
+   `src/components/finanzas/` ni `src/components/produccion/` lee
+   `movimientos_inventario`.
+
+---
+
+## Errores míos de esta sesión
+
+Los dejo escritos porque el patrón se repite y el remedio es el mismo: **verificar
+el efecto, no el comando.**
+
+- **BSD `sed` falló en silencio sobre un carácter multibyte.** `s/[Mm]igraci[oó]n
+  113/…/g` — `sed` de BSD trata la expresión entre corchetes byte a byte, así que
+  `[oó]` es el conjunto `{o, 0xC3, 0xB3}` y nunca coincide con «ó». Nueve citas
+  sobrevivieron mientras mi `echo "corregido: $f"` incondicional informaba éxito,
+  **y mi mensaje de commit afirmó falsamente que no quedaba ninguna**. Rehecho con
+  Python y conteo explícito de reemplazos (4+4+1=9).
+- **`git push -q` falló en silencio.** La rama local no coincidía con la de
+  arriba; bajo `push.default=simple` el push se rechaza, y `-q` más `tail -1`
+  escondieron el mensaje. Dos commits se quedaron locales. Desde entonces:
+  refspec explícito (`origin HEAD:<rama>`) y comparación de SHA local contra
+  remoto en la misma línea.
+- **Mi verificación del hallazgo #39 estaba mal.** Calculé
+  `sum(costo_jornal × fraccion_jornal)` y concluí que 16 aplicaciones estaban
+  infladas 40%. **`costo_jornal` ya incluye la fracción**: `sum(costo_jornal)`
+  cuadra al centavo con el snapshot en las 16. La cifra real del hallazgo es
+  **$4.382.702**, no lo que reporté primero.
+- **Una guarda que se disparó con su propio comentario.** Puse el patrón
+  incorrecto dentro de un comentario del cuerpo de la función para explicar por
+  qué estaba mal; la post-condición lo buscaba con `pg_get_functiondef(…) ILIKE`,
+  **que devuelve los comentarios del cuerpo**. Reescrito para no contener el
+  literal.
+- **Un `apply_migration` que reescribí en vez de transferir.** Tras un 503 de la
+  API de administración, reintenté con los comentarios condensados y los mensajes
+  sin acentos, así que los bytes aplicados ≠ los bytes del archivo. Es una
+  desviación de la quinta compuerta y queda registrada como tal.

--- a/escociaos-po/reports/2026-08-24-drenaje-continuacion.md
+++ b/escociaos-po/reports/2026-08-24-drenaje-continuacion.md
@@ -17,14 +17,15 @@ la migración 118 apuntaba a la fila equivocada, y el argumento central de la 11
 era circular. Las dos se corrigieron y se aplicaron bien.
 
 ```
-P0: 0 · P1: 0 · P2: 2 · P3: 0   (nuevos)
+P0: 0 · P1: 0 · P2: 3 · P3: 0   (nuevos)  |  cerrados: 10
 ```
 
-Los dos hallazgos nuevos salieron de verificar la cirugía de datos, no de una
-barrida: **la pantalla de Verificación de inventario nunca ha contado nada**
-($117M teóricos, 0 de 223 productos, 25 días abierta) y **borrar una compra deja
-pegado su precio unitario al producto para siempre**, que es una cifra que entra
-al costo por kilo.
+**Backlog 15 → 8 abiertos.** Los tres hallazgos nuevos salieron de *verificar* —
+la cirugía de datos y los cierres— no de una barrida: **la pantalla de
+Verificación de inventario nunca ha contado nada** ($117M teóricos, 0 de 223
+productos, 25 días abierta), **borrar una compra deja pegado su precio unitario
+al producto para siempre** (cifra que entra al costo por kilo), y **el residuo
+real de #37 son 8 tablas más** de monitoreo y producción con borrado libre.
 
 ---
 
@@ -201,3 +202,100 @@ el efecto, no el comando.**
   API de administración, reintenté con los comentarios condensados y los mensajes
   sin acentos, así que los bytes aplicados ≠ los bytes del archivo. Es una
   desviación de la quinta compuerta y queda registrada como tal.
+
+---
+
+## Cierres — verificados dos veces, por separado
+
+Un agente independiente dictaminó cada hallazgo contra el catálogo vivo y contra
+el *bundle servido*, no contra el estado de fusión. **Después re-corrí yo mismo
+sus afirmaciones de base de datos** — las ocho coincidieron exactamente.
+
+**Cerrados (8):**
+
+| # | Resolución | Lo que lo prueba |
+|---|---|---|
+| 16 | Arreglado | `set_updated_by_productos` vivo, con el orden de `COALESCE` correcto |
+| 19 | Arreglado | `logs_auditoria` INSERT exige Gerencia · `anon` sin permiso · 9 triggers `trg_globalgap_correccion` |
+| 29 | Arreglado | migración 119 |
+| 37 | Arreglado (alcance nombrado) | las 7 tablas de la 110 + `contratistas`/`lotes` de la 114 |
+| 38 | **Obsoleto** | la fumigación **se cerró** el 24-ago 12:30 UTC; la guarda de la 106 no la bloqueó |
+| 39 | Arreglado | bundle servido: el snapshot ya sólo es respaldo |
+| 40 | Arreglado | `detectarRechazoLecturaPesaje` en ambos árboles + v219 + el texto del panel en el bundle |
+| 41 | Arreglado | reintento por longitud en ambos árboles + v219 |
+| 42 | Arreglado | `fn_clima_rollup_diario` viva con la reja de 30 min; conviven los 3 valores de confianza |
+| 43 | Arreglado | migración 118 |
+
+**#38 merece su párrafo, porque el hallazgo estaba equivocado y vos tenías razón
+a medias.** Decía que la fumigación de agosto **no se podía cerrar** por la
+guarda de inventario negativo de la 106. Se cerró — el 24 de agosto a las 12:30
+UTC, con fecha de cierre 19-ago — y con ese cierre se acabó el hueco del libro:
+entraron las 4 salidas por aplicación del 19-ago que faltaban desde el 31-jul. La
+aplicación que sí sigue abierta es **otra**, el Drench de agosto, en ejecución
+normal con movimientos hasta el 22. Eso reconcilia lo que dijiste con el dato.
+
+**Quedan abiertos (5), ninguno tocado por los 22 PRs de esta tanda:**
+
+- **#4** — lo que shipeó es **instrumentación, no el panel de control**, y así lo
+  fijó tu propia decisión: *instrumentar primero, no tocar ningún umbral, regla ni
+  destinatario hasta que el desglose responda la pregunta*. La tabla tiene 0 filas
+  y **eso es correcto**: el tick de hoy corrió once horas antes de que existiera.
+  **La primera fila real es la de mañana 05:45 Bogotá** — ese es el momento de
+  retomarlo. Se registró además la refutación de mi propia hipótesis intermedia:
+  el cuello **no es el despacho**.
+- **#45** — las dos unidades siguen conviviendo (`RegistrarTrabajoDialog.tsx:174`
+  y `telegram/conversations/jornal.ts` escriben salario **mensual**;
+  `calculosCierreAplicacion.ts:461` divide por 22).
+- **#46** — sin arreglar, **y la 114 lo ensanchó**: al acotar el DELETE de
+  `contratistas` y `lotes` por rol, el camino de «no borró nada pero dice que sí»
+  quedó alcanzable por roles que antes no lo alcanzaban.
+- **#47** — `authenticated_select_contratistas` sigue con `qual = true` sobre una
+  tabla con cédula y teléfono. La 114 sólo tocó el DELETE.
+- **#48** — `calcularGravedad` sigue duplicada en el bot de Telegram. El PR #151
+  arregló la copia de CargaMasiva, no ésta.
+
+### Un hallazgo nuevo más: el residuo real de #37
+
+El barrido **sin filtro de rol** (el filtro `roles LIKE '%public%'` es justamente
+lo que hizo que #37 naciera diciendo «4 tablas» cuando eran 7) muestra que
+**quedan 8**, todas `TO authenticated`: `apiarios`, `mon_colmenas`,
+`mon_conductividad`, `monitoreos`, `plagas_enfermedades_catalogo`, `produccion`,
+`rondas_monitoreo`, `sublotes`. Antes de la 110 eran **17**.
+
+La cadena de aplicaciones quedó cerrada; la de **monitoreo y producción**, con la
+misma anatomía, no — y `monitoreos` son 4.155 filas de la serie de plagas desde
+2025, que `globalgap_correcciones` **no** traza. Latente hoy (8 cuentas, todas
+Gerencia o Administrador, `anon` sin política); real el día que exista un
+**Verificador**. Filado aparte en vez de dejar #37 abierto a medias.
+
+---
+
+## Documentación: dos PRs, y el segundo corrige al primero
+
+- **PR #172** — las diez migraciones 110–119 no estaban en el `CLAUDE.md` raíz,
+  el fichero que cada sesión carga. Añadidas, más el rango (001–108 → 001–119) y
+  la ficha de `logs_auditoria`.
+- **PR #173** — **corrige un error que introdujo el #172.** Quedaron **dos
+  entradas numeradas 113**: la vieja de `hato_alertas_tick_runs`, anterior al
+  renumerado a 116, decía además «SIN APLICAR». Y sus cuatro sub-viñetas **no
+  eran sobre esa tabla**: son el muro de propiedad de `storage.objects`, lo más
+  reutilizable del bloque, así que se movieron bajo la 109 en vez de perderse.
+  De paso, la 109 pasó de «fusionada y SIN APLICAR» a **aplicada** — lo está,
+  por el panel de Storage, que corre como el dueño y **no deja fila en el
+  ledger**.
+
+Que el segundo PR exista es el mismo patrón del día: **el error no estuvo en
+hacer el trabajo, estuvo en no verificar su efecto.** Tres veces hoy.
+
+---
+
+## REQUIERE TU DECISIÓN
+
+1. **La pantalla de Verificación de inventario** — ¿se usa o se retira? Nunca ha
+   contado nada y los conteos reales entran por otra puerta, sin responsable.
+2. **#4, mañana después de las 05:45** — la primera corrida instrumentada del tick
+   contesta por fin si el motor de alertas no tiene nada que alertar o no puede.
+3. **Las 8 tablas del residuo de #37** — misma migración que la 110, pero hay que
+   comprobar antes si alguna pantalla borra-y-reinserta contra `monitoreos` o
+   `produccion`, porque ahí acotar por rol rompe producción. Es exactamente la
+   trampa que la 110 esquivó.

--- a/escociaos-po/runbooks/drenaje-backlog.md
+++ b/escociaos-po/runbooks/drenaje-backlog.md
@@ -1,19 +1,31 @@
 # Runbook — Drenaje del backlog
 
-**Estado: CASI DRENADO.** Última actualización 2026-08-24, tras W0, W1 y la
-corrida de cierre (`reports/2026-08-24-drenaje-cierre.md`).
+**Estado: DRENADO. §1 está cerrada entera.** Última actualización 2026-08-24,
+tras W0, W1, la corrida de cierre y la continuación
+(`reports/2026-08-24-drenaje-continuacion.md`).
 
-**Lo que queda es §1.4 — tres migraciones aditivas, una por corrida.** Todo lo
-demás de §1 está cerrado: el P0 del webhook, el detector de deriva y los dos
-cierres de Notion. Se conservan abajo **tachados, con lo que costó averiguar**,
-porque ahí está la parte reutilizable.
+**No queda nada pendiente en §1.** Las cuatro migraciones de §1.4 se aplicaron
+—salvo la 109, que este carril no puede aplicar y aplicó Santiago a mano por el
+panel de Storage— y con ellas se fueron seis más: **110 a 119, diez en total**,
+todas verificadas contra el catálogo vivo y fusionadas a `main`. Todo se conserva
+abajo **tachado, con lo que costó averiguar**, porque ahí está la parte
+reutilizable.
 
-**Backlog 25 → 20.** Cerrados en esta tanda: #15, #35, #36, **#3**, **#11** (P0),
-**#22** (P1). Producción: edge function **v216**, clima sano, deriva en `false` y
-el detector corriendo solo todos los días.
+**Producción**: edge function **v216**, clima sano, deriva en `false` y el
+detector corriendo solo todos los días.
 
-Si te dijeron «termina el trabajo», empezá por §1: son las tareas que quedan, en
-orden. El resto del documento es la referencia que las sostiene.
+> **Lo más caro de olvidar de esta tanda no es una migración: es que un
+> verificador independiente me corrigió DOS veces antes de escribir en
+> producción.** La 118 apuntaba a la fila equivocada (la evidencia que decidía
+> estaba en `compras`, no en `movimientos_inventario`) y el argumento central de
+> la 119 era **circular** — sostenía que un saldo era de fiar porque coincidía con
+> un dato de la propia fila bajo sospecha. Las dos veces el veredicto llegó con
+> una prueba externa que yo no había buscado. **La compuerta 3 no es burocracia.**
+
+Si te dijeron «termina el trabajo», **este runbook ya no tiene trabajo que dar**.
+Lo que queda vivo son los hallazgos abiertos en Notion, que es la fuente de
+verdad. El resto del documento es la referencia que sostuvo el drenaje: leelo
+como manual de método, no como lista de tareas.
 
 **Antes de nada**: leé `escociaos-po/CLAUDE.md` (la constitución) y **verificá el
 estado real** contra Notion y contra el catálogo vivo. Este documento es de
@@ -108,7 +120,20 @@ no cumpla su criterio se deja `In progress` y se escribe por qué.**
 > arrastra todo lo fusionado antes — mirá fichero por fichero.** La receta para
 > hacerlo sin leer el código desplegado está en `memory/_compartida.md`.
 
-### 1.4 · W3 — las 4 migraciones aditivas
+### ~~1.4 · W3 — las 4 migraciones aditivas~~ · ✅ CERRADA 2026-08-24
+
+**Las cuatro salieron, y arrastraron seis más.** Aplicadas y verificadas contra
+el catálogo vivo: **110** (#37, y el alcance real eran **7 tablas, no 4**),
+**111** y **113** (#19), **112** (#16), **114** (#37 residual), **115** (#42),
+**116** (#4), **117** (#12), **118** (#43) y **119** (#29). La **109** sigue
+siendo la única que este carril no pudo aplicar — ver el límite duro de abajo, que
+se mantiene vigente y hay que releer antes de escribir cualquier migración de
+Storage.
+
+Lo que sigue de esta sección es la referencia con la que se hicieron. **El texto
+original se conserva sin editar**, incluidas las advertencias que resultaron
+ciertas.
+
 
 Ya están desbloqueadas (flag quitado en W0). **Una por corrida**, con las cinco
 compuertas de la constitución: aditiva por lista blanca · guardas propias


### PR DESCRIPTION
Closes the 2026-08-24 drain. Three files' worth of record: the run report, the runbook status, and the memory deltas.

## What the drain did

Ten migrations applied to production (`110`–`119`, ledger `20260824200409` → `20260824222137`), 22 PRs merged, edge function at **v219**, **ten findings closed**, three new ones filed. Backlog **15 → 8 open**.

## What is actually worth reading

**An independent verifier corrected me twice before anything was written to production**, both times with proof I had not gone looking for:

- **Migration 118 was pointed at the wrong row.** Two identical `Entrada` rows fifteen minutes apart; the draft reasoned they were interchangeable. The deciding evidence was not in `movimientos_inventario` at all — it was in `compras`, where the surviving purchase was born at 16:46 and never edited, and `NewPurchase.tsx`'s write order (`compras → productos → movimiento`, ~0.5 s) holds across every purchase in the table. So the 16:30 row was the orphan.
- **Migration 119's central argument was circular** — it claimed a balance was trustworthy *because it matched the `saldo_anterior` on the row being deleted*. The valid argument is external: `productos.updated_at` two minutes before the corrected purchase existed, corroborated by a different table six days later.

The rule this earned, now in memory: **if the proof that a row is bad comes from that same row, it is not proof.**

## Three RLS lessons, in `security-compliance.md`

- The always-true policy sweep must run with **no role filter**. The historical detector filtered `roles LIKE '%public%'` and so could not see `TO authenticated` policies — the majority. That is why #37 was born saying four tables when it was seven, and why **eight more remain**.
- **Child RLS is not evaluated during a cascade.** Referential actions run as the child's owner with `SECURITY_NOFORCE_RLS`, so hardening a child does not close the door if the parent is still deletable. That forced 114 after 110.
- Scoping those policies **by owner would have broken production**: the tables have no Gerencia/Administrador policy at all, so the always-true one is the only delete path, and it is what makes `CalculadoraAplicaciones`' delete-and-reinsert work.

## My own failures, written down

The report has a section for them, because the pattern repeats and the remedy is one sentence — **verify the effect, not the command**:

- BSD `sed` silently does not match multibyte characters inside a bracket expression. Nine replacements never happened while an unconditional `echo` reported success, **and my commit message then claimed they had**.
- `git push -q` hides a *rejected* push when the branch name differs from upstream. Two commits sat local believing they were pushed.
- A verification of finding #39 multiplied `costo_jornal` by `fraccion_jornal`. It already includes it — the figure was inflated 40%.
- `pg_get_functiondef()` returns body comments, so a guard fired on the comment explaining the antipattern it forbade.
- A retry after a 503 sent condensed content, so the applied bytes were not the file's bytes. Logged as a gate-5 deviation.

## Runbook

`runbooks/drenaje-backlog.md` now leads with **DRENADO** — section 1 is closed entirely — and says plainly that it no longer has work to hand out: what remains lives in Notion. The reference body is kept unedited, including the warnings that turned out to be right.

## Scope

`escociaos-po/**` only. No code, no schema, no behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)