### PR TITLE
docs: re-verify BUG_REPORT.md against production 2026-09-07

### DIFF
--- a/BUG_REPORT.md
+++ b/BUG_REPORT.md
@@ -2,6 +2,7 @@
 
 **Abierto:** 2026-02-24
 **Re-verificado contra producción y `main@7c232f6`:** 2026-08-03
+**Re-verificado contra producción y `main@1a97b2d`:** 2026-09-07 — sin cambio de veredicto; sólo se actualizan las cifras que habían quedado rancias
 **Estado:** 5 de los 6 problemas originales están cerrados. 1 sigue abierto, y no por la causa que decía este archivo.
 
 > **Cómo leer este archivo.** Cada issue lleva su veredicto y **la evidencia con la que se comprobó** (archivo:línea, SQL con su resultado). Un issue sin evidencia no se cierra. Si vuelve a aparecer un síntoma listado aquí como cerrado, es un bug **nuevo** — no una reapertura — y merece su propia entrada.
@@ -19,16 +20,18 @@
 | 5 | Guardar el reporte falla con error de RLS | ✅ **Corregido** |
 | 6 | La descarga del PDF no funciona | ✅ **No reproducible** |
 
-El módulo lleva **24 reportes generados y guardados**, con cadencia semanal ininterrumpida hasta la **semana 31 de 2026 (2026-08-01)**. La afirmación original de que "NADA funciona" dejó de ser cierta hace meses; este archivo simplemente no se actualizó.
+El módulo lleva **28 reportes generados y guardados**, con cadencia semanal hasta la **semana 35 de 2026 (2026-08-31)**. La afirmación original de que "NADA funciona" dejó de ser cierta hace meses; este archivo simplemente no se actualizó.
 
 ```sql
-select numero_semana, ano, (url_storage is not null) tiene_url, created_at::date
-from reportes_semanales order by created_at desc limit 4;
--- 31 | 2026 | true | 2026-08-01
--- 30 | 2026 | true | 2026-07-27
--- 29 | 2026 | true | 2026-07-21
--- 28 | 2026 | true | 2026-07-13
+-- verificado 2026-09-07
+select count(*) total, count(url_storage) con_url,
+       max(created_at)::date ultimo,
+       max(numero_semana) filter (where ano = 2026) ultima_semana
+from reportes_semanales;
+-- total = 28 | con_url = 28 | ultimo = 2026-08-31 | ultima_semana = 35
 ```
+
+> El reporte **no tiene cron**: `cron.job` sólo lista los seis trabajos de clima, hato, acciones y ronda de inventario. Una semana sin fila en `reportes_semanales` es cadencia humana, no un defecto.
 
 ---
 
@@ -115,19 +118,20 @@ const unitCost = item.costoEstimado > 0 && cantidadComprar > 0
 
 Cuando el producto está **totalmente cubierto por inventario** — el caso normal — `cantidadComprar` es 0, así que `unitCost` es 0 y ese insumo aporta **cero** al costo. Si ninguna línea requiere compra, `costoTotal` (línea 525) es 0 y `costoPorLitroKg` / `costoPorArbol` salen en 0.
 
-Hoy eso aplica a **7 de las 18 aplicaciones** registradas — las que tienen lista de compras pero ninguna línea por comprar (`cantidad_faltante = 0` en todas): *Drench Enero 26*, *Fumigación 01*, *Foco Irlanda*, *Fumigación control monalonion y hongos - Mayo*, *Fertilizante mes de junio*, *Fumigacion Post cosecha junio* y *Fumigación control acaro - Julio*.
+Al 2026-09-07 eso aplica a **8 de las 21 aplicaciones** registradas — las que tienen lista de compras pero ninguna línea por comprar (`cantidad_faltante = 0` en todas): *Drench Enero 26*, *Fumigación 01*, *Foco Irlanda*, *Fumigación control monalonion y hongos - Mayo*, *Fertilizante mes de junio*, *Fumigacion Post cosecha junio*, *Fumigación control acaro - Julio* y *Drench agosto* (nueva desde el 2026-08-03).
 
 ```sql
-select a.nombre_aplicacion, count(c.id) items,
+-- verificado 2026-09-07
+select a.nombre_aplicacion, a.estado, count(c.id) items,
        sum((coalesce(c.cantidad_faltante,0) > 0)::int) items_a_comprar
 from aplicaciones a join aplicaciones_compras c on c.aplicacion_id = a.id
-group by 1 having sum((coalesce(c.cantidad_faltante,0) > 0)::int) = 0;
--- 7 filas: toda la lista cubierta por inventario -> costoTotal = 0
+group by 1,2 having sum((coalesce(c.cantidad_faltante,0) > 0)::int) = 0;
+-- 8 filas, TODAS en estado 'Cerrada' -> toda la lista cubierta por inventario -> costoTotal = 0
 ```
 
 **Por qué no se corrige en este archivo:** existe una fuente de precio obvia (`productos.precio_unitario`, que es la que ya usa el motor de costo/kg en `calculosCostoKg.ts`), pero decidir **a qué precio se valora un insumo sacado de bodega** es una regla contable, no un bug de aritmética. Requiere aprobación del dueño antes de tocar un número que Gerencia lee.
 
