### PR TITLE
fix(clima): align Esco's rain-confidence gate with migration 122

### DIFF
--- a/src/__tests__/climaConfianzaParidadEsco.test.ts
+++ b/src/__tests__/climaConfianzaParidadEsco.test.ts
@@ -1,0 +1,106 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Paridad de la puerta de confianza de la lluvia: frontend ⇄ Esco.
+ *
+ * `src/utils/calculosClima.ts` (`lluviaConfiableDeResumen` + `esCotaInferior`) y
+ * `chat.tsx` (`lluviaConfiable`) contestan la MISMA pregunta — "¿cuántos mm
+ * puedo afirmar de este día?" — sobre la MISMA tabla. El comentario de
+ * `chat.tsx` se declara explícitamente "espejo" del primero. No pueden
+ * importarse entre sí: `chat.tsx` vive en el árbol de despliegue de la edge
+ * function, con imports de Deno. Misma restricción que ya produjo
+ * `priorizacion-scouting.ts` y `reportes-financieros.ts`.
+ *
+ * **Un espejo declarado que nadie vigila deja de ser un espejo.** El PR #178
+ * (migración 122) movió el original y no el espejo, y durante ese lapso Esco
+ * descartó 25 días con 90,63 mm de lluvia medida que la pantalla sí mostraba:
+ * abril de 2026 daba 514,35 mm por Esco contra 588,50 mm en la vista de Clima.
+ * Es la misma clase de defecto del incidente del 2026-08-16, donde Esco
+ * reportó "47 días sin lluvia" habiendo llovido 4 días antes.
+ *
+ * Por eso esto es una prueba y no un comentario.
+ */
+
+const RAIZ = resolve(__dirname, '../..');
+
+const COPIAS_ESCO = [
+  'src/supabase/functions/server/chat.tsx',
+  'supabase/functions/make-server-1ccce916/chat.tsx',
+];
+
+function leer(rel: string): string {
+  return readFileSync(resolve(RAIZ, rel), 'utf-8');
+}
+
+/** Cuerpo de `lluviaConfiable(...)` en una copia de `chat.tsx`. */
+function cuerpoLluviaConfiable(fuente: string): string {
+  const inicio = fuente.indexOf('function lluviaConfiable(');
+  expect(inicio, 'chat.tsx debe seguir declarando lluviaConfiable()').toBeGreaterThan(-1);
+  const fin = fuente.indexOf('\n}', inicio);
+  return fuente.slice(inicio, fin);
+}
+
+/** Línea de la consulta PostgREST de "última lluvia" en `chat.tsx`. */
+function consultaUltimaLluvia(fuente: string): string {
+  const linea = fuente
+    .split('\n')
+    .find((l) => l.includes('lluvia_total_mm=gt.0') && l.includes('order=fecha.desc'));
+  expect(linea, 'chat.tsx debe seguir teniendo la consulta de última lluvia').toBeDefined();
+  return linea as string;
+}
+
+describe('paridad de la puerta de confianza de lluvia (frontend ⇄ Esco)', () => {
+  it('el frontend descarta EXACTAMENTE `contador_congelado` — si esto cambia, hay que mover el espejo', () => {
+    const fuente = leer('src/utils/calculosClima.ts');
+    const m = fuente.match(/const CONFIANZAS_SIN_DATO = new Set\(\[([^\]]*)\]\)/);
+    expect(m, 'calculosClima.ts debe seguir declarando CONFIANZAS_SIN_DATO').not.toBeNull();
+    const etiquetas = (m as RegExpMatchArray)[1]
+      .split(',')
+      .map((s) => s.trim().replace(/^['"]|['"]$/g, ''))
+      .filter(Boolean);
+    expect(etiquetas).toEqual(['contador_congelado']);
+  });
+
+  it.each(COPIAS_ESCO)('%s: `lluviaConfiable` descarta `contador_congelado`', (rel) => {
+    expect(cuerpoLluviaConfiable(leer(rel))).toContain("=== 'contador_congelado'");
+  });
+
+  it.each(COPIAS_ESCO)(
+    '%s: `lluviaConfiable` NO descarta `cobertura_parcial` en bloque — sólo la cota inferior de 0 mm (migración 122)',
+    (rel) => {
+      const cuerpo = cuerpoLluviaConfiable(leer(rel));
+      // El descarte en bloque es exactamente lo que el PR #178 dejó atrás.
+      expect(cuerpo).not.toMatch(/if \(fila\.lluvia_confianza === 'cobertura_parcial'\) return null;/);
+      // Y la cota inferior de 0 mm sí tiene que seguir valiendo "sin dato".
+      expect(cuerpo).toMatch(/esCotaInferior\(fila\)[\s\S]*lluvia_total_mm === 0[\s\S]*return null/);
+    },
+  );
+
+  it.each(COPIAS_ESCO)(
+    '%s: la última lluvia no se busca con `eq.ok` — eso se salta `reconstruido` y `cobertura_parcial`',
+    (rel) => {
+      const linea = consultaUltimaLluvia(leer(rel));
+      expect(linea).not.toContain('lluvia_confianza=eq.ok');
+      // `reconstruido` es un valor de plena confianza desde la 122: si la
+      // consulta no lo admite, un día de lluvia reconstruida es invisible y la
+      // racha seca que reporta Esco se alarga sola.
+      expect(linea).toContain('reconstruido');
+    },
+  );
+
+  it.each(COPIAS_ESCO)(
+    '%s: el conteo de días sin dato pasa por `lluviaConfiable`, no por la etiqueta cruda',
+    (rel) => {
+      const fuente = leer(rel);
+      expect(fuente).toContain('diasSinDatoDesdeEntonces = (desdeRaw ?? []).filter((d) => lluviaConfiable(d) === null).length');
+    },
+  );
+
+  it('las dos copias de `chat.tsx` dicen lo mismo sobre la lluvia', () => {
+    const [a, b] = COPIAS_ESCO.map(leer);
+    expect(cuerpoLluviaConfiable(b)).toBe(cuerpoLluviaConfiable(a));
+    expect(consultaUltimaLluvia(b)).toBe(consultaUltimaLluvia(a));
+  });
+});

--- a/src/supabase/functions/server/chat.tsx
+++ b/src/supabase/functions/server/chat.tsx
@@ -2057,14 +2057,28 @@ interface FilaResumenClima {
  * cosas distintas, y confundirlas es exactamente lo que producia el bug de
  * lluvia duplicada.
  *
- * La migracion 103 agrega `cobertura_parcial` por la misma puerta: un dia que
- * la estacion capturo incompleto (corte de luz en la finca) tampoco tiene un
- * total que afirmar. Es el mismo error con el signo cambiado -- la 068 impedia
- * un DUPLICADO fabricado, la 103 impide un CERO fabricado.
+ * La migracion 103 agrego `cobertura_parcial` por la misma puerta, y la 122 la
+ * SACO: desde entonces ese dia trae un valor reconstruido desde una segunda
+ * senal independiente (`lluvia_evento_mm`), asi que es una cota inferior real y
+ * no un hueco. Solo la cota inferior de 0 mm sigue siendo "sin dato".
+ *
+ * Este espejo tiene que moverse cuando se mueve el original. Lo vigila
+ * `src/__tests__/climaConfianzaParidadEsco.test.ts`.
  */
+function esCotaInferior(fila: { lluvia_confianza?: string | null }): boolean {
+  return fila.lluvia_confianza === 'cobertura_parcial';
+}
+
 function lluviaConfiable(fila: { lluvia_total_mm: number | null; lluvia_confianza?: string | null }): number | null {
   if (fila.lluvia_confianza === 'contador_congelado') return null;
-  if (fila.lluvia_confianza === 'cobertura_parcial') return null;
+  // MIGRACION 122: `cobertura_parcial` ya NO es "sin dato". El rollup reconstruye
+  // la lluvia desde `lluvia_evento_mm` -- una senal independiente del contador
+  // diario -- y guarda lo que se midio en las horas capturadas. Eso es una COTA
+  // INFERIOR real: "llovio al menos esto", no "esto fue todo".
+  //
+  // La unica cota inferior que no informa nada es la de 0 mm: "no llovio durante
+  // las horas que miramos" no es "no llovio". Esa sigue valiendo null.
+  if (esCotaInferior(fila) && fila.lluvia_total_mm === 0) return null;
   return fila.lluvia_total_mm;
 }
 
@@ -2130,7 +2144,13 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     // rango pedido. "Hace cuanto no llueve" no puede depender de que el modelo
     // acierte la ventana — esa adivinanza es la que rompia el loop.
     supabaseQuery('clima_resumen_diario',
-      'select=fecha,lluvia_total_mm,lluvia_confianza&lluvia_total_mm=gt.0&lluvia_confianza=eq.ok&order=fecha.desc&limit=1',
+      // `in.(...)` y no `eq.ok`: la 122 agrego `reconstruido` (un valor de plena
+      // confianza, reconstruido desde la senal de evento) y devolvio el valor a
+      // `cobertura_parcial`. Con `eq.ok` la ultima lluvia se saltaba esos dias y
+      // Esco reportaba una racha seca mas larga que la real -- el mismo error del
+      // incidente del 2026-08-16. El `lluvia_total_mm=gt.0` ya descarta la cota
+      // inferior de 0 mm, que es la unica que no afirma nada.
+      'select=fecha,lluvia_total_mm,lluvia_confianza&lluvia_total_mm=gt.0&lluvia_confianza=in.(ok,reconstruido,cobertura_parcial)&order=fecha.desc&limit=1',
     ) as Promise<Array<{ fecha: string; lluvia_total_mm: number }>>,
   ]);
 
@@ -2151,7 +2171,7 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     temp_avg: r.temp_c_avg, temp_max: r.temp_c_max, temp_min: r.temp_c_min,
     humedad_avg: r.humedad_pct_avg, viento_avg: r.viento_kmh_avg,
     lluvia_mm: lluviaConfiable(r),
-    lluvia_sin_dato: r.lluvia_confianza === 'contador_congelado' || r.lluvia_confianza === 'cobertura_parcial',
+    lluvia_sin_dato: lluviaConfiable(r) === null,
     radiacion_avg: r.radiacion_wm2_avg, radiacion_max: r.radiacion_wm2_max,
   }));
 
