### PR TITLE
fix(clima): stop the daily retry cron from downgrading a day's aggregate

### DIFF
--- a/src/__tests__/climaReintentoNoEmpeora.test.ts
+++ b/src/__tests__/climaReintentoNoEmpeora.test.ts
@@ -1,0 +1,108 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { debeReagregarDia } from '../supabase/functions/server/clima-reagregacion';
+
+/**
+ * El reintento diario de días sin dato (migración 121) no puede DEGRADAR un día.
+ *
+ * Qué pasó, con fechas y números de producción:
+ *
+ *  - `CLAUDE.md` (migración 103, verificada contra producción el 2026-08-21):
+ *    «2026-08-19 quedó con `lecturas_count` = 167 de las 288 esperadas».
+ *  - El 2026-08-27, en la PRIMERA corrida del cron de la 121, el log dice
+ *    `[clima-reintento-sin-dato] 2026-08-19: 105 lecturas reagregadas` y
+ *    `0/2 día(s) resuelto(s) a 'ok' en esta corrida`. La fila quedó en 105.
+ *  - El 2026-08-28 volvió a pasar lo mismo (`105 lecturas reagregadas`,
+ *    `0/3 día(s) resuelto(s)`): no es un incidente, es lo que hace cada día.
+ *
+ * Mecanismo: `backfillUnDia` inserta lo que devuelva la History API de Ecowitt
+ * y vuelve a correr `fn_clima_rollup_diario`, que agrega sobre `clima_lecturas`
+ * — una tabla que la migración 036 poda a 24 h. Para un día viejo las lecturas
+ * originales ya no existen, así que el rollup sólo ve las recién insertadas y
+ * `lecturas_count` BAJA. Y `lecturas_count` ES exactamente el predicado del
+ * umbral de la migración 103, así que una respuesta parcial de Ecowitt puede
+ * empujar a `cobertura_parcial` un día que estaba mejor clasificado.
+ *
+ * La guarda es de PREVENCIÓN, no de detección: una vez que el rollup corrió, la
+ * fila anterior ya no se puede reconstruir — las lecturas que la sostenían
+ * fueron podadas hace días. Por eso `debeReagregarDia` se consulta ANTES de
+ * insertar nada.
+ *
+ * El caso que la guarda SÍ deja pasar es justamente aquel para el que existe el
+ * cron: la estación estuvo sin luz, se reconectó, y Ecowitt subió el búfer del
+ * día. Ahí la historia trae MÁS lecturas de las que se capturaron en vivo.
+ */
+
+const RAIZ = resolve(__dirname, '..', '..');
+const COPIAS_CLIMA = [
+  'src/supabase/functions/server/clima.tsx',
+  'supabase/functions/make-server-1ccce916/clima.tsx',
+];
+const COPIAS_REAGREGACION = [
+  'src/supabase/functions/server/clima-reagregacion.ts',
+  'supabase/functions/make-server-1ccce916/clima-reagregacion.ts',
+];
+
+function leer(rel: string): string {
+  return readFileSync(resolve(RAIZ, rel), 'utf-8');
+}
+
+describe('debeReagregarDia — el reintento nunca empeora un día', () => {
+  it('NO reagrega cuando Ecowitt devuelve menos lecturas de las que la fila ya declara (2026-08-19: 167 -> 105)', () => {
+    expect(debeReagregarDia(105, 167)).toBe(false);
+  });
+
+  it('reagrega cuando la estación se reconectó y Ecowitt subió el búfer (204 en vivo -> 288 en la historia)', () => {
+    expect(debeReagregarDia(288, 204)).toBe(true);
+  });
+
+  it('reagrega cuando el día no tiene fila todavía (sin_registro)', () => {
+    expect(debeReagregarDia(105, null)).toBe(true);
+    expect(debeReagregarDia(105, undefined)).toBe(true);
+  });
+
+  it('reagrega con la misma cobertura — igual no es peor', () => {
+    expect(debeReagregarDia(288, 288)).toBe(true);
+  });
+
+  it('reagrega cuando la fila declara 0 lecturas', () => {
+    expect(debeReagregarDia(1, 0)).toBe(true);
+  });
+
+  it('no reagrega si Ecowitt no devolvió ninguna lectura para un día que ya tenía cobertura', () => {
+    expect(debeReagregarDia(0, 105)).toBe(false);
+  });
+});
+
+describe('clima.tsx — la guarda está cableada en las dos copias del árbol', () => {
+  it('la consulta de candidatos trae `lecturas_count` junto a `lluvia_confianza`', () => {
+    for (const rel of COPIAS_CLIMA) {
+      const src = leer(rel);
+      expect(src, rel).toContain('select=fecha,lluvia_confianza,lecturas_count');
+    }
+  });
+
+  it('`backfillUnDia` consulta la guarda ANTES de disparar `fn_clima_rollup_diario`', () => {
+    for (const rel of COPIAS_CLIMA) {
+      const src = leer(rel);
+      const iGuarda = src.indexOf('debeReagregarDia(');
+      const iRollup = src.indexOf('rpc/fn_clima_rollup_diario');
+      expect(iGuarda, `${rel}: no llama a debeReagregarDia`).toBeGreaterThan(-1);
+      expect(iRollup, `${rel}: no llama al rollup`).toBeGreaterThan(-1);
+      expect(iGuarda, `${rel}: la guarda va DESPUÉS del rollup`).toBeLessThan(iRollup);
+    }
+  });
+
+  it('el comentario del endpoint ya no afirma que un día sin resolver queda intacto sin condición', () => {
+    for (const rel of COPIAS_CLIMA) {
+      const src = leer(rel);
+      expect(src, rel).not.toContain('Si Ecowitt TODAVÍA no lo tiene, el día queda');
+    }
+  });
+
+  it('las dos copias del árbol de edge function son idénticas', () => {
+    expect(leer(COPIAS_CLIMA[0])).toBe(leer(COPIAS_CLIMA[1]));
+    expect(leer(COPIAS_REAGREGACION[0])).toBe(leer(COPIAS_REAGREGACION[1]));
+  });
+});

