### PR TITLE
fix: toast de éxito al borrar contratista/lote filtrado por RLS (ESCO-46)

### DIFF
--- a/src/__tests__/deleteDevolvioFilas.test.ts
+++ b/src/__tests__/deleteDevolvioFilas.test.ts
@@ -1,0 +1,42 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { deleteDevolvioFilas } from '@/utils/supabase/deleteDevolvioFilas';
+
+/**
+ * ESCO-46: PostgREST DELETE + RLS. Sin `.select()`, un borrado filtrado
+ * vuelve `{ error: null }` y la UI toasteaba éxito. Con `.select()`,
+ * `data` vacío es la señal de que no se borró nada.
+ *
+ * Los componentes de Contratistas / Lotes / Sublotes no tienen harness de
+ * render en este repo. Se prueba el helper y se guarda que esos tres
+ * caminos lo usen después de `.delete().select()`.
+ */
+
+const SITIOS_DELETE = [
+  'components/empleados/Contratistas.tsx',
+  'components/configuracion/LotesConfig.tsx',
+  'components/configuracion/SublotesConfig.tsx',
+];
+
+describe('deleteDevolvioFilas', () => {
+  it('trata null/undefined/vacío como "no se borró nada"', () => {
+    expect(deleteDevolvioFilas(null)).toBe(false);
+    expect(deleteDevolvioFilas(undefined)).toBe(false);
+    expect(deleteDevolvioFilas([])).toBe(false);
+  });
+
+  it('trata una fila devuelta como borrado real', () => {
+    expect(deleteDevolvioFilas([{ id: '1' }])).toBe(true);
+  });
+});
+
+describe('ESCO-46: delete de contratista/lote/sublote verifica filas', () => {
+  it.each(SITIOS_DELETE)('%s llama .select() y deleteDevolvioFilas', (relativo) => {
+    const fuente = readFileSync(resolve(__dirname, '..', relativo), 'utf8');
+    expect(fuente).toContain('.delete()');
+    expect(fuente).toContain('.select()');
+    expect(fuente).toContain('deleteDevolvioFilas');
+    expect(fuente).toMatch(/No tienes permisos para eliminar/);
+  });
+});

