### PR TITLE
fix: log the days the clima retry cron fails to recover

### DIFF
--- a/src/__tests__/climaReintentoDiaFallidoLog.test.ts
+++ b/src/__tests__/climaReintentoDiaFallidoLog.test.ts
@@ -1,0 +1,111 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+
+/**
+ * Un día que FALLA en el reintento diario del clima (migración 121) tiene que
+ * dejar su propia línea en los logs de la edge function.
+ *
+ * Qué pasó, con fechas y números de producción:
+ *
+ *  - **2026-08-28 no tiene fila en `clima_resumen_diario`.** Sus vecinos sí
+ *    (08-27 con 349 lecturas, 08-29 con 311), así que no es una caída de varios
+ *    días: es exactamente uno.
+ *  - El cron `clima-reintento-sin-dato` (jobid 8) corrió los días 08-29, 08-30,
+ *    08-31, 09-01, 09-02, 09-03 y 09-04, las siete veces `succeeded`, y el día
+ *    sigue sin fila.
+ *  - El log de la corrida del 2026-09-04 11:00 UTC lista **4 candidatos**:
+ *    `2026-08-28, 2026-08-27, 2026-08-20, 2026-08-19`. Tres de los cuatro dejan
+ *    línea propia (`2026-08-19: 105 lecturas reagregadas`, `2026-08-20: 32
+ *    lecturas reagregadas`, `2026-08-27: … se deja intacta`). **El 2026-08-28
+ *    no aparece en ninguna línea.** El resumen dice `0/4 día(s) resuelto(s) a
+ *    'ok' en esta corrida, 1 dejado(s) intacto(s) por cobertura menor`: tres
+ *    días quedan explicados y el cuarto se evapora.
+ *
+ * Mecanismo: el bucle de candidatos mete `r.error` en el array `resultados` del
+ * cuerpo de la respuesta HTTP y no lo escribe a la consola. Ese cuerpo no llega
+ * a ningún lado — `pg_net` corta a los 5.000 ms y guarda `content = NULL`
+ * (verificado en `net._http_response` id 48883, 2026-09-04 11:00:00 UTC), y
+ * `pg_cron` igual reporta `succeeded` porque sólo registra que encoló.
+ *
+ * Consecuencia, y es la que importa: desde fuera **no se distingue «Ecowitt
+ * tampoco tiene el día» de «la llamada dio error»**. Un día irrecuperable y un
+ * día que nadie intentó se ven idénticos, indefinidamente.
+ *
+ * El bucle del backfill MANUAL (`/clima/backfill`) sí registra cada fallo con
+ * `console.warn(\`${'${log}'} ${'${dateStr}'}: ${'${resultado.error}'}\`)`. Esta prueba exige la
+ * misma simetría en el camino automático, que es el único que corre solo.
+ *
+ * Es una guarda ESTÁTICA porque el endpoint vive del lado de Deno: montarlo en
+ * Vitest exigiría simular Hono, `Deno.env` y cuatro `fetch` distintos para
+ * comprobar una línea de log. La misma decisión que ya tomaron
+ * `climaTablaCorrectaGuard`, `climaFrescuraGuard` y `climaReintentoNoEmpeora`.
+ */
+
+const RAIZ = resolve(__dirname, '..', '..');
+const COPIAS_CLIMA = [
+  'src/supabase/functions/server/clima.tsx',
+  'supabase/functions/make-server-1ccce916/clima.tsx',
+];
+
+function leer(rel: string): string {
+  return readFileSync(resolve(RAIZ, rel), 'utf-8');
+}
+
+/**
+ * El cuerpo del bucle de candidatos: desde la llamada a `backfillUnDia` hasta
+ * el `resultados.push(` que la sigue. Acotarlo importa — el fichero tiene otros
+ * `console.error`, y ninguno de ellos habla de un día candidato.
+ */
+function cuerpoDelBucleDeCandidatos(src: string, rel: string): string {
+  const iLlamada = src.indexOf('const r = await backfillUnDia(');
+  expect(iLlamada, `${rel}: no se encontró el bucle de candidatos del reintento`).toBeGreaterThan(-1);
+  const iPush = src.indexOf('resultados.push(', iLlamada);
+  expect(iPush, `${rel}: no se encontró el push de resultados`).toBeGreaterThan(iLlamada);
+  return src.slice(iLlamada, iPush);
+}
+
+describe('clima.tsx — un día que falla en el reintento deja rastro en los logs', () => {
+  it('el bucle de candidatos registra el fallo en la consola, no sólo en el cuerpo de la respuesta', () => {
+    for (const rel of COPIAS_CLIMA) {
+      const bloque = cuerpoDelBucleDeCandidatos(leer(rel), rel);
+      expect(
+        bloque,
+        `${rel}: un día con r.ok === false no escribe nada a la consola; el error muere en el cuerpo HTTP que pg_net descarta`,
+      ).toMatch(/if\s*\(!r\.ok\)[\s\S]*console\.(error|warn)/);
+    }
+  });
+
+  it('la línea nombra el día que falló, para poder distinguirlo de los demás candidatos', () => {
+    for (const rel of COPIAS_CLIMA) {
+      const bloque = cuerpoDelBucleDeCandidatos(leer(rel), rel);
+      expect(
+        bloque,
+        `${rel}: la línea de fallo no incluye la fecha del candidato`,
+      ).toContain('formatEcowittDate(dia.fecha)');
+    }
+  });
+
+  it('la línea incluye el motivo que devolvió `backfillUnDia`', () => {
+    for (const rel of COPIAS_CLIMA) {
+      const bloque = cuerpoDelBucleDeCandidatos(leer(rel), rel);
+      const conLog = bloque.slice(bloque.search(/console\.(error|warn)/));
+      expect(
+        conLog,
+        `${rel}: la línea de fallo no dice por qué falló (r.error)`,
+      ).toContain('r.error');
+    }
+  });
+
+  it('la línea lleva el prefijo `${log}`, así que sale junto a las demás del reintento', () => {
+    for (const rel of COPIAS_CLIMA) {
+      const bloque = cuerpoDelBucleDeCandidatos(leer(rel), rel);
+      const conLog = bloque.slice(bloque.search(/console\.(error|warn)/));
+      expect(conLog, `${rel}: la línea de fallo no lleva el prefijo del endpoint`).toContain('${log}');
+    }
+  });
+
+  it('las dos copias del árbol de edge function siguen idénticas', () => {
+    expect(leer(COPIAS_CLIMA[0])).toBe(leer(COPIAS_CLIMA[1]));
+  });
+});