-**Impacto acotado:** `fetchAplicacionesPlaneadas()` solo trae aplicaciones en estado `Calculada`. Hoy hay **una** (*Aplicacion Enmienda*) y no tiene filas en `aplicaciones_compras`, así que la sección de planeadas del reporte sale vacía casi siempre. Es un error latente, no uno que esté ensuciando el reporte cada semana.
+**Impacto acotado, re-verificado 2026-09-07:** `fetchAplicacionesPlaneadas()` solo trae aplicaciones en estado `Calculada`. Sigue habiendo **una** (*Aplicacion Enmienda*) y sigue sin filas en `aplicaciones_compras`; las 8 afectadas están todas `Cerrada`. Así que la sección de planeadas del reporte sale vacía casi siempre. Es un error latente, no uno que esté ensuciando el reporte cada semana.
 
 ---
 
@@ -172,12 +176,13 @@ Confirmado además por el hecho de que hay 24 reportes guardados (ver Resumen).
 
 **Síntoma original:** el PDF no se descargaba tras generar el reporte; se sospechaba de RLS en el bucket o de archivos que nunca llegaban a Storage.
 
-**Evidencia:** los 24 reportes tienen `url_storage` poblada, y el más reciente es de hace dos días. Un reporte que no llega a Storage no obtiene URL.
+**Evidencia:** los 28 reportes tienen `url_storage` poblada. Un reporte que no llega a Storage no obtiene URL.
 
 ```sql
+-- verificado 2026-09-07
 select count(*) total, count(url_storage) con_url, max(created_at)::date ultimo
 from reportes_semanales;
--- total = 24 | con_url = 24 | ultimo = 2026-08-01
+-- total = 28 | con_url = 28 | ultimo = 2026-08-31
 ```
 
 Si vuelve a fallar una descarga, ábrase como bug nuevo con el error del navegador: el modo de falla de 2026-02 (archivo inexistente) ya no aplica.


### PR DESCRIPTION
## Bug

`BUG_REPORT.md` is the file Santiago reads to know what is broken, and its numbers had gone stale enough that **its own embedded SQL no longer reproduced the result printed under it**. A bug list that cites figures you cannot reproduce costs attention every time it is opened.

## Root cause

Not a code defect — a record that was last re-verified on 2026-08-03 and has not been touched since, while production kept moving.

## Fix

Every verdict re-checked against production today. **No verdict changed.** Issues 1, 2, 4 and 5 stay closed; issue 6 stays non-reproducible; issue 3b stays open with its code untouched at `src/utils/fetchDatosReporteSemanal.ts:511-522`.

What was stale:

| Claim in the file | Reality 2026-09-07 |
|---|---|
| "24 reportes ... hasta la semana 31 (2026-08-01)" | **28** reportes, all with `url_storage`, last one **week 35 (2026-08-31)** |
| Issue 3b: "7 de las 18 aplicaciones" | **8 de 21** — *Drench agosto* joined the set |
| Issue 3b impact: 1 `Calculada`, no `aplicaciones_compras` rows | unchanged; the 8 affected are all `Cerrada`, so the impact stays **latent** |

```sql
-- reportes
select count(*) total, count(url_storage) con_url, max(created_at)::date ultimo,
       max(numero_semana) filter (where ano = 2026) ultima_semana
from reportes_semanales;
-- total = 28 | con_url = 28 | ultimo = 2026-08-31 | ultima_semana = 35

-- issue 3b
select a.nombre_aplicacion, a.estado, count(c.id) items,
       sum((coalesce(c.cantidad_faltante,0) > 0)::int) items_a_comprar
from aplicaciones a join aplicaciones_compras c on c.aplicacion_id = a.id
group by 1,2 having sum((coalesce(c.cantidad_faltante,0) > 0)::int) = 0;
-- 8 filas, todas 'Cerrada'
```

Also adds one sentence that keeps being re-derived from scratch every run: the weekly report **has no cron** (`cron.job` lists only the six clima / hato / acciones / ronda jobs), so a week with no row is human cadence, not an infrastructure defect.

## Verification

Documentation only — one file, no code path touched. `npx vitest run` 161 files / 3468 tests green, `npm run typecheck` clean, `npm run lint` 0 errors / 906 warnings, all unchanged from `main`.

## Rollback

Revert the commit.

## Follow-up

Issue 3b remains the only open item and it is **not** a bug fix: valuing an insumo taken from bodega is an accounting rule, so it needs Santiago's decision before any number Gerencia reads moves. It is filed as such, not shipped here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_011oMPFsThHx23PfvhfJqxhd

---
_Generated by [Claude Code](https://claude.ai/code/session_011oMPFsThHx23PfvhfJqxhd)_