### PR TITLE
fix(inventario): never derive a negative physical count in the ronda preview

### DIFF
--- a/src/__tests__/rondaInventarioInterpretacion.test.ts
+++ b/src/__tests__/rondaInventarioInterpretacion.test.ts
@@ -360,6 +360,60 @@ describe('adversarial: "faltan 3" sin cantidad física dictada -> derivado, rotu
     };
     expect(derivarFisico(hallazgo, 8)).toEqual({ estado: 'incompleto' });
   });
+
+  // Caso LITERAL de la primera ronda real (`rondas_transcritos`
+  // `98e62e81-a5a2-48ea-ba08-e785ac8f75a0`): el intérprete leyó «Tres bultos
+  // de 50 kilos de 15-15-15» como un FALTANTE de 150 kg sobre un teórico de
+  // 0, y el preview mostró `fisico: -150`. El signo estaba invertido -- lo
+  // narrado era un sobrante de +150 -- pero eso no se puede adivinar acá.
+  // Una existencia física negativa no existe, así que la resta sólo es un
+  // físico válido cuando no cruza el cero. Se devuelve `incompleto` en vez
+  // de recortar a 0: un 0 recortado es una cifra plausible que esconde una
+  // lectura mala, y el módulo prefiere siempre el camino más controlado
+  // (R-18) -- Uriel corrige y vuelve a confirmar.
+  it('faltante mayor que el teórico -> incompleto, nunca un físico negativo (caso real de la ronda de agosto)', () => {
+    const hallazgo: HallazgoCrudo = {
+      productoMencionado: '15-15-15',
+      productoConfianza: 'alta',
+      fragmentoLiteral: 'Tres bultos de 50 kilos de 15-15-15',
+      cantidadFisicaPresente: false,
+      cantidadFisica: 0,
+      cantidadFaltantePresente: true,
+      cantidadFaltante: 150,
+      causaClave: '',
+      causaConfianza: 'ninguna',
+      explicacionDavidCitada: '',
+    };
+
+    expect(derivarFisico(hallazgo, 0)).toEqual({ estado: 'incompleto' });
+
+    // Y el preview que se arma con eso NO se puede confirmar: la fila queda
+    // con `fisico: null`, así que `previewConfirmable` deja el botón
+    // [Confirmar] apagado y Uriel tiene que corregir por texto (A-9).
+    const alcance: ProductoEnAlcanceConTeorico[] = [
+      { productoId: 'p-15', nombre: '15-15-15', teoricoFoto: 0 },
+    ];
+    const fila = resolverFilaPreview(hallazgo, alcance);
+    expect(fila.fisico).toBeNull();
+    expect(fila.fisicoOrigen).toBeNull();
+    expect(previewConfirmable(construirPreview([fila]))).toBe(false);
+  });
+
+  it('el faltante que llega EXACTO al teórico sigue siendo un físico válido de 0', () => {
+    const hallazgo: HallazgoCrudo = {
+      productoMencionado: 'Martillos',
+      productoConfianza: 'alta',
+      fragmentoLiteral: 'faltan los 8 martillos',
+      cantidadFisicaPresente: false,
+      cantidadFisica: 0,
+      cantidadFaltantePresente: true,
+      cantidadFaltante: 8,
+      causaClave: '',
+      causaConfianza: 'ninguna',
+      explicacionDavidCitada: '',
+    };
+    expect(derivarFisico(hallazgo, 8)).toEqual({ estado: 'resuelto', fisico: 0, origen: 'derivado' });
+  });
 });
 
 describe('adversarial: producto no catalogado -> observación libre, no un hallazgo', () => {

--- a/src/supabase/functions/server/rondaInventario/interpretarNota.ts
+++ b/src/supabase/functions/server/rondaInventario/interpretarNota.ts
@@ -428,20 +428,35 @@ export type ResolucionFisico =
  *   1. `cantidadFisicaPresente` -> fisico = cantidadFisica, origen = 'dictado'.
  *   2. si no, `cantidadFaltantePresente` -> fisico = teoricoFoto - cantidadFaltante,
  *      origen = 'derivado'. El preview lo rotula "derivado" -- nunca se
- *      presenta como si Uriel lo hubiera dictado (CA-31).
+ *      presenta como si Uriel lo hubiera dictado (CA-31). **Sólo si la resta
+ *      no cruza el cero**: una existencia física negativa no existe, así que
+ *      un faltante mayor que el teórico significa que la lectura está mal, no
+ *      que haya menos que nada.
  *   3. si no -> el hallazgo queda incompleto y NO se puede confirmar hasta
  *      que Uriel dé la cifra (no se adivina un físico).
  *
  * `teoricoFoto` es el de `rondas_inventario_alcance` (la foto congelada de
  * R-5), nunca un número que el modelo haya dicho -- el esquema de salida ni
  * siquiera tiene esa ranura (D-T8).
+ *
+ * POR QUÉ `incompleto` Y NO UN RECORTE A 0. Un 0 recortado es una cifra
+ * plausible: se confirma sin fricción y entra como excepción a un registro de
+ * trazabilidad que Gerencia firma, escondiendo que el intérprete leyó mal.
+ * `incompleto` reusa el camino que ya existe (fila con `fisico: null` ->
+ * `previewConfirmable` en falso -> «Falta identificar o completar algún
+ * hallazgo antes de poder confirmar») y obliga a corregir, que es el sesgo
+ * hacia la vía más controlada del módulo (R-18). Caso real que lo motivó:
+ * «Tres bultos de 50 kilos de 15-15-15» sobre un teórico de 0 produjo
+ * `fisico: -150`, con el signo invertido -- lo narrado era un sobrante.
  */
 export function derivarFisico(hallazgo: HallazgoCrudo, teoricoFoto: number): ResolucionFisico {
   if (hallazgo.cantidadFisicaPresente) {
     return { estado: 'resuelto', fisico: hallazgo.cantidadFisica, origen: 'dictado' };
   }
   if (hallazgo.cantidadFaltantePresente) {
-    return { estado: 'resuelto', fisico: teoricoFoto - hallazgo.cantidadFaltante, origen: 'derivado' };
+    const derivado = teoricoFoto - hallazgo.cantidadFaltante;
+    if (derivado < 0) return { estado: 'incompleto' };
+    return { estado: 'resuelto', fisico: derivado, origen: 'derivado' };
   }
   return { estado: 'incompleto' };
 }

--- a/src/utils/rondaInventario/interpretarNota.ts
+++ b/src/utils/rondaInventario/interpretarNota.ts
@@ -411,20 +411,35 @@ export type ResolucionFisico =
  *   1. `cantidadFisicaPresente` -> fisico = cantidadFisica, origen = 'dictado'.
  *   2. si no, `cantidadFaltantePresente` -> fisico = teoricoFoto - cantidadFaltante,
  *      origen = 'derivado'. El preview lo rotula "derivado" -- nunca se
- *      presenta como si Uriel lo hubiera dictado (CA-31).
+ *      presenta como si Uriel lo hubiera dictado (CA-31). **Sólo si la resta
+ *      no cruza el cero**: una existencia física negativa no existe, así que
+ *      un faltante mayor que el teórico significa que la lectura está mal, no
+ *      que haya menos que nada.
  *   3. si no -> el hallazgo queda incompleto y NO se puede confirmar hasta
  *      que Uriel dé la cifra (no se adivina un físico).
  *
  * `teoricoFoto` es el de `rondas_inventario_alcance` (la foto congelada de
  * R-5), nunca un número que el modelo haya dicho -- el esquema de salida ni
  * siquiera tiene esa ranura (D-T8).
+ *
+ * POR QUÉ `incompleto` Y NO UN RECORTE A 0. Un 0 recortado es una cifra
+ * plausible: se confirma sin fricción y entra como excepción a un registro de
+ * trazabilidad que Gerencia firma, escondiendo que el intérprete leyó mal.
+ * `incompleto` reusa el camino que ya existe (fila con `fisico: null` ->
+ * `previewConfirmable` en falso -> «Falta identificar o completar algún
+ * hallazgo antes de poder confirmar») y obliga a corregir, que es el sesgo
+ * hacia la vía más controlada del módulo (R-18). Caso real que lo motivó:
+ * «Tres bultos de 50 kilos de 15-15-15» sobre un teórico de 0 produjo
+ * `fisico: -150`, con el signo invertido -- lo narrado era un sobrante.
  */
 export function derivarFisico(hallazgo: HallazgoCrudo, teoricoFoto: number): ResolucionFisico {
   if (hallazgo.cantidadFisicaPresente) {
     return { estado: 'resuelto', fisico: hallazgo.cantidadFisica, origen: 'dictado' };
   }
   if (hallazgo.cantidadFaltantePresente) {
-    return { estado: 'resuelto', fisico: teoricoFoto - hallazgo.cantidadFaltante, origen: 'derivado' };
+    const derivado = teoricoFoto - hallazgo.cantidadFaltante;
+    if (derivado < 0) return { estado: 'incompleto' };
+    return { estado: 'resuelto', fisico: derivado, origen: 'derivado' };
   }
   return { estado: 'incompleto' };
 }

--- a/supabase/functions/make-server-1ccce916/rondaInventario/interpretarNota.ts
+++ b/supabase/functions/make-server-1ccce916/rondaInventario/interpretarNota.ts
@@ -428,20 +428,35 @@ export type ResolucionFisico =
  *   1. `cantidadFisicaPresente` -> fisico = cantidadFisica, origen = 'dictado'.
  *   2. si no, `cantidadFaltantePresente` -> fisico = teoricoFoto - cantidadFaltante,
  *      origen = 'derivado'. El preview lo rotula "derivado" -- nunca se
- *      presenta como si Uriel lo hubiera dictado (CA-31).
+ *      presenta como si Uriel lo hubiera dictado (CA-31). **Sólo si la resta
+ *      no cruza el cero**: una existencia física negativa no existe, así que
+ *      un faltante mayor que el teórico significa que la lectura está mal, no
+ *      que haya menos que nada.
  *   3. si no -> el hallazgo queda incompleto y NO se puede confirmar hasta
  *      que Uriel dé la cifra (no se adivina un físico).
  *
  * `teoricoFoto` es el de `rondas_inventario_alcance` (la foto congelada de
  * R-5), nunca un número que el modelo haya dicho -- el esquema de salida ni
  * siquiera tiene esa ranura (D-T8).
+ *
+ * POR QUÉ `incompleto` Y NO UN RECORTE A 0. Un 0 recortado es una cifra
+ * plausible: se confirma sin fricción y entra como excepción a un registro de
+ * trazabilidad que Gerencia firma, escondiendo que el intérprete leyó mal.
+ * `incompleto` reusa el camino que ya existe (fila con `fisico: null` ->
+ * `previewConfirmable` en falso -> «Falta identificar o completar algún
+ * hallazgo antes de poder confirmar») y obliga a corregir, que es el sesgo
+ * hacia la vía más controlada del módulo (R-18). Caso real que lo motivó:
+ * «Tres bultos de 50 kilos de 15-15-15» sobre un teórico de 0 produjo
+ * `fisico: -150`, con el signo invertido -- lo narrado era un sobrante.
  */
 export function derivarFisico(hallazgo: HallazgoCrudo, teoricoFoto: number): ResolucionFisico {
   if (hallazgo.cantidadFisicaPresente) {
     return { estado: 'resuelto', fisico: hallazgo.cantidadFisica, origen: 'dictado' };
   }
   if (hallazgo.cantidadFaltantePresente) {
-    return { estado: 'resuelto', fisico: teoricoFoto - hallazgo.cantidadFaltante, origen: 'derivado' };
+    const derivado = teoricoFoto - hallazgo.cantidadFaltante;
+    if (derivado < 0) return { estado: 'incompleto' };
+    return { estado: 'resuelto', fisico: derivado, origen: 'derivado' };
   }
   return { estado: 'incompleto' };
 }


### PR DESCRIPTION
## Bug

Finding ESCO-60 (P2, `clase: codigo`). The ronda de inventario interpreter can derive a **negative physical count**, and the preview accepts it: `[Confirmar]` stays enabled, so a nonsense figure can be persisted into `rondas_excepciones` — a traceability record Gerencia signs.

Who hits it: Uriel, on any voice note where the interpreter reads a *faltante* larger than the frozen theoretical of that product. Since the module shipped (2026-08-28); the six post-launch commits on `src/utils/rondaInventario/` never touched `derivarFisico`.

**Live proof, first real ronda.** `rondas_transcritos` id `98e62e81-a5a2-48ea-ba08-e785ac8f75a0`, preview `filas[0]`:

```json
{"fisico": -150, "unidad": "Kilos", "teorico": 0, "fisicoOrigen": "derivado", "nombreProducto": "15-15-15"}
```

The narration was «Tres bultos de 50 kilos de 15-15-15» — three 50 kg sacks physically **in** the warehouse but not in the system, i.e. a surplus of **+150**. The sign was inverted, and the module happily offered `-150` for confirmation.

**What this bug is NOT.** An earlier version of this finding claimed a `-150` would reach `fn_ronda_aplicar_ajuste` and post a negative movement against real stock. That was **refuted** against the live function bodies and is not re-asserted here: migration 132 added `IF v_cantidad_confirmada < 0 THEN RAISE EXCEPTION` to `fn_ronda_proponer_ajuste`, and `fn_ronda_aplicar_ajuste` aborts when `v_nuevo < 0`. Two independent server-side guards. `productos.cantidad_actual` is not at risk. The residual damage is a nonsense number displayed and storable in the exception record.

## Root cause

`src/utils/rondaInventario/interpretarNota.ts:426-428` (at `origin/main` `01e3690`):

```ts
if (hallazgo.cantidadFaltantePresente) {
  return { estado: 'resuelto', fisico: teoricoFoto - hallazgo.cantidadFaltante, origen: 'derivado' };
}
```

The subtraction has no floor and no `'incompleto'` branch for negatives. A negative then flows straight through:

- `resolverHallazgos.ts:177` copies it into `FilaPreview.fisico`.
- `preview.ts:85-88` — `previewConfirmable` is literally `f.productoIdentificado && f.fisico !== null`, and `-150 !== null`, so `[Confirmar]` stays enabled.
- `rondas_excepciones.cantidad_fisica` is `NUMERIC NOT NULL` with **no `CHECK >= 0`** (verified against `pg_constraint`), and `fn_ronda_confirmar_hallazgos` validates only `IF v_cantidad_fisica IS NULL` (verified against the live `pg_get_functiondef`). So a `-150` would be accepted and stored.

## Fix

One branch in `derivarFisico`:

```ts
const derivado = teoricoFoto - hallazgo.cantidadFaltante;
if (derivado < 0) return { estado: 'incompleto' };
return { estado: 'resuelto', fisico: derivado, origen: 'derivado' };
```

This is the minimal change because it reuses machinery that already exists: `resolverHallazgo` maps `'incompleto'` to `fisico: null` **and** `paraConfirmar: null`, and `previewConfirmable` already refuses a `null` físico. So the preview renders the line that is already written for this case — «Falta identificar o completar algún hallazgo antes de poder confirmar. Corrige por texto.» — and Uriel corrects instead of confirming a guess. **`previewConfirmable` needed no change**, and no Telegram file was touched.

**It deliberately does NOT clamp to 0.** A clamped 0 is a plausible figure: it confirms with no friction and hides a bad interpretation inside a signed traceability record. `'incompleto'` is the module's documented bias toward the more controlled path (R-18).

`teoricoFoto - cantidadFaltante === 0` is untouched and still a valid físico of 0 — a test pins that, so the guard cannot drift into rejecting a legitimate empty shelf.

## Verification

Test extended: `src/__tests__/rondaInventarioInterpretacion.test.ts`, two cases in the existing `derivarFisico` describe — the literal live case (teórico 0, faltante 150), asserting `incompleto` **and** that the resulting preview is not confirmable end to end; plus the boundary case (faltante === teórico → físico 0, still `resuelto`).

Red before the fix, on the exact live value:

```
FAIL  faltante mayor que el teórico -> incompleto, nunca un físico negativo
AssertionError: expected { estado: 'resuelto', …(2) } to deeply equal { estado: 'incompleto' }
- Expected: { "estado": "incompleto" }
+ Received: { "estado": "resuelto", "fisico": -150, "origen": "derivado" }
Tests  1 failed | 28 passed (29)
```

Green after:

- `npx vitest run` — **157 files / 3435 tests, all green** (was 157/3433 on `main`; +2 new).
- `npm run lint` — **0 errors**, 906 warnings (all pre-existing).
- `npx tsc --noEmit` — clean.
- `rondaInventarioParidadServidor.test.ts` green, and `regenerar-copias-ronda-inventario.py --check` reports «OK: 16 copias al día con el generador».

## Edge function

`src/utils/rondaInventario/` is mirrored into both edge-function trees. The two copies were **regenerated** with `docs/inventario/regenerar-copias-ronda-inventario.py`, never hand-edited.

**This PR requires an edge function redeploy to take effect** — the interpreter runs server-side in the voice pipeline:

```
npx supabase functions deploy make-server-1ccce916
```

## Rollback

`git revert` the commit, then regenerate the copies and redeploy the edge function. No migration, no data change, no schema change — nothing to undo in the database.

## Follow-up (deliberately out of scope)

The filed action also proposed the **server-side half**: a sign guard inside `fn_ronda_confirmar_hallazgos` plus `ALTER TABLE rondas_excepciones ADD CONSTRAINT excepcion_fisico_no_negativo CHECK (cantidad_fisica >= 0)`. That is a `ddl_aditivo` change and this finding is classified `codigo`, so it is **not** included here — no migration file ships in this PR.

It still looks warranted, and the reason is stated plainly: this PR closes the only *known* producer of a negative, but the database still accepts one from any other writer. The live `fn_ronda_confirmar_hallazgos` body checks only `IS NULL`, and the column has no `CHECK`. Migration 132 already set the precedent for exactly this guard one state later in the machine (`fn_ronda_proponer_ajuste`), so the confirm step is the asymmetric gap. Expected rows affected: **zero** — the only `rondas_excepciones` row in production is `cantidad_fisica = 3`, `fisico_origen = 'dictado'` (the `-150` preview was corrected by Uriel and never confirmed).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011smCQ79t6Lv9xk822XKa3D

---
_Generated by [Claude Code](https://claude.ai/code/session_011smCQ79t6Lv9xk822XKa3D)_