### PR TITLE
fix(inventario): bound the ronda draft's text-correction window to 30 minutes

### DIFF
--- a/src/__tests__/rondaBorradorVentanaCorreccion.test.ts
+++ b/src/__tests__/rondaBorradorVentanaCorreccion.test.ts
@@ -1,0 +1,136 @@
+// ARCHIVO: __tests__/rondaBorradorVentanaCorreccion.test.ts
+// DESCRIPCIÓN: Regresión de ESCO-62 — un borrador `preview_pendiente` de la
+// ronda de inventario se tragaba TODO mensaje de texto posterior de ese
+// usuario de Telegram, SIN NINGÚN LÍMITE DE EDAD.
+//
+// Evidencia viva (`rondas_transcritos`, id 98e62e81-…, consultada
+// 2026-09-04, la fila sigue igual):
+//
+//   created_at 2026-08-28T23:29:21.471Z   estado sin_confirmar   intentos 4
+//   correcciones[0] 2026-08-28T23:29:51.043Z  «Si, es 15 15 15, un fertilizante»
+//   correcciones[1] 2026-08-29T02:15:11.797Z  «Cuéntame qué pasó esta semana …»
+//   correcciones[2] 2026-08-29T02:15:39.394Z  «Cómo nos fue esta semana …»
+//
+// Las dos últimas son preguntas para Esco, no correcciones de inventario:
+// llegaron 2 h 45 min DESPUÉS de la nota de voz y el bucle de preview las
+// consumió igual (`bot.ts` nunca llama `next()` cuando hay un pendiente).
+// Agotaron `MAX_INTENTOS_PREVIEW` y el hallazgo narrado terminó
+// `sin_confirmar` — la línea «1 hallazgo(s) narrado(s) sin confirmar» del
+// reporte de cierre de esa ronda ES esa pérdida.
+//
+// El arreglo acota la consulta de `obtenerTranscritoPendienteMasReciente`
+// con una ventana de `MINUTOS_VENTANA_CORRECCION_TEXTO`. NO muta la fila
+// (CA-37: un borrador sin confirmar sobrevive a un redespliegue y sigue
+// contando como hallazgo narrado sin confirmar; nunca expira solo) — deja
+// de CAPTURAR texto, nada más.
+//
+// Este archivo tiene dos mitades:
+//   1. Unit sobre los helpers puros de `@/utils/rondaInventario/preview`.
+//   2. Guard estático sobre los DOS árboles de edge function: ni
+//      `ronda-helpers.ts` ni `bot.ts` se pueden importar desde vitest
+//      (importan `jsr:@supabase/supabase-js@2` y `grammy`), así que la
+//      protección contra una regresión ahí es textual.
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { join } from 'node:path';
+import {
+  MINUTOS_VENTANA_CORRECCION_TEXTO,
+  limiteVentanaCorreccionTexto,
+  correccionPorTextoVigente,
+  horaBogota,
+} from '@/utils/rondaInventario/preview';
+
+/** La fila real de la traza, en UTC. */
+const CREADO_EN = '2026-08-28T23:29:21.471Z';
+const CORRECCION_LEGITIMA = '2026-08-28T23:29:51.043Z'; // +30 s
+const PREGUNTA_A_ESCO_1 = '2026-08-29T02:15:11.797Z'; // +2 h 45 min 50 s
+const PREGUNTA_A_ESCO_2 = '2026-08-29T02:15:39.394Z'; // +2 h 46 min 18 s
+
+describe('ESCO-62 — ventana de vigencia del borrador para correcciones por texto', () => {
+  it('la ventana es de 30 minutos', () => {
+    expect(MINUTOS_VENTANA_CORRECCION_TEXTO).toBe(30);
+  });
+
+  it('la corrección legítima de la traza (+30 s) SÍ cae dentro de la ventana', () => {
+    expect(correccionPorTextoVigente(CREADO_EN, new Date(CORRECCION_LEGITIMA))).toBe(true);
+  });
+
+  it('las dos preguntas a Esco de la traza (+2 h 45 min) quedan FUERA de la ventana', () => {
+    expect(correccionPorTextoVigente(CREADO_EN, new Date(PREGUNTA_A_ESCO_1))).toBe(false);
+    expect(correccionPorTextoVigente(CREADO_EN, new Date(PREGUNTA_A_ESCO_2))).toBe(false);
+  });
+
+  it('el borde es inclusivo a los 30 min exactos y excluyente un milisegundo después', () => {
+    const creado = new Date(CREADO_EN).getTime();
+    const treintaMin = MINUTOS_VENTANA_CORRECCION_TEXTO * 60 * 1000;
+    expect(correccionPorTextoVigente(CREADO_EN, new Date(creado + treintaMin))).toBe(true);
+    expect(correccionPorTextoVigente(CREADO_EN, new Date(creado + treintaMin + 1))).toBe(false);
+  });
+
+  it('limiteVentanaCorreccionTexto devuelve el instante ISO desde el que un borrador sigue capturando texto', () => {
+    const ahora = new Date('2026-08-29T02:15:11.797Z');
+    expect(limiteVentanaCorreccionTexto(ahora)).toBe('2026-08-29T01:45:11.797Z');
+    // Y el borrador de la traza queda por debajo de ese corte, que es
+    // exactamente lo que hace que el `.gte('created_at', …)` no lo devuelva.
+    expect(CREADO_EN < limiteVentanaCorreccionTexto(ahora)).toBe(true);
+  });
+
+  it('horaBogota convierte el instante UTC de la nota a la hora de pared del verificador', () => {
+    // 23:29 UTC = 18:29 en Bogotá (UTC-5, sin horario de verano).
+    expect(horaBogota(CREADO_EN)).toBe('18:29');
+    // Cruce de día hacia atrás: 02:15 UTC del 29 son las 21:15 del 28.
+    expect(horaBogota(PREGUNTA_A_ESCO_1)).toBe('21:15');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Guard estático sobre los dos árboles de edge function
+// ---------------------------------------------------------------------------
+
+const ARBOLES_EDGE = [
+  'src/supabase/functions/server',
+  'supabase/functions/make-server-1ccce916',
+];
+
+function leer(arbol: string, relativo: string): string {
+  return readFileSync(join(process.cwd(), arbol, relativo), 'utf8');
+}
+
+/** Cuerpo de `obtenerTranscritoPendienteMasReciente` — desde su declaración
+ * hasta el siguiente `export ` del archivo. */
+function cuerpoDelHelper(fuente: string): string {
+  const inicio = fuente.indexOf('export async function obtenerTranscritoPendienteMasReciente');
+  expect(inicio).toBeGreaterThan(-1);
+  const siguiente = fuente.indexOf('\nexport ', inicio + 1);
+  return fuente.slice(inicio, siguiente === -1 ? undefined : siguiente);
+}
+
+describe('ESCO-62 — guard estático: la consulta del borrador pendiente está acotada en el tiempo', () => {
+  for (const arbol of ARBOLES_EDGE) {
+    it(`${arbol}/telegram/ronda-helpers.ts acota por created_at con la constante compartida`, () => {
+      const cuerpo = cuerpoDelHelper(leer(arbol, 'telegram/ronda-helpers.ts'));
+      // Sin este predicado, un borrador de hace tres horas (o tres días)
+      // sigue interceptando cada mensaje de texto del verificador.
+      expect(cuerpo).toContain(".gte('created_at'");
+      expect(cuerpo).toContain('limiteVentanaCorreccionTexto()');
+      // El `created_at` tiene que venir en el SELECT: el aviso de
+      // intercepción le dice a Uriel de qué nota se trata.
+      expect(cuerpo).toContain('actor_telegram_id, created_at');
+    });
+
+    it(`${arbol}/telegram/ronda-helpers.ts importa la ventana del módulo puro, no la redefine`, () => {
+      const fuente = leer(arbol, 'telegram/ronda-helpers.ts');
+      expect(fuente).toContain('limiteVentanaCorreccionTexto');
+      expect(fuente).toContain("from '../rondaInventario/preview.ts'");
+    });
+
+    it(`${arbol}/telegram/bot.ts avisa que está tomando el texto como corrección`, () => {
+      const fuente = leer(arbol, 'telegram/bot.ts');
+      // La intercepción nunca es silenciosa mientras sigue vigente: el
+      // mensaje nombra la hora de la nota y la salida ("cancelar").
+      expect(fuente).toContain('como corrección de tu nota de las');
+      expect(fuente).toContain('horaBogota(');
+    });
+  }
+});

--- a/src/supabase/functions/server/rondaInventario/preview.ts
+++ b/src/supabase/functions/server/rondaInventario/preview.ts
@@ -246,3 +246,82 @@ export const MAX_INTENTOS_PREVIEW = 4;
 export function intentosPreviewAgotados(intentosPreview: number): boolean {
   return intentosPreview >= MAX_INTENTOS_PREVIEW;
 }
+
+// ---------------------------------------------------------------------------
+// Ventana de vigencia del borrador como destinatario de una corrección por
+// TEXTO LIBRE (ESCO-62)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minutos durante los que un borrador `preview_pendiente` sigue capturando
+ * el texto libre que su autor mande a continuación (§7.3: "el texto libre
+ * que Uriel mande después ES la corrección").
+ *
+ * Existe porque esa captura NO tenía ningún límite de edad: la consulta de
+ * `obtenerTranscritoPendienteMasReciente` filtraba sólo por actor + estado,
+ * y el handler de `bot.ts` consume el mensaje (nunca cede el turno) cada vez
+ * que esa consulta devuelve una fila. Caso real, `rondas_transcritos`
+ * 98e62e81-…: una nota de las 23:29 UTC del 2026-08-28 se comió dos
+ * preguntas para Esco de las 02:15 del 29 -- **2 h 45 min después** --, las
+ * reinterpretó como correcciones, agotó `MAX_INTENTOS_PREVIEW` y dejó el
+ * hallazgo narrado en `sin_confirmar`. El propio usuario volvió a preguntar
+ * lo mismo por la web 4 min 30 s más tarde (`chat_messages`), que es la
+ * prueba de que nunca quiso corregir nada.
+ *
+ * 30 minutos es **decisión de la operación de mantenimiento, pendiente de
+ * confirmación de Santiago**: es holgadamente mayor que cualquier tiempo de
+ * confirmación observado (la única nota confirmada de la primera ronda real
+ * se resolvió en un intento) y bastante menor que las 2 h 45 min del caso
+ * que rompió.
+ *
+ * Lo que esta ventana NO hace: **no muta la fila**. El borrador sigue en
+ * `preview_pendiente`, sobrevive a un redespliegue y sigue contando como
+ * "hallazgo narrado sin confirmar" en el reporte de cierre (CA-37). Deja de
+ * INTERCEPTAR texto, nada más. Los botones [Confirmar]/[Descartar]/[Deshacer]
+ * llevan su propio `transcrito_id` en el `callback_data` y no pasan por esta
+ * ventana -- siguen funcionando con el borrador tan viejo como sea.
+ */
+export const MINUTOS_VENTANA_CORRECCION_TEXTO = 30;
+
+/**
+ * Instante ISO (UTC) a partir del cual un borrador todavía captura texto:
+ * lo que va como `.gte('created_at', …)` en la consulta del pendiente.
+ *
+ * Devuelve el `toISOString()` COMPLETO, nunca recortado a `AAAA-MM-DD` --
+ * `rondas_transcritos.created_at` es `timestamptz` y la comparación es de
+ * instantes, no de días calendario (por eso no aplica la trampa "hoy" del
+ * CLAUDE.md raíz, que es sobre recortar la fecha).
+ */
+export function limiteVentanaCorreccionTexto(ahora: Date = new Date()): string {
+  return new Date(ahora.getTime() - MINUTOS_VENTANA_CORRECCION_TEXTO * 60 * 1000).toISOString();
+}
+
+/**
+ * `true` si el borrador creado en `creadoEn` todavía está dentro de la
+ * ventana. Misma regla que `limiteVentanaCorreccionTexto`, expresada del
+ * lado del dato en vez del lado de la consulta -- el borde de los 30 min
+ * exactos es INCLUSIVO en las dos (`>=`), para que la fila que la base
+ * devuelve y la que este predicado acepta sean siempre la misma.
+ */
+export function correccionPorTextoVigente(creadoEn: string, ahora: Date = new Date()): boolean {
+  const creado = new Date(creadoEn).getTime();
+  if (Number.isNaN(creado)) return false;
+  return creado >= new Date(limiteVentanaCorreccionTexto(ahora)).getTime();
+}
+
+/**
+ * Hora de pared en Bogotá, 'HH:MM', de un instante ISO. Mismo criterio de
+ * conversión que `primerDiaMesBogota()`/`hoyBogota()` (Bogotá es UTC-5 sin
+ * horario de verano; no se usa `Intl` con timezone para no depender de la
+ * tzdata del runtime de Deno).
+ *
+ * Sólo para MOSTRAR: es lo que hace que el aviso de intercepción nombre la
+ * nota concreta ("tu nota de las 18:29") en vez de dejar al verificador
+ * adivinando cuál de sus mensajes se está reinterpretando.
+ */
+export function horaBogota(iso: string): string {
+  const bogota = new Date(new Date(iso).getTime() - 5 * 60 * 60 * 1000);
+  const hh = String(bogota.getUTCHours()).padStart(2, '0');
+  const mm = String(bogota.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}

--- a/src/supabase/functions/server/telegram/bot.ts
+++ b/src/supabase/functions/server/telegram/bot.ts
@@ -79,6 +79,7 @@ import {
   construirPreview,
   construirTextoConCorrecciones,
   formatearCantidad,
+  horaBogota,
   intentosPreviewAgotados,
   MAX_INTENTOS_PREVIEW,
   previewConfirmable,
@@ -2106,6 +2107,16 @@ function getBot(): Bot<BotContext> {
       await ctx.reply("La lectura por voz no está disponible ahora mismo. Avisa a un administrador.");
       return;
     }
+
+    // ESCO-62: la intercepcion nunca es silenciosa mientras la ventana sigue
+    // vigente. Antes, un texto cualquiera desaparecia dentro del bucle de
+    // preview sin que el verificador supiera que lo estaban leyendo como una
+    // correccion de una nota anterior -- y la unica salida ("cancelar", commit
+    // 2516b3f) exigia conocer la palabra de antemano. Ahora el mensaje nombra
+    // la nota concreta por su hora y ofrece la salida en el mismo renglon.
+    await ctx.reply(
+      `Estoy tomando esto como corrección de tu nota de las ${horaBogota(pendiente.created_at)} -- escribe cancelar si no era eso.`,
+    );
 
     await ctx.replyWithChatAction("typing");
 

--- a/src/supabase/functions/server/telegram/ronda-helpers.ts
+++ b/src/supabase/functions/server/telegram/ronda-helpers.ts
@@ -29,7 +29,7 @@
 
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2';
 import type { FilaPreview } from '../rondaInventario/preview.ts';
-import { formatearCantidad } from '../rondaInventario/preview.ts';
+import { formatearCantidad, limiteVentanaCorreccionTexto } from '../rondaInventario/preview.ts';
 import type { AlcanceItem, HallazgoParaConfirmar, ProductoFueraDeAlcance } from '../rondaInventario/resolverHallazgos.ts';
 import type { CasoExcepcion, CasoProponer, CasoSantiago } from '../rondaInventario/resolucion.ts';
 import { buscarCausaRaiz } from '../rondaInventario/causasRaiz.ts';
@@ -162,6 +162,10 @@ export interface TranscritoRondaRow {
   intentos_preview: number;
   estado: 'preview_pendiente' | 'confirmado' | 'sin_confirmar' | 'descartado';
   actor_telegram_id: string | null;
+  /** Instante de creacion del borrador. Lo consume la ventana de vigencia
+   * de `obtenerTranscritoPendienteMasReciente` y el aviso de interceptacion
+   * de `bot.ts`, que nombra la hora de la nota. */
+  created_at: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -306,16 +310,32 @@ export async function obtenerResumenExcepcionesRonda(
  * la más reciente, que es la que Uriel tiene fresca en la cabeza. Los
  * botones [Confirmar]/[Descartar]/[Deshacer] de CADA mensaje siguen
  * llevando su propio `transcrito_id` en el `callback_data` y no dependen de
- * esta función. */
+ * esta función.
+ *
+ * ACOTADO EN EL TIEMPO (ESCO-62): sólo devuelve el borrador si se creó
+ * dentro de `MINUTOS_VENTANA_CORRECCION_TEXTO` (ver `preview.ts`). Sin ese
+ * `.gte`, la consulta filtraba únicamente por actor + estado y el handler de
+ * `bot.ts` consume el mensaje siempre que devuelve fila: un borrador sin
+ * confirmar de hace horas se tragaba en silencio cada texto posterior de ese
+ * usuario. Caso real 98e62e81-…: dos preguntas para Esco de 2 h 45 min
+ * después entraron como correcciones, agotaron `MAX_INTENTOS_PREVIEW` y
+ * dejaron el hallazgo narrado en `sin_confirmar`.
+ *
+ * La fila NO se toca (CA-37): sigue `preview_pendiente`, sobrevive a un
+ * redespliegue y sigue contando como hallazgo narrado sin confirmar en el
+ * reporte de cierre. Lo único que caduca es su capacidad de INTERCEPTAR
+ * texto libre -- los botones, que llevan su `transcrito_id`, siguen
+ * funcionando por `obtenerTranscritoPorId` sin ninguna ventana. */
 export async function obtenerTranscritoPendienteMasReciente(
   supabase: SupabaseClient,
   telegramUsuarioId: string,
 ): Promise<TranscritoRondaRow | null> {
   const { data, error } = await supabase
     .from('rondas_transcritos')
-    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id')
+    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id, created_at')
     .eq('actor_telegram_id', telegramUsuarioId)
     .eq('estado', 'preview_pendiente')
+    .gte('created_at', limiteVentanaCorreccionTexto())
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle();
@@ -329,7 +349,7 @@ export async function obtenerTranscritoPendienteMasReciente(
 export async function obtenerTranscritoPorId(supabase: SupabaseClient, transcritoId: string): Promise<TranscritoRondaRow | null> {
   const { data, error } = await supabase
     .from('rondas_transcritos')
-    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id')
+    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id, created_at')
     .eq('id', transcritoId)
     .maybeSingle();
   if (error) {

--- a/src/utils/rondaInventario/preview.ts
+++ b/src/utils/rondaInventario/preview.ts
@@ -229,3 +229,82 @@ export const MAX_INTENTOS_PREVIEW = 4;
 export function intentosPreviewAgotados(intentosPreview: number): boolean {
   return intentosPreview >= MAX_INTENTOS_PREVIEW;
 }
+
+// ---------------------------------------------------------------------------
+// Ventana de vigencia del borrador como destinatario de una corrección por
+// TEXTO LIBRE (ESCO-62)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minutos durante los que un borrador `preview_pendiente` sigue capturando
+ * el texto libre que su autor mande a continuación (§7.3: "el texto libre
+ * que Uriel mande después ES la corrección").
+ *
+ * Existe porque esa captura NO tenía ningún límite de edad: la consulta de
+ * `obtenerTranscritoPendienteMasReciente` filtraba sólo por actor + estado,
+ * y el handler de `bot.ts` consume el mensaje (nunca cede el turno) cada vez
+ * que esa consulta devuelve una fila. Caso real, `rondas_transcritos`
+ * 98e62e81-…: una nota de las 23:29 UTC del 2026-08-28 se comió dos
+ * preguntas para Esco de las 02:15 del 29 -- **2 h 45 min después** --, las
+ * reinterpretó como correcciones, agotó `MAX_INTENTOS_PREVIEW` y dejó el
+ * hallazgo narrado en `sin_confirmar`. El propio usuario volvió a preguntar
+ * lo mismo por la web 4 min 30 s más tarde (`chat_messages`), que es la
+ * prueba de que nunca quiso corregir nada.
+ *
+ * 30 minutos es **decisión de la operación de mantenimiento, pendiente de
+ * confirmación de Santiago**: es holgadamente mayor que cualquier tiempo de
+ * confirmación observado (la única nota confirmada de la primera ronda real
+ * se resolvió en un intento) y bastante menor que las 2 h 45 min del caso
+ * que rompió.
+ *
+ * Lo que esta ventana NO hace: **no muta la fila**. El borrador sigue en
+ * `preview_pendiente`, sobrevive a un redespliegue y sigue contando como
+ * "hallazgo narrado sin confirmar" en el reporte de cierre (CA-37). Deja de
+ * INTERCEPTAR texto, nada más. Los botones [Confirmar]/[Descartar]/[Deshacer]
+ * llevan su propio `transcrito_id` en el `callback_data` y no pasan por esta
+ * ventana -- siguen funcionando con el borrador tan viejo como sea.
+ */
+export const MINUTOS_VENTANA_CORRECCION_TEXTO = 30;
+
+/**
+ * Instante ISO (UTC) a partir del cual un borrador todavía captura texto:
+ * lo que va como `.gte('created_at', …)` en la consulta del pendiente.
+ *
+ * Devuelve el `toISOString()` COMPLETO, nunca recortado a `AAAA-MM-DD` --
+ * `rondas_transcritos.created_at` es `timestamptz` y la comparación es de
+ * instantes, no de días calendario (por eso no aplica la trampa "hoy" del
+ * CLAUDE.md raíz, que es sobre recortar la fecha).
+ */
+export function limiteVentanaCorreccionTexto(ahora: Date = new Date()): string {
+  return new Date(ahora.getTime() - MINUTOS_VENTANA_CORRECCION_TEXTO * 60 * 1000).toISOString();
+}
+
+/**
+ * `true` si el borrador creado en `creadoEn` todavía está dentro de la
+ * ventana. Misma regla que `limiteVentanaCorreccionTexto`, expresada del
+ * lado del dato en vez del lado de la consulta -- el borde de los 30 min
+ * exactos es INCLUSIVO en las dos (`>=`), para que la fila que la base
+ * devuelve y la que este predicado acepta sean siempre la misma.
+ */
+export function correccionPorTextoVigente(creadoEn: string, ahora: Date = new Date()): boolean {
+  const creado = new Date(creadoEn).getTime();
+  if (Number.isNaN(creado)) return false;
+  return creado >= new Date(limiteVentanaCorreccionTexto(ahora)).getTime();
+}
+
+/**
+ * Hora de pared en Bogotá, 'HH:MM', de un instante ISO. Mismo criterio de
+ * conversión que `primerDiaMesBogota()`/`hoyBogota()` (Bogotá es UTC-5 sin
+ * horario de verano; no se usa `Intl` con timezone para no depender de la
+ * tzdata del runtime de Deno).
+ *
+ * Sólo para MOSTRAR: es lo que hace que el aviso de intercepción nombre la
+ * nota concreta ("tu nota de las 18:29") en vez de dejar al verificador
+ * adivinando cuál de sus mensajes se está reinterpretando.
+ */
+export function horaBogota(iso: string): string {
+  const bogota = new Date(new Date(iso).getTime() - 5 * 60 * 60 * 1000);
+  const hh = String(bogota.getUTCHours()).padStart(2, '0');
+  const mm = String(bogota.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}

--- a/supabase/functions/make-server-1ccce916/rondaInventario/preview.ts
+++ b/supabase/functions/make-server-1ccce916/rondaInventario/preview.ts
@@ -246,3 +246,82 @@ export const MAX_INTENTOS_PREVIEW = 4;
 export function intentosPreviewAgotados(intentosPreview: number): boolean {
   return intentosPreview >= MAX_INTENTOS_PREVIEW;
 }
+
+// ---------------------------------------------------------------------------
+// Ventana de vigencia del borrador como destinatario de una corrección por
+// TEXTO LIBRE (ESCO-62)
+// ---------------------------------------------------------------------------
+
+/**
+ * Minutos durante los que un borrador `preview_pendiente` sigue capturando
+ * el texto libre que su autor mande a continuación (§7.3: "el texto libre
+ * que Uriel mande después ES la corrección").
+ *
+ * Existe porque esa captura NO tenía ningún límite de edad: la consulta de
+ * `obtenerTranscritoPendienteMasReciente` filtraba sólo por actor + estado,
+ * y el handler de `bot.ts` consume el mensaje (nunca cede el turno) cada vez
+ * que esa consulta devuelve una fila. Caso real, `rondas_transcritos`
+ * 98e62e81-…: una nota de las 23:29 UTC del 2026-08-28 se comió dos
+ * preguntas para Esco de las 02:15 del 29 -- **2 h 45 min después** --, las
+ * reinterpretó como correcciones, agotó `MAX_INTENTOS_PREVIEW` y dejó el
+ * hallazgo narrado en `sin_confirmar`. El propio usuario volvió a preguntar
+ * lo mismo por la web 4 min 30 s más tarde (`chat_messages`), que es la
+ * prueba de que nunca quiso corregir nada.
+ *
+ * 30 minutos es **decisión de la operación de mantenimiento, pendiente de
+ * confirmación de Santiago**: es holgadamente mayor que cualquier tiempo de
+ * confirmación observado (la única nota confirmada de la primera ronda real
+ * se resolvió en un intento) y bastante menor que las 2 h 45 min del caso
+ * que rompió.
+ *
+ * Lo que esta ventana NO hace: **no muta la fila**. El borrador sigue en
+ * `preview_pendiente`, sobrevive a un redespliegue y sigue contando como
+ * "hallazgo narrado sin confirmar" en el reporte de cierre (CA-37). Deja de
+ * INTERCEPTAR texto, nada más. Los botones [Confirmar]/[Descartar]/[Deshacer]
+ * llevan su propio `transcrito_id` en el `callback_data` y no pasan por esta
+ * ventana -- siguen funcionando con el borrador tan viejo como sea.
+ */
+export const MINUTOS_VENTANA_CORRECCION_TEXTO = 30;
+
+/**
+ * Instante ISO (UTC) a partir del cual un borrador todavía captura texto:
+ * lo que va como `.gte('created_at', …)` en la consulta del pendiente.
+ *
+ * Devuelve el `toISOString()` COMPLETO, nunca recortado a `AAAA-MM-DD` --
+ * `rondas_transcritos.created_at` es `timestamptz` y la comparación es de
+ * instantes, no de días calendario (por eso no aplica la trampa "hoy" del
+ * CLAUDE.md raíz, que es sobre recortar la fecha).
+ */
+export function limiteVentanaCorreccionTexto(ahora: Date = new Date()): string {
+  return new Date(ahora.getTime() - MINUTOS_VENTANA_CORRECCION_TEXTO * 60 * 1000).toISOString();
+}
+
+/**
+ * `true` si el borrador creado en `creadoEn` todavía está dentro de la
+ * ventana. Misma regla que `limiteVentanaCorreccionTexto`, expresada del
+ * lado del dato en vez del lado de la consulta -- el borde de los 30 min
+ * exactos es INCLUSIVO en las dos (`>=`), para que la fila que la base
+ * devuelve y la que este predicado acepta sean siempre la misma.
+ */
+export function correccionPorTextoVigente(creadoEn: string, ahora: Date = new Date()): boolean {
+  const creado = new Date(creadoEn).getTime();
+  if (Number.isNaN(creado)) return false;
+  return creado >= new Date(limiteVentanaCorreccionTexto(ahora)).getTime();
+}
+
+/**
+ * Hora de pared en Bogotá, 'HH:MM', de un instante ISO. Mismo criterio de
+ * conversión que `primerDiaMesBogota()`/`hoyBogota()` (Bogotá es UTC-5 sin
+ * horario de verano; no se usa `Intl` con timezone para no depender de la
+ * tzdata del runtime de Deno).
+ *
+ * Sólo para MOSTRAR: es lo que hace que el aviso de intercepción nombre la
+ * nota concreta ("tu nota de las 18:29") en vez de dejar al verificador
+ * adivinando cuál de sus mensajes se está reinterpretando.
+ */
+export function horaBogota(iso: string): string {
+  const bogota = new Date(new Date(iso).getTime() - 5 * 60 * 60 * 1000);
+  const hh = String(bogota.getUTCHours()).padStart(2, '0');
+  const mm = String(bogota.getUTCMinutes()).padStart(2, '0');
+  return `${hh}:${mm}`;
+}

--- a/supabase/functions/make-server-1ccce916/telegram/bot.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/bot.ts
@@ -79,6 +79,7 @@ import {
   construirPreview,
   construirTextoConCorrecciones,
   formatearCantidad,
+  horaBogota,
   intentosPreviewAgotados,
   MAX_INTENTOS_PREVIEW,
   previewConfirmable,
@@ -2106,6 +2107,16 @@ function getBot(): Bot<BotContext> {
       await ctx.reply("La lectura por voz no está disponible ahora mismo. Avisa a un administrador.");
       return;
     }
+
+    // ESCO-62: la intercepcion nunca es silenciosa mientras la ventana sigue
+    // vigente. Antes, un texto cualquiera desaparecia dentro del bucle de
+    // preview sin que el verificador supiera que lo estaban leyendo como una
+    // correccion de una nota anterior -- y la unica salida ("cancelar", commit
+    // 2516b3f) exigia conocer la palabra de antemano. Ahora el mensaje nombra
+    // la nota concreta por su hora y ofrece la salida en el mismo renglon.
+    await ctx.reply(
+      `Estoy tomando esto como corrección de tu nota de las ${horaBogota(pendiente.created_at)} -- escribe cancelar si no era eso.`,
+    );
 
     await ctx.replyWithChatAction("typing");
 

--- a/supabase/functions/make-server-1ccce916/telegram/ronda-helpers.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/ronda-helpers.ts
@@ -29,7 +29,7 @@
 
 import type { SupabaseClient } from 'jsr:@supabase/supabase-js@2';
 import type { FilaPreview } from '../rondaInventario/preview.ts';
-import { formatearCantidad } from '../rondaInventario/preview.ts';
+import { formatearCantidad, limiteVentanaCorreccionTexto } from '../rondaInventario/preview.ts';
 import type { AlcanceItem, HallazgoParaConfirmar, ProductoFueraDeAlcance } from '../rondaInventario/resolverHallazgos.ts';
 import type { CasoExcepcion, CasoProponer, CasoSantiago } from '../rondaInventario/resolucion.ts';
 import { buscarCausaRaiz } from '../rondaInventario/causasRaiz.ts';
@@ -162,6 +162,10 @@ export interface TranscritoRondaRow {
   intentos_preview: number;
   estado: 'preview_pendiente' | 'confirmado' | 'sin_confirmar' | 'descartado';
   actor_telegram_id: string | null;
+  /** Instante de creacion del borrador. Lo consume la ventana de vigencia
+   * de `obtenerTranscritoPendienteMasReciente` y el aviso de interceptacion
+   * de `bot.ts`, que nombra la hora de la nota. */
+  created_at: string;
 }
 
 // ---------------------------------------------------------------------------
@@ -306,16 +310,32 @@ export async function obtenerResumenExcepcionesRonda(
  * la más reciente, que es la que Uriel tiene fresca en la cabeza. Los
  * botones [Confirmar]/[Descartar]/[Deshacer] de CADA mensaje siguen
  * llevando su propio `transcrito_id` en el `callback_data` y no dependen de
- * esta función. */
+ * esta función.
+ *
+ * ACOTADO EN EL TIEMPO (ESCO-62): sólo devuelve el borrador si se creó
+ * dentro de `MINUTOS_VENTANA_CORRECCION_TEXTO` (ver `preview.ts`). Sin ese
+ * `.gte`, la consulta filtraba únicamente por actor + estado y el handler de
+ * `bot.ts` consume el mensaje siempre que devuelve fila: un borrador sin
+ * confirmar de hace horas se tragaba en silencio cada texto posterior de ese
+ * usuario. Caso real 98e62e81-…: dos preguntas para Esco de 2 h 45 min
+ * después entraron como correcciones, agotaron `MAX_INTENTOS_PREVIEW` y
+ * dejaron el hallazgo narrado en `sin_confirmar`.
+ *
+ * La fila NO se toca (CA-37): sigue `preview_pendiente`, sobrevive a un
+ * redespliegue y sigue contando como hallazgo narrado sin confirmar en el
+ * reporte de cierre. Lo único que caduca es su capacidad de INTERCEPTAR
+ * texto libre -- los botones, que llevan su `transcrito_id`, siguen
+ * funcionando por `obtenerTranscritoPorId` sin ninguna ventana. */
 export async function obtenerTranscritoPendienteMasReciente(
   supabase: SupabaseClient,
   telegramUsuarioId: string,
 ): Promise<TranscritoRondaRow | null> {
   const { data, error } = await supabase
     .from('rondas_transcritos')
-    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id')
+    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id, created_at')
     .eq('actor_telegram_id', telegramUsuarioId)
     .eq('estado', 'preview_pendiente')
+    .gte('created_at', limiteVentanaCorreccionTexto())
     .order('created_at', { ascending: false })
     .limit(1)
     .maybeSingle();
@@ -329,7 +349,7 @@ export async function obtenerTranscritoPendienteMasReciente(
 export async function obtenerTranscritoPorId(supabase: SupabaseClient, transcritoId: string): Promise<TranscritoRondaRow | null> {
   const { data, error } = await supabase
     .from('rondas_transcritos')
-    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id')
+    .select('id, ronda_id, transcrito, correcciones, preview, intentos_preview, estado, actor_telegram_id, created_at')
     .eq('id', transcritoId)
     .maybeSingle();
   if (error) {


### PR DESCRIPTION
## Bug

An unconfirmed `preview_pendiente` draft of the ronda de inventario swallowed **every** later text message from that Telegram user, **with no age limit**. It ate two questions meant for Esco and lost a narrated hallazgo.

Who hits it: the field counter (Uriel, module `inventario_ronda`) — anyone who records a voice note, does not confirm it, and later types anything at all. Since when: the voice preview loop shipped 2026-08-28 (migrations 124–130, Fase 3).

**Live trace**, `rondas_transcritos` id `98e62e81-a5a2-48ea-ba08-e785ac8f75a0` — re-verified against production 2026-09-04, the row is unchanged:

```
created_at 2026-08-28T23:29:21.471Z   estado sin_confirmar   intentos_preview 4
correcciones[0] 2026-08-28T23:29:51.043Z  «Si, es 15 15 15, un fertilizante»      <- legítima, +30 s
correcciones[1] 2026-08-29T02:15:11.797Z  «Cuéntame qué pasó esta semana …»       <- +2 h 45 min
correcciones[2] 2026-08-29T02:15:39.394Z  «Cómo nos fue esta semana …»            <- +2 h 46 min
```

The last two have nothing to do with inventory. They were reinterpreted as corrections of a voice note recorded 2 h 45 min earlier, exhausted `MAX_INTENTOS_PREVIEW` (4) and left the transcript `sin_confirmar`. The line «1 hallazgo(s) narrado(s) sin confirmar» at the foot of that ronda's closing report **is** that loss.

Independent proof the user did not want to correct anything, from a different table: `chat_messages`, `role='user'`, `2026-08-29T02:20:09.599Z` — the same question reworded, 4 min 30 s later, in Esco's web interface, because the bot would not answer it.

The `cancelar` escape added in `2516b3f` is mitigation, not a fix: it requires the user to already know the magic word, and the draft stayed alive forever until someone typed it.

## Root cause

`src/supabase/functions/server/telegram/ronda-helpers.ts:310` — `obtenerTranscritoPendienteMasReciente` filtered **only** by `actor_telegram_id` + `estado='preview_pendiente'`, ordered `created_at DESC LIMIT 1`. There was no time predicate.

`src/supabase/functions/server/telegram/bot.ts:2055-2062` — `bot.on('message:text')` **consumes** the message (it never calls `next()`) every time that query returns a row. So any draft, of any age, permanently captured that user's text and pushed it into the reinterpret loop instead of letting it fall through to Esco.

## Fix

Three changes, no refactor:

1. **The query is bounded.** `.gte('created_at', limiteVentanaCorreccionTexto())` in `obtenerTranscritoPendienteMasReciente`. A draft older than the window stops being returned, so the handler calls `next()` and the message reaches Esco as it should.
2. **The window is a named, exported, greppable constant.** `MINUTOS_VENTANA_CORRECCION_TEXTO = 30` in `src/utils/rondaInventario/preview.ts` (which already owns `MAX_INTENTOS_PREVIEW`, `aplicarCorreccion` and `construirTextoConCorrecciones`), mirrored into both edge trees by `docs/inventario/regenerar-copias-ronda-inventario.py`. **30 minutes is the maintenance operation's choice, pending Santiago's confirmation** — comfortably longer than any observed confirmation time and far shorter than the 2 h 45 min that broke. Changing it is one constant plus one number in the test.
3. **The interception is never silent while it is still in force.** The reply now names the note by its Bogotá wall-clock time and offers the exit on the same line: `Estoy tomando esto como corrección de tu nota de las 18:29 -- escribe cancelar si no era eso.`

**CA-37 is preserved, verified against `src/components/inventory/CLAUDE.md`.** The row is never mutated: it stays `preview_pendiente`, survives a redeploy, and keeps counting as a narrated-unconfirmed hallazgo in the closing report. Only its ability to *intercept free text* expires. The `[Confirmar]`/`[Descartar]`/`[Deshacer]` buttons carry their own `transcrito_id` in `callback_data` and resolve through `obtenerTranscritoPorId`, which has **no** window — a draft of any age is still confirmable, discardable and undoable by button. No discrepancy with the module contract was found.

## Verification

New test `src/__tests__/rondaBorradorVentanaCorreccion.test.ts` (12 tests), written **before** the fix and confirmed red: `12 failed (12)`. Green after: `12 passed (12)`. It has two halves, because `ronda-helpers.ts` and `bot.ts` cannot be imported from vitest (they pull `jsr:@supabase/supabase-js@2` and `grammy`):

- **Unit** on the pure helpers, driven by the real timestamps of the trace: the +30 s correction is inside the window, both +2 h 45 min questions are outside, the 30-minute edge is inclusive and excluding one millisecond later, and `horaBogota` converts `23:29Z` to `18:29`.
- **Static guard** over **both** edge trees: the body of `obtenerTranscritoPendienteMasReciente` carries `.gte('created_at'` + `limiteVentanaCorreccionTexto()` and selects `created_at`; `bot.ts` carries the interception notice. A regression in either copy turns the suite red.

Full run on this branch:

- `npx vitest run` — **158 files / 3445 tests, all green** (`main@01e3690` was 157/3433).
- `npm run typecheck` — clean.
- `npm run lint` — **0 errors / 906 warnings**, byte-identical to the count on clean `main@01e3690` (measured by stashing this change): this PR adds **zero** warnings. `eslint` on the two lintable changed files returns nothing.
- Edge-tree parity: `diff -w` over `tail -n +2` gives **0 differing lines** for `telegram/bot.ts`, `telegram/ronda-helpers.ts` and `rondaInventario/preview.ts`.
- The generated `rondaInventario/` copies were produced by `docs/inventario/regenerar-copias-ronda-inventario.py`, never hand-edited (`rondaInventarioParidadServidor.test.ts` passes).

## Deploy

**`npx supabase functions deploy make-server-1ccce916` is required.** The fix is entirely inside the edge function; merging alone changes nothing in production. Per the deploy-drift rule, verify by content of the deployed bundle (grep `limiteVentanaCorreccionTexto` and `como corrección de tu nota de las`, with a positive control), not by `updated_at`.

## Rollback

`git revert` the commit, then redeploy the edge function. There is no migration, no data change and no schema change: the only production artifact is the deployed bundle.

## Follow-up — deliberately out of scope

- **Item 4 of the filed action (drop a correction whose `producto_confianza` is `ninguna`) was NOT implemented, on evidence.** `productoConfianza` is parsed by `parsearRespuestaModelo` and then **consumed by nothing** — `resolverProducto` ignores it entirely (it matches by exact normalized name, D-T7) and so does `derivarVia`. Making it gate persistence would be a new product rule, not a bug fix. Worse, it collides with a designed path: a genuine note whose product cannot be identified yet is exactly the case where Uriel keeps correcting, and refusing to persist those corrections would prevent `MAX_INTENTOS_PREVIEW` from ever being reached, killing the `sin_confirmar` terminal of §7.3. It also would not have caught this bug — the reinterpretation always includes the ORIGINAL transcript, so an off-topic message still yields the original hallazgos with high confidence. Recommend filing it separately as a `decision` for Santiago.
- 30 minutes needs Santiago's sign-off; it is one constant.
- The two known gaps in `src/components/inventory/CLAUDE.md` (`cerrada_sin_ajuste` unreachable, R-16/CA-14 free-text observation) are untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011smCQ79t6Lv9xk822XKa3D

---
_Generated by [Claude Code](https://claude.ai/code/session_011smCQ79t6Lv9xk822XKa3D)_