@@ -2195,10 +2215,13 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
   // haria que Esco afirmara "N dias sin llover" incluyendo dias que nadie vio.
   let diasSinDatoDesdeEntonces = 0;
   if (ultimaLluviaFecha) {
+    // Se traen las dos etiquetas sospechosas y se filtran con la MISMA regla que
+    // el resto del modulo: un dia `cobertura_parcial` con lluvia medida NO es un
+    // dia sin dato (migracion 122), solo lo es el de 0 mm.
     const desdeRaw = await supabaseQuery('clima_resumen_diario',
-      `select=fecha&lluvia_confianza=in.(contador_congelado,cobertura_parcial)&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
-    ) as Array<{ fecha: string }>;
-    diasSinDatoDesdeEntonces = (desdeRaw ?? []).length;
+      `select=fecha,lluvia_total_mm,lluvia_confianza&lluvia_confianza=in.(contador_congelado,cobertura_parcial)&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
+    ) as Array<{ fecha: string; lluvia_total_mm: number | null; lluvia_confianza: string | null }>;
+    diasSinDatoDesdeEntonces = (desdeRaw ?? []).filter((d) => lluviaConfiable(d) === null).length;
   }
 
   const lluvia = {
@@ -2207,7 +2230,7 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     dias_sin_lluvia: ultimaLluviaFecha ? diasEntre(ultimaLluviaFecha, hoy) : null,
     dias_sin_dato_en_ese_lapso: diasSinDatoDesdeEntonces,
     nota: diasSinDatoDesdeEntonces > 0
-      ? `Hay ${diasSinDatoDesdeEntonces} dia(s) con el contador del pluviometro congelado desde la ultima lluvia registrada: en esos dias NO se sabe si llovio, asi que "dias sin lluvia" es un maximo. Reportalo como tal, nunca como certeza.`
+      ? `Hay ${diasSinDatoDesdeEntonces} dia(s) sin dato de lluvia utilizable desde la ultima lluvia registrada (contador del pluviometro congelado, o el dia capturado incompleto sin lluvia medida): en esos dias NO se sabe si llovio, asi que "dias sin lluvia" es un maximo. Reportalo como tal, nunca como certeza.`
       : 'Sin huecos de datos desde la ultima lluvia registrada.',
   };
 