--- a/src/supabase/functions/server/clima-reagregacion.ts
+++ b/src/supabase/functions/server/clima-reagregacion.ts
@@ -1,0 +1,64 @@
+// clima-reagregacion.ts — la única decisión pura del reintento diario de clima
+// (migración 121): ¿vale la pena volver a agregar este día, o reagregarlo lo
+// dejaría PEOR de como está?
+//
+// Sin imports de Deno/Supabase (mismo patrón que `ganado-inventario.ts`,
+// `cost-aggregation.ts`, `hato-aggregation.ts`) para que sea testeable desde
+// Vitest sin cruzar la frontera del árbol de despliegue.
+// Guardado por `src/__tests__/climaReintentoNoEmpeora.test.ts`.
+//
+// ---------------------------------------------------------------------------
+// Por qué existe
+// ---------------------------------------------------------------------------
+// `backfillUnDia` inserta en `clima_lecturas` lo que devuelva la History API de
+// Ecowitt y después corre `fn_clima_rollup_diario`, que agrega **sobre esa
+// tabla** — la que la migración 036 poda a 24 h. Para un día viejo las lecturas
+// originales ya no existen, así que el rollup sólo ve las recién insertadas y
+// `lecturas_count` puede BAJAR. No es cosmético: `lecturas_count` es exactamente
+// el predicado del umbral de cobertura de la migración 103, así que una
+// respuesta parcial de Ecowitt puede empujar a `cobertura_parcial` un día que
+// estaba mejor clasificado.
+//
+// Ocurrió en producción, y no una vez: el 2026-08-27, en la primera corrida del
+// cron de la 121, `2026-08-19` pasó de 167 lecturas (valor verificado contra
+// producción el 2026-08-21, migración 103) a 105 — en un día que la propia
+// corrida reportó como NO resuelto. El 2026-08-28 volvió a hacer lo mismo.
+//
+// ---------------------------------------------------------------------------
+// Por qué la guarda PREVIENE en vez de DETECTAR
+// ---------------------------------------------------------------------------
+// Una comprobación después del rollup detectaría la regresión pero no podría
+// deshacerla: la fila anterior se calculó sobre lecturas que ya fueron podadas,
+// así que no hay desde dónde reconstruirla. Por eso esto se consulta ANTES de
+// insertar y antes de disparar el rollup.
+//
+// ---------------------------------------------------------------------------
+// Qué SÍ deja pasar, que es el caso para el que el cron existe
+// ---------------------------------------------------------------------------
+// La estación se quedó sin luz/internet, se reconectó, y Ecowitt subió el búfer
+// local del día. Ahí la historia trae MÁS lecturas de las que se capturaron en
+// vivo, la guarda no interviene, y el día se recupera igual que antes.
+//
+// Costo conocido y aceptado: para un día MUY reciente, `lecturas_count` puede
+// venir inflado por las lecturas de 5 minutos que todavía viven en la ventana
+// de 24 h de `clima_lecturas`; si la historia devuelve menos que ese conteo, el
+// día se omite. Se pierde a lo sumo una fusión marginal — nunca una
+// recuperación real, que por definición trae más lecturas. El backfill manual
+// (`POST /clima/backfill`, el que reparó la historia con la 122) no pasa por
+// esta guarda: es una acción humana deliberada.
+
+/**
+ * ¿Se puede reagregar este día sin riesgo de empeorar su cobertura?
+ *
+ * @param lecturasNuevas  Lecturas que la History API de Ecowitt devolvió para el día.
+ * @param lecturasPrevias `clima_resumen_diario.lecturas_count` de la fila que ya existe;
+ *                        `null`/`undefined` cuando el día todavía no tiene fila.
+ * @returns `true` si la cobertura no puede retroceder (o no hay nada que perder).
+ */
+export function debeReagregarDia(
+  lecturasNuevas: number,
+  lecturasPrevias: number | null | undefined,
+): boolean {
+  if (lecturasPrevias == null) return true;
+  return lecturasNuevas >= lecturasPrevias;
+}

