### PR TITLE
fix: stamp responsable on manual inventory movements

### DIFF
--- a/src/__tests__/movimientoInventarioResponsable.test.ts
+++ b/src/__tests__/movimientoInventarioResponsable.test.ts
@@ -1,0 +1,129 @@
+// ARCHIVO: __tests__/movimientoInventarioResponsable.test.ts
+// DESCRIPCIÓN: `movimientos_inventario` es el libro de trazabilidad de insumos que
+// GlobalGAP audita. Toda fila tiene que decir QUIÉN la escribió, y la única forma de
+// saberlo es que el escritor estampe `responsable` en el propio INSERT: la tabla
+// **no tiene ningún trigger de atribución** (verificado contra `pg_trigger` en
+// producción 2026-08-28: 0 triggers no internos), y la migración 112 cubre
+// `productos.updated_by`, que es otra columna de otra tabla.
+//
+// El defecto que motivó este guard: `NuevoMovimientoModal` -- el ÚNICO camino de la
+// app para un ajuste manual de stock -- construía su payload sin la clave
+// `responsable`. Como nada la rellena después, toda corrección manual de inventario
+// nacía sin persona responsable.
+//
+// Evidencia en producción (2026-08-28), antes del arreglo:
+//   select responsable, count(*) from movimientos_inventario group by 1;
+//     aescociahass@gmail.com  138
+//     sforero94@gmail.com      18
+//     santiago@thinksid.co      1
+//     NULL                      3   <- las 3 del modal, todas 'Ajuste', 2026-08-24
+// O sea: 3 de 160 filas en total, pero el **100 % de las escrituras de este camino**.
+//
+// El formato es un EMAIL, no un nombre: las 157 filas atribuidas guardan email, y el
+// RPC `fn_cerrar_aplicacion` (migración 106) lo deriva server-side de
+// `auth.jwt() ->> 'email'`. Un escritor nuevo que guarde un nombre partiría la columna
+// en dos formatos sin que nada falle.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+
+/** Los tres escritores TS de `movimientos_inventario`. El cuarto escritor es el RPC
+ * `fn_cerrar_aplicacion` (migración 106), cubierto en su propio caso más abajo. */
+const ESCRITORES_TS = [
+  'src/components/inventory/NuevoMovimientoModal.tsx',
+  'src/components/inventory/NewPurchase.tsx',
+  'src/components/inventory/PurchaseHistory.tsx',
+];
+
+/**
+ * Devuelve el cuerpo `{ … }` de cada `.from('movimientos_inventario').insert({ … })`
+ * del archivo, recortado por balanceo de llaves. Mirar el archivo entero no sirve:
+ * `responsable` puede aparecer en un tipo o en un comentario y el guard quedaría verde
+ * con el INSERT igual de mudo.
+ */
+function payloadsDeInsert(fuente: string): string[] {
+  const payloads: string[] = [];
+  const marcador = "from('movimientos_inventario')";
+  let desde = 0;
+
+  for (;;) {
+    const iTabla = fuente.indexOf(marcador, desde);
+    if (iTabla === -1) break;
+    desde = iTabla + marcador.length;
+
+    const iInsert = fuente.indexOf('.insert(', iTabla);
+    if (iInsert === -1) continue;
+    // Solo cuenta si el `.insert(` pertenece a esta misma cadena: si entre medias
+    // aparece otro `from(`, este `from` no era un INSERT.
+    if (fuente.slice(iTabla + marcador.length, iInsert).includes('.from(')) continue;
+
+    const iLlave = fuente.indexOf('{', iInsert);
+    if (iLlave === -1) continue;
+
+    let profundidad = 0;
+    let fin = -1;
+    for (let i = iLlave; i < fuente.length; i++) {
+      if (fuente[i] === '{') profundidad++;
+      else if (fuente[i] === '}') {
+        profundidad--;
+        if (profundidad === 0) {
+          fin = i;
+          break;
+        }
+      }
+    }
+    if (fin === -1) continue;
+
+    payloads.push(fuente.slice(iLlave, fin + 1));
+  }
+
+  return payloads;
+}
+
+describe('guard: todo INSERT en movimientos_inventario estampa `responsable`', () => {
+  it.each(ESCRITORES_TS)('%s', (archivo) => {
+    const fuente = readFileSync(join(process.cwd(), archivo), 'utf-8');
+    const payloads = payloadsDeInsert(fuente);
+
+    expect(
+      payloads.length,
+      `${archivo} ya no inserta en movimientos_inventario; si el escritor se movió, ` +
+        'actualizá ESCRITORES_TS en vez de borrar el caso.',
+    ).toBeGreaterThan(0);
+
+    for (const payload of payloads) {
+      expect(
+        /(^|[\s,{])responsable\s*[,:]/.test(payload),
+        `${archivo} inserta en movimientos_inventario sin la clave \`responsable\`. ` +
+          'La tabla no tiene trigger de atribución, así que la fila queda sin persona ' +
+          'responsable para siempre y el libro que audita GlobalGAP no puede decir ' +
+          'quién movió el stock. Tomalo de la sesión: `user?.email ?? null`.',
+      ).toBe(true);
+    }
+  });
+
+  it('el valor sale de la sesión y es un EMAIL, no un nombre libre', () => {
+    for (const archivo of ESCRITORES_TS) {
+      const fuente = readFileSync(join(process.cwd(), archivo), 'utf-8');
+
+      expect(
+        /user\?\.email/.test(fuente),
+        `${archivo} escribe movimientos_inventario.responsable pero no lo deriva de ` +
+          '`user?.email`. Las 157 filas atribuidas en producción guardan email y el RPC ' +
+          '`fn_cerrar_aplicacion` deriva `auth.jwt() ->> \'email\'`: un segundo formato ' +
+          'parte la columna en dos sin que nada falle.',
+      ).toBe(true);
+    }
+  });
+
+  it('el RPC fn_cerrar_aplicacion (migración 106) deriva responsable del JWT', () => {
+    const fuente = readFileSync(
+      join(process.cwd(), 'src/sql/migrations/106_cierre_aplicacion_transaccional.sql'),
+      'utf-8',
+    );
+
+    expect(fuente.includes("auth.jwt() ->> 'email'")).toBe(true);
+    expect(/INSERT INTO movimientos_inventario[\s\S]{0,400}?responsable/i.test(fuente)).toBe(true);
+  });
+});

--- a/src/components/inventory/NuevoMovimientoModal.tsx
+++ b/src/components/inventory/NuevoMovimientoModal.tsx
@@ -1,6 +1,7 @@
 import { useState, useEffect } from 'react';
 import { Package, Search, AlertCircle, CheckCircle, X } from 'lucide-react';
 import { getSupabase } from '../../utils/supabase/client';
+import { useAuth } from '../../contexts/AuthContext';
 import { Button } from '../ui/button';
 import { Input } from '../ui/input';
 import { Dialog, DialogContent, DialogHeader, DialogTitle, DialogDescription, DialogBody, DialogFooter } from '../ui/dialog';
@@ -24,6 +25,7 @@ interface NuevoMovimientoModalProps {
 }
 
 export function NuevoMovimientoModal({ isOpen, onClose, onSuccess }: NuevoMovimientoModalProps) {
+  const { user } = useAuth();
   const [searchTerm, setSearchTerm] = useState('');
   const [products, setProducts] = useState<Product[]>([]);
   const [selectedProduct, setSelectedProduct] = useState<Product | null>(null);
@@ -141,6 +143,10 @@ export function NuevoMovimientoModal({ isOpen, onClose, onSuccess }: NuevoMovimi
           unidad: selectedProduct.unidad_medida,
           saldo_anterior: saldoAnterior,
           saldo_nuevo: nuevoSaldo,
+          // `movimientos_inventario` no tiene trigger de atribución: si el escritor no
+          // estampa el responsable, la fila queda sin autor para siempre. Email, igual
+          // que NewPurchase y que `fn_cerrar_aplicacion` (auth.jwt() ->> 'email').
+          responsable: user?.email || null,
           observaciones: observaciones || null,
           provisional: false
         } as any);


### PR DESCRIPTION
## Bug

`NuevoMovimientoModal` is the **only** UI path for a manual stock adjustment, and its `movimientos_inventario` INSERT payload omitted `responsable` entirely. Nothing fills it in afterwards, so every manual inventory correction is written with no responsible person.

Today that is 3 rows of 160 — but it is **100 % of the writes this path has ever made**. `movimientos_inventario` is the input traceability ledger GlobalGAP audits: a stock correction with no author cannot be questioned later.

## Root cause

`src/components/inventory/NuevoMovimientoModal.tsx:134-146` — the insert payload was `{fecha_movimiento, producto_id, tipo_movimiento, cantidad, unidad, saldo_anterior, saldo_nuevo, observaciones, provisional}`. No `responsable` key.

No trigger covers the gap. Verified against production:

```sql
select t.tgname from pg_trigger t
where t.tgrelid = 'public.movimientos_inventario'::regclass and not t.tgisinternal;
-- 0 rows
```

Migration 112 exists but covers `productos.updated_by` — a different column on a different table.

## Evidence

```sql
select responsable, count(*) n from movimientos_inventario group by 1 order by n desc;
```

| responsable | n |
|---|---|
| `aescociahass@gmail.com` | 138 |
| `sforero94@gmail.com` | 18 |
| **NULL** | **3** |
| `santiago@thinksid.co` | 1 |

The 3 unattributed rows are the only ones this modal has ever written — all `tipo_movimiento = 'Ajuste'`, all 2026-08-24, all with `observaciones = 'Ajusté por inventario físico '`:

| producto | delta | saldo | created_at (UTC) |
|---|---|---|---|
| Acondicionador sys | +0,95 | 2,85 → 3,80 | 12:28:42 |
| Proxam 200 EC | +0,30 | 9,00 → 9,30 | 12:29:50 |
| Magister | +0,30 | 9,00 → 9,30 | 12:30:23 |

Every other `tipo_movimiento` is fully attributed (`Salida por Aplicación` 108/108, `Entrada` 37/37) — the gap is exclusive to this modal.

**What this does not claim**: there is no evidence stock was invented. The three rows state a reason and leave a surplus (0,76 / 0,18 / 0,18), not the bare minimum the subsequent application closure needed. The stronger accusation was refuted during triage and is not being relitigated here.

## Fix

Six lines in `NuevoMovimientoModal.tsx`: import `useAuth`, read `user`, and add `responsable: user?.email || null` to the payload.

**Email, not a name** — chosen against the live data, not by preference. All 157 attributed rows hold an email; `NewPurchase.tsx:416` writes `user?.email || null`; and `fn_cerrar_aplicacion` (migration 106) derives `auth.jwt() ->> 'email'` server-side. A second format would split the column with nothing failing.

## Verification

New guard `src/__tests__/movimientoInventarioResponsable.test.ts` (5 cases). It extracts each `.from('movimientos_inventario').insert({…})` payload by **brace balancing** rather than grepping the file, so a `responsable` appearing in a type declaration or a comment cannot satisfy it while the INSERT stays mute.

Pre-fix run — fails on the target, passes for the two already-compliant writers, which is what proves the guard discriminates:

```
 ✓ src/components/inventory/NewPurchase.tsx
 ✓ src/components/inventory/PurchaseHistory.tsx
 × src/components/inventory/NuevoMovimientoModal.tsx
AssertionError: src/components/inventory/NuevoMovimientoModal.tsx inserta en
movimientos_inventario sin la clave `responsable`. …
 Tests  2 failed | 3 passed (5)
```

Post-fix: `5 passed (5)`.

Full suite on the branch:

- `npm test` → **138 files / 3078 tests, all passing**
- `npm run lint` → **0 errors**, 908 warnings (unchanged from baseline)
- `npm run typecheck` → clean

## Rollback

`git revert 83e662f`. Reverting restores the defect but touches no data — this change only affects rows written from here on.

## Follow-up (deliberately out of scope)

- **Not backfilled.** The real author of the 3 existing rows is not recoverable from the database, so they stay NULL rather than being attributed to a guess.
- **The migration-106 abort message** — when the never-negative-inventory guard aborts a closure, the screen does not say which product is short or by how much. Filed as separate work in the finding; not touched here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B2L2D6A3pFqqRoaGw1187

---
_Generated by [Claude Code](https://claude.ai/code/session_015B2L2D6A3pFqqRoaGw1187)_