--- a/supabase/functions/make-server-1ccce916/chat.tsx
+++ b/supabase/functions/make-server-1ccce916/chat.tsx
@@ -2057,14 +2057,28 @@ interface FilaResumenClima {
  * cosas distintas, y confundirlas es exactamente lo que producia el bug de
  * lluvia duplicada.
  *
- * La migracion 103 agrega `cobertura_parcial` por la misma puerta: un dia que
- * la estacion capturo incompleto (corte de luz en la finca) tampoco tiene un
- * total que afirmar. Es el mismo error con el signo cambiado -- la 068 impedia
- * un DUPLICADO fabricado, la 103 impide un CERO fabricado.
+ * La migracion 103 agrego `cobertura_parcial` por la misma puerta, y la 122 la
+ * SACO: desde entonces ese dia trae un valor reconstruido desde una segunda
+ * senal independiente (`lluvia_evento_mm`), asi que es una cota inferior real y
+ * no un hueco. Solo la cota inferior de 0 mm sigue siendo "sin dato".
+ *
+ * Este espejo tiene que moverse cuando se mueve el original. Lo vigila
+ * `src/__tests__/climaConfianzaParidadEsco.test.ts`.
  */
+function esCotaInferior(fila: { lluvia_confianza?: string | null }): boolean {
+  return fila.lluvia_confianza === 'cobertura_parcial';
+}
+
 function lluviaConfiable(fila: { lluvia_total_mm: number | null; lluvia_confianza?: string | null }): number | null {
   if (fila.lluvia_confianza === 'contador_congelado') return null;
-  if (fila.lluvia_confianza === 'cobertura_parcial') return null;
+  // MIGRACION 122: `cobertura_parcial` ya NO es "sin dato". El rollup reconstruye
+  // la lluvia desde `lluvia_evento_mm` -- una senal independiente del contador
+  // diario -- y guarda lo que se midio en las horas capturadas. Eso es una COTA
+  // INFERIOR real: "llovio al menos esto", no "esto fue todo".
+  //
+  // La unica cota inferior que no informa nada es la de 0 mm: "no llovio durante
+  // las horas que miramos" no es "no llovio". Esa sigue valiendo null.
+  if (esCotaInferior(fila) && fila.lluvia_total_mm === 0) return null;
   return fila.lluvia_total_mm;
 }
 
@@ -2130,7 +2144,13 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     // rango pedido. "Hace cuanto no llueve" no puede depender de que el modelo
     // acierte la ventana — esa adivinanza es la que rompia el loop.
     supabaseQuery('clima_resumen_diario',
-      'select=fecha,lluvia_total_mm,lluvia_confianza&lluvia_total_mm=gt.0&lluvia_confianza=eq.ok&order=fecha.desc&limit=1',
+      // `in.(...)` y no `eq.ok`: la 122 agrego `reconstruido` (un valor de plena
+      // confianza, reconstruido desde la senal de evento) y devolvio el valor a
+      // `cobertura_parcial`. Con `eq.ok` la ultima lluvia se saltaba esos dias y
+      // Esco reportaba una racha seca mas larga que la real -- el mismo error del
+      // incidente del 2026-08-16. El `lluvia_total_mm=gt.0` ya descarta la cota
+      // inferior de 0 mm, que es la unica que no afirma nada.
+      'select=fecha,lluvia_total_mm,lluvia_confianza&lluvia_total_mm=gt.0&lluvia_confianza=in.(ok,reconstruido,cobertura_parcial)&order=fecha.desc&limit=1',
     ) as Promise<Array<{ fecha: string; lluvia_total_mm: number }>>,
   ]);
 