--- a/src/supabase/functions/server/clima.tsx
+++ b/src/supabase/functions/server/clima.tsx
@@ -1,6 +1,7 @@
 import { Context } from 'https://deno.land/x/hono@v4.0.0/mod.ts';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 import { parseOpenWeatherForecast } from './external-tools.ts';
+import { debeReagregarDia } from './clima-reagregacion.ts';
 
 // ============================================================================
 // Ecowitt Cloud API Types
@@ -443,6 +444,8 @@ function parseEcowittHistory(histData: EcowittHistoryData, stationId: string) {
 interface ResultadoBackfillDia {
   ok: boolean;
   lecturas: number;
+  /** El día se dejó intacto porque reagregarlo habría bajado su cobertura. */
+  omitido?: boolean;
   error?: string;
 }
 
@@ -451,6 +454,10 @@ async function backfillUnDia(
   creds: { appKey: string; apiKey: string; mac: string },
   sb: { supabaseUrl: string; serviceKey: string },
   log: string,
+  /** `clima_resumen_diario.lecturas_count` de la fila que ya existe. Sólo lo
+   *  pasa el reintento automático (migración 121); el backfill manual lo deja
+   *  sin definir a propósito, porque es una acción humana deliberada. */
+  lecturasPrevias?: number | null,
 ): Promise<ResultadoBackfillDia> {
   const ecowittDateStr = formatEcowittDate(fecha);
 
@@ -491,6 +498,21 @@ async function backfillUnDia(
   const readings = parseEcowittHistory(response.data as EcowittHistoryData, creds.mac);
   if (readings.length === 0) {
     return { ok: false, lecturas: 0, error: '0 lecturas parseadas' };
+  }
+
+  // Guarda de no-empeorar (ver `clima-reagregacion.ts` para el mecanismo
+  // completo). El rollup agrega sobre `clima_lecturas`, que la migración 036
+  // poda a 24 h, así que reagregar un día viejo con una respuesta PARCIAL de
+  // Ecowitt baja su `lecturas_count` — y ése es exactamente el predicado del
+  // umbral de cobertura de la 103. Se comprueba acá, antes de insertar y antes
+  // del rollup, porque después de que el rollup corre la fila anterior ya no se
+  // puede reconstruir: las lecturas que la sostenían fueron podadas hace días.
+  if (!debeReagregarDia(readings.length, lecturasPrevias)) {
+    console.info(
+      `${log} ${ecowittDateStr}: Ecowitt devolvió ${readings.length} lectura(s) y la fila ya declara `
+      + `${lecturasPrevias} — se deja intacta (reagregar habría bajado la cobertura)`,
+    );
+    return { ok: true, lecturas: readings.length, omitido: true };
   }
 
   // Lecturas crudas -> clima_lecturas. `ignore-duplicates` sobre el
@@ -640,9 +662,18 @@ export async function handleClimaBackfill(c: Context): Promise<Response> {
 // Ecowitt sólo por los que todavía no tienen un dato confiable. Si la
 // estación ya se reconectó y Ecowitt tiene el día completo en su nube
 // (buffer local que sube al volver la luz/el internet), el día pasa a
-// 'ok' con el número real. Si Ecowitt TODAVÍA no lo tiene, el día queda
-// exactamente como estaba -- nunca se inventa un valor para forzar que
+// 'ok' con el número real. Nunca se inventa un valor para forzar que
 // "avance".
+//
+// Cuidado con lo que "queda como estaba" quiere decir. Con respuesta VACÍA
+// de Ecowitt es literal: no se escribe nada. Con respuesta PARCIAL no lo era
+// -- el rollup agrega sobre `clima_lecturas`, podada a 24 h por la migración
+// 036, así que reagregar un día viejo con menos lecturas de las que la fila
+// declara BAJABA su `lecturas_count`, que es el predicado del umbral de
+// cobertura de la 103. Pasó en producción con 2026-08-19 (167 -> 105) en la
+// primera corrida de este cron. Lo cierra `debeReagregarDia`, que se consulta
+// antes de tocar nada: un día sólo se reagrega si su cobertura no puede
+// retroceder.
 //
 // Importante sobre `contador_congelado`: a diferencia de `cobertura_parcial`
 // (un hueco de captura, justo lo que este reintento puede recuperar),
@@ -689,7 +720,7 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
     const queryUrl = `${sb.supabaseUrl}/rest/v1/clima_resumen_diario`
       + `?station_id=eq.${encodeURIComponent(creds.mac)}`
       + `&fecha=gte.${desdeStr}&fecha=lte.${ayerStr}`
-      + `&select=fecha,lluvia_confianza`;
+      + `&select=fecha,lluvia_confianza,lecturas_count`;
     const queryRes = await fetch(queryUrl, {
       headers: { apikey: sb.serviceKey, Authorization: `Bearer ${sb.serviceKey}` },
     });
@@ -698,18 +729,21 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
       console.error(`${log} No se pudo leer clima_resumen_diario (${queryRes.status}): ${body}`);
       return c.json({ error: 'No se pudo leer clima_resumen_diario', details: body }, 502);
     }
-    const filas: { fecha: string; lluvia_confianza: string }[] = await queryRes.json();
-    const confianzaPorFecha = new Map(filas.map((f) => [f.fecha, f.lluvia_confianza]));
+    const filas: { fecha: string; lluvia_confianza: string; lecturas_count: number | null }[] =
+      await queryRes.json();
+    const filaPorFecha = new Map(filas.map((f) => [f.fecha, f]));
 
-    const candidatos: Date[] = [];
+    // `lecturasPrevias` viaja con el candidato porque es lo que la guarda de
+    // no-empeorar necesita ver antes de reagregar (ver `backfillUnDia`).
+    const candidatos: { fecha: Date; lecturasPrevias: number | null }[] = [];
     for (let i = 0; i < DIAS_REINTENTO_SIN_DATO; i++) {
       const d = new Date(ayer.getTime() - i * 24 * 60 * 60 * 1000);
       const fechaStr = formatEcowittDate(d);
-      const confianza = confianzaPorFecha.get(fechaStr);
+      const fila = filaPorFecha.get(fechaStr);
       // Sin fila en absoluto ("sin_registro" del lado del frontend) o con
       // una confianza que hoy vale NULL -- las dos son candidatas.
-      if (confianza === undefined || CONFIANZAS_A_REINTENTAR.has(confianza)) {
-        candidatos.push(d);
+      if (fila === undefined || CONFIANZAS_A_REINTENTAR.has(fila.lluvia_confianza)) {
+        candidatos.push({ fecha: d, lecturasPrevias: fila?.lecturas_count ?? null });
       }
     }
 
@@ -718,14 +752,20 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
       return c.json({ message: 'Nada que reintentar', candidatos: 0 }, 200);
     }
 
-    console.info(`${log} ${candidatos.length} día(s) candidato(s): ${candidatos.map(formatEcowittDate).join(', ')}`);
+    console.info(`${log} ${candidatos.length} día(s) candidato(s): ${candidatos.map((cand) => formatEcowittDate(cand.fecha)).join(', ')}`);
 
-    const resultados: { fecha: string; consultaOk: boolean; error?: string }[] = [];
+    const resultados: { fecha: string; consultaOk: boolean; omitido?: boolean; error?: string }[] = [];
     for (const dia of candidatos) {
-      const r = await backfillUnDia(dia, creds, sb, log);
-      resultados.push({ fecha: formatEcowittDate(dia), consultaOk: r.ok, error: r.ok ? undefined : r.error });
+      const r = await backfillUnDia(dia.fecha, creds, sb, log, dia.lecturasPrevias);
+      resultados.push({
+        fecha: formatEcowittDate(dia.fecha),
+        consultaOk: r.ok,
+        omitido: r.omitido,
+        error: r.ok ? undefined : r.error,
+      });
       await sleep(150);
     }
+    const omitidos = resultados.filter((r) => r.omitido).length;
 
     // Se vuelve a preguntar a la base cuántos candidatos quedaron 'ok'
     // DESPUÉS del reintento -- "la consulta a Ecowitt no dio error" no es
@@ -744,17 +784,21 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
     });
     if (verifRes.ok) {
       const fechasOk = new Set(((await verifRes.json()) as { fecha: string }[]).map((f) => f.fecha));
-      resueltos = candidatos.filter((d) => fechasOk.has(formatEcowittDate(d))).length;
+      resueltos = candidatos.filter((d) => fechasOk.has(formatEcowittDate(d.fecha))).length;
     } else {
       console.warn(`${log} no se pudo verificar cuántos candidatos quedaron 'ok' tras el reintento`);
     }
 
-    console.info(`${log} ${resueltos ?? '?'}/${candidatos.length} día(s) resuelto(s) a 'ok' en esta corrida`);
+    console.info(
+      `${log} ${resueltos ?? '?'}/${candidatos.length} día(s) resuelto(s) a 'ok' en esta corrida`
+      + (omitidos > 0 ? `, ${omitidos} dejado(s) intacto(s) por cobertura menor` : ''),
+    );
 
     return c.json({
       message: 'Reintento completo',
       candidatos: candidatos.length,
       resueltos,
+      omitidos,
       resultados,
     }, 200);
   } catch (error) {

--- a/supabase/functions/make-server-1ccce916/clima-reagregacion.ts
+++ b/supabase/functions/make-server-1ccce916/clima-reagregacion.ts
@@ -1,0 +1,64 @@
+// clima-reagregacion.ts — la única decisión pura del reintento diario de clima
+// (migración 121): ¿vale la pena volver a agregar este día, o reagregarlo lo
+// dejaría PEOR de como está?
+//
+// Sin imports de Deno/Supabase (mismo patrón que `ganado-inventario.ts`,
+// `cost-aggregation.ts`, `hato-aggregation.ts`) para que sea testeable desde
+// Vitest sin cruzar la frontera del árbol de despliegue.
+// Guardado por `src/__tests__/climaReintentoNoEmpeora.test.ts`.
+//
+// ---------------------------------------------------------------------------
+// Por qué existe
+// ---------------------------------------------------------------------------
+// `backfillUnDia` inserta en `clima_lecturas` lo que devuelva la History API de
+// Ecowitt y después corre `fn_clima_rollup_diario`, que agrega **sobre esa
+// tabla** — la que la migración 036 poda a 24 h. Para un día viejo las lecturas
+// originales ya no existen, así que el rollup sólo ve las recién insertadas y
+// `lecturas_count` puede BAJAR. No es cosmético: `lecturas_count` es exactamente
+// el predicado del umbral de cobertura de la migración 103, así que una
+// respuesta parcial de Ecowitt puede empujar a `cobertura_parcial` un día que
+// estaba mejor clasificado.
+//
+// Ocurrió en producción, y no una vez: el 2026-08-27, en la primera corrida del
+// cron de la 121, `2026-08-19` pasó de 167 lecturas (valor verificado contra
+// producción el 2026-08-21, migración 103) a 105 — en un día que la propia
+// corrida reportó como NO resuelto. El 2026-08-28 volvió a hacer lo mismo.
+//
+// ---------------------------------------------------------------------------
+// Por qué la guarda PREVIENE en vez de DETECTAR
+// ---------------------------------------------------------------------------
+// Una comprobación después del rollup detectaría la regresión pero no podría
+// deshacerla: la fila anterior se calculó sobre lecturas que ya fueron podadas,
+// así que no hay desde dónde reconstruirla. Por eso esto se consulta ANTES de
+// insertar y antes de disparar el rollup.
+//
+// ---------------------------------------------------------------------------
+// Qué SÍ deja pasar, que es el caso para el que el cron existe
+// ---------------------------------------------------------------------------
+// La estación se quedó sin luz/internet, se reconectó, y Ecowitt subió el búfer
+// local del día. Ahí la historia trae MÁS lecturas de las que se capturaron en
+// vivo, la guarda no interviene, y el día se recupera igual que antes.
+//
+// Costo conocido y aceptado: para un día MUY reciente, `lecturas_count` puede
+// venir inflado por las lecturas de 5 minutos que todavía viven en la ventana
+// de 24 h de `clima_lecturas`; si la historia devuelve menos que ese conteo, el
+// día se omite. Se pierde a lo sumo una fusión marginal — nunca una
+// recuperación real, que por definición trae más lecturas. El backfill manual
+// (`POST /clima/backfill`, el que reparó la historia con la 122) no pasa por
+// esta guarda: es una acción humana deliberada.
+
+/**
+ * ¿Se puede reagregar este día sin riesgo de empeorar su cobertura?
+ *
+ * @param lecturasNuevas  Lecturas que la History API de Ecowitt devolvió para el día.
+ * @param lecturasPrevias `clima_resumen_diario.lecturas_count` de la fila que ya existe;
+ *                        `null`/`undefined` cuando el día todavía no tiene fila.
+ * @returns `true` si la cobertura no puede retroceder (o no hay nada que perder).
+ */
+export function debeReagregarDia(
+  lecturasNuevas: number,
+  lecturasPrevias: number | null | undefined,
+): boolean {
+  if (lecturasPrevias == null) return true;
+  return lecturasNuevas >= lecturasPrevias;
+}

--- a/supabase/functions/make-server-1ccce916/clima.tsx
+++ b/supabase/functions/make-server-1ccce916/clima.tsx
@@ -1,6 +1,7 @@
 import { Context } from 'https://deno.land/x/hono@v4.0.0/mod.ts';
 import { createClient } from 'jsr:@supabase/supabase-js@2';
 import { parseOpenWeatherForecast } from './external-tools.ts';
+import { debeReagregarDia } from './clima-reagregacion.ts';
 
 // ============================================================================
 // Ecowitt Cloud API Types
@@ -443,6 +444,8 @@ function parseEcowittHistory(histData: EcowittHistoryData, stationId: string) {
 interface ResultadoBackfillDia {
   ok: boolean;
   lecturas: number;
+  /** El día se dejó intacto porque reagregarlo habría bajado su cobertura. */
+  omitido?: boolean;
   error?: string;
 }
 
@@ -451,6 +454,10 @@ async function backfillUnDia(
   creds: { appKey: string; apiKey: string; mac: string },
   sb: { supabaseUrl: string; serviceKey: string },
   log: string,
+  /** `clima_resumen_diario.lecturas_count` de la fila que ya existe. Sólo lo
+   *  pasa el reintento automático (migración 121); el backfill manual lo deja
+   *  sin definir a propósito, porque es una acción humana deliberada. */
+  lecturasPrevias?: number | null,
 ): Promise<ResultadoBackfillDia> {
   const ecowittDateStr = formatEcowittDate(fecha);
 
@@ -491,6 +498,21 @@ async function backfillUnDia(
   const readings = parseEcowittHistory(response.data as EcowittHistoryData, creds.mac);
   if (readings.length === 0) {
     return { ok: false, lecturas: 0, error: '0 lecturas parseadas' };
+  }
+
+  // Guarda de no-empeorar (ver `clima-reagregacion.ts` para el mecanismo
+  // completo). El rollup agrega sobre `clima_lecturas`, que la migración 036
+  // poda a 24 h, así que reagregar un día viejo con una respuesta PARCIAL de
+  // Ecowitt baja su `lecturas_count` — y ése es exactamente el predicado del
+  // umbral de cobertura de la 103. Se comprueba acá, antes de insertar y antes
+  // del rollup, porque después de que el rollup corre la fila anterior ya no se
+  // puede reconstruir: las lecturas que la sostenían fueron podadas hace días.
+  if (!debeReagregarDia(readings.length, lecturasPrevias)) {
+    console.info(
+      `${log} ${ecowittDateStr}: Ecowitt devolvió ${readings.length} lectura(s) y la fila ya declara `
+      + `${lecturasPrevias} — se deja intacta (reagregar habría bajado la cobertura)`,
+    );
+    return { ok: true, lecturas: readings.length, omitido: true };
   }
 
   // Lecturas crudas -> clima_lecturas. `ignore-duplicates` sobre el
@@ -640,9 +662,18 @@ export async function handleClimaBackfill(c: Context): Promise<Response> {
 // Ecowitt sólo por los que todavía no tienen un dato confiable. Si la
 // estación ya se reconectó y Ecowitt tiene el día completo en su nube
 // (buffer local que sube al volver la luz/el internet), el día pasa a
-// 'ok' con el número real. Si Ecowitt TODAVÍA no lo tiene, el día queda
-// exactamente como estaba -- nunca se inventa un valor para forzar que
+// 'ok' con el número real. Nunca se inventa un valor para forzar que
 // "avance".
+//
+// Cuidado con lo que "queda como estaba" quiere decir. Con respuesta VACÍA
+// de Ecowitt es literal: no se escribe nada. Con respuesta PARCIAL no lo era
+// -- el rollup agrega sobre `clima_lecturas`, podada a 24 h por la migración
+// 036, así que reagregar un día viejo con menos lecturas de las que la fila
+// declara BAJABA su `lecturas_count`, que es el predicado del umbral de
+// cobertura de la 103. Pasó en producción con 2026-08-19 (167 -> 105) en la
+// primera corrida de este cron. Lo cierra `debeReagregarDia`, que se consulta
+// antes de tocar nada: un día sólo se reagrega si su cobertura no puede
+// retroceder.
 //
 // Importante sobre `contador_congelado`: a diferencia de `cobertura_parcial`
 // (un hueco de captura, justo lo que este reintento puede recuperar),
@@ -689,7 +720,7 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
     const queryUrl = `${sb.supabaseUrl}/rest/v1/clima_resumen_diario`
       + `?station_id=eq.${encodeURIComponent(creds.mac)}`
       + `&fecha=gte.${desdeStr}&fecha=lte.${ayerStr}`
-      + `&select=fecha,lluvia_confianza`;
+      + `&select=fecha,lluvia_confianza,lecturas_count`;
     const queryRes = await fetch(queryUrl, {
       headers: { apikey: sb.serviceKey, Authorization: `Bearer ${sb.serviceKey}` },
     });
@@ -698,18 +729,21 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
       console.error(`${log} No se pudo leer clima_resumen_diario (${queryRes.status}): ${body}`);
       return c.json({ error: 'No se pudo leer clima_resumen_diario', details: body }, 502);
     }
-    const filas: { fecha: string; lluvia_confianza: string }[] = await queryRes.json();
-    const confianzaPorFecha = new Map(filas.map((f) => [f.fecha, f.lluvia_confianza]));
+    const filas: { fecha: string; lluvia_confianza: string; lecturas_count: number | null }[] =
+      await queryRes.json();
+    const filaPorFecha = new Map(filas.map((f) => [f.fecha, f]));
 
-    const candidatos: Date[] = [];
+    // `lecturasPrevias` viaja con el candidato porque es lo que la guarda de
+    // no-empeorar necesita ver antes de reagregar (ver `backfillUnDia`).
+    const candidatos: { fecha: Date; lecturasPrevias: number | null }[] = [];
     for (let i = 0; i < DIAS_REINTENTO_SIN_DATO; i++) {
       const d = new Date(ayer.getTime() - i * 24 * 60 * 60 * 1000);
       const fechaStr = formatEcowittDate(d);
-      const confianza = confianzaPorFecha.get(fechaStr);
+      const fila = filaPorFecha.get(fechaStr);
       // Sin fila en absoluto ("sin_registro" del lado del frontend) o con
       // una confianza que hoy vale NULL -- las dos son candidatas.
-      if (confianza === undefined || CONFIANZAS_A_REINTENTAR.has(confianza)) {
-        candidatos.push(d);
+      if (fila === undefined || CONFIANZAS_A_REINTENTAR.has(fila.lluvia_confianza)) {
+        candidatos.push({ fecha: d, lecturasPrevias: fila?.lecturas_count ?? null });
       }
     }
 
@@ -718,14 +752,20 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
       return c.json({ message: 'Nada que reintentar', candidatos: 0 }, 200);
     }
 
-    console.info(`${log} ${candidatos.length} día(s) candidato(s): ${candidatos.map(formatEcowittDate).join(', ')}`);
+    console.info(`${log} ${candidatos.length} día(s) candidato(s): ${candidatos.map((cand) => formatEcowittDate(cand.fecha)).join(', ')}`);
 
-    const resultados: { fecha: string; consultaOk: boolean; error?: string }[] = [];
+    const resultados: { fecha: string; consultaOk: boolean; omitido?: boolean; error?: string }[] = [];
     for (const dia of candidatos) {
-      const r = await backfillUnDia(dia, creds, sb, log);
-      resultados.push({ fecha: formatEcowittDate(dia), consultaOk: r.ok, error: r.ok ? undefined : r.error });
+      const r = await backfillUnDia(dia.fecha, creds, sb, log, dia.lecturasPrevias);
+      resultados.push({
+        fecha: formatEcowittDate(dia.fecha),
+        consultaOk: r.ok,
+        omitido: r.omitido,
+        error: r.ok ? undefined : r.error,
+      });
       await sleep(150);
     }
+    const omitidos = resultados.filter((r) => r.omitido).length;
 
     // Se vuelve a preguntar a la base cuántos candidatos quedaron 'ok'
     // DESPUÉS del reintento -- "la consulta a Ecowitt no dio error" no es
@@ -744,17 +784,21 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
     });
     if (verifRes.ok) {
       const fechasOk = new Set(((await verifRes.json()) as { fecha: string }[]).map((f) => f.fecha));
-      resueltos = candidatos.filter((d) => fechasOk.has(formatEcowittDate(d))).length;
+      resueltos = candidatos.filter((d) => fechasOk.has(formatEcowittDate(d.fecha))).length;
     } else {
       console.warn(`${log} no se pudo verificar cuántos candidatos quedaron 'ok' tras el reintento`);
     }
 
-    console.info(`${log} ${resueltos ?? '?'}/${candidatos.length} día(s) resuelto(s) a 'ok' en esta corrida`);
+    console.info(
+      `${log} ${resueltos ?? '?'}/${candidatos.length} día(s) resuelto(s) a 'ok' en esta corrida`
+      + (omitidos > 0 ? `, ${omitidos} dejado(s) intacto(s) por cobertura menor` : ''),
+    );
 
     return c.json({
       message: 'Reintento completo',
       candidatos: candidatos.length,
       resueltos,
+      omitidos,
       resultados,
     }, 200);
   } catch (error) {


### PR DESCRIPTION
## Bug

Notion #53 (P2, `Clase = codigo`, `Esfuerzo = S`). The migration 121 retry cron (`POST /clima/reintentar-sin-dato`, 06:00 Bogotá) re-aggregates every candidate day from the Ecowitt History API **without ever comparing against the row that already exists**, so it can rewrite a historical aggregate downwards on a day it did not resolve.

Who hits it: nobody sees an error — the retry reports success. What degrades is `clima_resumen_diario.lecturas_count`, which **is** the predicate of migration 103's coverage threshold, so a partial Ecowitt response can push a better-classified day into `cobertura_parcial` and null out its rain. It runs daily.

Today's damage is nil (the two affected days, 2026-08-19/20, are the real farm blackout and stay `cobertura_parcial` with `lluvia_total_mm = 0,00` before and after). What is missing is the margin: the 21-day window is what limits the blast radius today, and that is a side effect of the constant `DIAS_REINTENTO_SIN_DATO = 21`, not a design decision.

## Evidence

**Production, verified twice — this is not a one-off.**

`CLAUDE.md` (migration 103, checked against production 2026-08-21): *«2026-08-19 quedó con `lecturas_count` = 167 de las 288 esperadas»*.

Today, read-only via the Supabase connector:

```sql
select fecha, lecturas_count, lluvia_confianza, lluvia_total_mm
from clima_resumen_diario
where station_id like '84:1F:E8:35:D8:73%' and fecha >= current_date - 21;
-- 2026-08-19 | 105 | cobertura_parcial | 0.00
-- 2026-08-20 |  32 | cobertura_parcial | 0.00
```

Edge function logs, first cron run (2026-08-27) and again this morning:

```
2026-08-28T11:00:01.737Z  [clima-reintento-sin-dato] 3 día(s) candidato(s): 2026-08-27, 2026-08-20, 2026-08-19
2026-08-28T11:00:12.583Z  [clima-reintento-sin-dato] 2026-08-19: 105 lecturas reagregadas
2026-08-28T11:00:19.434Z  [clima-reintento-sin-dato] 0/3 día(s) resuelto(s) a 'ok' en esta corrida
```

It rewrote the historical record **downwards on a day it explicitly reported as not resolved**, and it does so every morning.

## Root cause

`src/supabase/functions/server/clima.tsx` — the retry loop called `await backfillUnDia(dia, creds, sb, log)` per candidate with no reference to the existing row (the candidate query selected only `fecha, lluvia_confianza`). `backfillUnDia` inserts whatever the History API returns into `clima_lecturas` and re-runs `fn_clima_rollup_diario`, which aggregates **over that table** — the one migration 036 prunes to 24h. For an old day the original readings no longer exist, so the rollup sees only the freshly inserted ones and the count drops.

The endpoint's own comment asserted the opposite: *«Si Ecowitt TODAVÍA no lo tiene, el día queda exactamente como estaba»*. That holds for an **empty** response; for a **partial** one it overwrote.

## Fix

**Prevention, not detection.** A check placed after the rollup could observe the regression but could not undo it: the previous row was computed over readings that were pruned days ago, so there is nothing left to rebuild it from. The guard therefore runs *before* the insert and before the rollup.

- New pure module `clima-reagregacion.ts` exporting `debeReagregarDia(lecturasNuevas, lecturasPrevias)` — Deno-free so Vitest can import it, same pattern as `ganado-inventario.ts` / `hato-aggregation.ts`. Rule: no existing row → proceed; otherwise proceed only if `lecturasNuevas >= lecturasPrevias`.
- `backfillUnDia` gains an optional `lecturasPrevias` and returns `{ ok: true, omitido: true }` without touching anything when the guard says no. **The manual `/clima/backfill` route passes nothing and is unchanged** — it is a deliberate human action and it is what repaired history under migration 122.
- The retry handler selects `lecturas_count` alongside `lluvia_confianza`, carries it with each candidate, and reports `omitidos` in the JSON response and in the summary log line.
- Corrected the stale comment block.

Deliberately **not** duplicating migration 103's `240` threshold into TypeScript: the guard needs no knowledge of it, and a threshold living in two languages is exactly the divergence this codebase punishes elsewhere.

**Known, accepted cost** (documented in the module header): for a very recent day, `lecturas_count` can be inflated by 5-minute live rows still inside the 24h window, so a smaller history response is skipped. At most a marginal merge is lost — never a real recovery, which by definition brings *more* readings. The primary case the cron exists for (station reconnects, Ecowitt uploads its buffer) passes the guard untouched.

## Verification

Test added: `src/__tests__/climaReintentoNoEmpeora.test.ts` (10 tests) — six behavioural cases on `debeReagregarDia` including the production numbers, plus four wiring guards across both trees.

Written **before** the fix and run against a stub modelling the shipped behaviour (always re-aggregate). Pre-fix result — **5 failed / 5 passed**:

```
× NO reagrega cuando Ecowitt devuelve menos lecturas de las que la fila ya declara (2026-08-19: 167 -> 105)
    AssertionError: expected true to be false
× no reagrega si Ecowitt no devolvió ninguna lectura para un día que ya tenía cobertura
    AssertionError: expected true to be false
× la consulta de candidatos trae `lecturas_count` junto a `lluvia_confianza`
    expected '…' to contain 'select=fecha,lluvia_confianza,lecturas_count'
× `backfillUnDia` consulta la guarda ANTES de disparar `fn_clima_rollup_diario`
    no llama a debeReagregarDia: expected -1 to be greater than -1
× el comentario del endpoint ya no afirma que un día sin resolver queda intacto sin condición
```

Post-fix: 10/10 pass.

Full suite, from this branch:

```
npm test        Test Files  138 passed (138)   Tests  3083 passed (3083)
npm run lint    ✖ 908 problems (0 errors, 908 warnings)
npm run typecheck   clean
```

Both edge-function trees are byte-identical (`diff` returns nothing on `clima.tsx` and `clima-reagregacion.ts`), and the test asserts that so it cannot drift.

## ⚠️ Requires edge function redeploy after merge

`npx supabase functions deploy make-server-1ccce916` — **the merge alone changes nothing in production**; the cron keeps running the current bundle every morning at 06:00 Bogotá until the function is redeployed.

Nothing else is required: no migration, no secret, no cron change. The deploy is not blocked on any un-run DB half (the 105 trap) — `verificarAccesoClima` is already live and `CLIMA_SYNC_SECRET` is provisioned on both sides.

After deploying, the next 06:00 run should log `… día(s) resuelto(s) a 'ok' en esta corrida, N dejado(s) intacto(s) por cobertura menor` and `clima_resumen_diario.lecturas_count` for 2026-08-19/20 should stop moving.

## Rollback

Revert the commit and redeploy the edge function. No data was written by this change and no schema is touched.

## Follow-up (out of scope, not investigated)

- `clima_resumen_diario.station_id` for the Ecowitt series carries a **trailing space** (`'84:1F:E8:35:D8:73 '`), presumably from the `ECOWITT_MAC` secret. Harmless today (every writer and reader uses the same value) but any hand-written query matching the MAC exactly returns zero rows.
- 2026-08-27 shows `lecturas_count = 349` — more than the 288 a day can hold — because the retry merges history rows at timestamps offset from the live 5-minute rows. Worth a look separately; it is what makes the guard slightly conservative on very recent days.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_015B2L2D6A3pFqqRoaGw1187

---
_Generated by [Claude Code](https://claude.ai/code/session_015B2L2D6A3pFqqRoaGw1187)_