--- a/src/supabase/functions/server/clima.tsx
+++ b/src/supabase/functions/server/clima.tsx
@@ -757,6 +757,11 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
     const resultados: { fecha: string; consultaOk: boolean; omitido?: boolean; error?: string }[] = [];
     for (const dia of candidatos) {
       const r = await backfillUnDia(dia.fecha, creds, sb, log, dia.lecturasPrevias);
+      // El cuerpo de la respuesta no llega a ningún lado: pg_net corta a los
+      // 5 s y guarda `content = NULL`, y pg_cron reporta `succeeded` igual.
+      // Sin esta línea, un día que falla NO deja rastro y no se distingue de
+      // uno que nadie intentó (2026-08-28: 7 reintentos, 0 líneas de log).
+      if (!r.ok) console.error(`${log} ${formatEcowittDate(dia.fecha)}: NO recuperado -- ${r.error}`);
       resultados.push({
         fecha: formatEcowittDate(dia.fecha),
         consultaOk: r.ok,

--- a/supabase/functions/make-server-1ccce916/clima.tsx
+++ b/supabase/functions/make-server-1ccce916/clima.tsx
@@ -757,6 +757,11 @@ export async function handleClimaReintentoSinDato(c: Context): Promise<Response>
     const resultados: { fecha: string; consultaOk: boolean; omitido?: boolean; error?: string }[] = [];
     for (const dia of candidatos) {
       const r = await backfillUnDia(dia.fecha, creds, sb, log, dia.lecturasPrevias);
+      // El cuerpo de la respuesta no llega a ningún lado: pg_net corta a los
+      // 5 s y guarda `content = NULL`, y pg_cron reporta `succeeded` igual.
+      // Sin esta línea, un día que falla NO deja rastro y no se distingue de
+      // uno que nadie intentó (2026-08-28: 7 reintentos, 0 líneas de log).
+      if (!r.ok) console.error(`${log} ${formatEcowittDate(dia.fecha)}: NO recuperado -- ${r.error}`);
       resultados.push({
         fecha: formatEcowittDate(dia.fecha),
         consultaOk: r.ok,


### PR DESCRIPTION
## Finding — ESCO-64 (P2, `codigo`, Confianza Alta, Esfuerzo S)

2026-08-28 is entirely absent from `clima_resumen_diario`, and the daily self-repair cron fails on it **silently**.

`handleClimaReintentoSinDato` (migration 121) puts `r.error` into the `resultados` array of the HTTP response body and never writes it to the console. That body reaches nobody: `pg_net` times out at 5.000 ms and stores `content = NULL`, and `pg_cron` still reports `succeeded`.

**Consequence, and it is the one that matters:** from outside, *"Ecowitt does not have the day either"* and *"the call errored"* look identical, indefinitely. An unrecoverable day and a day nobody attempted are indistinguishable.

## Evidence (read-only, reproduced 2026-09-04)

**1. The day is missing and its neighbours are not.**

```sql
select fecha, lecturas_count, lluvia_total_mm, lluvia_confianza
from clima_resumen_diario where fecha between '2026-08-26' and '2026-08-30' order by fecha;
```
```
2026-08-26 | 287 | 0.25 | ok
2026-08-27 | 349 | 0.00 | cobertura_parcial
2026-08-29 | 311 | 0.00 | ok          <-- 2026-08-28 is absent
2026-08-30 | 288 | 0.00 | ok
```
`select count(*) from clima_resumen_diario where fecha='2026-08-28'` → **0**, checked 2026-09-04 11:27 UTC.

**2. Seven cron runs, all `succeeded`, and the day is still missing.** `cron.job_run_details` for jobid 8 (`clima-reintento-sin-dato`, `0 11 * * *`, `active = true`): 08-29, 08-30, 08-31, 09-01, 09-02, 09-03 and **09-04** — seven `succeeded`, `return_message = "1 row"`.

**3. `pg_net` discards the response.** `net._http_response` id `48883`, created 2026-09-04 11:00:00.033 UTC:
```
status_code = NULL
error_msg   = Timeout of 5000 ms reached. Total time: 5001.323000 ms
content     = NULL   (null, not empty)
```

**4. The edge function logs prove the discard — this is the decisive artifact.** Function logs of the same run (`query_logs`, `source = 'function_logs'`, 2026-09-04 11:00:03 → 11:00:07 UTC):

```
[clima-reintento-sin-dato] 4 día(s) candidato(s): 2026-08-28, 2026-08-27, 2026-08-20, 2026-08-19
[clima-reintento-sin-dato] 2026-08-27: Ecowitt devolvió 162 lectura(s) y la fila ya declara 349 — se deja intacta
[clima-reintento-sin-dato] 2026-08-20: 32 lecturas reagregadas
[clima-reintento-sin-dato] 2026-08-19: 105 lecturas reagregadas
[clima-reintento-sin-dato] 0/4 día(s) resuelto(s) a 'ok' en esta corrida, 1 dejado(s) intacto(s) por cobertura menor
--> POST /make-server-1ccce916/clima/reintentar-sin-dato 200 4s
```

Three of the four candidates leave their own line. **2026-08-28 leaves none.** The summary accounts for three days and the fourth evaporates.

**5. The asymmetry that makes this a defect and not a design choice.** The manual `/clima/backfill` loop already logs every failure (`clima.tsx:625`, `console.warn(\`${log} ${dateStr}: ${resultado.error}\`)`). Only the automatic path — the one that runs unattended — is silent.

## What changed

One line, in both edge-function trees, byte-identical, inside the candidate loop of `handleClimaReintentoSinDato`:

```ts
if (!r.ok) console.error(`${log} ${formatEcowittDate(dia.fecha)}: NO recuperado -- ${r.error}`);
```

- `src/supabase/functions/server/clima.tsx`
- `supabase/functions/make-server-1ccce916/clima.tsx`
- `src/__tests__/climaReintentoDiaFallidoLog.test.ts` (new)

No refactor. The rain-confidence logic of migrations 068 / 103 / 115 / 122 is untouched, and no threshold changed. **Rows affected: 0.**

## The test

`climaReintentoDiaFallidoLog.test.ts` is a **static guard**, the same pattern as `climaTablaCorrectaGuard`, `climaFrescuraGuard` and `climaReintentoNoEmpeora`: the endpoint lives on the Deno side, and exercising it at runtime would need Hono, `Deno.env` and four distinct `fetch` mocks to assert one log line. It reads both copies of `clima.tsx`, isolates the candidate-loop body, and asserts the failure branch logs to the console with the date, the reason and the `${log}` prefix. It also asserts the two trees stay identical.

It was written **before** the fix and confirmed red:

```
Tests  4 failed | 1 passed (5)
AssertionError: la línea de fallo no dice por qué falló (r.error): expected ' ' to contain 'r.error'
```

After the fix: `5 passed`.

## How it was verified

| Gate | Result |
|---|---|
| `npm run lint` | **0 errors**, 906 warnings (unchanged pre-existing baseline) |
| `npm run typecheck` | clean |
| `npm test` | **158 files / 3438 tests, all passing** |
| Tree sync | `diff` of the two `clima.tsx` copies is empty; `md5sum` identical |

## Rollback

Revert the commit. The change is one log line plus one test file; there is no data, schema or behaviour change to undo.

## ⚠️ REDEPLOY REQUIRED

This touches `supabase/functions/**`. Merging does **not** make it live:

```
npx supabase functions deploy make-server-1ccce916
```

**Verify the deploy by CONTENT of the bundle, never by `list_edge_functions.updated_at`.** A successful deploy from a stale checkout increments the version and moves `updated_at` anyway — that happened twice in three days (v223 on 2026-08-28, v236 on 2026-08-30). Before deploying, `git fetch && git checkout <sha of main>`. After deploying, `get_edge_function` → save to a file → grep for `NO recuperado` (the new identifier) **plus a positive control that already existed** (e.g. `dejado(s) intacto(s) por cobertura menor`) — without the control, "0 occurrences" cannot distinguish an old version from a bundle that carries no source. `ezbr_sha256` must also move; a deploy that does not move the hash deployed nothing.

## What this PR deliberately does NOT do

It does not attempt to recover 2026-08-28. Firing `POST /make-server-1ccce916/clima/backfill` **writes domain data**, so it is out of scope for an unattended run and was not called. That step is left for Santiago — see the note in the run report.

**It has a deadline.** `DIAS_REINTENTO_SIN_DATO = 21` (`clima.tsx:692`), so 2026-08-28 stops being a candidate after **2026-09-18**. The raw `clima_lecturas` were pruned by the 24 h window long ago, so Ecowitt's History API is the only remaining path.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011smCQ79t6Lv9xk822XKa3D

---
_Generated by [Claude Code](https://claude.ai/code/session_011smCQ79t6Lv9xk822XKa3D)_