--- a/src/components/configuracion/LotesConfig.tsx
+++ b/src/components/configuracion/LotesConfig.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getSupabase } from '../../utils/supabase/client';
+import { deleteDevolvioFilas } from '@/utils/supabase/deleteDevolvioFilas';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { Input } from '../ui/input';
@@ -167,6 +168,15 @@ export function LotesConfig() {
 
       if (error) {
         throw error;
+      }
+
+      // `.select()` ya estaba; faltaba mirar `data`. RLS (migración 114)
+      // filtra la fila y PostgREST devuelve `[]` sin error. ESCO-46.
+      if (!deleteDevolvioFilas(data)) {
+        toast.error('No tienes permisos para eliminar este lote.');
+        setDeleteDialogOpen(false);
+        setLoteToDelete(null);
+        return;
       }
       
       toast.success('Lote eliminado exitosamente');

--- a/src/components/configuracion/SublotesConfig.tsx
+++ b/src/components/configuracion/SublotesConfig.tsx
@@ -1,5 +1,6 @@
 import { useState, useEffect } from 'react';
 import { getSupabase } from '../../utils/supabase/client';
+import { deleteDevolvioFilas } from '@/utils/supabase/deleteDevolvioFilas';
 import { Button } from '../ui/button';
 import { Card } from '../ui/card';
 import { Input } from '../ui/input';
@@ -193,12 +194,21 @@ export function SublotesConfig() {
     if (!subloteToDelete) return;
 
     try {
-      const { error } = await supabase
+      // Mismo flujo que lotes (Configuración). Sin `.select()`, un DELETE
+      // filtrado por RLS se ve como éxito. ESCO-46.
+      const { data, error } = await supabase
         .from('sublotes')
         .delete()
-        .eq('id', subloteToDelete.id);
+        .eq('id', subloteToDelete.id)
+        .select();
 
       if (error) throw error;
+      if (!deleteDevolvioFilas(data)) {
+        toast.error('No tienes permisos para eliminar este sublote.');
+        setDeleteDialogOpen(false);
+        setSubloteToDelete(null);
+        return;
+      }
       
       toast.success('Sublote eliminado exitosamente');
       await cargarDatos();

--- a/src/components/empleados/Contratistas.tsx
+++ b/src/components/empleados/Contratistas.tsx
@@ -1,5 +1,6 @@
 import React, { useState, useEffect } from 'react';
 import { getSupabase } from '../../utils/supabase/client';
+import { deleteDevolvioFilas } from '@/utils/supabase/deleteDevolvioFilas';
 import { useFormPersistence } from '@/hooks/useFormPersistence';
 import { FormDraftBanner } from '@/components/shared/FormDraftBanner';
 import { ConfirmDialog } from '../ui/confirm-dialog';
@@ -203,10 +204,16 @@ const Contratistas: React.FC = () => {
         return;
       }
 
-      // Eliminar contratista
-      const { error } = await supabase.from('contratistas').delete().eq('id', id);
+      // Eliminar contratista. `.select()` es carga útil: sin él, RLS que
+      // filtra la fila (migración 114) vuelve `{ error: null }` y el toast
+      // de éxito miente. ESCO-46.
+      const { data, error } = await supabase.from('contratistas').delete().eq('id', id).select();
 
       if (error) throw error;
+      if (!deleteDevolvioFilas(data)) {
+        showAlert('error', 'No tienes permisos para eliminar este contratista.');
+        return;
+      }
 
       showAlert('success', 'Contratista eliminado exitosamente');
       await fetchContratistas();

--- a/src/utils/supabase/deleteDevolvioFilas.ts
+++ b/src/utils/supabase/deleteDevolvioFilas.ts
@@ -1,0 +1,12 @@
+/**
+ * PostgREST + RLS: un `.delete()` sin `.select()` reporta éxito cuando la
+ * política filtra la fila — `{ error: null, data: null }`. Con `.select()`
+ * (Prefer: return=representation) vuelve `{ error: null, data: [] }` si no
+ * se borró nada. El cliente JS no lanza en ninguno de los dos casos, así
+ * que "no hay error" no significa "se eliminó".
+ *
+ * Llamar después de `.delete().eq(...).select()`. ESCO-46.
+ */
+export function deleteDevolvioFilas(data: unknown[] | null | undefined): boolean {
+  return Array.isArray(data) && data.length > 0;
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## ESCO-46

Borrar un contratista o un lote mostraba toast de éxito aunque la base no hubiera borrado nada. Tras la migración 114 (RLS: DELETE solo Gerencia/Administrador) esto es más probable, no menos: el rol sin permiso queda filtrado en silencio y PostgREST responde `{ error: null }`.

Notion: [Deleting a contratista or a lote shows a success toast…](https://app.notion.com/p/Deleting-a-contratista-or-a-lote-shows-a-success-toast-when-RLS-silently-filters-the-row-out-and-m-3c667755ed6881879161e3a056daf06f)

## Qué se encontró

La hipótesis se confirma, con un matiz:

- **Contratistas** (`Contratistas.tsx`): `.delete()` **sin** `.select()`. `error === null` se trataba como éxito.
- **Lotes** (`LotesConfig.tsx`): ya tenía `.select()`, pero **no miraba `data`**. RLS filtra → `data = []` → toast de éxito igual.
- **Sublotes** (mismo flujo en Configuración): el mismo patrón que contratistas. Lo incluí porque es el delete hermano de lote en la misma pantalla.

No se tocó la migración 114 ni ninguna política RLS.

## Qué cambió

Helper `deleteDevolvioFilas()`: después de `.delete().select()`, exige `data.length > 0`. Si no, mensaje de permiso (copy existente: «No tienes permisos para eliminar este lote.» y equivalentes), no toast de éxito. El borrado real sigue mostrando éxito.

## Cómo verificar

1. **Éxito (Gerencia/Administrador):** borrar un contratista sin registros de trabajo, o un lote/sublote sin FKs → toast/alerta de éxito y la fila desaparece.
2. **Sin permiso:** con un rol que SELECT sí y DELETE no (p. ej. Verificador, o cualquier autenticado que no sea Gerencia/Administrador tras 114): confirmar el borrado → **no** debe aparecer «eliminado exitosamente»; sí «No tienes permisos para eliminar este…». Recargar: la fila sigue.
3. Tests: `npx vitest run src/__tests__/deleteDevolvioFilas.test.ts`

@sforero94 para review.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-13a5a30b-1639-4438-8810-575848ae5397?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-13a5a30b-1639-4438-8810-575848ae5397&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

