### PR TITLE
fix(telegram): skip unlinked subscribers when resolving alert recipients

### DIFF
--- a/src/__tests__/telegramDestinatarioVinculadoGuard.test.ts
+++ b/src/__tests__/telegramDestinatarioVinculadoGuard.test.ts
@@ -1,0 +1,84 @@
+/**
+ * Guarda estatica: ningun resolvedor de destinatarios de Telegram puede
+ * empujar el `telegram_id` de un usuario SIN VINCULAR.
+ *
+ * `telegram_usuarios.telegram_id` es NULL mientras la persona no canjea su
+ * codigo de vinculacion. Una suscripcion en `telegram_alertas_suscripciones`
+ * se puede crear antes de ese canje, asi que un suscrito puede estar
+ * `activo = true` y con `telegram_id` en NULL a la vez. `String(null)` es la
+ * cadena "null", que se cuela en la lista de destinatarios como si fuera un
+ * chat real.
+ *
+ * El dano no es el envio fallido, es lo que ese fantasma tapa: los trabajos
+ * del tick de la ronda reclaman su clave en `rondas_avisos` ANTES de enviar
+ * (§8.1 del brief tecnico), y solo se saltan el reclamo cuando
+ * `destinatarios.length === 0`. Un destinatario fantasma hace que ese guardia
+ * nunca dispare, el aviso queda marcado como enviado y no se reintenta jamas.
+ *
+ * `obtenerDestinatariosModuloRonda` (telegram/ronda-helpers.ts) ya lo filtra
+ * con `.not('telegram_id', 'is', null)` y entra en la lista como control
+ * positivo: si algun dia se le quitara el filtro, este test tambien se pone
+ * rojo.
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+const RAIZ = resolve(__dirname, '../..');
+
+/** Cada entrada: fichero + la funcion que resuelve destinatarios en el. */
+const RESOLVEDORES: ReadonlyArray<{ fichero: string; funcion: string }> = [
+  { fichero: 'src/supabase/functions/server/ronda-inventario-tick.ts', funcion: 'resolverDestinatarios' },
+  { fichero: 'supabase/functions/make-server-1ccce916/ronda-inventario-tick.ts', funcion: 'resolverDestinatarios' },
+  { fichero: 'src/supabase/functions/server/hato-alertas-tick.ts', funcion: 'resolverFilasSuscripcion' },
+  { fichero: 'supabase/functions/make-server-1ccce916/hato-alertas-tick.ts', funcion: 'resolverFilasSuscripcion' },
+  { fichero: 'src/supabase/functions/server/telegram/ronda-helpers.ts', funcion: 'obtenerDestinatariosModuloRonda' },
+  { fichero: 'supabase/functions/make-server-1ccce916/telegram/ronda-helpers.ts', funcion: 'obtenerDestinatariosModuloRonda' },
+];
+
+/** Quita comentarios de linea y de bloque para no aceptar una guarda que solo
+ * existe dentro de un comentario que la explica. */
+function sinComentarios(fuente: string): string {
+  return fuente.replace(/\/\*[\s\S]*?\*\//g, '').replace(/^[ \t]*\/\/.*$/gm, '');
+}
+
+/** Cuerpo aproximado de la funcion: desde su declaracion hasta la siguiente
+ * declaracion de nivel superior. Suficiente para una guarda estatica. */
+function cuerpoDeFuncion(fuente: string, funcion: string): string | null {
+  const inicio = fuente.search(new RegExp(`(async\\s+)?function\\s+${funcion}\\b`));
+  if (inicio === -1) return null;
+  const resto = fuente.slice(inicio);
+  const siguiente = resto.slice(1).search(/^(export\s+)?(async\s+)?(function|const|interface|type)\s/m);
+  return siguiente === -1 ? resto : resto.slice(0, siguiente + 1);
+}
+
+/** Una guarda valida: comparacion explicita contra null/undefined, o el
+ * filtro de PostgREST `.not('...telegram_id', 'is', null)`. */
+const GUARDA = /telegram_id\s*(?:===|==|!==|!=)\s*(?:null|undefined)|\.not\(\s*['"][\w.]*telegram_id['"]\s*,\s*['"]is['"]\s*,\s*null\s*\)/;
+
+describe('destinatarios de Telegram: nunca un usuario sin vincular', () => {
+  it('la lista de resolvedores no esta vacia', () => {
+    expect(RESOLVEDORES.length).toBeGreaterThan(0);
+  });
+
+  for (const { fichero, funcion } of RESOLVEDORES) {
+    it(`${fichero} :: ${funcion} filtra telegram_id nulo`, () => {
+      const fuente = sinComentarios(readFileSync(resolve(RAIZ, fichero), 'utf-8'));
+
+      // Non-vacuous: la funcion tiene que existir de verdad.
+      expect(fuente).toContain(funcion);
+      const cuerpo = cuerpoDeFuncion(fuente, funcion);
+      expect(cuerpo, `no se encontro el cuerpo de ${funcion} en ${fichero}`).not.toBeNull();
+
+      // Y tiene que mencionar telegram_id, o el cuerpo extraido no es el bueno.
+      expect(cuerpo!).toContain('telegram_id');
+
+      expect(
+        GUARDA.test(cuerpo!),
+        `${funcion} en ${fichero} empuja un telegram_id sin comprobar que no sea NULL. ` +
+          'Un suscrito activo pero sin vincular entra como destinatario "null".',
+      ).toBe(true);
+    });
+  }
+});

--- a/src/supabase/functions/server/hato-alertas-tick.ts
+++ b/src/supabase/functions/server/hato-alertas-tick.ts
@@ -172,6 +172,10 @@ function resolverFilasSuscripcion(filas: FilaSuscripcionCruda[]): FilaSuscripcio
     .map((f) => {
       const usuario = Array.isArray(f.telegram_usuarios) ? f.telegram_usuarios[0] : f.telegram_usuarios;
       if (usuario == null) return null;
+      // Sin vincular todavia => `telegram_id` NULL => `String(null)` = "null",
+      // un destinatario fantasma. Ver el mismo guardia en
+      // ronda-inventario-tick.ts y en telegram/ronda-helpers.ts.
+      if (usuario.telegram_id === null || usuario.telegram_id === undefined) return null;
       return {
         alerta_clave: f.alerta_clave,
         recibe: f.recibe,

--- a/src/supabase/functions/server/ronda-inventario-tick.ts
+++ b/src/supabase/functions/server/ronda-inventario-tick.ts
@@ -162,6 +162,14 @@ async function resolverDestinatarios(sb: SupabaseClient, claveAlerta: string, mo
   for (const fila of (data ?? []) as FilaSuscripcionCruda[]) {
     const usuario = Array.isArray(fila.telegram_usuarios) ? fila.telegram_usuarios[0] : fila.telegram_usuarios;
     if (!usuario) continue;
+    // Un suscrito ACTIVO pero todavia SIN VINCULAR tiene `telegram_id` en NULL:
+    // `String(null)` es la cadena "null", que se cuela como destinatario
+    // fantasma. Eso derrota el guardia `destinatarios.length === 0` de los tres
+    // trabajos que reclaman su clave en `rondas_avisos` ANTES de enviar, asi
+    // que el aviso queda marcado como enviado y no se reintenta nunca. Mismo
+    // criterio que `obtenerDestinatariosModuloRonda` en telegram/ronda-helpers.ts,
+    // que ya filtra con `.not('telegram_id', 'is', null)`.
+    if (usuario.telegram_id === null || usuario.telegram_id === undefined) continue;
     if (moduloExigido && !(usuario.modulos_permitidos ?? []).includes(moduloExigido)) continue;
     destinatarios.push(String(usuario.telegram_id));
   }

--- a/supabase/functions/make-server-1ccce916/hato-alertas-tick.ts
+++ b/supabase/functions/make-server-1ccce916/hato-alertas-tick.ts
@@ -172,6 +172,10 @@ function resolverFilasSuscripcion(filas: FilaSuscripcionCruda[]): FilaSuscripcio
     .map((f) => {
       const usuario = Array.isArray(f.telegram_usuarios) ? f.telegram_usuarios[0] : f.telegram_usuarios;
       if (usuario == null) return null;
+      // Sin vincular todavia => `telegram_id` NULL => `String(null)` = "null",
+      // un destinatario fantasma. Ver el mismo guardia en
+      // ronda-inventario-tick.ts y en telegram/ronda-helpers.ts.
+      if (usuario.telegram_id === null || usuario.telegram_id === undefined) return null;
       return {
         alerta_clave: f.alerta_clave,
         recibe: f.recibe,

--- a/supabase/functions/make-server-1ccce916/ronda-inventario-tick.ts
+++ b/supabase/functions/make-server-1ccce916/ronda-inventario-tick.ts
@@ -162,6 +162,14 @@ async function resolverDestinatarios(sb: SupabaseClient, claveAlerta: string, mo
   for (const fila of (data ?? []) as FilaSuscripcionCruda[]) {
     const usuario = Array.isArray(fila.telegram_usuarios) ? fila.telegram_usuarios[0] : fila.telegram_usuarios;
     if (!usuario) continue;
+    // Un suscrito ACTIVO pero todavia SIN VINCULAR tiene `telegram_id` en NULL:
+    // `String(null)` es la cadena "null", que se cuela como destinatario
+    // fantasma. Eso derrota el guardia `destinatarios.length === 0` de los tres
+    // trabajos que reclaman su clave en `rondas_avisos` ANTES de enviar, asi
+    // que el aviso queda marcado como enviado y no se reintenta nunca. Mismo
+    // criterio que `obtenerDestinatariosModuloRonda` en telegram/ronda-helpers.ts,
+    // que ya filtra con `.not('telegram_id', 'is', null)`.
+    if (usuario.telegram_id === null || usuario.telegram_id === undefined) continue;
     if (moduloExigido && !(usuario.modulos_permitidos ?? []).includes(moduloExigido)) continue;
     destinatarios.push(String(usuario.telegram_id));
   }


### PR DESCRIPTION
## Bug

`telegram_usuarios.telegram_id` es NULL mientras la persona no canjea su código de vinculación, pero una fila de `telegram_alertas_suscripciones` se puede crear antes de ese canje. Los dos resolvedores de destinatarios de los ticks empujaban `String(usuario.telegram_id)` sin comprobarlo, así que un suscrito **activo pero sin vincular** entraba en la lista como la cadena literal `"null"`.

**Ocurrió en producción el 2026-09-01.** Uriel Parada (`activo=true`, `telegram_id IS NULL`, alta el 2026-08-28) está suscrito con `recibe=true` a las tres alertas `inventario.*`:

```sql
SELECT s.alerta_clave, u.nombre_display, u.activo, (u.telegram_id IS NULL) AS sin_vincular
FROM telegram_alertas_suscripciones s
JOIN telegram_usuarios u ON u.id = s.telegram_usuario_id
WHERE s.recibe AND u.activo AND u.telegram_id IS NULL;
-- inventario.reporte_cierre     | Uriel Parada | t | t
-- inventario.revision_dia_15    | Uriel Parada | t | t
-- inventario.ronda_recordatorio | Uriel Parada | t | t
```

El recordatorio de la ronda de septiembre quedó registrado como enviado:

```sql
SELECT clave, enviado_en FROM rondas_avisos ORDER BY enviado_en;
-- recordatorio:2026-09 | 2026-09-01 12:00:03.149862+00
```

y a día de hoy (2026-09-03) `rondas_inventario` sigue teniendo **una sola** fila, la de `2026-08-01`, ya `cerrada`. La ronda de septiembre no está abierta y el recordatorio no se reintentará.

## Root cause

`src/supabase/functions/server/ronda-inventario-tick.ts:150` (`resolverDestinatarios`) y `src/supabase/functions/server/hato-alertas-tick.ts:170` (`resolverFilasSuscripcion`) filtran únicamente `telegram_usuarios.activo = true`. Ninguno comprueba `telegram_id`, y `String(null)` es `"null"`.

**El daño no es el envío fallido — `enviarATodos` ya tolera un fallo puntual. Es lo que el fantasma tapa.** Los trabajos de recordatorio y del día 15 reclaman su clave en `rondas_avisos` **antes** de enviar (§8.1 del brief técnico) y sólo se saltan el reclamo cuando `destinatarios.length === 0`. Un destinatario fantasma hace que ese guardia no dispare nunca: la clave queda reclamada, el aviso se da por enviado y no se reintenta. El propio código documenta ese trade-off en `ronda-inventario-tick.ts:246-251`, asumiendo que la lista vacía es el único caso — y un `telegram_id` nulo la deja no vacía sin que haya nadie del otro lado.

El contrato correcto ya existe en este mismo módulo: `obtenerDestinatariosModuloRonda` (`telegram/ronda-helpers.ts:611`) filtra con `.not('telegram_id', 'is', null)`. Los dos ticks son los que se quedaron atrás.

## Fix

Una comprobación explícita de `null`/`undefined` antes de empujar el `telegram_id`, en los dos resolvedores y en los dos árboles de edge function (4 ficheros, 2 líneas efectivas). No cambia a quién se le manda nada: sólo deja de fabricar un destinatario que no existe.

**Los dos sitios van en el mismo PR a propósito.** Es un mecanismo con dos puntos de llamada sobre la misma tabla, no dos defectos: arreglar uno y dejar la línea idéntica al lado es exactamente lo que regenera el hallazgo. Hoy sólo el de la ronda tiene consecuencia observada — no hay ningún suscrito del hato sin vincular —, así que el del hato es latente.

## Verification

Guarda estática nueva: `src/__tests__/telegramDestinatarioVinculadoGuard.test.ts`, siguiendo el patrón de `dialogScrollContract` / `movimientoInventarioResponsable`. Cubre los 6 ficheros (los 2 resolvedores × 2 árboles + `ronda-helpers.ts` × 2 como **control positivo**, que ya pasaba).

- **Rojo antes**: con los 4 ficheros como están en `origin/main` → **4 fallan, 3 pasan** (los 3 que pasan son el control positivo y el chequeo de lista no vacía, o sea que el test no pasa en vacío).
- **Verde después**: 7/7.
- Strippea comentarios antes de buscar, para no aceptar una guarda que sólo viva en el comentario que la explica; y exige que el cuerpo de la función exista y mencione `telegram_id` antes de evaluar nada.

Suite completa sobre la rama:

```
tsc --noEmit   limpio
npm run lint   0 errores / 900 warnings
npx vitest run 155 ficheros / 3393 tests, todo verde
```

(Línea base `main@297a230`: 154 / 3386. El delta es exactamente esta guarda.)

## Rollback

`git revert` del commit. Sin migración, sin cambio de datos, sin cambio de esquema.

## Deploy

**Toca los dos árboles de edge function, así que no surte efecto hasta desplegar:** `npx supabase functions deploy make-server-1ccce916`. Los dos árboles quedan sincronizados (verificado con `tail -n +2` + `diff -w`).

## Follow-up — deliberadamente fuera de alcance

1. **El recordatorio de septiembre ya se perdió y este arreglo no lo recupera.** La clave `recordatorio:2026-09` está reclamada. Reenviarlo es un borrado de una fila de `rondas_avisos` — `datos`, no `codigo` — y va como propuesta aparte, no en este PR.
2. **Uriel sigue sin vincular** (su `codigo_expira_at` vence el 2026-09-04) y **David García no tiene el módulo `inventario_explicacion`**. Las dos son operativas y ya estaban señaladas en el cuerpo del PR #188.
3. **No se toca el orden reclamar-antes-de-enviar.** Es una decisión de diseño documentada en §8.1; este PR sólo deja de derrotar el guardia que la protege.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01FiBvSQJZAu7RtEeQT8tQBu

---
_Generated by [Claude Code](https://claude.ai/code/session_01FiBvSQJZAu7RtEeQT8tQBu)_