### PR TITLE
fix(inventario): revert precio_unitario when a purchase is deleted

### DIFF
--- a/src/__tests__/eliminarCompraConReversion.test.ts
+++ b/src/__tests__/eliminarCompraConReversion.test.ts
@@ -44,6 +44,9 @@ interface StubOptions {
   productoUpdateError?: { message: string } | null;
   compraDeleteError?: { message: string } | null;
   rpcError?: { message: string } | null;
+  /** Compra anterior del mismo producto que sobrevive al borrado (null = no hay ninguna). */
+  compraAnterior?: { costo_unitario: number } | null;
+  compraAnteriorError?: { message: string } | null;
 }
 
 /** Registro de llamadas por tabla/método, en el orden real en que ocurrieron. */
@@ -81,7 +84,26 @@ function crearSupabaseStub(options: StubOptions = {}) {
     }),
   };
 
+  // Cadena de la consulta a la compra anterior:
+  //   .select().eq().neq().order().order().limit().maybeSingle()
+  const compraAnteriorFiltros = {
+    eq: vi.fn(() => compraAnteriorFiltros),
+    neq: vi.fn(() => compraAnteriorFiltros),
+    order: vi.fn(() => compraAnteriorFiltros),
+    limit: vi.fn(() => compraAnteriorFiltros),
+    maybeSingle: vi.fn(() =>
+      Promise.resolve({
+        data: options.compraAnterior ?? null,
+        error: options.compraAnteriorError ?? null,
+      }),
+    ),
+  };
+
   const comprasMock = {
+    select: vi.fn(() => {
+      orden.push('compras.select');
+      return compraAnteriorFiltros;
+    }),
     delete: vi.fn(() => {
       orden.push('compras.delete');
       return { eq: vi.fn(() => Promise.resolve({ error: options.compraDeleteError ?? null })) };
@@ -107,7 +129,7 @@ function crearSupabaseStub(options: StubOptions = {}) {
     rpc,
     storage: { from: vi.fn(() => ({ remove: storageRemove })) },
     // Expuestos para inspeccionar llamadas desde los tests
-    _spies: { productosMock, movimientosMock, comprasMock, rpc, storageRemove },
+    _spies: { productosMock, movimientosMock, comprasMock, compraAnteriorFiltros, rpc, storageRemove },
     _orden: orden,
     // eslint-disable-next-line @typescript-eslint/no-explicit-any
   } as any;
@@ -181,6 +203,97 @@ describe('eliminarCompraConReversion', () => {
     );
 
     expect(supabase._spies.comprasMock.delete).not.toHaveBeenCalled();
+  });
+
+  /**
+   * Finding #50: `NewPurchase.tsx` escribe `cantidad_actual` Y `precio_unitario` en un
+   * mismo UPDATE, pero la reversión sólo devolvía la cantidad. Resultado: el producto se
+   * quedaba con el precio de la compra borrada para siempre y sin rastro en el ledger —
+   * y `productos.precio_unitario` alimenta el costo de insumos de costo/kg por lote
+   * (`calculosCostoKg.ts`) y el KPI de valor de inventario.
+   *
+   * Caso probado en producción (2026-07-24): Sulcamag quedó con `precio_unitario` 669,96
+   * —el de la factura 4379, cargada contra el producto equivocado y luego revertida—
+   * mientras `cantidad_actual` sí volvió a 16,00.
+   */
+  describe('reversión de precio_unitario (finding #50)', () => {
+    it('restaura el precio de la compra anterior del mismo producto, en el MISMO update que la cantidad', async () => {
+      const supabase = crearSupabaseStub({
+        cantidadActualProducto: 100,
+        compraAnterior: { costo_unitario: 4200 },
+      });
+      const compra = crearCompra({ cantidad: 20, costo_unitario: 5000 });
+
+      await eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co');
+
+      expect(supabase._spies.productosMock.update).toHaveBeenCalledTimes(1);
+      const [payloadProducto] = supabase._spies.productosMock.update.mock.calls[0];
+      expect(payloadProducto.cantidad_actual).toBe(80);
+      expect(payloadProducto.precio_unitario).toBe(4200);
+      // Jamás se conserva el precio de la compra que se está borrando.
+      expect(payloadProducto.precio_unitario).not.toBe(5000);
+    });
+
+    it('sin compra anterior deja precio_unitario en NULL — nunca conserva el de la compra borrada', async () => {
+      const supabase = crearSupabaseStub({
+        cantidadActualProducto: 100,
+        compraAnterior: null,
+      });
+      const compra = crearCompra({ cantidad: 20, costo_unitario: 669.96 });
+
+      await eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co');
+
+      const [payloadProducto] = supabase._spies.productosMock.update.mock.calls[0];
+      expect(payloadProducto).toHaveProperty('precio_unitario');
+      expect(payloadProducto.precio_unitario).toBeNull();
+    });
+
+    it('excluye la compra que se está borrando y toma la más reciente que queda', async () => {
+      const supabase = crearSupabaseStub({
+        cantidadActualProducto: 100,
+        compraAnterior: { costo_unitario: 4200 },
+      });
+      const compra = crearCompra({ id: 'compra-1', producto_id: 'prod-1', cantidad: 20 });
+
+      await eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co');
+
+      const filtros = supabase._spies.compraAnteriorFiltros;
+      expect(filtros.eq).toHaveBeenCalledWith('producto_id', 'prod-1');
+      expect(filtros.neq).toHaveBeenCalledWith('id', 'compra-1');
+      expect(filtros.order).toHaveBeenCalledWith('fecha_compra', { ascending: false });
+      expect(filtros.order).toHaveBeenCalledWith('created_at', { ascending: false });
+      expect(filtros.limit).toHaveBeenCalledWith(1);
+    });
+
+    it('si la lectura de la compra anterior falla, aborta ANTES de escribir el ledger y el stock', async () => {
+      const supabase = crearSupabaseStub({
+        cantidadActualProducto: 100,
+        compraAnteriorError: { message: 'timeout' },
+      });
+      const compra = crearCompra({ cantidad: 20 });
+
+      await expect(
+        eliminarCompraConReversion(supabase, compra, 'consuelo@escocia.co'),
+      ).rejects.toThrow(/compra anterior/i);
+
+      expect(supabase._spies.movimientosMock.insert).not.toHaveBeenCalled();
+      expect(supabase._spies.productosMock.update).not.toHaveBeenCalled();
+      expect(supabase._spies.comprasMock.delete).not.toHaveBeenCalled();
+    });
+
+    it('la compra anterior se lee antes de escribir nada', async () => {
+      const supabase = crearSupabaseStub({
+        cantidadActualProducto: 100,
+        compraAnterior: { costo_unitario: 4200 },
+      });
+
+      await eliminarCompraConReversion(supabase, crearCompra({ cantidad: 20 }), null);
+
+      expect(supabase._orden).toContain('compras.select');
+      expect(supabase._orden.indexOf('compras.select')).toBeLessThan(
+        supabase._orden.indexOf('movimientos_inventario.insert'),
+      );
+    });
   });
 
   it('la limpieza de gasto pendiente y de la factura son no bloqueantes: un error ahí no impide eliminar la compra', async () => {

--- a/src/components/inventory/PurchaseHistory.tsx
+++ b/src/components/inventory/PurchaseHistory.tsx
@@ -61,6 +61,15 @@ interface Purchase {
  * sin dejar rastro. No es atómico (llamado desde el navegador, sin RPC), pero el
  * orden garantiza que nunca se pierde la trazabilidad silenciosamente.
  *
+ * `precio_unitario` se revierte junto con la cantidad, en el MISMO update, porque
+ * `NewPurchase.tsx` los escribe juntos: revertir sólo la cantidad dejaba pegado al
+ * producto el precio de la compra borrada, para siempre y sin rastro en el ledger.
+ * Eso mueve una cifra financiera en silencio -- `productos.precio_unitario` alimenta
+ * el costo de insumos de costo/kg por lote (`calculosCostoKg.ts`) y el KPI de valor
+ * de inventario. Se restaura el precio de la compra más reciente que SOBREVIVE al
+ * borrado; si no queda ninguna, `NULL` (sin dato), nunca el precio borrado -- el
+ * sistema distingue "sin dato" de cero, y el precio viejo es una afirmación falsa.
+ *
  * Exportada (en vez de quedar inline en `handleDeletePurchase`) para poder probar esta
  * secuencia sin renderizar el componente -- este repo no tiene @testing-library/react.
  */
@@ -85,7 +94,29 @@ export async function eliminarCompraConReversion(
     throw new Error('No se puede eliminar la compra porque resultaría en inventario negativo');
   }
 
-  // 2. Dejar el rastro en el ledger ANTES de tocar el stock -- si esto falla, se
+  // 2. Averiguar a qué precio hay que volver: el de la compra más reciente del mismo
+  // producto que sobrevive a este borrado. Se lee ANTES de escribir nada, así un fallo
+  // de lectura aborta con el inventario y el ledger todavía intactos.
+  const { data: compraAnterior, error: compraAnteriorError } = await supabase
+    .from('compras')
+    .select('costo_unitario')
+    .eq('producto_id', purchase.producto_id)
+    .neq('id', purchase.id)
+    .order('fecha_compra', { ascending: false })
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+
+  if (compraAnteriorError) {
+    throw new Error('Error al obtener la compra anterior del producto: ' + compraAnteriorError.message);
+  }
+
+  // Sin compra anterior no hay precio conocido: `null` es "sin dato". Conservar el de
+  // la compra que se está borrando sería afirmar un precio que ya no respalda ningún
+  // documento.
+  const precioARestaurar = compraAnterior?.costo_unitario ?? null;
+
+  // 3. Dejar el rastro en el ledger ANTES de tocar el stock -- si esto falla, se
   // aborta acá y el inventario queda intacto.
   const { error: movementAjusteError } = await supabase
     .from('movimientos_inventario')
@@ -108,18 +139,20 @@ export async function eliminarCompraConReversion(
     throw new Error('Error al registrar el movimiento de ajuste de inventario: ' + movementAjusteError.message);
   }
 
-  // 3. Revertir el stock del producto -- solo después de que el ledger quedó escrito.
+  // 4. Revertir el stock Y el precio del producto -- solo después de que el ledger
+  // quedó escrito, y los dos en el mismo update en que la compra los escribió.
   const { error: inventoryError } = await supabase
     .from('productos')
     .update({
       cantidad_actual: nuevaCantidad,
+      precio_unitario: precioARestaurar,
       updated_at: new Date().toISOString(),
     })
     .eq('id', purchase.producto_id);
 
   if (inventoryError) throw new Error('Error al actualizar inventario: ' + inventoryError.message);
 
-  // 4. Eliminar gasto pendiente asociado (si existe)
+  // 5. Eliminar gasto pendiente asociado (si existe)
   // Uses SECURITY DEFINER RPC to bypass fin_gastos RLS (Administrador can't delete directly)
   const { error: gastoError } = await supabase
     .rpc('fn_cleanup_compra_dependencies', { p_compra_id: purchase.id });
@@ -129,7 +162,7 @@ export async function eliminarCompraConReversion(
     // Non-blocking: FK is ON DELETE SET NULL as safety net
   }
 
-  // 5. Eliminar factura de Storage (si existe)
+  // 6. Eliminar factura de Storage (si existe)
   if (purchase.link_factura) {
     const { error: storageError } = await supabase.storage
       .from('facturas')
@@ -140,7 +173,7 @@ export async function eliminarCompraConReversion(
     }
   }
 
-  // 6. Eliminar la compra
+  // 7. Eliminar la compra
   const { error: deleteError } = await supabase
     .from('compras')
     .delete()


### PR DESCRIPTION
Finding Notion #50 (P2, `Clase=codigo`, `Esfuerzo=S`) — corrida `2026-08-28-viernes`.

## Bug

Deleting a purchase reverts the stock but not the unit price it wrote, so the product keeps the deleted purchase's `precio_unitario` forever — and that column feeds cost/kg.

Who hits it: anyone who deletes a purchase from `/inventario` → Historial de Compras (Administrador + Gerencia). Since the beginning of the purchase-deletion flow.

## Root cause

`src/components/inventory/NewPurchase.tsx:390-399` writes `cantidad_actual` **and** `precio_unitario` to `productos` in a single `UPDATE`:

```ts
.update({
  cantidad_actual: cantidadNueva,
  precio_unitario: item.precio_unitario_real,
  activo: …,
  updated_at: …,
})
```

`eliminarCompraConReversion` (`src/components/inventory/PurchaseHistory.tsx`) reverted only `cantidad_actual` and `updated_at`. The price stayed, and — unlike the quantity, which the compensating `Salida Otros` movement records — nothing in `movimientos_inventario` says the price ever changed, so the drift leaves no trace.

## Impact

`productos.precio_unitario` feeds two things Gerencia reads:

- the inventory-value KPI (`InventoryList.tsx:433/515`, `MovementsDashboard.tsx:201/281`);
- the insumo half of cost/kg per lote — `movimientos_diarios_productos × productos.precio_unitario` (`useCostoKg.ts:164-180`, engine `calculosCostoKg.ts`).

Deleting a purchase of a product that **is** consumed moves the cost/kg of every lote it was applied to, silently.

## Evidence — reproduced against production (read-only)

```sql
select nombre, precio_unitario, cantidad_actual, updated_at
from productos where nombre in ('Sulcamag','Silicalmag');
```
```
Silicalmag | 669.96 | 8000.00 | 2026-07-24 20:07:54.803773+00
Sulcamag   | 669.96 |   16.00 | 2026-07-24 20:05:47.226015+00
```

Sulcamag carries `precio_unitario` **669,96 — byte-identical to Silicalmag's**, and equal to `5.359.680 / 8.000`, the unit price of factura 4379, which was loaded against the wrong product on 2026-07-15 and reverted on 2026-07-24 20:05:47. The stock went back to 16,00 kg; the price did not.

And Sulcamag has **zero rows in `compras`** today (verified: the full `compras` table holds 31 rows, none for Sulcamag) — so the price it displays is backed by no document at all. Migration 119 recorded this exact case as deliberately not fixed, because that product's previous value is unrecoverable. The code defect is the part that does have a fix.

## Fix

The smallest change that removes the cause. In `eliminarCompraConReversion`, a new step 2 — **before any write** — looks up the most recent surviving purchase of the same product:

```ts
.from('compras')
.select('costo_unitario')
.eq('producto_id', purchase.producto_id)
.neq('id', purchase.id)
.order('fecha_compra', { ascending: false })
.order('created_at', { ascending: false })
.limit(1)
.maybeSingle();
```

and its `costo_unitario` is written in the **same** `UPDATE` as `cantidad_actual`, mirroring how `NewPurchase` writes them.

Three decisions worth naming:

- **No surviving purchase → `NULL`, never the deleted price.** `productos.precio_unitario` is `numeric`, `is_nullable = YES`, no default (verified in `information_schema.columns`), so `NULL` is legal. The system distinguishes "sin dato" from zero; keeping the deleted purchase's price is a false assertion.
- **"Most recent surviving" is correct in both directions.** Deleting the latest purchase falls back to the one before it; deleting an *older* purchase leaves the latest one's price in place, which is what the product should already have.
- **The lookup runs before the ledger insert**, so a read failure aborts with stock, ledger and `compras` row all still intact — same discipline as the existing "write the ledger before touching stock" ordering.

**Sulcamag is deliberately untouched.** This PR changes no data; it only stops the drift from happening again.

## Verification

New `describe('reversión de precio_unitario (finding #50)')` block in `src/__tests__/eliminarCompraConReversion.test.ts`, 5 tests, extending the existing hand-built Supabase stub (no `@testing-library/react` in this repo):

1. restores the previous purchase's price in the same `update` as the quantity;
2. with no previous purchase writes `precio_unitario: null` — and the key never comes back as the deleted price;
3. the query excludes the row being deleted and orders `fecha_compra` desc, `created_at` desc, `limit 1`;
4. a failed lookup aborts before the ledger insert, the stock update and the `compras` delete;
5. `compras.select` happens before `movimientos_inventario.insert`.

All 5 **fail on `main`** (`expected undefined to be 4200`, `to have property "precio_unitario"`, `expected "vi.fn()" to be called with…`, `promise resolved "undefined" instead of rejecting`, `expected [ …(4) ] to include 'compras.select'`) and pass with the fix.

Checks, on this branch:

- `npm test` → **137 files / 3.078 tests, all green** (main is 137 / 3.073; +5 is exactly this PR)
- `npm run lint` → **0 errors**, 908 warnings (unchanged pre-existing baseline)
- `npm run typecheck` (`tsc --noEmit`) → clean

No edge function touched, so no redeploy needed. No migration.

## Rollback

`git revert c842333`. Nothing else — no data was written, no schema changed.

## Follow-up (deliberately out of scope)

- `useCostoKg.ts:180` reads the price as `Number(p.productos?.precio_unitario) || 0`, so a `NULL` price is costed at **$0** rather than surfaced as "sin dato". That is pre-existing behaviour for every product that has never had a price, and changing it is a display-contract decision, not part of this fix.
- `ProductForm.tsx` can also set `precio_unitario` by hand. As before this PR, a purchase (and now its deletion) overwrites that manual value. Unchanged behaviour, noted so it is not a surprise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B2L2D6A3pFqqRoaGw1187

---
_Generated by [Claude Code](https://claude.ai/code/session_015B2L2D6A3pFqqRoaGw1187)_