### PR TITLE
Clima: backfill refactor + daily retry for unreliable rainfall data

### DIFF
--- a/src/__tests__/calculosClima.test.ts
+++ b/src/__tests__/calculosClima.test.ts
@@ -509,6 +509,119 @@ describe('construirFranjaLluvia', () => {
   });
 });
 
+describe('calcularRachaSinLluvia', () => {
+  let calcularRachaSinLluvia: (
+    resumenes: ResumenDiario[],
+    hastaISO: string,
+    umbralMm?: number,
+  ) => import('@/utils/calculosClima').RachaSinLluvia;
+
+  beforeAll(async () => {
+    const mod = await import('@/utils/calculosClima');
+    calcularRachaSinLluvia = mod.calcularRachaSinLluvia;
+  });
+
+  it('cuenta los días consecutivos por debajo del umbral, empezando en AYER -- nunca en hastaISO', () => {
+    const rows = [
+      // Termina la racha más atrás, para aislar la aserción de este test
+      // (que hastaISO se ignora) de la lógica de "se corta ante lluvia real".
+      resumenDia({ fecha: '2026-08-11', lluvia_total_mm: 20, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-12', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-13', lluvia_total_mm: 0.5, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-14', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+      // hastaISO trae una lluvia fuerte a propósito: si el conteo la mirara,
+      // la racha daría 0. Debe ignorarse -- el resumen de "hoy" no existe
+      // todavía en producción (el rollup nocturno lo escribe mañana).
+      resumenDia({ fecha: '2026-08-15', lluvia_total_mm: 40, lluvia_confianza: 'ok' }),
+    ];
+    const racha = calcularRachaSinLluvia(rows, '2026-08-15', 10);
+    expect(racha.dias).toBe(3);
+    expect(racha.desdeFecha).toBe('2026-08-12');
+    expect(racha.hastaFecha).toBe('2026-08-14');
+    expect(racha.cortadaPorFaltaDeDato).toBe(false);
+    expect(racha.ultimaLluviaFecha).toBe('2026-08-11');
+  });
+
+  it('una llovizna por debajo del umbral NO rompe la racha', () => {
+    const rows = [
+      resumenDia({ fecha: '2026-08-11', lluvia_total_mm: 15, lluvia_confianza: 'ok' }), // termina la racha
+      resumenDia({ fecha: '2026-08-12', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-13', lluvia_total_mm: 2, lluvia_confianza: 'ok' }), // llovizna inmaterial
+      resumenDia({ fecha: '2026-08-14', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+    ];
+    const racha = calcularRachaSinLluvia(rows, '2026-08-15', 10);
+    expect(racha.dias).toBe(3);
+    expect(racha.cortadaPorFaltaDeDato).toBe(false);
+  });
+
+  it('se corta en el primer día con lluvia >= umbral, y expone esa lluvia', () => {
+    const rows = [
+      resumenDia({ fecha: '2026-08-11', lluvia_total_mm: 25, lluvia_confianza: 'ok' }), // más atrás, no debe importar
+      resumenDia({ fecha: '2026-08-12', lluvia_total_mm: 15, lluvia_confianza: 'ok' }), // corta acá
+      resumenDia({ fecha: '2026-08-13', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-14', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+    ];
+    const racha = calcularRachaSinLluvia(rows, '2026-08-15', 10);
+    expect(racha.dias).toBe(2);
+    expect(racha.ultimaLluviaFecha).toBe('2026-08-12');
+    expect(racha.ultimaLluviaMm).toBe(15);
+    expect(racha.cortadaPorFaltaDeDato).toBe(false);
+  });
+
+  it('umbral configurable: la misma serie da rachas distintas según el umbral', () => {
+    const rows = [
+      resumenDia({ fecha: '2026-08-13', lluvia_total_mm: 3, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-14', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+    ];
+    expect(calcularRachaSinLluvia(rows, '2026-08-15', 10).dias).toBe(2); // 3mm no rompe con umbral 10
+    expect(calcularRachaSinLluvia(rows, '2026-08-15', 1).dias).toBe(1); // 3mm sí rompe con umbral 1
+  });
+
+  it('un día sin dato confiable corta el conteo sin asumir que fue seco (contador congelado)', () => {
+    const rows = [
+      resumenDia({ fecha: '2026-08-11', lluvia_total_mm: 0, lluvia_confianza: 'ok' }), // más atrás del hueco, no cuenta
+      resumenDia({ fecha: '2026-08-12', lluvia_total_mm: null, lluvia_confianza: 'contador_congelado' }),
+      resumenDia({ fecha: '2026-08-13', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+      resumenDia({ fecha: '2026-08-14', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+    ];
+    const racha = calcularRachaSinLluvia(rows, '2026-08-15', 10);
+    expect(racha.dias).toBe(2); // sólo 13 y 14 -- se detiene en 12, no lo cruza
+    expect(racha.cortadaPorFaltaDeDato).toBe(true);
+    expect(racha.fechaFaltaDeDato).toBe('2026-08-12');
+    expect(racha.ultimaLluviaFecha).toBeNull();
+  });
+
+  it('un día `cobertura_parcial` corta el conteo igual que el contador congelado (migración 103)', () => {
+    const rows = [
+      resumenDia({ fecha: '2026-08-13', lluvia_total_mm: 0, lluvia_confianza: 'cobertura_parcial', lecturas_count: 167 }),
+      resumenDia({ fecha: '2026-08-14', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+    ];
+    const racha = calcularRachaSinLluvia(rows, '2026-08-15', 10);
+    expect(racha.dias).toBe(1);
+    expect(racha.cortadaPorFaltaDeDato).toBe(true);
+    expect(racha.fechaFaltaDeDato).toBe('2026-08-13');
+  });
+
+  it('un día sin ninguna fila corta el conteo igual que uno sin dato confiable', () => {
+    const rows = [
+      resumenDia({ fecha: '2026-08-14', lluvia_total_mm: 0, lluvia_confianza: 'ok' }),
+      // 2026-08-13 no tiene fila -- la estación no sincronizó ese día
+    ];
+    const racha = calcularRachaSinLluvia(rows, '2026-08-15', 10);
+    expect(racha.dias).toBe(1);
+    expect(racha.cortadaPorFaltaDeDato).toBe(true);
+    expect(racha.fechaFaltaDeDato).toBe('2026-08-13');
+  });
+
+  it('sin historia en absoluto, la racha es 0 y queda marcada sin confirmar', () => {
+    const racha = calcularRachaSinLluvia([], '2026-08-15', 10);
+    expect(racha.dias).toBe(0);
+    expect(racha.cortadaPorFaltaDeDato).toBe(true);
+    expect(racha.desdeFecha).toBeNull();
+    expect(racha.hastaFecha).toBeNull();
+  });
+});
+
 // ===========================================================================
 // La puerta por la que TODO consumidor de clima_resumen_diario tiene que pasar
 // ===========================================================================

--- a/src/__tests__/rachaSinLluvia.test.tsx
+++ b/src/__tests__/rachaSinLluvia.test.tsx
@@ -1,0 +1,47 @@
+import { describe, it, expect } from 'vitest';
+import { renderToStaticMarkup } from 'react-dom/server';
+import type { RachaSinLluvia as RachaSinLluviaDatos } from '@/utils/calculosClima';
+import { RachaSinLluvia } from '@/components/dashboard/RachaSinLluvia';
+
+function racha(overrides: Partial<RachaSinLluviaDatos>): RachaSinLluviaDatos {
+  return {
+    dias: 0,
+    desdeFecha: null,
+    hastaFecha: null,
+    ultimaLluviaFecha: null,
+    ultimaLluviaMm: null,
+    cortadaPorFaltaDeDato: false,
+    fechaFaltaDeDato: null,
+    ...overrides,
+  };
+}
+
+function render(r: RachaSinLluviaDatos, umbralMm = 10) {
+  return renderToStaticMarkup(<RachaSinLluvia racha={r} umbralMm={umbralMm} />);
+}
+
+describe('RachaSinLluvia', () => {
+  it('muestra el conteo y el umbral', () => {
+    const html = render(racha({ dias: 12 }));
+    expect(html).toContain('12');
+    expect(html).toContain('10');
+  });
+
+  it('cuando la racha terminó en lluvia real, muestra esa fecha y su valor', () => {
+    const html = render(racha({ dias: 3, ultimaLluviaFecha: '2026-08-12', ultimaLluviaMm: 15 }));
+    expect(html).toContain('15');
+    expect(html).not.toContain('No se puede confirmar');
+  });
+
+  it('cuando la racha se cortó por falta de dato, avisa en vez de mostrar el número como si fuera confiable', () => {
+    const html = render(racha({ dias: 2, cortadaPorFaltaDeDato: true, fechaFaltaDeDato: '2026-08-12' }));
+    expect(html).toContain('No se puede confirmar');
+    // La fecha del hueco aparece en el aviso, no se esconde
+    expect(html).toContain('ago');
+  });
+
+  it('no pinta nada si no hay racha y tampoco hay hueco de dato que reportar', () => {
+    const html = render(racha({ dias: 0, cortadaPorFaltaDeDato: false }));
+    expect(html).toBe('');
+  });
+});

--- a/src/components/dashboard/ClimaCard.tsx
+++ b/src/components/dashboard/ClimaCard.tsx
@@ -9,11 +9,14 @@ import { fechaAISODate, obtenerFechaHoy } from '@/utils/fechas';
 import { formatNumber } from '@/utils/format';
 import {
   construirFranjaLluvia,
+  calcularRachaSinLluvia,
+  UMBRAL_LLUVIA_MATERIAL_MM,
   clasificarFrescuraLectura,
   etiquetaEdadLectura,
   minutosDesdeLectura,
 } from '@/utils/calculosClima';
 import { FranjaLluvia } from './FranjaLluvia';
+import { RachaSinLluvia } from './RachaSinLluvia';
 import type { ResumenClima } from '@/types/clima';
 
 interface DiaPronostico {
@@ -59,6 +62,14 @@ export function ClimaCard() {
   // llega como 'sin_dato', nunca como 0mm.
   const franjaLluvia10Dias = useMemo(
     () => construirFranjaLluvia(resumenesDiarios, 10, obtenerFechaHoy()),
+    [resumenesDiarios],
+  );
+
+  // Racha de días sin lluvia material (pedido de Santiago 2026-08-26): cuenta
+  // hacia atrás desde ayer, se corta ante lluvia >= umbral o ante el primer
+  // día sin dato confiable -- nunca asume seco donde el dato no lo respalda.
+  const rachaSinLluvia = useMemo(
+    () => calcularRachaSinLluvia(resumenesDiarios, obtenerFechaHoy()),
     [resumenesDiarios],
   );
 
@@ -130,6 +141,7 @@ export function ClimaCard() {
         {resumenSemana && <ResumenSemana resumen={resumenSemana} sunHoursSemana={sunHoursSemana} />}
 
         <FranjaLluvia dias={franjaLluvia10Dias} visibleEnMovil={7} />
+        <RachaSinLluvia racha={rachaSinLluvia} umbralMm={UMBRAL_LLUVIA_MATERIAL_MM} />
       </div>
     );
   }
@@ -197,6 +209,7 @@ export function ClimaCard() {
       {resumenSemana && <ResumenSemana resumen={resumenSemana} sunHoursSemana={sunHoursSemana} />}
 
       <FranjaLluvia dias={franjaLluvia10Dias} visibleEnMovil={7} />
+      <RachaSinLluvia racha={rachaSinLluvia} umbralMm={UMBRAL_LLUVIA_MATERIAL_MM} />
     </div>
   );
 }

--- a/src/components/dashboard/RachaSinLluvia.tsx
+++ b/src/components/dashboard/RachaSinLluvia.tsx
@@ -1,0 +1,42 @@
+import { Umbrella } from 'lucide-react';
+import type { RachaSinLluvia as RachaSinLluviaDatos } from '@/utils/calculosClima';
+import { formatearMm } from './FranjaLluvia';
+import { formatearFechaCorta } from '@/utils/fechas';
+
+interface RachaSinLluviaProps {
+  racha: RachaSinLluviaDatos;
+  umbralMm: number;
+}
+
+/**
+ * Racha de días sin lluvia material (umbral configurable, `UMBRAL_LLUVIA_MATERIAL_MM`
+ * en `calculosClima.ts`). Cuenta hacia atrás desde ayer -- nunca "hoy", cuyo
+ * resumen todavía no existe. Si un día sin dato confiable corta el conteo
+ * (contador congelado, cobertura parcial, o ninguna fila), lo dice
+ * explícitamente en vez de mostrar un número que asumió en silencio que ese
+ * día no llovió -- mismo principio que `FranjaLluvia`.
+ */
+export function RachaSinLluvia({ racha, umbralMm }: RachaSinLluviaProps) {
+  if (racha.dias === 0 && !racha.ultimaLluviaFecha && !racha.cortadaPorFaltaDeDato) return null;
+
+  return (
+    <div className="pt-3 border-t border-gray-100 flex items-start gap-2">
+      <Umbrella className="w-3.5 h-3.5 text-brand-brown/40 shrink-0 mt-0.5" aria-hidden="true" />
+      <div className="text-xs">
+        <p className="text-foreground">
+          <span className="font-medium">{racha.dias}</span> días sin lluvia ≥{formatearMm(umbralMm)}
+          {racha.ultimaLluviaFecha && racha.ultimaLluviaMm !== null && (
+            <span className="text-brand-brown/60">
+              {' '}· última: {formatearMm(racha.ultimaLluviaMm)} el {formatearFechaCorta(racha.ultimaLluviaFecha)}
+            </span>
+          )}
+        </p>
+        {racha.cortadaPorFaltaDeDato && (
+          <p className="text-amber-600 mt-0.5">
+            No se puede confirmar más atrás del {racha.fechaFaltaDeDato ? formatearFechaCorta(racha.fechaFaltaDeDato) : 'último día'} — falta dato confiable de lluvia ese día
+          </p>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/src/components/dashboard/index.ts
+++ b/src/components/dashboard/index.ts
@@ -17,6 +17,7 @@ export { EstadoHeader } from './EstadoHeader';
 export type { EstadoHeaderProps } from './EstadoHeader';
 export { ClimaCard } from './ClimaCard';
 export { FranjaLluvia } from './FranjaLluvia';
+export { RachaSinLluvia } from './RachaSinLluvia';
 export { QuickLinksRow } from './QuickLinksRow';
 export { DashboardKPICard } from './DashboardKPICard';
 export { PlagasKPICard } from './PlagasKPICard';

--- a/src/sql/migrations/121_clima_reintento_sin_dato_cron.sql
+++ b/src/sql/migrations/121_clima_reintento_sin_dato_cron.sql
@@ -1,0 +1,90 @@
+-- =====================================================================
+-- 121: Reintento diario de días de clima sin dato confiable
+-- Fecha: 2026-08-26
+--
+-- Pedido directo del dueño: "no quiero que registre null ni invente el 0.
+-- Quiero que haga backfill del día una vez la estación recupere conexión y
+-- se pueda consultar el dato real que sí existe en Ecowitt."
+--
+-- El rollup nocturno (068/103/115) ya hace la mitad correcta: cuando el día
+-- llega incompleto o con el contador de lluvia congelado, escribe NULL en
+-- vez de inventar un cero o un duplicado. Lo que faltaba es la otra mitad:
+-- si la estación se reconecta y Ecowitt SÍ tiene el dato completo en su
+-- propia nube (buffer local que se sube al volver la luz/el internet), acá
+-- nada volvía a mirar ese día -- quedaba en `sin_dato` para siempre aunque
+-- el dato real ya estuviera disponible del otro lado de la API.
+--
+-- Este archivo agrega el pg_cron. La lógica del reintento vive en el edge
+-- function (`clima.tsx`, handler `handleClimaReintentoSinDato`) porque
+-- necesita llamar la History API de Ecowitt -- SQL no hace peticiones HTTP
+-- salientes por su cuenta, sólo a través de `net.http_post` hacia edge
+-- functions propias, igual que el resto de los cron de este módulo (030,
+-- 060, 068, 102, 105).
+--
+-- IMPORTANTE -- de paso, `handleClimaReintentoSinDato` (y el propio
+-- `/clima/backfill`, que se reescribió en el mismo commit) dejaron de tener
+-- su propia clasificación de confianza en TypeScript
+-- (`aggregateReadingsToDaily`, que NO aplicaba ninguno de los chequeos de
+-- 068/103/115 -- un backfill viejo podía escribir 'ok' sobre un día con el
+-- contador congelado). Ahora ambos insertan las lecturas crudas en
+-- `clima_lecturas` y llaman al RPC `fn_clima_rollup_diario(p_fecha)` --
+-- la MISMA función que corre el cron nocturno -- así que sólo hay UN lugar
+-- en todo el sistema que decide `lluvia_confianza`. Backfill manual,
+-- reintento automático y rollup nocturno concuerdan siempre, por
+-- construcción, no por disciplina de mantenerlos sincronizados a mano.
+--
+-- Reutiliza el secreto compartido de la 105 (`CLIMA_SYNC_SECRET` /
+-- `clima_sync_secret` en Vault) -- el nuevo endpoint pasa por la misma
+-- puerta `verificarAccesoClima` que ya protege `/clima/sync` y
+-- `/clima/backfill`, no hace falta un secreto nuevo.
+--
+-- Horario: 06:00 Bogotá (11:00 UTC) -- después del rollup nocturno (00:15
+-- Bogotá, migración 068) para que el resumen de ayer ya exista, y separado
+-- por >10 min de hato-alertas-tick (05:45, migración 060) y acciones-tick
+-- (05:50, migración 102) para que no compitan por la misma instancia de la
+-- edge function en el mismo minuto (mismo criterio que dejó escrito la
+-- 102). Una vez al día alcanza: no es una alerta urgente, es un
+-- autocorrector de historia -- si la estación tarda varios días en
+-- reconectar, la ventana de `DIAS_REINTENTO_SIN_DATO = 21` (definida en
+-- `clima.tsx`) lo sigue cubriendo en la corrida del día siguiente.
+--
+-- Idempotente: `cron.schedule` hace upsert por nombre de job, y el reintento
+-- en sí es seguro de re-ejecutar -- si un día ya está 'ok' no vuelve a
+-- pedirlo (ver el filtro en `handleClimaReintentoSinDato`).
+-- =====================================================================
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+CREATE EXTENSION IF NOT EXISTS pg_net  WITH SCHEMA extensions;
+
+SELECT cron.schedule(
+  'clima-reintento-sin-dato',
+  '0 11 * * *',
+  $$
+  SELECT net.http_post(
+    url := 'https://ywhtjwawnkeqlwxbvgup.supabase.co/functions/v1/make-server-1ccce916/clima/reintentar-sin-dato',
+    headers := jsonb_build_object(
+      'Content-Type', 'application/json',
+      'x-clima-sync-secret',
+        (SELECT decrypted_secret FROM vault.decrypted_secrets WHERE name = 'clima_sync_secret')
+    ),
+    body := '{}'::jsonb
+  );
+  $$
+);
+
+-- Misma guarda que dejó la 105: si el secreto no existe todavía, el header
+-- viaja vacío y el endpoint responde 503 (fail-closed, nunca corre
+-- "abierto") en vez de fallar en silencio. El secreto ya debería existir en
+-- este punto (se creó para la 105) -- esto es una red de seguridad, no se
+-- espera que dispare.
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM vault.decrypted_secrets WHERE name = 'clima_sync_secret') THEN
+    RAISE WARNING 'El secreto de Vault "clima_sync_secret" no existe -- el reintento diario de clima responderá 503 hasta que se cree (ver migración 105).';
+  END IF;
+END $$;
+
+-- =============================================================================
+-- ROLLBACK (manual)
+--   SELECT cron.unschedule('clima-reintento-sin-dato');
+-- =============================================================================

--- a/src/supabase/functions/server/clima.tsx
+++ b/src/supabase/functions/server/clima.tsx
@@ -418,55 +418,108 @@ function parseEcowittHistory(histData: EcowittHistoryData, stationId: string) {
   return readings;
 }
 
-// Aggregate an array of parsed 5-min readings into a single daily summary row
-// for clima_resumen_diario. Readings must already be unit-converted (°C, km/h, mm).
-function aggregateReadingsToDaily(
-  readings: ReturnType<typeof parseEcowittHistory>,
-  fecha: string,
-  stationId: string
-) {
-  const nonNull = (vals: (number | null)[]): number[] =>
-    vals.filter((v): v is number => v !== null);
+// ============================================================================
+// Backfill de UN día: pide la History API de Ecowitt para ese día, inserta
+// las lecturas crudas en clima_lecturas (mismo camino que el sync de 5 min,
+// `handleClimaSync`) y deja que `fn_clima_rollup_diario` (068/103/115) sea
+// la ÚNICA lógica que decide `lluvia_confianza` -- nunca se reimplementa esa
+// clasificación acá.
+//
+// Antes esta función agregaba en TypeScript (`aggregateReadingsToDaily`,
+// eliminada) y escribía `clima_resumen_diario` directo con un simple
+// `max(lluvia_diaria_mm)`, sin aplicar ninguno de los tres chequeos de
+// confianza -- un backfill podía escribir 'ok' sobre un día con el contador
+// de lluvia congelado o capturado a medias, exactamente lo que esas
+// migraciones existen para impedir. Insertar en `clima_lecturas` y llamar
+// al mismo RPC que corre el cron nocturno hace que backfill manual,
+// reintento automático (migración 121) y rollup nocturno concuerden
+// siempre, por construcción -- no por disciplina de mantener dos copias de
+// la lógica sincronizadas.
+//
+// Usado por `handleClimaBackfill` (disparo manual) y
+// `handleClimaReintentoSinDato` (cron diario, migración 121).
+// ============================================================================
 
-  const temps = nonNull(readings.map(r => r.temp_c));
-  const humidity = nonNull(readings.map(r => r.humedad_pct));
-  const wind = nonNull(readings.map(r => r.viento_kmh));
-  const gust = nonNull(readings.map(r => r.rafaga_kmh));
-  const windDir = nonNull(readings.map(r => r.viento_dir));
-  const rain = nonNull(readings.map(r => r.lluvia_diaria_mm));
-  const solar = nonNull(readings.map(r => r.radiacion_wm2));
-  const uv = nonNull(readings.map(r => r.uv_index));
+interface ResultadoBackfillDia {
+  ok: boolean;
+  lecturas: number;
+  error?: string;
+}
 
-  const avg = (arr: number[]) => arr.length > 0 ? round2(arr.reduce((s, v) => s + v, 0) / arr.length) : null;
-  const min = (arr: number[]) => arr.length > 0 ? round2(Math.min(...arr)) : null;
-  const max = (arr: number[]) => arr.length > 0 ? round2(Math.max(...arr)) : null;
+async function backfillUnDia(
+  fecha: Date,
+  creds: { appKey: string; apiKey: string; mac: string },
+  sb: { supabaseUrl: string; serviceKey: string },
+  log: string,
+): Promise<ResultadoBackfillDia> {
+  const ecowittDateStr = formatEcowittDate(fecha);
 
-  // Circular mean for wind direction
-  let windDirMean: number | null = null;
-  if (windDir.length > 0) {
-    const sinSum = windDir.reduce((s, d) => s + Math.sin(d * Math.PI / 180), 0);
-    const cosSum = windDir.reduce((s, d) => s + Math.cos(d * Math.PI / 180), 0);
-    windDirMean = round2(((Math.atan2(sinSum / windDir.length, cosSum / windDir.length) * 180 / Math.PI) % 360 + 360) % 360);
+  const url = new URL('https://api.ecowitt.net/api/v3/device/history');
+  url.searchParams.set('application_key', creds.appKey);
+  url.searchParams.set('api_key', creds.apiKey);
+  url.searchParams.set('mac', creds.mac);
+  url.searchParams.set('start_date', `${ecowittDateStr} 00:00:00`);
+  url.searchParams.set('end_date', `${ecowittDateStr} 23:59:59`);
+  url.searchParams.set('call_back', 'outdoor.temperature,outdoor.humidity,wind,rainfall_piezo,solar_and_uvi');
+  url.searchParams.set('cycle_type', 'auto');
+
+  const apiRes = await fetch(url.toString());
+  if (!apiRes.ok) {
+    const body = await apiRes.text().catch(() => '');
+    return { ok: false, lecturas: 0, error: `Ecowitt API HTTP ${apiRes.status} — ${body}` };
   }
 
-  return {
-    fecha,
-    station_id: stationId,
-    temp_c_min: min(temps),
-    temp_c_max: max(temps),
-    temp_c_avg: avg(temps),
-    humedad_pct_min: min(humidity),
-    humedad_pct_max: max(humidity),
-    humedad_pct_avg: avg(humidity),
-    lluvia_total_mm: max(rain), // Ecowitt daily accumulator — max = day total
-    viento_kmh_avg: avg(wind),
-    rafaga_kmh_max: max(gust),
-    viento_dir_predominante: windDirMean,
-    radiacion_wm2_avg: avg(solar),
-    radiacion_wm2_max: max(solar),
-    uv_index_max: uv.length > 0 ? Math.max(...uv) : null,
-    lecturas_count: readings.length,
-  };
+  const response: EcowittHistoryResponse = await apiRes.json();
+  if (response.code !== 0) {
+    return { ok: false, lecturas: 0, error: `Ecowitt: ${response.msg}` };
+  }
+  if (!response.data || Object.keys(response.data).length === 0) {
+    return { ok: false, lecturas: 0, error: 'sin datos de Ecowitt para ese día' };
+  }
+
+  const readings = parseEcowittHistory(response.data as EcowittHistoryData, creds.mac);
+  if (readings.length === 0) {
+    return { ok: false, lecturas: 0, error: '0 lecturas parseadas' };
+  }
+
+  // Lecturas crudas -> clima_lecturas. `ignore-duplicates` sobre el
+  // UNIQUE(station_id, timestamp) de la migración 029 hace que reintentar
+  // un día ya cargado sea idempotente en vez de fallar.
+  const insertRes = await fetch(`${sb.supabaseUrl}/rest/v1/clima_lecturas`, {
+    method: 'POST',
+    headers: {
+      apikey: sb.serviceKey,
+      Authorization: `Bearer ${sb.serviceKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal,resolution=ignore-duplicates',
+    },
+    body: JSON.stringify(readings),
+  });
+  if (!insertRes.ok) {
+    const errorText = await insertRes.text();
+    return { ok: false, lecturas: 0, error: `insert clima_lecturas falló — ${errorText}` };
+  }
+
+  // fn_clima_rollup_diario agrega, clasifica lluvia_confianza y escribe
+  // clima_resumen_diario -- y al final poda clima_lecturas > 24h, así que
+  // las lecturas históricas recién insertadas no se quedan pisando la
+  // ventana rodante del sync en vivo.
+  const rpcRes = await fetch(`${sb.supabaseUrl}/rest/v1/rpc/fn_clima_rollup_diario`, {
+    method: 'POST',
+    headers: {
+      apikey: sb.serviceKey,
+      Authorization: `Bearer ${sb.serviceKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ p_fecha: ecowittDateStr }),
+  });
+  if (!rpcRes.ok) {
+    const errorText = await rpcRes.text();
+    return { ok: false, lecturas: readings.length, error: `fn_clima_rollup_diario falló — ${errorText}` };
+  }
+
+  console.info(`${log} ${ecowittDateStr}: ${readings.length} lecturas reagregadas`);
+  return { ok: true, lecturas: readings.length };
 }
 
 export async function handleClimaBackfill(c: Context): Promise<Response> {
@@ -522,85 +575,24 @@ export async function handleClimaBackfill(c: Context): Promise<Response> {
     let totalDays = 0;
     const errors: string[] = [];
 
-    // Iterate day by day
+    // Iterate day by day -- backfillUnDia hace la pregunta a Ecowitt y deja
+    // que fn_clima_rollup_diario clasifique lluvia_confianza (ver el
+    // comentario de esa función).
     const current = new Date(fromDate);
     while (current <= toDate) {
       const dateStr = formatDateParam(current);
-      const ecowittDateStr = formatEcowittDate(current);
-      totalDays++;
 
       try {
-        // Fetch history for this day from Ecowitt
-        const url = new URL('https://api.ecowitt.net/api/v3/device/history');
-        url.searchParams.set('application_key', creds.appKey);
-        url.searchParams.set('api_key', creds.apiKey);
-        url.searchParams.set('mac', creds.mac);
-        url.searchParams.set('start_date', `${ecowittDateStr} 00:00:00`);
-        url.searchParams.set('end_date', `${ecowittDateStr} 23:59:59`);
-        url.searchParams.set('call_back', 'outdoor.temperature,outdoor.humidity,wind,rainfall_piezo,solar_and_uvi');
-        url.searchParams.set('cycle_type', 'auto');
-
-        const apiRes = await fetch(url.toString());
-
-        if (!apiRes.ok) {
-          const body = await apiRes.text().catch(() => '');
-          errors.push(`${dateStr}: Ecowitt API HTTP ${apiRes.status}`);
-          console.warn(`${log} ${dateStr}: Ecowitt API ${apiRes.status} — ${body}`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        const response: EcowittHistoryResponse = await apiRes.json();
-
-        if (response.code !== 0) {
-          errors.push(`${dateStr}: ${response.msg}`);
-          console.warn(`${log} ${dateStr}: Ecowitt error — ${response.msg}`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        if (!response.data || Object.keys(response.data).length === 0) {
-          console.info(`${log} ${dateStr}: no data`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        // Parse historical data into readings
-        const readings = parseEcowittHistory(response.data as EcowittHistoryData, creds.mac);
-
-        if (readings.length === 0) {
-          console.info(`${log} ${dateStr}: no readings`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        // Aggregate into daily summary and upsert into clima_resumen_diario
-        const dailySummary = aggregateReadingsToDaily(readings, ecowittDateStr, creds.mac);
-
-        const insertRes = await fetch(`${sb.supabaseUrl}/rest/v1/clima_resumen_diario?on_conflict=fecha,station_id`, {
-          method: 'POST',
-          headers: {
-            apikey: sb.serviceKey,
-            Authorization: `Bearer ${sb.serviceKey}`,
-            'Content-Type': 'application/json',
-            Prefer: 'return=minimal,resolution=merge-duplicates',
-          },
-          body: JSON.stringify(dailySummary),
-        });
-
-        if (!insertRes.ok) {
-          const errorText = await insertRes.text();
-          errors.push(`${dateStr}: insert failed — ${errorText}`);
-          console.error(`${log} ${dateStr}: insert failed — ${errorText}`);
-        } else {
+        const resultado = await backfillUnDia(current, creds, sb, log);
+        totalDays++;
+        if (resultado.ok) {
           totalSynced += 1;
-          console.info(`${log} ${dateStr}: daily summary inserted (${readings.length} readings aggregated)`);
+        } else {
+          errors.push(`${dateStr}: ${resultado.error}`);
+          console.warn(`${log} ${dateStr}: ${resultado.error}`);
         }
       } catch (err) {
+        totalDays++;
         errors.push(`${dateStr}: ${String(err)}`);
         console.error(`${log} ${dateStr}: ${err}`);
       }
@@ -616,6 +608,143 @@ export async function handleClimaBackfill(c: Context): Promise<Response> {
       synced: totalSynced,
       days: totalDays,
       errors: errors.length > 0 ? errors : undefined,
+    }, 200);
+  } catch (error) {
+    console.error(`${log} Unhandled error:`, error);
+    return c.json({ error: String(error) }, 500);
+  }
+}
+
+// ============================================================================
+// Handler: reintento diario de días sin dato confiable (migración 121)
+// POST /clima/reintentar-sin-dato -- disparado por el pg_cron
+// 'clima-reintento-sin-dato' a las 06:00 Bogotá.
+//
+// Pedido del dueño: "no quiero que registre null ni invente el 0. Quiero
+// que haga backfill del día una vez la estación recupere conexión y se
+// pueda consultar el dato real que sí existe en Ecowitt." El rollup
+// nocturno ya hace la mitad correcta -- nunca fabrica un cero -- pero nada
+// volvía a mirar un día ya sellado `sin_dato`. Esto es esa segunda mitad:
+// revisa los últimos DIAS_REINTENTO_SIN_DATO días y le vuelve a preguntar a
+// Ecowitt sólo por los que todavía no tienen un dato confiable. Si la
+// estación ya se reconectó y Ecowitt tiene el día completo en su nube
+// (buffer local que sube al volver la luz/el internet), el día pasa a
+// 'ok' con el número real. Si Ecowitt TODAVÍA no lo tiene, el día queda
+// exactamente como estaba -- nunca se inventa un valor para forzar que
+// "avance".
+//
+// Importante sobre `contador_congelado`: a diferencia de `cobertura_parcial`
+// (un hueco de captura, justo lo que este reintento puede recuperar),
+// `contador_congelado` es un bug del firmware del sensor -- el contador
+// acumulado de Ecowitt no se reinició, y eso ya quedó grabado así del lado
+// de Ecowitt, con estación conectada y las 288 lecturas del día presentes.
+// Reintentarlo es inofensivo (misma pregunta, misma respuesta previsible) y
+// se incluye por si el sensor se corrige o el valor cambia, pero no hay
+// garantía de que se resuelva -- es un problema de HARDWARE, no de
+// conexión.
+// ============================================================================
+
+/** Ventana hacia atrás que cada corrida revisa. 21 días cubre de sobra
+ *  cualquier corte de luz/internet razonable sin recorrer toda la historia
+ *  en cada disparo diario. */
+const DIAS_REINTENTO_SIN_DATO = 21;
+
+/** `lluvia_confianza` que vale la pena reintentar -- las dos que guardan
+ *  NULL por falta de dato (068/103). `sin_time_piezo` se deja afuera a
+ *  propósito: ese día ya tiene un número en el que se confía, no está en
+ *  NULL, reintentarlo no lo mejora. */
+const CONFIANZAS_A_REINTENTAR = new Set(['contador_congelado', 'cobertura_parcial']);
+
+export async function handleClimaReintentoSinDato(c: Context): Promise<Response> {
+  const log = '[clima-reintento-sin-dato]';
+
+  const acceso = await verificarAccesoClima(c);
+  if (acceso instanceof Response) return acceso;
+
+  try {
+    const creds = getEcowittCredentials();
+    if (!creds) return c.json({ error: 'Missing Ecowitt credentials' }, 500);
+    const sb = getSupabaseConfig();
+    if (!sb) return c.json({ error: 'Missing Supabase config' }, 500);
+
+    const ayer = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const desde = new Date(ayer.getTime() - (DIAS_REINTENTO_SIN_DATO - 1) * 24 * 60 * 60 * 1000);
+    const desdeStr = formatEcowittDate(desde);
+    const ayerStr = formatEcowittDate(ayer);
+
+    // Se pregunta a la base qué días están sin dato en vez de reintentar la
+    // ventana completa a ciegas -- un día ya 'ok' no necesita otra llamada
+    // a Ecowitt.
+    const queryUrl = `${sb.supabaseUrl}/rest/v1/clima_resumen_diario`
+      + `?station_id=eq.${encodeURIComponent(creds.mac)}`
+      + `&fecha=gte.${desdeStr}&fecha=lte.${ayerStr}`
+      + `&select=fecha,lluvia_confianza`;
+    const queryRes = await fetch(queryUrl, {
+      headers: { apikey: sb.serviceKey, Authorization: `Bearer ${sb.serviceKey}` },
+    });
+    if (!queryRes.ok) {
+      const body = await queryRes.text().catch(() => '');
+      console.error(`${log} No se pudo leer clima_resumen_diario (${queryRes.status}): ${body}`);
+      return c.json({ error: 'No se pudo leer clima_resumen_diario', details: body }, 502);
+    }
+    const filas: { fecha: string; lluvia_confianza: string }[] = await queryRes.json();
+    const confianzaPorFecha = new Map(filas.map((f) => [f.fecha, f.lluvia_confianza]));
+
+    const candidatos: Date[] = [];
+    for (let i = 0; i < DIAS_REINTENTO_SIN_DATO; i++) {
+      const d = new Date(ayer.getTime() - i * 24 * 60 * 60 * 1000);
+      const fechaStr = formatEcowittDate(d);
+      const confianza = confianzaPorFecha.get(fechaStr);
+      // Sin fila en absoluto ("sin_registro" del lado del frontend) o con
+      // una confianza que hoy vale NULL -- las dos son candidatas.
+      if (confianza === undefined || CONFIANZAS_A_REINTENTAR.has(confianza)) {
+        candidatos.push(d);
+      }
+    }
+
+    if (candidatos.length === 0) {
+      console.info(`${log} nada que reintentar en los últimos ${DIAS_REINTENTO_SIN_DATO} días`);
+      return c.json({ message: 'Nada que reintentar', candidatos: 0 }, 200);
+    }
+
+    console.info(`${log} ${candidatos.length} día(s) candidato(s): ${candidatos.map(formatEcowittDate).join(', ')}`);
+
+    const resultados: { fecha: string; consultaOk: boolean; error?: string }[] = [];
+    for (const dia of candidatos) {
+      const r = await backfillUnDia(dia, creds, sb, log);
+      resultados.push({ fecha: formatEcowittDate(dia), consultaOk: r.ok, error: r.ok ? undefined : r.error });
+      await sleep(150);
+    }
+
+    // Se vuelve a preguntar a la base cuántos candidatos quedaron 'ok'
+    // DESPUÉS del reintento -- "la consulta a Ecowitt no dio error" no es
+    // lo mismo que "el día se resolvió"; puede seguir incompleto del lado
+    // de Ecowitt. Si esta verificación en sí falla, se dice explícitamente
+    // (`resueltos: null`) en vez de reportar 0 como si nada se hubiera
+    // arreglado.
+    let resueltos: number | null = null;
+    const verifQueryUrl = `${sb.supabaseUrl}/rest/v1/clima_resumen_diario`
+      + `?station_id=eq.${encodeURIComponent(creds.mac)}`
+      + `&fecha=gte.${desdeStr}&fecha=lte.${ayerStr}`
+      + `&lluvia_confianza=eq.ok`
+      + `&select=fecha`;
+    const verifRes = await fetch(verifQueryUrl, {
+      headers: { apikey: sb.serviceKey, Authorization: `Bearer ${sb.serviceKey}` },
+    });
+    if (verifRes.ok) {
+      const fechasOk = new Set(((await verifRes.json()) as { fecha: string }[]).map((f) => f.fecha));
+      resueltos = candidatos.filter((d) => fechasOk.has(formatEcowittDate(d))).length;
+    } else {
+      console.warn(`${log} no se pudo verificar cuántos candidatos quedaron 'ok' tras el reintento`);
+    }
+
+    console.info(`${log} ${resueltos ?? '?'}/${candidatos.length} día(s) resuelto(s) a 'ok' en esta corrida`);
+
+    return c.json({
+      message: 'Reintento completo',
+      candidatos: candidatos.length,
+      resueltos,
+      resultados,
     }, 200);
   } catch (error) {
     console.error(`${log} Unhandled error:`, error);

--- a/src/supabase/functions/server/index.tsx
+++ b/src/supabase/functions/server/index.tsx
@@ -7,7 +7,7 @@ import { crearUsuario, editarUsuario, eliminarUsuario } from "./usuarios.tsx";
 import { toggleProductoActivo } from "./productos.tsx";
 import { handleGenerarReporteSemanal } from "./generar-reporte-semanal-endpoint.ts";
 import { handleChatMessage } from "./chat.tsx";
-import { handleClimaSync, handleClimaBackfill, handleClimaForecast } from "./clima.tsx";
+import { handleClimaSync, handleClimaBackfill, handleClimaReintentoSinDato, handleClimaForecast } from "./clima.tsx";
 import { handleHatoChequeoPreview } from "./hato-chequeo-preview.ts";
 import { handleHatoChequeoCommit } from "./hato-chequeo-commit.ts";
 import { handleHatoChequeoFoto } from "./hato-chequeo-foto.ts";
@@ -116,6 +116,14 @@ app.post("/make-server-1ccce916/clima/sync", async (c) => {
 // de Ecowitt de una sola llamada.
 app.post("/make-server-1ccce916/clima/backfill", async (c) => {
   return await handleClimaBackfill(c);
+});
+
+// Reintento diario de días sin dato confiable de lluvia (migración 121,
+// pg_cron 'clima-reintento-sin-dato' a las 06:00 Bogotá). Mismo gate que
+// /clima/sync y /clima/backfill. Nunca inventa un valor: si Ecowitt todavía
+// no tiene el día completo, el día queda exactamente como estaba.
+app.post("/make-server-1ccce916/clima/reintentar-sin-dato", async (c) => {
+  return await handleClimaReintentoSinDato(c);
 });
 
 // Short-range forecast (OpenWeatherMap proxy) for the main dashboard's weather card

--- a/src/utils/calculosClima.ts
+++ b/src/utils/calculosClima.ts
@@ -109,6 +109,87 @@ export function construirFranjaLluvia(
   return resultado;
 }
 
+// ============================================================================
+// Racha de días sin lluvia material (2026-08-26, pedido de Santiago)
+// ============================================================================
+
+/** Umbral por debajo del cual un día NO cuenta como "lluvia" para la racha
+ *  — una llovizna de 1-2mm no rompe una racha seca. Es una decisión de
+ *  producto, no una constante agronómica fija: ajustar acá si el umbral
+ *  cambia, nunca duplicarlo inline en el componente. */
+export const UMBRAL_LLUVIA_MATERIAL_MM = 10;
+
+export interface RachaSinLluvia {
+  /** Días consecutivos confirmados con lluvia < umbral, contados hacia atrás
+   *  desde el último día con resumen escrito (nunca "hoy": el rollup
+   *  nocturno recién escribe el resumen de hoy mañana en la madrugada). */
+  dias: number;
+  /** Día más antiguo y más reciente que entran en la racha — null si dias=0. */
+  desdeFecha: string | null;
+  hastaFecha: string | null;
+  /** Si la racha terminó porque hubo lluvia material, acá queda esa lluvia. */
+  ultimaLluviaFecha: string | null;
+  ultimaLluviaMm: number | null;
+  /** true si lo que cortó el conteo NO fue lluvia confirmada sino quedarse
+   *  sin dato confiable (contador congelado, cobertura parcial, o directamente
+   *  ninguna fila). La racha reportada es un piso, nunca un número exacto en
+   *  ese caso: no hay evidencia de que haya llovido en el hueco, pero tampoco
+   *  se puede afirmar que no llovió — mismo principio que `construirFranjaLluvia`,
+   *  nunca se inventa un día seco donde el dato no lo respalda. */
+  cortadaPorFaltaDeDato: boolean;
+  /** Fecha del primer día sin dato confiable que cortó el conteo, cuando
+   *  `cortadaPorFaltaDeDato` es true. */
+  fechaFaltaDeDato: string | null;
+}
+
+/**
+ * Cuenta hacia atrás desde `hastaISO` (normalmente hoy) los días consecutivos
+ * de lluvia por debajo de `umbralMm`, empezando en AYER — el resumen de hoy
+ * todavía no existe. Se detiene en el primer día con lluvia >= umbralMm
+ * (racha confirmada) o en el primer día sin dato confiable (racha "al menos
+ * X días", con `cortadaPorFaltaDeDato: true`). Nunca cruza un día sin dato
+ * asumiendo que fue seco — sería fabricar exactamente el cero que
+ * `lluviaConfiableDeResumen` existe para evitar.
+ */
+export function calcularRachaSinLluvia(
+  resumenes: ResumenDiario[],
+  hastaISO: string,
+  umbralMm: number = UMBRAL_LLUVIA_MATERIAL_MM,
+): RachaSinLluvia {
+  const porFecha = new Map(resumenes.map((r) => [r.fecha, r]));
+  const [anio, mes, dia] = hastaISO.split('-').map(Number);
+
+  let dias = 0;
+  let desdeFecha: string | null = null;
+  let hastaFecha: string | null = null;
+
+  // Tope de un año: red de seguridad si nunca aparece lluvia ni un hueco de
+  // dato (no debería pasar en la práctica), no una regla de negocio.
+  for (let i = 1; i <= 366; i++) {
+    const fechaDia = new Date(anio, mes - 1, dia - i);
+    const fechaStr = fechaAISODate(fechaDia);
+    const fila = porFecha.get(fechaStr);
+
+    if (!fila) {
+      return { dias, desdeFecha, hastaFecha, ultimaLluviaFecha: null, ultimaLluviaMm: null, cortadaPorFaltaDeDato: true, fechaFaltaDeDato: fechaStr };
+    }
+
+    const mm = lluviaConfiableDeResumen(fila);
+    if (mm === null) {
+      return { dias, desdeFecha, hastaFecha, ultimaLluviaFecha: null, ultimaLluviaMm: null, cortadaPorFaltaDeDato: true, fechaFaltaDeDato: fechaStr };
+    }
+    if (mm >= umbralMm) {
+      return { dias, desdeFecha, hastaFecha, ultimaLluviaFecha: fechaStr, ultimaLluviaMm: mm, cortadaPorFaltaDeDato: false, fechaFaltaDeDato: null };
+    }
+
+    dias++;
+    hastaFecha = hastaFecha ?? fechaStr;
+    desdeFecha = fechaStr;
+  }
+
+  return { dias, desdeFecha, hastaFecha, ultimaLluviaFecha: null, ultimaLluviaMm: null, cortadaPorFaltaDeDato: true, fechaFaltaDeDato: null };
+}
+
 // Cardinal direction from degrees (0-360)
 const CARDINALS = ['N', 'NE', 'E', 'SE', 'S', 'SO', 'O', 'NO'] as const;
 

--- a/supabase/functions/make-server-1ccce916/clima.tsx
+++ b/supabase/functions/make-server-1ccce916/clima.tsx
@@ -418,55 +418,108 @@ function parseEcowittHistory(histData: EcowittHistoryData, stationId: string) {
   return readings;
 }
 
-// Aggregate an array of parsed 5-min readings into a single daily summary row
-// for clima_resumen_diario. Readings must already be unit-converted (°C, km/h, mm).
-function aggregateReadingsToDaily(
-  readings: ReturnType<typeof parseEcowittHistory>,
-  fecha: string,
-  stationId: string
-) {
-  const nonNull = (vals: (number | null)[]): number[] =>
-    vals.filter((v): v is number => v !== null);
+// ============================================================================
+// Backfill de UN día: pide la History API de Ecowitt para ese día, inserta
+// las lecturas crudas en clima_lecturas (mismo camino que el sync de 5 min,
+// `handleClimaSync`) y deja que `fn_clima_rollup_diario` (068/103/115) sea
+// la ÚNICA lógica que decide `lluvia_confianza` -- nunca se reimplementa esa
+// clasificación acá.
+//
+// Antes esta función agregaba en TypeScript (`aggregateReadingsToDaily`,
+// eliminada) y escribía `clima_resumen_diario` directo con un simple
+// `max(lluvia_diaria_mm)`, sin aplicar ninguno de los tres chequeos de
+// confianza -- un backfill podía escribir 'ok' sobre un día con el contador
+// de lluvia congelado o capturado a medias, exactamente lo que esas
+// migraciones existen para impedir. Insertar en `clima_lecturas` y llamar
+// al mismo RPC que corre el cron nocturno hace que backfill manual,
+// reintento automático (migración 121) y rollup nocturno concuerden
+// siempre, por construcción -- no por disciplina de mantener dos copias de
+// la lógica sincronizadas.
+//
+// Usado por `handleClimaBackfill` (disparo manual) y
+// `handleClimaReintentoSinDato` (cron diario, migración 121).
+// ============================================================================
 
-  const temps = nonNull(readings.map(r => r.temp_c));
-  const humidity = nonNull(readings.map(r => r.humedad_pct));
-  const wind = nonNull(readings.map(r => r.viento_kmh));
-  const gust = nonNull(readings.map(r => r.rafaga_kmh));
-  const windDir = nonNull(readings.map(r => r.viento_dir));
-  const rain = nonNull(readings.map(r => r.lluvia_diaria_mm));
-  const solar = nonNull(readings.map(r => r.radiacion_wm2));
-  const uv = nonNull(readings.map(r => r.uv_index));
+interface ResultadoBackfillDia {
+  ok: boolean;
+  lecturas: number;
+  error?: string;
+}
 
-  const avg = (arr: number[]) => arr.length > 0 ? round2(arr.reduce((s, v) => s + v, 0) / arr.length) : null;
-  const min = (arr: number[]) => arr.length > 0 ? round2(Math.min(...arr)) : null;
-  const max = (arr: number[]) => arr.length > 0 ? round2(Math.max(...arr)) : null;
+async function backfillUnDia(
+  fecha: Date,
+  creds: { appKey: string; apiKey: string; mac: string },
+  sb: { supabaseUrl: string; serviceKey: string },
+  log: string,
+): Promise<ResultadoBackfillDia> {
+  const ecowittDateStr = formatEcowittDate(fecha);
 
-  // Circular mean for wind direction
-  let windDirMean: number | null = null;
-  if (windDir.length > 0) {
-    const sinSum = windDir.reduce((s, d) => s + Math.sin(d * Math.PI / 180), 0);
-    const cosSum = windDir.reduce((s, d) => s + Math.cos(d * Math.PI / 180), 0);
-    windDirMean = round2(((Math.atan2(sinSum / windDir.length, cosSum / windDir.length) * 180 / Math.PI) % 360 + 360) % 360);
+  const url = new URL('https://api.ecowitt.net/api/v3/device/history');
+  url.searchParams.set('application_key', creds.appKey);
+  url.searchParams.set('api_key', creds.apiKey);
+  url.searchParams.set('mac', creds.mac);
+  url.searchParams.set('start_date', `${ecowittDateStr} 00:00:00`);
+  url.searchParams.set('end_date', `${ecowittDateStr} 23:59:59`);
+  url.searchParams.set('call_back', 'outdoor.temperature,outdoor.humidity,wind,rainfall_piezo,solar_and_uvi');
+  url.searchParams.set('cycle_type', 'auto');
+
+  const apiRes = await fetch(url.toString());
+  if (!apiRes.ok) {
+    const body = await apiRes.text().catch(() => '');
+    return { ok: false, lecturas: 0, error: `Ecowitt API HTTP ${apiRes.status} — ${body}` };
   }
 
-  return {
-    fecha,
-    station_id: stationId,
-    temp_c_min: min(temps),
-    temp_c_max: max(temps),
-    temp_c_avg: avg(temps),
-    humedad_pct_min: min(humidity),
-    humedad_pct_max: max(humidity),
-    humedad_pct_avg: avg(humidity),
-    lluvia_total_mm: max(rain), // Ecowitt daily accumulator — max = day total
-    viento_kmh_avg: avg(wind),
-    rafaga_kmh_max: max(gust),
-    viento_dir_predominante: windDirMean,
-    radiacion_wm2_avg: avg(solar),
-    radiacion_wm2_max: max(solar),
-    uv_index_max: uv.length > 0 ? Math.max(...uv) : null,
-    lecturas_count: readings.length,
-  };
+  const response: EcowittHistoryResponse = await apiRes.json();
+  if (response.code !== 0) {
+    return { ok: false, lecturas: 0, error: `Ecowitt: ${response.msg}` };
+  }
+  if (!response.data || Object.keys(response.data).length === 0) {
+    return { ok: false, lecturas: 0, error: 'sin datos de Ecowitt para ese día' };
+  }
+
+  const readings = parseEcowittHistory(response.data as EcowittHistoryData, creds.mac);
+  if (readings.length === 0) {
+    return { ok: false, lecturas: 0, error: '0 lecturas parseadas' };
+  }
+
+  // Lecturas crudas -> clima_lecturas. `ignore-duplicates` sobre el
+  // UNIQUE(station_id, timestamp) de la migración 029 hace que reintentar
+  // un día ya cargado sea idempotente en vez de fallar.
+  const insertRes = await fetch(`${sb.supabaseUrl}/rest/v1/clima_lecturas`, {
+    method: 'POST',
+    headers: {
+      apikey: sb.serviceKey,
+      Authorization: `Bearer ${sb.serviceKey}`,
+      'Content-Type': 'application/json',
+      Prefer: 'return=minimal,resolution=ignore-duplicates',
+    },
+    body: JSON.stringify(readings),
+  });
+  if (!insertRes.ok) {
+    const errorText = await insertRes.text();
+    return { ok: false, lecturas: 0, error: `insert clima_lecturas falló — ${errorText}` };
+  }
+
+  // fn_clima_rollup_diario agrega, clasifica lluvia_confianza y escribe
+  // clima_resumen_diario -- y al final poda clima_lecturas > 24h, así que
+  // las lecturas históricas recién insertadas no se quedan pisando la
+  // ventana rodante del sync en vivo.
+  const rpcRes = await fetch(`${sb.supabaseUrl}/rest/v1/rpc/fn_clima_rollup_diario`, {
+    method: 'POST',
+    headers: {
+      apikey: sb.serviceKey,
+      Authorization: `Bearer ${sb.serviceKey}`,
+      'Content-Type': 'application/json',
+    },
+    body: JSON.stringify({ p_fecha: ecowittDateStr }),
+  });
+  if (!rpcRes.ok) {
+    const errorText = await rpcRes.text();
+    return { ok: false, lecturas: readings.length, error: `fn_clima_rollup_diario falló — ${errorText}` };
+  }
+
+  console.info(`${log} ${ecowittDateStr}: ${readings.length} lecturas reagregadas`);
+  return { ok: true, lecturas: readings.length };
 }
 
 export async function handleClimaBackfill(c: Context): Promise<Response> {
@@ -522,85 +575,24 @@ export async function handleClimaBackfill(c: Context): Promise<Response> {
     let totalDays = 0;
     const errors: string[] = [];
 
-    // Iterate day by day
+    // Iterate day by day -- backfillUnDia hace la pregunta a Ecowitt y deja
+    // que fn_clima_rollup_diario clasifique lluvia_confianza (ver el
+    // comentario de esa función).
     const current = new Date(fromDate);
     while (current <= toDate) {
       const dateStr = formatDateParam(current);
-      const ecowittDateStr = formatEcowittDate(current);
-      totalDays++;
 
       try {
-        // Fetch history for this day from Ecowitt
-        const url = new URL('https://api.ecowitt.net/api/v3/device/history');
-        url.searchParams.set('application_key', creds.appKey);
-        url.searchParams.set('api_key', creds.apiKey);
-        url.searchParams.set('mac', creds.mac);
-        url.searchParams.set('start_date', `${ecowittDateStr} 00:00:00`);
-        url.searchParams.set('end_date', `${ecowittDateStr} 23:59:59`);
-        url.searchParams.set('call_back', 'outdoor.temperature,outdoor.humidity,wind,rainfall_piezo,solar_and_uvi');
-        url.searchParams.set('cycle_type', 'auto');
-
-        const apiRes = await fetch(url.toString());
-
-        if (!apiRes.ok) {
-          const body = await apiRes.text().catch(() => '');
-          errors.push(`${dateStr}: Ecowitt API HTTP ${apiRes.status}`);
-          console.warn(`${log} ${dateStr}: Ecowitt API ${apiRes.status} — ${body}`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        const response: EcowittHistoryResponse = await apiRes.json();
-
-        if (response.code !== 0) {
-          errors.push(`${dateStr}: ${response.msg}`);
-          console.warn(`${log} ${dateStr}: Ecowitt error — ${response.msg}`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        if (!response.data || Object.keys(response.data).length === 0) {
-          console.info(`${log} ${dateStr}: no data`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        // Parse historical data into readings
-        const readings = parseEcowittHistory(response.data as EcowittHistoryData, creds.mac);
-
-        if (readings.length === 0) {
-          console.info(`${log} ${dateStr}: no readings`);
-          current.setDate(current.getDate() + 1);
-          await sleep(100);
-          continue;
-        }
-
-        // Aggregate into daily summary and upsert into clima_resumen_diario
-        const dailySummary = aggregateReadingsToDaily(readings, ecowittDateStr, creds.mac);
-
-        const insertRes = await fetch(`${sb.supabaseUrl}/rest/v1/clima_resumen_diario?on_conflict=fecha,station_id`, {
-          method: 'POST',
-          headers: {
-            apikey: sb.serviceKey,
-            Authorization: `Bearer ${sb.serviceKey}`,
-            'Content-Type': 'application/json',
-            Prefer: 'return=minimal,resolution=merge-duplicates',
-          },
-          body: JSON.stringify(dailySummary),
-        });
-
-        if (!insertRes.ok) {
-          const errorText = await insertRes.text();
-          errors.push(`${dateStr}: insert failed — ${errorText}`);
-          console.error(`${log} ${dateStr}: insert failed — ${errorText}`);
-        } else {
+        const resultado = await backfillUnDia(current, creds, sb, log);
+        totalDays++;
+        if (resultado.ok) {
           totalSynced += 1;
-          console.info(`${log} ${dateStr}: daily summary inserted (${readings.length} readings aggregated)`);
+        } else {
+          errors.push(`${dateStr}: ${resultado.error}`);
+          console.warn(`${log} ${dateStr}: ${resultado.error}`);
         }
       } catch (err) {
+        totalDays++;
         errors.push(`${dateStr}: ${String(err)}`);
         console.error(`${log} ${dateStr}: ${err}`);
       }
@@ -616,6 +608,143 @@ export async function handleClimaBackfill(c: Context): Promise<Response> {
       synced: totalSynced,
       days: totalDays,
       errors: errors.length > 0 ? errors : undefined,
+    }, 200);
+  } catch (error) {
+    console.error(`${log} Unhandled error:`, error);
+    return c.json({ error: String(error) }, 500);
+  }
+}
+
+// ============================================================================
+// Handler: reintento diario de días sin dato confiable (migración 121)
+// POST /clima/reintentar-sin-dato -- disparado por el pg_cron
+// 'clima-reintento-sin-dato' a las 06:00 Bogotá.
+//
+// Pedido del dueño: "no quiero que registre null ni invente el 0. Quiero
+// que haga backfill del día una vez la estación recupere conexión y se
+// pueda consultar el dato real que sí existe en Ecowitt." El rollup
+// nocturno ya hace la mitad correcta -- nunca fabrica un cero -- pero nada
+// volvía a mirar un día ya sellado `sin_dato`. Esto es esa segunda mitad:
+// revisa los últimos DIAS_REINTENTO_SIN_DATO días y le vuelve a preguntar a
+// Ecowitt sólo por los que todavía no tienen un dato confiable. Si la
+// estación ya se reconectó y Ecowitt tiene el día completo en su nube
+// (buffer local que sube al volver la luz/el internet), el día pasa a
+// 'ok' con el número real. Si Ecowitt TODAVÍA no lo tiene, el día queda
+// exactamente como estaba -- nunca se inventa un valor para forzar que
+// "avance".
+//
+// Importante sobre `contador_congelado`: a diferencia de `cobertura_parcial`
+// (un hueco de captura, justo lo que este reintento puede recuperar),
+// `contador_congelado` es un bug del firmware del sensor -- el contador
+// acumulado de Ecowitt no se reinició, y eso ya quedó grabado así del lado
+// de Ecowitt, con estación conectada y las 288 lecturas del día presentes.
+// Reintentarlo es inofensivo (misma pregunta, misma respuesta previsible) y
+// se incluye por si el sensor se corrige o el valor cambia, pero no hay
+// garantía de que se resuelva -- es un problema de HARDWARE, no de
+// conexión.
+// ============================================================================
+
+/** Ventana hacia atrás que cada corrida revisa. 21 días cubre de sobra
+ *  cualquier corte de luz/internet razonable sin recorrer toda la historia
+ *  en cada disparo diario. */
+const DIAS_REINTENTO_SIN_DATO = 21;
+
+/** `lluvia_confianza` que vale la pena reintentar -- las dos que guardan
+ *  NULL por falta de dato (068/103). `sin_time_piezo` se deja afuera a
+ *  propósito: ese día ya tiene un número en el que se confía, no está en
+ *  NULL, reintentarlo no lo mejora. */
+const CONFIANZAS_A_REINTENTAR = new Set(['contador_congelado', 'cobertura_parcial']);
+
+export async function handleClimaReintentoSinDato(c: Context): Promise<Response> {
+  const log = '[clima-reintento-sin-dato]';
+
+  const acceso = await verificarAccesoClima(c);
+  if (acceso instanceof Response) return acceso;
+
+  try {
+    const creds = getEcowittCredentials();
+    if (!creds) return c.json({ error: 'Missing Ecowitt credentials' }, 500);
+    const sb = getSupabaseConfig();
+    if (!sb) return c.json({ error: 'Missing Supabase config' }, 500);
+
+    const ayer = new Date(Date.now() - 24 * 60 * 60 * 1000);
+    const desde = new Date(ayer.getTime() - (DIAS_REINTENTO_SIN_DATO - 1) * 24 * 60 * 60 * 1000);
+    const desdeStr = formatEcowittDate(desde);
+    const ayerStr = formatEcowittDate(ayer);
+
+    // Se pregunta a la base qué días están sin dato en vez de reintentar la
+    // ventana completa a ciegas -- un día ya 'ok' no necesita otra llamada
+    // a Ecowitt.
+    const queryUrl = `${sb.supabaseUrl}/rest/v1/clima_resumen_diario`
+      + `?station_id=eq.${encodeURIComponent(creds.mac)}`
+      + `&fecha=gte.${desdeStr}&fecha=lte.${ayerStr}`
+      + `&select=fecha,lluvia_confianza`;
+    const queryRes = await fetch(queryUrl, {
+      headers: { apikey: sb.serviceKey, Authorization: `Bearer ${sb.serviceKey}` },
+    });
+    if (!queryRes.ok) {
+      const body = await queryRes.text().catch(() => '');
+      console.error(`${log} No se pudo leer clima_resumen_diario (${queryRes.status}): ${body}`);
+      return c.json({ error: 'No se pudo leer clima_resumen_diario', details: body }, 502);
+    }
+    const filas: { fecha: string; lluvia_confianza: string }[] = await queryRes.json();
+    const confianzaPorFecha = new Map(filas.map((f) => [f.fecha, f.lluvia_confianza]));
+
+    const candidatos: Date[] = [];
+    for (let i = 0; i < DIAS_REINTENTO_SIN_DATO; i++) {
+      const d = new Date(ayer.getTime() - i * 24 * 60 * 60 * 1000);
+      const fechaStr = formatEcowittDate(d);
+      const confianza = confianzaPorFecha.get(fechaStr);
+      // Sin fila en absoluto ("sin_registro" del lado del frontend) o con
+      // una confianza que hoy vale NULL -- las dos son candidatas.
+      if (confianza === undefined || CONFIANZAS_A_REINTENTAR.has(confianza)) {
+        candidatos.push(d);
+      }
+    }
+
+    if (candidatos.length === 0) {
+      console.info(`${log} nada que reintentar en los últimos ${DIAS_REINTENTO_SIN_DATO} días`);
+      return c.json({ message: 'Nada que reintentar', candidatos: 0 }, 200);
+    }
+
+    console.info(`${log} ${candidatos.length} día(s) candidato(s): ${candidatos.map(formatEcowittDate).join(', ')}`);
+
+    const resultados: { fecha: string; consultaOk: boolean; error?: string }[] = [];
+    for (const dia of candidatos) {
+      const r = await backfillUnDia(dia, creds, sb, log);
+      resultados.push({ fecha: formatEcowittDate(dia), consultaOk: r.ok, error: r.ok ? undefined : r.error });
+      await sleep(150);
+    }
+
+    // Se vuelve a preguntar a la base cuántos candidatos quedaron 'ok'
+    // DESPUÉS del reintento -- "la consulta a Ecowitt no dio error" no es
+    // lo mismo que "el día se resolvió"; puede seguir incompleto del lado
+    // de Ecowitt. Si esta verificación en sí falla, se dice explícitamente
+    // (`resueltos: null`) en vez de reportar 0 como si nada se hubiera
+    // arreglado.
+    let resueltos: number | null = null;
+    const verifQueryUrl = `${sb.supabaseUrl}/rest/v1/clima_resumen_diario`
+      + `?station_id=eq.${encodeURIComponent(creds.mac)}`
+      + `&fecha=gte.${desdeStr}&fecha=lte.${ayerStr}`
+      + `&lluvia_confianza=eq.ok`
+      + `&select=fecha`;
+    const verifRes = await fetch(verifQueryUrl, {
+      headers: { apikey: sb.serviceKey, Authorization: `Bearer ${sb.serviceKey}` },
+    });
+    if (verifRes.ok) {
+      const fechasOk = new Set(((await verifRes.json()) as { fecha: string }[]).map((f) => f.fecha));
+      resueltos = candidatos.filter((d) => fechasOk.has(formatEcowittDate(d))).length;
+    } else {
+      console.warn(`${log} no se pudo verificar cuántos candidatos quedaron 'ok' tras el reintento`);
+    }
+
+    console.info(`${log} ${resueltos ?? '?'}/${candidatos.length} día(s) resuelto(s) a 'ok' en esta corrida`);
+
+    return c.json({
+      message: 'Reintento completo',
+      candidatos: candidatos.length,
+      resueltos,
+      resultados,
     }, 200);
   } catch (error) {
     console.error(`${log} Unhandled error:`, error);

--- a/supabase/functions/make-server-1ccce916/index.ts
+++ b/supabase/functions/make-server-1ccce916/index.ts
@@ -7,7 +7,7 @@ import { crearUsuario, editarUsuario, eliminarUsuario } from "./usuarios.tsx";
 import { toggleProductoActivo } from "./productos.tsx";
 import { handleGenerarReporteSemanal } from "./generar-reporte-semanal-endpoint.ts";
 import { handleChatMessage } from "./chat.tsx";
-import { handleClimaSync, handleClimaBackfill, handleClimaForecast } from "./clima.tsx";
+import { handleClimaSync, handleClimaBackfill, handleClimaReintentoSinDato, handleClimaForecast } from "./clima.tsx";
 import { handleHatoChequeoPreview } from "./hato-chequeo-preview.ts";
 import { handleHatoChequeoCommit } from "./hato-chequeo-commit.ts";
 import { handleHatoChequeoFoto } from "./hato-chequeo-foto.ts";
@@ -116,6 +116,14 @@ app.post("/make-server-1ccce916/clima/sync", async (c) => {
 // de Ecowitt de una sola llamada.
 app.post("/make-server-1ccce916/clima/backfill", async (c) => {
   return await handleClimaBackfill(c);
+});
+
+// Reintento diario de días sin dato confiable de lluvia (migración 121,
+// pg_cron 'clima-reintento-sin-dato' a las 06:00 Bogotá). Mismo gate que
+// /clima/sync y /clima/backfill. Nunca inventa un valor: si Ecowitt todavía
+// no tiene el día completo, el día queda exactamente como estaba.
+app.post("/make-server-1ccce916/clima/reintentar-sin-dato", async (c) => {
+  return await handleClimaReintentoSinDato(c);
 });
 
 // Short-range forecast (OpenWeatherMap proxy) for the main dashboard's weather card


### PR DESCRIPTION
## Summary

Refactors the climate data backfill system to eliminate duplicate aggregation logic and adds a new daily cron job that retries days with unreliable rainfall confidence classifications. Both changes ensure that manual backfill, automatic retry, and the nightly rollup all use the same single source of truth for confidence classification — the `fn_clima_rollup_diario` RPC function.

## Key Changes

- **Removed `aggregateReadingsToDaily` function**: This TypeScript function was applying its own rainfall confidence logic (a simple `max(lluvia_diaria_mm)`) without the three validation checks that migrations 068/103/115 implement. Backfill could overwrite a day marked `contador_congelado` or `cobertura_parcial` with an incorrect `ok` status.

- **New `backfillUnDia` function**: Extracts the per-day backfill logic into a reusable helper that:
  - Fetches raw readings from Ecowitt History API
  - Inserts them into `clima_lecturas` (same path as the 5-min sync)
  - Calls `fn_clima_rollup_diario(p_fecha)` to aggregate and classify confidence
  - Returns a structured result (`ResultadoBackfillDia`) for error handling

- **Refactored `handleClimaBackfill`**: Now calls `backfillUnDia` for each day instead of duplicating API logic and aggregation inline. Cleaner error handling and logging.

- **New `handleClimaReintentoSinDato` endpoint**: Daily cron handler (migration 121) that:
  - Queries the last 21 days of `clima_resumen_diario` for days with `lluvia_confianza` in `{'contador_congelado', 'cobertura_parcial'}` or missing entirely
  - Retries only those days via `backfillUnDia`
  - Lets `fn_clima_rollup_diario` decide if the day now has reliable data or remains unreliable
  - Implements the owner's requirement: "don't invent a zero; backfill the real data once the station reconnects"

- **New migration 121** (`src/sql/migrations/121_clima_reintento_sin_dato_cron.sql`): Registers the pg_cron job `clima-reintento-sin-dato` to run daily at 06:00 Bogotá (11:00 UTC), after the nightly rollup (00:15 Bogotá).

- **New `calcularRachaSinLluvia` utility** (`src/utils/calculosClima.ts`): Calculates consecutive dry-day streaks (rainfall < configurable threshold) counting backward from yesterday. Stops at the first day with material rainfall or at the first day with unreliable data (never assumes a missing day was dry). Includes unit tests and a new `RachaSinLluvia` component for dashboard display.

- **Updated `ClimaCard`**: Integrates the new dry-streak calculation and display component.

## Implementation Details

- **Idempotent retry**: The `clima_lecturas` insert uses `resolution=ignore-duplicates` on the `UNIQUE(station_id, timestamp)` constraint (migration 029), so retrying a day already loaded is safe.

- **Single source of truth**: All three paths (manual backfill, automatic retry, nightly rollup) now call the same RPC function, eliminating the risk of inconsistent confidence classifications.

- **Dry-streak logic**: Mirrors the philosophy of `construirFranjaLluvia` — never fabricates a zero where data is missing. A gap in `clima_resumen_diario` or a day marked `contador_congelado`/`cobertura_parcial` stops the count and sets `cortadaPorFaltaDeDato: true`, signaling uncertainty rather than a confirmed dry streak.

- **Shared secret**: Reuses `CLIMA_SYNC_SECRET` (migration 105) for access control; no new credential needed.

https://claude.ai/code/session_01ToHQnZPiVFGHfBcTTiT2AU