@@ -2151,7 +2171,7 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     temp_avg: r.temp_c_avg, temp_max: r.temp_c_max, temp_min: r.temp_c_min,
     humedad_avg: r.humedad_pct_avg, viento_avg: r.viento_kmh_avg,
     lluvia_mm: lluviaConfiable(r),
-    lluvia_sin_dato: r.lluvia_confianza === 'contador_congelado' || r.lluvia_confianza === 'cobertura_parcial',
+    lluvia_sin_dato: lluviaConfiable(r) === null,
     radiacion_avg: r.radiacion_wm2_avg, radiacion_max: r.radiacion_wm2_max,
   }));
 
@@ -2195,10 +2215,13 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
   // haria que Esco afirmara "N dias sin llover" incluyendo dias que nadie vio.
   let diasSinDatoDesdeEntonces = 0;
   if (ultimaLluviaFecha) {
+    // Se traen las dos etiquetas sospechosas y se filtran con la MISMA regla que
+    // el resto del modulo: un dia `cobertura_parcial` con lluvia medida NO es un
+    // dia sin dato (migracion 122), solo lo es el de 0 mm.
     const desdeRaw = await supabaseQuery('clima_resumen_diario',
-      `select=fecha&lluvia_confianza=in.(contador_congelado,cobertura_parcial)&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
-    ) as Array<{ fecha: string }>;
-    diasSinDatoDesdeEntonces = (desdeRaw ?? []).length;
+      `select=fecha,lluvia_total_mm,lluvia_confianza&lluvia_confianza=in.(contador_congelado,cobertura_parcial)&fecha=gt.${e(ultimaLluviaFecha)}&limit=3000`,
+    ) as Array<{ fecha: string; lluvia_total_mm: number | null; lluvia_confianza: string | null }>;
+    diasSinDatoDesdeEntonces = (desdeRaw ?? []).filter((d) => lluviaConfiable(d) === null).length;
   }
 
   const lluvia = {
@@ -2207,7 +2230,7 @@ async function execClimateData(args: Record<string, unknown>): Promise<string> {
     dias_sin_lluvia: ultimaLluviaFecha ? diasEntre(ultimaLluviaFecha, hoy) : null,
     dias_sin_dato_en_ese_lapso: diasSinDatoDesdeEntonces,
     nota: diasSinDatoDesdeEntonces > 0
-      ? `Hay ${diasSinDatoDesdeEntonces} dia(s) con el contador del pluviometro congelado desde la ultima lluvia registrada: en esos dias NO se sabe si llovio, asi que "dias sin lluvia" es un maximo. Reportalo como tal, nunca como certeza.`
+      ? `Hay ${diasSinDatoDesdeEntonces} dia(s) sin dato de lluvia utilizable desde la ultima lluvia registrada (contador del pluviometro congelado, o el dia capturado incompleto sin lluvia medida): en esos dias NO se sabe si llovio, asi que "dias sin lluvia" es un maximo. Reportalo como tal, nunca como certeza.`
       : 'Sin huecos de datos desde la ultima lluvia registrada.',
   };
 


### PR DESCRIPTION
## Bug

Esco answers a different number than the screen for the same rain.

Measured against production today:

| Mes | Vista de Clima / tablero / reporte | Esco | Diferencia |
|---|---|---|---|
| 2026-03 | 90,41 mm | 75,44 mm | **−14,97 mm** (16,6%) |
| 2026-04 | 588,50 mm | 514,35 mm | **−74,15 mm** (12,6%) |
| 2026-05 | 24,10 mm | 22,59 mm | −1,51 mm |

25 days (2026-03-18 → 2026-08-20) carrying **90,63 mm of measured rain** are
visible on every screen and invisible to Esco.

```sql
select lluvia_confianza, count(*) dias,
       round(sum(lluvia_total_mm)::numeric,2) mm
from clima_resumen_diario group by 1;
-- ok                  1865   9859.79
-- contador_congelado    27     29.18
-- cobertura_parcial     25      90.63   <-- discarded by Esco only
```

Who hits it: anyone asking Esco a rain question, in the browser or on Telegram.
Since `62649c1` (PR #178, merged 2026-08-26) — one day.

## Root cause

`src/supabase/functions/server/chat.tsx:2065-2069` declares itself, in its own
docstring, an "espejo de `lluviaConfiableDeResumen()`". PR #178 moved the
original and not the mirror:

```ts
// chat.tsx — unchanged by #178
if (fila.lluvia_confianza === 'cobertura_parcial') return null;
```

```ts
// src/utils/calculosClima.ts — changed by #178
const CONFIANZAS_SIN_DATO = new Set(['contador_congelado']);
```

The mirror can't `import` the original — `chat.tsx` lives in the edge-function
deployment tree with Deno imports. Same constraint that produced
`priorizacion-scouting.ts` and `reportes-financieros.ts`, both of which **do**
have parity tests. This one had none.

A second, latent edge on the same commit — `chat.tsx:2133`:

```
lluvia_confianza=eq.ok
```

Migration 122 introduced a fifth label, `reconstruido`, which is a *fully
trusted* value by design. `eq.ok` excludes it. There are 0 `reconstruido` rows
today, so this has not fired — but the first rainy day the rollup reconstructs
becomes invisible to "hace cuánto no llueve", and Esco reports a longer dry
streak than reality. That is exactly the 2026-08-16 incident
(`docs/archive/incidents/2026-08-16-esco-clima-ventana-24h.md`), where Esco
reported "47 días sin lluvia" four days after it rained.

## Fix

Minimal, in both edge-function trees:

- `lluviaConfiable` stops discarding `cobertura_parcial` wholesale. It keeps
  discarding the one case that genuinely says nothing — a **lower bound of
  0 mm** ("no llovió durante las horas que miramos" is not "no llovió"),
  mirroring `esCotaInferior(fila) && mm === 0` in `calculosClima.ts:192`.
- The "última lluvia" query goes from `eq.ok` to
  `in.(ok,reconstruido,cobertura_parcial)`. The existing `lluvia_total_mm=gt.0`
  already excludes the 0-lower-bound, so no fabricated value can enter.
- The "días sin dato" count now filters through `lluviaConfiable` instead of the
  raw label, so a `cobertura_parcial` day with measured rain stops being counted
  as a day nobody saw. Its `nota` text is corrected to match the number it
  describes.

No business rule changes: #178 already decided that a partial day carries a real
lower bound. This makes the declared mirror actually mirror.

## Verification

New guard `src/__tests__/climaConfianzaParidadEsco.test.ts` (10 tests) — reads
the sources, since the two sides cannot import each other. **6 of the 10 fail on
`main` and all 10 pass with this change** (verified by stashing the `chat.tsx`
edits and re-running). It also pins `CONFIANZAS_SIN_DATO` to exactly
`['contador_congelado']`, so the next person who moves the original gets a red
test instead of a silent divergence.

```
main:  136 files / 3063 tests · lint 0 errors, 904 warnings · tsc clean
here:  137 files / 3073 tests · lint 0 errors, 908 warnings · tsc clean
```

Both `chat.tsx` copies edited in the same commit; the test asserts they agree.

## Deploy

**Requires `npx supabase functions deploy make-server-1ccce916`.** Merging alone
changes nothing for Esco — per the 2026-08-24 lesson, this finding closes against
`list_edge_functions.updated_at`, not against the merge.

## Rollback

Revert the commit. No migration, no data touched, no schema change.

## Follow-up (deliberately out of scope)

`acciones-paquete-io.ts:220` and `acciones-paquete.ts:576` still type
`lluvia_confianza` as `'ok' | 'contador_congelado' | 'sin_time_piezo' | null` —
neither `cobertura_parcial` nor `reconstruido` is in the union, and
`diasOk`/`diasCongelados` (`acciones-paquete.ts:787-788`) count neither. The
recommended-actions engine therefore under-reports its own rain-data coverage.
Filed separately; it is a different consumer with a different contract.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FR81Fjj9SbqcP9tMeEVy9S

---
_Generated by [Claude Code](https://claude.ai/code/session_01FR81Fjj9SbqcP9tMeEVy9S)_