### PR TITLE
fix(hato): paginate the chequeo history read so PostgREST cannot truncate it

### DIFF
--- a/src/__tests__/hatoChequeoHistoricoPaginadoGuard.test.ts
+++ b/src/__tests__/hatoChequeoHistoricoPaginadoGuard.test.ts
@@ -1,0 +1,91 @@
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'fs';
+import { resolve } from 'path';
+import { paginarSelect } from '../supabase/functions/server/paginar-select';
+
+/**
+ * Guarda de la lectura del histórico de `hato_chequeo_vacas` en los TRES
+ * endpoints de chequeo (`preview`, `commit`, `foto`), en los DOS árboles de
+ * edge function.
+ *
+ * **El defecto.** Los tres leían el histórico completo con
+ * `.select(...).in('animal_id', animalIds)` — sin `.range(...)` y sin
+ * `order by`. PostgREST corta en 1.000 filas por página y **no avisa**:
+ * devuelve `error: null` y un arreglo corto. Verificado contra producción el
+ * 2026-09-07: `hato_chequeo_vacas` tiene **1.479 filas** en 32 chequeos, de
+ * las cuales **711** pertenecen a las 35 vacas del roster actual
+ * (`etapa='vaca' AND estado='activa'`). Todavía por debajo del tope — el
+ * defecto es LATENTE — pero cada chequeo suma ~35 filas del roster, así que
+ * el margen es de unos ocho chequeos.
+ *
+ * **Por qué no es cosmético.** Ese histórico alimenta los tres mapas de
+ * deduplicación del commit:
+ *
+ *   - `seleccionarUltimoChequeoPorAnimal`  → la línea base del diff
+ *   - `seleccionarUltimaCriaAnteriorPorAnimal` → dedupe del `parto`
+ *   - `seleccionarFechasServicioConocidasPorAnimal` → dedupe del `servicio`
+ *
+ * Si el corte se traga la fila que ya registraba ese parto o ese servicio, el
+ * commit emite un SEGUNDO evento para el mismo hecho: exactamente la clase de
+ * duplicado que costó las migraciones 075, 076 y 080. Y como la consulta no
+ * lleva `order by`, qué 1.000 filas llegan lo decide el orden físico del heap
+ * — el fallo no deja hueco visible y ni siquiera es determinista.
+ *
+ * Las dos reglas que fija esta prueba:
+ *  1. Los seis ficheros leen `hato_chequeo_vacas` por `paginarSelect` + `.range`.
+ *  2. `paginarSelect` recupera de verdad más de 1.000 filas.
+ */
+
+const FICHEROS = [
+  'src/supabase/functions/server/hato-chequeo-commit.ts',
+  'src/supabase/functions/server/hato-chequeo-preview.ts',
+  'src/supabase/functions/server/hato-chequeo-foto.ts',
+  'supabase/functions/make-server-1ccce916/hato-chequeo-commit.ts',
+  'supabase/functions/make-server-1ccce916/hato-chequeo-preview.ts',
+  'supabase/functions/make-server-1ccce916/hato-chequeo-foto.ts',
+];
+
+describe('endpoints de chequeo — histórico de hato_chequeo_vacas paginado', () => {
+  it.each(FICHEROS)('%s pagina la lectura del histórico', (ruta) => {
+    const fuente = readFileSync(resolve(__dirname, '../..', ruta), 'utf-8');
+
+    expect(fuente).toContain("import { paginarSelect } from './paginar-select.ts';");
+
+    // Cada bloque `.from('hato_chequeo_vacas')` tiene que cerrar en `.range(`.
+    const bloques = [...fuente.matchAll(/\.from\('hato_chequeo_vacas'\)[\s\S]{0,600}?;/g)];
+    expect(bloques.length).toBeGreaterThan(0);
+    for (const [bloque] of bloques) {
+      expect(bloque).toContain('.range(desde, hasta)');
+    }
+  });
+
+  it('paginarSelect recupera las 1.479 filas reales, no las primeras 1.000', async () => {
+    // Reproducción del corte: un backend que nunca devuelve más de 1.000
+    // filas por llamada, como PostgREST.
+    const TOTAL = 1479;
+    const todas = Array.from({ length: TOTAL }, (_, i) => ({ fila: i }));
+    const { filas, error } = await paginarSelect<{ fila: number }>((desde, hasta) =>
+      Promise.resolve({ data: todas.slice(desde, Math.min(hasta + 1, desde + 1000)), error: null }),
+    );
+    expect(error).toBeNull();
+    expect(filas).toHaveLength(TOTAL);
+    // La consulta vieja se habría quedado acá, en la fila 1.000.
+    expect(filas[filas.length - 1].fila).toBe(TOTAL - 1);
+  });
+
+  it('paginarSelect propaga el error del backend sin devolver filas a medias', async () => {
+    const { filas, error } = await paginarSelect<{ fila: number }>(() =>
+      Promise.resolve({ data: null, error: { message: 'boom' } }),
+    );
+    expect(error?.message).toBe('boom');
+    expect(filas).toHaveLength(0);
+  });
+
+  it('paginarSelect denuncia el tope de páginas en vez de entregar una lectura incompleta', async () => {
+    // Un backend que siempre devuelve una página llena: nunca hay página corta.
+    const { error } = await paginarSelect<{ fila: number }>((desde) =>
+      Promise.resolve({ data: Array.from({ length: 1000 }, (_, i) => ({ fila: desde + i })), error: null }),
+    );
+    expect(error?.message).toMatch(/tope de 20 páginas/);
+  });
+});

--- a/src/supabase/functions/server/hato-chequeo-commit.ts
+++ b/src/supabase/functions/server/hato-chequeo-commit.ts
@@ -55,6 +55,7 @@ import {
   type FilaUltimaCriaHistorico,
 } from './importHato/commitChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { paginarSelect } from './paginar-select.ts';
 
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053), igual que preview.
 
@@ -242,10 +243,13 @@ export async function handleHatoChequeoCommit(c: Context): Promise<Response> {
   // deduplicar el `parto` que `descomponerSX` deriva más abajo).
   let historicoUltimaCria: FilaUltimaCriaHistorico[] = [];
   if (animalIds.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_chequeo_vacas')
-      .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, ultima_cria_raw, created_at, hato_chequeos(fecha)')
-      .in('animal_id', animalIds);
+    const { filas: data, error } = await paginarSelect<Record<string, unknown>>((desde, hasta) =>
+      supabase
+        .from('hato_chequeo_vacas')
+        .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, ultima_cria_raw, created_at, hato_chequeos(fecha)')
+        .in('animal_id', animalIds)
+        .range(desde, hasta),
+    );
     if (error) return respuestaError(c, 500, { error: `No se pudo leer hato_chequeo_vacas: ${error.message}` });
     historico = (data ?? []).map((fila: Record<string, unknown>) => {
       const chequeoRow = fila.hato_chequeos as { fecha: string } | { fecha: string }[] | null;

--- a/src/supabase/functions/server/hato-chequeo-foto.ts
+++ b/src/supabase/functions/server/hato-chequeo-foto.ts
@@ -50,6 +50,7 @@ import {
   type LecturaOcrPagina,
 } from './importHato/ocrChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { paginarSelect } from './paginar-select.ts';
 import { derivarEstadoReproductivo } from './calculos-hato.ts';
 import {
   categorizarAnimal,
@@ -534,12 +535,15 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
   const animalIds = animales.map((a) => a.id);
   let historico: FilaChequeoVacaHistorico[] = [];
   if (animalIds.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_chequeo_vacas')
-      .select(
-        'animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)',
-      )
-      .in('animal_id', animalIds);
+    const { filas: data, error } = await paginarSelect<Record<string, unknown>>((desde, hasta) =>
+      supabase
+        .from('hato_chequeo_vacas')
+        .select(
+          'animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)',
+        )
+        .in('animal_id', animalIds)
+        .range(desde, hasta),
+    );
     if (error) return respuestaError(c, 500, `No se pudo leer hato_chequeo_vacas: ${error.message}`);
     historico = (data ?? []).map((fila: Record<string, unknown>) => {
       const chequeo = fila.hato_chequeos as { fecha: string } | { fecha: string }[] | null;

--- a/src/supabase/functions/server/hato-chequeo-preview.ts
+++ b/src/supabase/functions/server/hato-chequeo-preview.ts
@@ -33,6 +33,7 @@ import type {
 } from './importHato/diffChequeo.ts';
 import type { HojaCruda } from './importHato/tipos.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { paginarSelect } from './paginar-select.ts';
 import { derivarEstadoReproductivo, etiquetaEstadoReproductivo, type EstadoActualHatoRow } from './calculos-hato.ts';
 import {
   construirUmbralesCategoriaHatoDesdeFilas,
@@ -249,10 +250,13 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
   const animalIds = animales.map((a) => a.id);
   let historico: FilaChequeoVacaHistorico[] = [];
   if (animalIds.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_chequeo_vacas')
-      .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)')
-      .in('animal_id', animalIds);
+    const { filas: data, error } = await paginarSelect<Record<string, unknown>>((desde, hasta) =>
+      supabase
+        .from('hato_chequeo_vacas')
+        .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)')
+        .in('animal_id', animalIds)
+        .range(desde, hasta),
+    );
     if (error) return respuestaError(c, 500, `No se pudo leer hato_chequeo_vacas: ${error.message}`);
     historico = (data ?? []).map((fila: Record<string, unknown>) => {
       const chequeo = fila.hato_chequeos as { fecha: string } | { fecha: string }[] | null;

--- a/src/supabase/functions/server/paginar-select.ts
+++ b/src/supabase/functions/server/paginar-select.ts
@@ -1,0 +1,55 @@
+// paginar-select.ts — paginación determinista para los `select` de los
+// endpoints de chequeo del hato.
+//
+// PostgREST/`supabase-js` corta toda respuesta en 1.000 filas por página y
+// **no avisa**: la llamada devuelve `error: null` y un arreglo corto. El repo
+// ya arrastra tres copias del mismo remedio para tres consumidores distintos
+// (`fetchAll` en el navegador, `supabaseQueryAll` en `chat.tsx`, `paginar` en
+// `acciones-paquete-io.ts`); esta es la que usan los tres endpoints de chequeo,
+// que leen el histórico completo de `hato_chequeo_vacas`.
+//
+// Por qué importa acá y no es cosmético: ese histórico alimenta los tres mapas
+// de deduplicación del commit (`seleccionarUltimoChequeoPorAnimal`,
+// `seleccionarUltimaCriaAnteriorPorAnimal` y
+// `seleccionarFechasServicioConocidasPorAnimal`). Si el corte se traga la fila
+// que ya registraba un parto o un servicio, el commit emite un SEGUNDO evento
+// para el mismo hecho — exactamente la clase de duplicado que costó las
+// migraciones 075, 076 y 080. Y la consulta no lleva `order by`, así que qué
+// 1.000 filas llegan lo decide el orden físico del heap: el defecto no deja
+// hueco visible y ni siquiera es determinista.
+
+const TAMANO_PAGINA = 1000;
+const MAX_PAGINAS = 20; // 20.000 filas: techo de seguridad, no un límite esperado
+
+/**
+ * Ejecuta `ejecutar` página por página hasta recibir una página corta.
+ *
+ * `ejecutar` debe construir una consulta NUEVA en cada llamada: los query
+ * builders de `supabase-js` no se pueden reutilizar entre ejecuciones.
+ */
+export async function paginarSelect<T>(
+  ejecutar: (desde: number, hasta: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+): Promise<{ filas: T[]; error: { message: string } | null }> {
+  const filas: T[] = [];
+
+  for (let pagina = 0; pagina < MAX_PAGINAS; pagina += 1) {
+    const desde = pagina * TAMANO_PAGINA;
+    const { data, error } = await ejecutar(desde, desde + TAMANO_PAGINA - 1);
+
+    if (error) return { filas, error };
+
+    const lote = data ?? [];
+    filas.push(...lote);
+
+    // Página corta = última página.
+    if (lote.length < TAMANO_PAGINA) return { filas, error: null };
+  }
+
+  // Techo alcanzado: se devuelve como error en vez de entregar filas
+  // incompletas en silencio, que es justo el modo de falla que este módulo
+  // existe para cerrar.
+  return {
+    filas,
+    error: { message: `paginarSelect: tope de ${MAX_PAGINAS} páginas alcanzado; la lectura está incompleta` },
+  };
+}

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-commit.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-commit.ts
@@ -55,6 +55,7 @@ import {
   type FilaUltimaCriaHistorico,
 } from './importHato/commitChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { paginarSelect } from './paginar-select.ts';
 
 const ROLES_PERMITIDOS = new Set(['Administrador', 'Gerencia']); // mismo patrón de escritura que el resto de hato_* (migración 053), igual que preview.
 
@@ -242,10 +243,13 @@ export async function handleHatoChequeoCommit(c: Context): Promise<Response> {
   // deduplicar el `parto` que `descomponerSX` deriva más abajo).
   let historicoUltimaCria: FilaUltimaCriaHistorico[] = [];
   if (animalIds.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_chequeo_vacas')
-      .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, ultima_cria_raw, created_at, hato_chequeos(fecha)')
-      .in('animal_id', animalIds);
+    const { filas: data, error } = await paginarSelect<Record<string, unknown>>((desde, hasta) =>
+      supabase
+        .from('hato_chequeo_vacas')
+        .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, ultima_cria_raw, created_at, hato_chequeos(fecha)')
+        .in('animal_id', animalIds)
+        .range(desde, hasta),
+    );
     if (error) return respuestaError(c, 500, { error: `No se pudo leer hato_chequeo_vacas: ${error.message}` });
     historico = (data ?? []).map((fila: Record<string, unknown>) => {
       const chequeoRow = fila.hato_chequeos as { fecha: string } | { fecha: string }[] | null;

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-foto.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-foto.ts
@@ -50,6 +50,7 @@ import {
   type LecturaOcrPagina,
 } from './importHato/ocrChequeo.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { paginarSelect } from './paginar-select.ts';
 import { derivarEstadoReproductivo } from './calculos-hato.ts';
 import {
   categorizarAnimal,
@@ -534,12 +535,15 @@ export async function handleHatoChequeoFoto(c: Context): Promise<Response> {
   const animalIds = animales.map((a) => a.id);
   let historico: FilaChequeoVacaHistorico[] = [];
   if (animalIds.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_chequeo_vacas')
-      .select(
-        'animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)',
-      )
-      .in('animal_id', animalIds);
+    const { filas: data, error } = await paginarSelect<Record<string, unknown>>((desde, hasta) =>
+      supabase
+        .from('hato_chequeo_vacas')
+        .select(
+          'animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)',
+        )
+        .in('animal_id', animalIds)
+        .range(desde, hasta),
+    );
     if (error) return respuestaError(c, 500, `No se pudo leer hato_chequeo_vacas: ${error.message}`);
     historico = (data ?? []).map((fila: Record<string, unknown>) => {
       const chequeo = fila.hato_chequeos as { fecha: string } | { fecha: string }[] | null;

--- a/supabase/functions/make-server-1ccce916/hato-chequeo-preview.ts
+++ b/supabase/functions/make-server-1ccce916/hato-chequeo-preview.ts
@@ -33,6 +33,7 @@ import type {
 } from './importHato/diffChequeo.ts';
 import type { HojaCruda } from './importHato/tipos.ts';
 import { construirHatoConfigDesdeFilas, type FilaHatoConfig } from './hato-config-desde-tabla.ts';
+import { paginarSelect } from './paginar-select.ts';
 import { derivarEstadoReproductivo, etiquetaEstadoReproductivo, type EstadoActualHatoRow } from './calculos-hato.ts';
 import {
   construirUmbralesCategoriaHatoDesdeFilas,
@@ -249,10 +250,13 @@ export async function handleHatoChequeoPreview(c: Context): Promise<Response> {
   const animalIds = animales.map((a) => a.id);
   let historico: FilaChequeoVacaHistorico[] = [];
   if (animalIds.length > 0) {
-    const { data, error } = await supabase
-      .from('hato_chequeo_vacas')
-      .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)')
-      .in('animal_id', animalIds);
+    const { filas: data, error } = await paginarSelect<Record<string, unknown>>((desde, hasta) =>
+      supabase
+        .from('hato_chequeo_vacas')
+        .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, created_at, hato_chequeos(fecha)')
+        .in('animal_id', animalIds)
+        .range(desde, hasta),
+    );
     if (error) return respuestaError(c, 500, `No se pudo leer hato_chequeo_vacas: ${error.message}`);
     historico = (data ?? []).map((fila: Record<string, unknown>) => {
       const chequeo = fila.hato_chequeos as { fecha: string } | { fecha: string }[] | null;

--- a/supabase/functions/make-server-1ccce916/paginar-select.ts
+++ b/supabase/functions/make-server-1ccce916/paginar-select.ts
@@ -1,0 +1,55 @@
+// paginar-select.ts — paginación determinista para los `select` de los
+// endpoints de chequeo del hato.
+//
+// PostgREST/`supabase-js` corta toda respuesta en 1.000 filas por página y
+// **no avisa**: la llamada devuelve `error: null` y un arreglo corto. El repo
+// ya arrastra tres copias del mismo remedio para tres consumidores distintos
+// (`fetchAll` en el navegador, `supabaseQueryAll` en `chat.tsx`, `paginar` en
+// `acciones-paquete-io.ts`); esta es la que usan los tres endpoints de chequeo,
+// que leen el histórico completo de `hato_chequeo_vacas`.
+//
+// Por qué importa acá y no es cosmético: ese histórico alimenta los tres mapas
+// de deduplicación del commit (`seleccionarUltimoChequeoPorAnimal`,
+// `seleccionarUltimaCriaAnteriorPorAnimal` y
+// `seleccionarFechasServicioConocidasPorAnimal`). Si el corte se traga la fila
+// que ya registraba un parto o un servicio, el commit emite un SEGUNDO evento
+// para el mismo hecho — exactamente la clase de duplicado que costó las
+// migraciones 075, 076 y 080. Y la consulta no lleva `order by`, así que qué
+// 1.000 filas llegan lo decide el orden físico del heap: el defecto no deja
+// hueco visible y ni siquiera es determinista.
+
+const TAMANO_PAGINA = 1000;
+const MAX_PAGINAS = 20; // 20.000 filas: techo de seguridad, no un límite esperado
+
+/**
+ * Ejecuta `ejecutar` página por página hasta recibir una página corta.
+ *
+ * `ejecutar` debe construir una consulta NUEVA en cada llamada: los query
+ * builders de `supabase-js` no se pueden reutilizar entre ejecuciones.
+ */
+export async function paginarSelect<T>(
+  ejecutar: (desde: number, hasta: number) => PromiseLike<{ data: T[] | null; error: { message: string } | null }>,
+): Promise<{ filas: T[]; error: { message: string } | null }> {
+  const filas: T[] = [];
+
+  for (let pagina = 0; pagina < MAX_PAGINAS; pagina += 1) {
+    const desde = pagina * TAMANO_PAGINA;
+    const { data, error } = await ejecutar(desde, desde + TAMANO_PAGINA - 1);
+
+    if (error) return { filas, error };
+
+    const lote = data ?? [];
+    filas.push(...lote);
+
+    // Página corta = última página.
+    if (lote.length < TAMANO_PAGINA) return { filas, error: null };
+  }
+
+  // Techo alcanzado: se devuelve como error en vez de entregar filas
+  // incompletas en silencio, que es justo el modo de falla que este módulo
+  // existe para cerrar.
+  return {
+    filas,
+    error: { message: `paginarSelect: tope de ${MAX_PAGINAS} páginas alcanzado; la lectura está incompleta` },
+  };
+}


### PR DESCRIPTION
## Bug

The three chequeo endpoints — `POST /hato/chequeo/preview`, `/commit` and `/foto` — read the **full** `hato_chequeo_vacas` history for the animals in the uploaded planilla with an unpaginated `select`:

```ts
const { data, error } = await supabase
  .from('hato_chequeo_vacas')
  .select('animal_id, pl, num_partos, fecha_servicio, toro, tipo_servicio, fecha_secar, fecha_probable_parto, estado, ultima_cria_raw, created_at, hato_chequeos(fecha)')
  .in('animal_id', animalIds);
```

`src/supabase/functions/server/hato-chequeo-commit.ts:245-249`, `hato-chequeo-preview.ts:252-256`, `hato-chequeo-foto.ts:537-542` (plus the three mirrors under `supabase/functions/make-server-1ccce916/`).

PostgREST caps every response at 1.000 rows and returns `error: null` with a short array — the truncation is silent. The query also carries no `order by`, so which 1.000 rows arrive is decided by the physical heap order, i.e. the failure is not even deterministic.

Who hits it: Martha, on every chequeo upload (`.xlsx` or photo). **Latent today** — see the numbers below — but it fires without any error, so nothing would announce it.

## Root cause

The three reads have no `.range(...)`. That history is the input of the three dedupe maps the commit path uses to avoid re-emitting lifecycle events:

- `seleccionarUltimoChequeoPorAnimal` → the diff baseline
- `seleccionarUltimaCriaAnteriorPorAnimal` → dedupe of the derived `parto`
- `seleccionarFechasServicioConocidasPorAnimal` → dedupe of the derived `servicio`

A row dropped by the cap means the commit emits a **second** `parto` or `servicio` event for a fact already recorded — the exact duplicate class that cost migrations 075, 076 and 080 in July 2026.

Measured against production 2026-09-07:

```sql
with roster as (select id from hato_animales where etapa='vaca' and estado='activa')
select (select count(*) from roster) vacas_roster,
       (select count(*) from hato_chequeo_vacas v join roster r on r.id=v.animal_id) filas_del_roster,
       (select count(*) from hato_chequeo_vacas) filas_totales,
       (select count(distinct chequeo_id) from hato_chequeo_vacas) chequeos;
-- vacas_roster = 35 | filas_del_roster = 711 | filas_totales = 1479 | chequeos = 32
```

711 of 1.000 for the current roster, and each chequeo adds ~35 roster rows: about eight chequeos of margin.

## Fix

Adds `paginar-select.ts` — the same page-until-short-page loop the repo already uses three times (`fetchAll` in the browser, `supabaseQueryAll` in `chat.tsx`, `paginar` in `acciones-paquete-io.ts`) — and routes the three reads through it with `.range(desde, hasta)`. Mirrored byte-identically into `supabase/functions/make-server-1ccce916/`.

The helper returns `{ filas, error }` rather than throwing, so the existing `if (error) return respuestaError(...)` handling at each call site is unchanged. On hitting the 20-page ceiling it returns an **error** instead of handing back a partial read — the failure mode this module exists to close.

Nothing else changed: no reordering, no new columns, no change to the dedupe logic.

## Verification

- New static guard `src/__tests__/hatoChequeoHistoricoPaginadoGuard.test.ts` (9 tests) over all six files plus unit tests of `paginarSelect` (1.479 rows recovered, error propagation, page-ceiling).
- Red before / green after confirmed by stashing only the three endpoint files: **6 failed / 3 passed** → **9 passed**.
- `npx vitest run` — **161 files / 3468 tests, all green** (main was 160 / 3459).
- `npm run typecheck` — clean.
- `npm run lint` — **0 errors / 906 warnings**, identical to the baseline on `main`.

## Deploy

Touches edge-function source in both trees, so this needs `npx supabase functions deploy make-server-1ccce916` after merge. There is no DB change and no migration.

## Rollback

Revert the commit. The three endpoints go back to the single unpaginated read; no data written by this branch, so nothing to undo in the database.

## Follow-up

Deliberately out of scope: the four pagination helpers in this repo are still four separate copies (`fetchAll`, `supabaseQueryAll`, `paginar`, `paginarSelect`). Consolidating them crosses the deployment-tree boundary and is a refactor, not this fix. Also not touched here: the same three files' `hato_animales` and `hato_eventos` reads, which are bounded by the planilla roster and by `fecha < chequeo.fecha` respectively and stay far below the cap.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oMPFsThHx23PfvhfJqxhd

---
_Generated by [Claude Code](https://claude.ai/code/session_011oMPFsThHx23PfvhfJqxhd)_