### PR TITLE
fix(telegram): false error after successful insemination+pajilla write

### DIFF
--- a/src/__tests__/eventoHatoUndo.test.ts
+++ b/src/__tests__/eventoHatoUndo.test.ts
@@ -1,0 +1,245 @@
+/**
+ * Deshacer de /evento (issue #204, incidente 2026-09-08).
+ *
+ * El botón llevaba `hato_ev_undo:${eventoUuid}:${usoUuid}` (~86 bytes).
+ * Telegram corta `callback_data` a 64 bytes: la escritura ya había
+ * ocurrido y el usuario veía "Error registrando el evento".
+ */
+
+import { describe, it, expect } from 'vitest';
+import { readFileSync } from 'node:fs';
+import { resolve } from 'node:path';
+
+import {
+  LIMITE_BYTES_CALLBACK_TELEGRAM,
+  atribucionDesdeFilaTelegram,
+  bytesCallbackData,
+  callbackDeshacerEventoLegacy,
+  construirCallbackDeshacerEvento,
+  elegirUsoIdParaDeshacer,
+  parsearCallbackDeshacerEvento,
+  usoIdDesdeDatosEvento,
+} from '../supabase/functions/server/telegram/eventoHatoUndo';
+
+const EVENTO_ID = 'aaaaaaaa-bbbb-cccc-dddd-eeeeeeeeeeee';
+const USO_ID = '11111111-2222-3333-4444-555555555555';
+const USO_OTRO = '99999999-8888-7777-6666-555555555555';
+
+const COPIAS_HELPER = [
+  'src/supabase/functions/server/telegram/eventoHatoUndo.ts',
+  'supabase/functions/make-server-1ccce916/telegram/eventoHatoUndo.ts',
+];
+
+const COPIAS_CONVERSACION = [
+  'src/supabase/functions/server/telegram/conversations/eventoHato.ts',
+  'supabase/functions/make-server-1ccce916/telegram/conversations/eventoHato.ts',
+];
+
+const COPIAS_BOT = [
+  'src/supabase/functions/server/telegram/bot.ts',
+  'supabase/functions/make-server-1ccce916/telegram/bot.ts',
+];
+
+const RAIZ = resolve(__dirname, '../..');
+
+function leer(ruta: string): string {
+  return readFileSync(resolve(RAIZ, ruta), 'utf8');
+}
+
+describe('callback_data de Deshacer ≤ 64 bytes', () => {
+  it('el formato viejo con usoId supera el límite de Telegram (la hipótesis del incidente)', () => {
+    const viejo = callbackDeshacerEventoLegacy(EVENTO_ID, USO_ID);
+    expect(bytesCallbackData(viejo)).toBeGreaterThan(LIMITE_BYTES_CALLBACK_TELEGRAM);
+    expect(viejo.length).toBeGreaterThan(64);
+  });
+
+  it('el formato viejo sin usoId cabía (por eso monta/parto no fallaban)', () => {
+    const viejoSinUso = callbackDeshacerEventoLegacy(EVENTO_ID, null);
+    expect(bytesCallbackData(viejoSinUso)).toBeLessThanOrEqual(LIMITE_BYTES_CALLBACK_TELEGRAM);
+  });
+
+  it('el callback nuevo (solo evento) cabe, con o sin pajilla detrás', () => {
+    const callback = construirCallbackDeshacerEvento(EVENTO_ID);
+    expect(bytesCallbackData(callback)).toBeLessThanOrEqual(LIMITE_BYTES_CALLBACK_TELEGRAM);
+    expect(callback).toBe(`hato_ev_undo:${EVENTO_ID}`);
+    expect(callback).not.toContain(USO_ID);
+  });
+
+  it('rechaza un eventoId que no es UUID', () => {
+    expect(() => construirCallbackDeshacerEvento('no-es-uuid')).toThrow(/inválido/);
+  });
+});
+
+describe('parsearCallbackDeshacerEvento', () => {
+  it('acepta el formato nuevo (solo evento)', () => {
+    expect(parsearCallbackDeshacerEvento(`hato_ev_undo:${EVENTO_ID}`)).toEqual({
+      eventoId: EVENTO_ID,
+      usoId: null,
+    });
+  });
+
+  it('acepta el formato viejo con uso y el de monta (`:-`)', () => {
+    expect(parsearCallbackDeshacerEvento(`hato_ev_undo:${EVENTO_ID}:${USO_ID}`)).toEqual({
+      eventoId: EVENTO_ID,
+      usoId: USO_ID,
+    });
+    expect(parsearCallbackDeshacerEvento(`hato_ev_undo:${EVENTO_ID}:-`)).toEqual({
+      eventoId: EVENTO_ID,
+      usoId: null,
+    });
+  });
+
+  it('rechaza basura', () => {
+    expect(parsearCallbackDeshacerEvento('hato_ev_undo:foo')).toBeNull();
+    expect(parsearCallbackDeshacerEvento('ronda_undo:' + EVENTO_ID)).toBeNull();
+  });
+});
+
+describe('elegirUsoIdParaDeshacer', () => {
+  const evento = {
+    animal_id: 'vaca-1',
+    fecha: '2026-08-11',
+    created_at: '2026-09-08T14:00:00.000Z',
+  };
+  const usoCercano = {
+    id: USO_ID,
+    animal_id: 'vaca-1',
+    fecha_uso: '2026-08-11',
+    created_at: '2026-09-08T14:00:00.400Z',
+  };
+  const usoLejano = {
+    id: USO_OTRO,
+    animal_id: 'vaca-1',
+    fecha_uso: '2026-08-11',
+    created_at: '2026-09-08T14:02:10.000Z',
+  };
+
+  it('el id del callback viejo gana', () => {
+    expect(
+      elegirUsoIdParaDeshacer({
+        usoIdCallback: USO_OTRO,
+        datosEvento: { pajilla_uso_id: USO_ID },
+        evento,
+        usos: [usoCercano, usoLejano],
+      }),
+    ).toBe(USO_OTRO);
+  });
+
+  it('si el callback no trae uso, lee datos.pajilla_uso_id', () => {
+    expect(usoIdDesdeDatosEvento({ origen: 'telegram', pajilla_uso_id: USO_ID })).toBe(USO_ID);
+    expect(
+      elegirUsoIdParaDeshacer({
+        usoIdCallback: null,
+        datosEvento: { pajilla_uso_id: USO_ID },
+        evento,
+        usos: [],
+      }),
+    ).toBe(USO_ID);
+  });
+
+  it('sin anotación, elige el uso de la misma vaca y fecha más cercano al evento', () => {
+    expect(
+      elegirUsoIdParaDeshacer({
+        usoIdCallback: null,
+        datosEvento: { origen: 'telegram' },
+        evento,
+        usos: [usoLejano, usoCercano],
+      }),
+    ).toBe(USO_ID);
+  });
+
+  it('no inventa un uso de otra vaca u otra fecha', () => {
+    expect(
+      elegirUsoIdParaDeshacer({
+        usoIdCallback: null,
+        datosEvento: null,
+        evento,
+        usos: [
+          { ...usoCercano, animal_id: 'otra-vaca' },
+          { ...usoCercano, id: USO_OTRO, fecha_uso: '2026-08-10' },
+        ],
+      }),
+    ).toBeNull();
+  });
+});
+
+describe('atribucionDesdeFilaTelegram', () => {
+  it('copia usuario_id y nombre_display cuando la fila está vinculada', () => {
+    expect(
+      atribucionDesdeFilaTelegram({
+        usuario_id: 'user-martha',
+        nombre_display: 'Martha Vega',
+      }),
+    ).toEqual({ usuarioId: 'user-martha', nombreDisplay: 'Martha Vega' });
+  });
+
+  it('queda null si no hay fila (cuenta sin vincular)', () => {
+    expect(atribucionDesdeFilaTelegram(null)).toEqual({
+      usuarioId: null,
+      nombreDisplay: null,
+    });
+  });
+});
+
+describe('las dos copias del árbol de edge functions están en sync', () => {
+  it('eventoHatoUndo.ts es byte-idéntico', () => {
+    expect(leer(COPIAS_HELPER[0])).toBe(leer(COPIAS_HELPER[1]));
+  });
+
+  it('eventoHato.ts es byte-idéntico', () => {
+    expect(leer(COPIAS_CONVERSACION[0])).toBe(leer(COPIAS_CONVERSACION[1]));
+  });
+
+  it('el handler hato_ev_undo de bot.ts es byte-idéntico', () => {
+    const cuerpos = COPIAS_BOT.map((ruta) => {
+      const fuente = leer(ruta);
+      const inicio = fuente.indexOf("bot.callbackQuery(/^hato_ev_undo:");
+      expect(inicio).toBeGreaterThan(-1);
+      const fin = fuente.indexOf("bot.callbackQuery(/^hato_alerta:", inicio);
+      expect(fin).toBeGreaterThan(inicio);
+      return fuente.slice(inicio, fin);
+    });
+    expect(cuerpos[0]).toBe(cuerpos[1]);
+  });
+});
+
+describe('contrato en el código (no volver al callback largo ni al catch mentiroso)', () => {
+  for (const ruta of COPIAS_CONVERSACION) {
+    it(`${ruta} no concatena usoId en el callback`, () => {
+      const fuente = leer(ruta);
+      expect(fuente).not.toMatch(/hato_ev_undo:\$\{[^}]+\}:\$\{/);
+      expect(fuente).toContain('construirCallbackDeshacerEvento');
+    });
+
+    it(`${ruta} resuelve telegram_usuarios en el instante de escribir`, () => {
+      const fuente = leer(ruta);
+      expect(fuente).toContain('ctx.from?.id');
+      expect(fuente).toContain('telegram_usuarios');
+      expect(fuente).toContain('atribucionDesdeFilaTelegram');
+      // La lectura al entrar al flujo es la que dejaba created_by en NULL
+      // cuando el plugin replayaba sin ctx.telegramUser.
+      expect(fuente).not.toMatch(/const usuarioId = ctx\.telegramUser/);
+    });
+
+    it(`${ruta} no trata un fallo del reply de éxito como fallo de escritura`, () => {
+      const fuente = leer(ruta);
+      expect(fuente).toContain('let escrito = false');
+      expect(fuente).toContain('El evento quedó guardado');
+      const idxEscrito = fuente.indexOf('escrito = true');
+      const idxReply = fuente.lastIndexOf('ctx.reply(textoExito');
+      const idxCatch = fuente.lastIndexOf('Error registrando el evento');
+      expect(idxEscrito).toBeGreaterThan(-1);
+      expect(idxReply).toBeGreaterThan(idxEscrito);
+      expect(idxCatch).toBeGreaterThan(idxReply);
+    });
+  }
+
+  for (const ruta of COPIAS_BOT) {
+    it(`${ruta} busca el uso por evento cuando el callback no lo trae`, () => {
+      const fuente = leer(ruta);
+      expect(fuente).toContain('elegirUsoIdParaDeshacer');
+      expect(fuente).toContain('hato_pajillas_uso');
+      expect(fuente).toContain('pajilla_uso_id');
+    });
+  }
+});

--- a/src/supabase/functions/server/telegram/bot.ts
+++ b/src/supabase/functions/server/telegram/bot.ts
@@ -19,6 +19,11 @@ import { gastoConversation } from "./conversations/gasto.ts";
 import { ingresoConversation } from "./conversations/ingreso.ts";
 import { pesajeLecheConversation } from "./conversations/pesajeLeche.ts";
 import { eventoHatoConversation } from "./conversations/eventoHato.ts";
+import {
+  elegirUsoIdParaDeshacer,
+  parsearCallbackDeshacerEvento,
+  usoIdDesdeDatosEvento,
+} from "./eventoHatoUndo.ts";
 import { cierreRondaConversation } from "./conversations/cierreRonda.ts";
 import { excepcionDavidConversation } from "./conversations/excepcionDavid.ts";
 // `produccionQuincenal` (litros al camión) se retiró del bot -- SOW 3 de
@@ -1393,18 +1398,18 @@ function getBot(): Bot<BotContext> {
   // borrar un evento derivado de un chequeo aprobado.
   // --------------------------------------------------------------------------
 
-  bot.callbackQuery(/^hato_ev_undo:([0-9a-f-]+):([0-9a-f-]+|-)$/, async (ctx) => {
-    const eventoId = ctx.match?.[1];
-    const usoId = ctx.match?.[2];
-    if (!eventoId) {
+  bot.callbackQuery(/^hato_ev_undo:/, async (ctx) => {
+    const parsed = parsearCallbackDeshacerEvento(ctx.callbackQuery.data ?? "");
+    if (!parsed) {
       await ctx.answerCallbackQuery({ text: "No se pudo procesar." });
       return;
     }
+    const eventoId = parsed.eventoId;
 
     const sb = getSupabaseAdmin();
     const { data: evento } = await sb
       .from("hato_eventos")
-      .select("id, fuente")
+      .select("id, fuente, animal_id, fecha, created_at, datos, tipo, tipo_servicio")
       .eq("id", eventoId)
       .maybeSingle();
 
@@ -1417,9 +1422,45 @@ function getBot(): Bot<BotContext> {
       return;
     }
 
+    // El callback ya no lleva el usoId (límite de 64 bytes). Se busca por
+    // datos.pajilla_uso_id o, si falta, por vaca+fecha del mismo instante.
+    // Solo se listan usos cuando el evento es una inseminación: deshacer un
+    // parto o una monta del mismo día no puede devolver la pajilla de otra.
+    let usos: Array<{
+      id: string;
+      animal_id: string | null;
+      fecha_uso: string;
+      created_at: string;
+    }> = [];
+    const esInseminacion =
+      evento.tipo === "servicio" && evento.tipo_servicio === "inseminacion";
+    if (
+      esInseminacion &&
+      !parsed.usoId &&
+      !usoIdDesdeDatosEvento(evento.datos)
+    ) {
+      const { data: usosData } = await sb
+        .from("hato_pajillas_uso")
+        .select("id, animal_id, fecha_uso, created_at")
+        .eq("animal_id", evento.animal_id)
+        .eq("fecha_uso", evento.fecha);
+      usos = (usosData ?? []) as typeof usos;
+    }
+
+    const usoId = elegirUsoIdParaDeshacer({
+      usoIdCallback: parsed.usoId,
+      datosEvento: evento.datos,
+      evento: {
+        animal_id: evento.animal_id as string,
+        fecha: evento.fecha as string,
+        created_at: evento.created_at as string,
+      },
+      usos,
+    });
+
     // El uso de pajilla se borra PRIMERO: si fallara después del evento, el
     // inventario quedaría descontado por un servicio que ya no existe.
-    if (usoId && usoId !== "-") {
+    if (usoId) {
       const { error: errorUso } = await sb.from("hato_pajillas_uso").delete().eq("id", usoId);
       if (errorUso) {
         await ctx.answerCallbackQuery({ text: "No se pudo devolver la pajilla. No borré nada." });

--- a/src/supabase/functions/server/telegram/conversations/eventoHato.ts
+++ b/src/supabase/functions/server/telegram/conversations/eventoHato.ts
@@ -43,6 +43,10 @@ import {
   type HatoConfig,
 } from "../../calculos-hato.ts";
 import { construirHatoConfigDesdeFilas } from "../../hato-config-desde-tabla.ts";
+import {
+  atribucionDesdeFilaTelegram,
+  construirCallbackDeshacerEvento,
+} from "../eventoHatoUndo.ts";
 
 function getSupabaseAdmin() {
   const url = Deno.env.get("SUPABASE_URL")!;
@@ -198,8 +202,7 @@ export async function eventoHatoConversation(
   conversation: Conversation<BotContext>,
   ctx: BotContext,
 ) {
-  const usuarioId = ctx.telegramUser?.usuario_id ?? null;
-
+  let escrito = false;
   try {
     // ── Paso 1: ¿qué pasó? ────────────────────────────────────────────
     const kbTipo = new InlineKeyboard()
@@ -532,6 +535,31 @@ export async function eventoHatoConversation(
     // ── Paso 8: escribir ──────────────────────────────────────────────
     const guardado = await conversation.external(async () => {
       const sb = getSupabaseAdmin();
+      // `ctx.telegramUser` es flavor propio y no sobrevive el replay del
+      // plugin de conversaciones (hallazgo 2026-08-28 en excepcionDavid).
+      // `ctx.from.id` sí es nativo de grammY. Se reconsulta acá, en el
+      // instante de escribir: si se leyera al entrar al flujo, un replay
+      // tardío dejaría created_by y registrado_por en NULL — que es lo
+      // que quedó en las dos filas de Martha del 2026-09-08.
+      const telegramId = ctx.from?.id;
+      let filaTelegram: { usuario_id: string | null; nombre_display: string | null } | null =
+        null;
+      if (telegramId != null) {
+        const { data: tgUser } = await sb
+          .from("telegram_usuarios")
+          .select("usuario_id, nombre_display")
+          .eq("telegram_id", telegramId)
+          .eq("activo", true)
+          .maybeSingle();
+        filaTelegram = (tgUser as { usuario_id: string | null; nombre_display: string | null } | null) ??
+          null;
+      }
+      const { usuarioId, nombreDisplay } = atribucionDesdeFilaTelegram(filaTelegram);
+
+      const datosEvento: Record<string, unknown> = {
+        origen: "telegram",
+        registrado_por: nombreDisplay,
+      };
       const { data, error } = await sb
         .from("hato_eventos")
         .insert({
@@ -547,7 +575,7 @@ export async function eventoHatoConversation(
           fuente: "telegram",
           // chequeo_vaca_id se deja NULL: es lo que vuelve este evento
           // intocable por fn_hato_commit_chequeo (065).
-          datos: { origen: "telegram", registrado_por: ctx.telegramUser?.nombre_display ?? null },
+          datos: datosEvento,
           created_by: usuarioId,
         })
         .select("id")
@@ -573,23 +601,48 @@ export async function eventoHatoConversation(
           console.error("[Telegram] No se pudo descontar la pajilla:", usoErr.message);
         } else {
           usoId = uso!.id as string;
+          // Anotar el id en datos: el callback de Deshacer ya no cabe dos
+          // UUID (límite de 64 bytes). Si este UPDATE falla, el handler
+          // busca el uso por vaca+fecha+cercanía temporal.
+          const { error: linkErr } = await sb
+            .from("hato_eventos")
+            .update({ datos: { ...datosEvento, pajilla_uso_id: usoId } })
+            .eq("id", data!.id);
+          if (linkErr) {
+            console.error(
+              "[Telegram] No se pudo anotar pajilla_uso_id en el evento:",
+              linkErr.message,
+            );
+          }
         }
       }
       return { eventoId: data!.id as string, usoId };
     });
+    escrito = true;
 
-    const kbDeshacer = new InlineKeyboard().text(
-      "↩️ Deshacer",
-      `hato_ev_undo:${guardado.eventoId}:${guardado.usoId ?? "-"}`,
-    );
-    await ctx.reply(
-      `✅ Registrado.\n\n${resumen}\n\nSi te equivocaste de vaca, usa Deshacer.\nUsa /start para volver al menú.`,
-      { reply_markup: kbDeshacer, parse_mode: "Markdown" },
-    );
+    const textoExito =
+      `✅ Registrado.\n\n${resumen}\n\nSi te equivocaste de vaca, usa Deshacer.\nUsa /start para volver al menú.`;
+    const textoExitoSinBoton =
+      `✅ Registrado.\n\n${resumen}\n\nEl evento quedó guardado. Usa /start para volver al menú.`;
+    try {
+      const kbDeshacer = new InlineKeyboard().text(
+        "↩️ Deshacer",
+        construirCallbackDeshacerEvento(guardado.eventoId),
+      );
+      await ctx.reply(textoExito, { reply_markup: kbDeshacer, parse_mode: "Markdown" });
+    } catch (replyErr: unknown) {
+      const msgReply = replyErr instanceof Error ? replyErr.message : "Error desconocido";
+      console.error("[Telegram] Evento hato: escrito, fallo al enviar Deshacer:", msgReply);
+      await ctx.reply(textoExitoSinBoton, { parse_mode: "Markdown" });
+    }
   } catch (err: unknown) {
     if (err instanceof Error && err.message === "Conversation already halted") return;
     const msg = err instanceof Error ? err.message : "Error desconocido";
     console.error("[Telegram] Evento hato conversation error:", msg);
+    if (escrito) {
+      await ctx.reply("✅ El evento quedó guardado. Usa /start para volver al menú.");
+      return;
+    }
     await ctx.reply(`Error registrando el evento: ${msg}\n\nUsa /start para volver al menú.`);
   }
 }

--- a/src/supabase/functions/server/telegram/eventoHatoUndo.ts
+++ b/src/supabase/functions/server/telegram/eventoHatoUndo.ts
@@ -1,0 +1,125 @@
+// telegram/eventoHatoUndo.ts — helpers puros del Deshacer de /evento.
+//
+// El 2026-09-08 Martha registró Electra+Jericó dos veces: ambas escrituras
+// llegaron a `hato_eventos` + `hato_pajillas_uso`, y ella vio
+// "Error registrando el evento". El botón Deshacer armaba
+// `hato_ev_undo:${eventoUuid}:${usoUuid}` (~86 bytes). Telegram rechaza
+// `callback_data` de más de 64 bytes; el `ctx.reply` fallaba y el catch
+// de la conversación mentía. El camino sin pajilla (`…:-`, ~51 bytes)
+// nunca falló.
+//
+// Contrato: el callback lleva SOLO el id del evento. El uso de pajilla
+// se recupera del `datos.pajilla_uso_id` del evento, o —si esa anotación
+// no está— del uso de la misma vaca y fecha más cercano en el tiempo.
+// Sin migración: `hato_pajillas_uso` no tiene `evento_id`.
+//
+// Este archivo no importa Deno ni grammy a propósito: Vitest lo carga
+// directo. Las dos copias del árbol de edge functions tienen que ser
+// byte-idénticas.
+
+export const PREFIJO_DESHACER_EVENTO = "hato_ev_undo:";
+export const LIMITE_BYTES_CALLBACK_TELEGRAM = 64;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function esUuid(valor: string): boolean {
+  return UUID_RE.test(valor);
+}
+
+export function bytesCallbackData(data: string): number {
+  return new TextEncoder().encode(data).length;
+}
+
+/** Formato viejo que Telegram rechazaba cuando había uso de pajilla. */
+export function callbackDeshacerEventoLegacy(eventoId: string, usoId: string | null): string {
+  return `${PREFIJO_DESHACER_EVENTO}${eventoId}:${usoId ?? "-"}`;
+}
+
+export function construirCallbackDeshacerEvento(eventoId: string): string {
+  if (!esUuid(eventoId)) {
+    throw new Error("eventoId inválido para Deshacer");
+  }
+  const callback = `${PREFIJO_DESHACER_EVENTO}${eventoId.toLowerCase()}`;
+  if (bytesCallbackData(callback) > LIMITE_BYTES_CALLBACK_TELEGRAM) {
+    throw new Error("callback_data de Deshacer excede el límite de Telegram");
+  }
+  return callback;
+}
+
+export function parsearCallbackDeshacerEvento(
+  data: string,
+): { eventoId: string; usoId: string | null } | null {
+  const m = data.match(
+    /^hato_ev_undo:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?::([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|-))?$/i,
+  );
+  if (!m) return null;
+  return {
+    eventoId: m[1].toLowerCase(),
+    usoId: !m[2] || m[2] === "-" ? null : m[2].toLowerCase(),
+  };
+}
+
+export function usoIdDesdeDatosEvento(datos: unknown): string | null {
+  if (!datos || typeof datos !== "object") return null;
+  const raw = (datos as Record<string, unknown>).pajilla_uso_id;
+  if (typeof raw !== "string" || !esUuid(raw)) return null;
+  return raw.toLowerCase();
+}
+
+export interface EventoParaDeshacerUso {
+  animal_id: string;
+  fecha: string;
+  created_at: string;
+}
+
+export interface UsoCandidatoDeshacer {
+  id: string;
+  animal_id: string | null;
+  fecha_uso: string;
+  created_at: string;
+}
+
+/**
+ * Resuelve el uso de pajilla que hay que devolver al deshacer.
+ *
+ * Prioridad: id del callback (botones viejos) → `datos.pajilla_uso_id` →
+ * el uso de la misma vaca y fecha más cercano a `evento.created_at`.
+ * El caller solo pasa candidatos cuando el evento es una inseminación;
+ * si no, `usos` va vacío y no se inventa un uso de otro tipo de evento.
+ */
+export function elegirUsoIdParaDeshacer(args: {
+  usoIdCallback: string | null;
+  datosEvento: unknown;
+  evento: EventoParaDeshacerUso;
+  usos: UsoCandidatoDeshacer[];
+}): string | null {
+  if (args.usoIdCallback && esUuid(args.usoIdCallback)) {
+    return args.usoIdCallback.toLowerCase();
+  }
+  const desdeDatos = usoIdDesdeDatosEvento(args.datosEvento);
+  if (desdeDatos) return desdeDatos;
+
+  const candidatos = args.usos.filter(
+    (u) => u.animal_id === args.evento.animal_id && u.fecha_uso === args.evento.fecha,
+  );
+  if (candidatos.length === 0) return null;
+  const tEvento = Date.parse(args.evento.created_at);
+  if (Number.isNaN(tEvento)) return null;
+  candidatos.sort(
+    (a, b) =>
+      Math.abs(Date.parse(a.created_at) - tEvento) -
+      Math.abs(Date.parse(b.created_at) - tEvento),
+  );
+  return candidatos[0].id;
+}
+
+/** Atribución que el bot escribe con service_role (auth.uid() es NULL). */
+export function atribucionDesdeFilaTelegram(
+  fila: { usuario_id: string | null; nombre_display: string | null } | null,
+): { usuarioId: string | null; nombreDisplay: string | null } {
+  return {
+    usuarioId: fila?.usuario_id ?? null,
+    nombreDisplay: fila?.nombre_display ?? null,
+  };
+}

--- a/supabase/functions/make-server-1ccce916/telegram/bot.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/bot.ts
@@ -19,6 +19,11 @@ import { gastoConversation } from "./conversations/gasto.ts";
 import { ingresoConversation } from "./conversations/ingreso.ts";
 import { pesajeLecheConversation } from "./conversations/pesajeLeche.ts";
 import { eventoHatoConversation } from "./conversations/eventoHato.ts";
+import {
+  elegirUsoIdParaDeshacer,
+  parsearCallbackDeshacerEvento,
+  usoIdDesdeDatosEvento,
+} from "./eventoHatoUndo.ts";
 import { cierreRondaConversation } from "./conversations/cierreRonda.ts";
 import { excepcionDavidConversation } from "./conversations/excepcionDavid.ts";
 // `produccionQuincenal` (litros al camión) se retiró del bot -- SOW 3 de
@@ -1393,18 +1398,18 @@ function getBot(): Bot<BotContext> {
   // borrar un evento derivado de un chequeo aprobado.
   // --------------------------------------------------------------------------
 
-  bot.callbackQuery(/^hato_ev_undo:([0-9a-f-]+):([0-9a-f-]+|-)$/, async (ctx) => {
-    const eventoId = ctx.match?.[1];
-    const usoId = ctx.match?.[2];
-    if (!eventoId) {
+  bot.callbackQuery(/^hato_ev_undo:/, async (ctx) => {
+    const parsed = parsearCallbackDeshacerEvento(ctx.callbackQuery.data ?? "");
+    if (!parsed) {
       await ctx.answerCallbackQuery({ text: "No se pudo procesar." });
       return;
     }
+    const eventoId = parsed.eventoId;
 
     const sb = getSupabaseAdmin();
     const { data: evento } = await sb
       .from("hato_eventos")
-      .select("id, fuente")
+      .select("id, fuente, animal_id, fecha, created_at, datos, tipo, tipo_servicio")
       .eq("id", eventoId)
       .maybeSingle();
 
@@ -1417,9 +1422,45 @@ function getBot(): Bot<BotContext> {
       return;
     }
 
+    // El callback ya no lleva el usoId (límite de 64 bytes). Se busca por
+    // datos.pajilla_uso_id o, si falta, por vaca+fecha del mismo instante.
+    // Solo se listan usos cuando el evento es una inseminación: deshacer un
+    // parto o una monta del mismo día no puede devolver la pajilla de otra.
+    let usos: Array<{
+      id: string;
+      animal_id: string | null;
+      fecha_uso: string;
+      created_at: string;
+    }> = [];
+    const esInseminacion =
+      evento.tipo === "servicio" && evento.tipo_servicio === "inseminacion";
+    if (
+      esInseminacion &&
+      !parsed.usoId &&
+      !usoIdDesdeDatosEvento(evento.datos)
+    ) {
+      const { data: usosData } = await sb
+        .from("hato_pajillas_uso")
+        .select("id, animal_id, fecha_uso, created_at")
+        .eq("animal_id", evento.animal_id)
+        .eq("fecha_uso", evento.fecha);
+      usos = (usosData ?? []) as typeof usos;
+    }
+
+    const usoId = elegirUsoIdParaDeshacer({
+      usoIdCallback: parsed.usoId,
+      datosEvento: evento.datos,
+      evento: {
+        animal_id: evento.animal_id as string,
+        fecha: evento.fecha as string,
+        created_at: evento.created_at as string,
+      },
+      usos,
+    });
+
     // El uso de pajilla se borra PRIMERO: si fallara después del evento, el
     // inventario quedaría descontado por un servicio que ya no existe.
-    if (usoId && usoId !== "-") {
+    if (usoId) {
       const { error: errorUso } = await sb.from("hato_pajillas_uso").delete().eq("id", usoId);
       if (errorUso) {
         await ctx.answerCallbackQuery({ text: "No se pudo devolver la pajilla. No borré nada." });

--- a/supabase/functions/make-server-1ccce916/telegram/conversations/eventoHato.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/conversations/eventoHato.ts
@@ -43,6 +43,10 @@ import {
   type HatoConfig,
 } from "../../calculos-hato.ts";
 import { construirHatoConfigDesdeFilas } from "../../hato-config-desde-tabla.ts";
+import {
+  atribucionDesdeFilaTelegram,
+  construirCallbackDeshacerEvento,
+} from "../eventoHatoUndo.ts";
 
 function getSupabaseAdmin() {
   const url = Deno.env.get("SUPABASE_URL")!;
@@ -198,8 +202,7 @@ export async function eventoHatoConversation(
   conversation: Conversation<BotContext>,
   ctx: BotContext,
 ) {
-  const usuarioId = ctx.telegramUser?.usuario_id ?? null;
-
+  let escrito = false;
   try {
     // ── Paso 1: ¿qué pasó? ────────────────────────────────────────────
     const kbTipo = new InlineKeyboard()
@@ -532,6 +535,31 @@ export async function eventoHatoConversation(
     // ── Paso 8: escribir ──────────────────────────────────────────────
     const guardado = await conversation.external(async () => {
       const sb = getSupabaseAdmin();
+      // `ctx.telegramUser` es flavor propio y no sobrevive el replay del
+      // plugin de conversaciones (hallazgo 2026-08-28 en excepcionDavid).
+      // `ctx.from.id` sí es nativo de grammY. Se reconsulta acá, en el
+      // instante de escribir: si se leyera al entrar al flujo, un replay
+      // tardío dejaría created_by y registrado_por en NULL — que es lo
+      // que quedó en las dos filas de Martha del 2026-09-08.
+      const telegramId = ctx.from?.id;
+      let filaTelegram: { usuario_id: string | null; nombre_display: string | null } | null =
+        null;
+      if (telegramId != null) {
+        const { data: tgUser } = await sb
+          .from("telegram_usuarios")
+          .select("usuario_id, nombre_display")
+          .eq("telegram_id", telegramId)
+          .eq("activo", true)
+          .maybeSingle();
+        filaTelegram = (tgUser as { usuario_id: string | null; nombre_display: string | null } | null) ??
+          null;
+      }
+      const { usuarioId, nombreDisplay } = atribucionDesdeFilaTelegram(filaTelegram);
+
+      const datosEvento: Record<string, unknown> = {
+        origen: "telegram",
+        registrado_por: nombreDisplay,
+      };
       const { data, error } = await sb
         .from("hato_eventos")
         .insert({
@@ -547,7 +575,7 @@ export async function eventoHatoConversation(
           fuente: "telegram",
           // chequeo_vaca_id se deja NULL: es lo que vuelve este evento
           // intocable por fn_hato_commit_chequeo (065).
-          datos: { origen: "telegram", registrado_por: ctx.telegramUser?.nombre_display ?? null },
+          datos: datosEvento,
           created_by: usuarioId,
         })
         .select("id")
@@ -573,23 +601,48 @@ export async function eventoHatoConversation(
           console.error("[Telegram] No se pudo descontar la pajilla:", usoErr.message);
         } else {
           usoId = uso!.id as string;
+          // Anotar el id en datos: el callback de Deshacer ya no cabe dos
+          // UUID (límite de 64 bytes). Si este UPDATE falla, el handler
+          // busca el uso por vaca+fecha+cercanía temporal.
+          const { error: linkErr } = await sb
+            .from("hato_eventos")
+            .update({ datos: { ...datosEvento, pajilla_uso_id: usoId } })
+            .eq("id", data!.id);
+          if (linkErr) {
+            console.error(
+              "[Telegram] No se pudo anotar pajilla_uso_id en el evento:",
+              linkErr.message,
+            );
+          }
         }
       }
       return { eventoId: data!.id as string, usoId };
     });
+    escrito = true;
 
-    const kbDeshacer = new InlineKeyboard().text(
-      "↩️ Deshacer",
-      `hato_ev_undo:${guardado.eventoId}:${guardado.usoId ?? "-"}`,
-    );
-    await ctx.reply(
-      `✅ Registrado.\n\n${resumen}\n\nSi te equivocaste de vaca, usa Deshacer.\nUsa /start para volver al menú.`,
-      { reply_markup: kbDeshacer, parse_mode: "Markdown" },
-    );
+    const textoExito =
+      `✅ Registrado.\n\n${resumen}\n\nSi te equivocaste de vaca, usa Deshacer.\nUsa /start para volver al menú.`;
+    const textoExitoSinBoton =
+      `✅ Registrado.\n\n${resumen}\n\nEl evento quedó guardado. Usa /start para volver al menú.`;
+    try {
+      const kbDeshacer = new InlineKeyboard().text(
+        "↩️ Deshacer",
+        construirCallbackDeshacerEvento(guardado.eventoId),
+      );
+      await ctx.reply(textoExito, { reply_markup: kbDeshacer, parse_mode: "Markdown" });
+    } catch (replyErr: unknown) {
+      const msgReply = replyErr instanceof Error ? replyErr.message : "Error desconocido";
+      console.error("[Telegram] Evento hato: escrito, fallo al enviar Deshacer:", msgReply);
+      await ctx.reply(textoExitoSinBoton, { parse_mode: "Markdown" });
+    }
   } catch (err: unknown) {
     if (err instanceof Error && err.message === "Conversation already halted") return;
     const msg = err instanceof Error ? err.message : "Error desconocido";
     console.error("[Telegram] Evento hato conversation error:", msg);
+    if (escrito) {
+      await ctx.reply("✅ El evento quedó guardado. Usa /start para volver al menú.");
+      return;
+    }
     await ctx.reply(`Error registrando el evento: ${msg}\n\nUsa /start para volver al menú.`);
   }
 }

--- a/supabase/functions/make-server-1ccce916/telegram/eventoHatoUndo.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/eventoHatoUndo.ts
@@ -1,0 +1,125 @@
+// telegram/eventoHatoUndo.ts — helpers puros del Deshacer de /evento.
+//
+// El 2026-09-08 Martha registró Electra+Jericó dos veces: ambas escrituras
+// llegaron a `hato_eventos` + `hato_pajillas_uso`, y ella vio
+// "Error registrando el evento". El botón Deshacer armaba
+// `hato_ev_undo:${eventoUuid}:${usoUuid}` (~86 bytes). Telegram rechaza
+// `callback_data` de más de 64 bytes; el `ctx.reply` fallaba y el catch
+// de la conversación mentía. El camino sin pajilla (`…:-`, ~51 bytes)
+// nunca falló.
+//
+// Contrato: el callback lleva SOLO el id del evento. El uso de pajilla
+// se recupera del `datos.pajilla_uso_id` del evento, o —si esa anotación
+// no está— del uso de la misma vaca y fecha más cercano en el tiempo.
+// Sin migración: `hato_pajillas_uso` no tiene `evento_id`.
+//
+// Este archivo no importa Deno ni grammy a propósito: Vitest lo carga
+// directo. Las dos copias del árbol de edge functions tienen que ser
+// byte-idénticas.
+
+export const PREFIJO_DESHACER_EVENTO = "hato_ev_undo:";
+export const LIMITE_BYTES_CALLBACK_TELEGRAM = 64;
+
+const UUID_RE =
+  /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i;
+
+export function esUuid(valor: string): boolean {
+  return UUID_RE.test(valor);
+}
+
+export function bytesCallbackData(data: string): number {
+  return new TextEncoder().encode(data).length;
+}
+
+/** Formato viejo que Telegram rechazaba cuando había uso de pajilla. */
+export function callbackDeshacerEventoLegacy(eventoId: string, usoId: string | null): string {
+  return `${PREFIJO_DESHACER_EVENTO}${eventoId}:${usoId ?? "-"}`;
+}
+
+export function construirCallbackDeshacerEvento(eventoId: string): string {
+  if (!esUuid(eventoId)) {
+    throw new Error("eventoId inválido para Deshacer");
+  }
+  const callback = `${PREFIJO_DESHACER_EVENTO}${eventoId.toLowerCase()}`;
+  if (bytesCallbackData(callback) > LIMITE_BYTES_CALLBACK_TELEGRAM) {
+    throw new Error("callback_data de Deshacer excede el límite de Telegram");
+  }
+  return callback;
+}
+
+export function parsearCallbackDeshacerEvento(
+  data: string,
+): { eventoId: string; usoId: string | null } | null {
+  const m = data.match(
+    /^hato_ev_undo:([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12})(?::([0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}|-))?$/i,
+  );
+  if (!m) return null;
+  return {
+    eventoId: m[1].toLowerCase(),
+    usoId: !m[2] || m[2] === "-" ? null : m[2].toLowerCase(),
+  };
+}
+
+export function usoIdDesdeDatosEvento(datos: unknown): string | null {
+  if (!datos || typeof datos !== "object") return null;
+  const raw = (datos as Record<string, unknown>).pajilla_uso_id;
+  if (typeof raw !== "string" || !esUuid(raw)) return null;
+  return raw.toLowerCase();
+}
+
+export interface EventoParaDeshacerUso {
+  animal_id: string;
+  fecha: string;
+  created_at: string;
+}
+
+export interface UsoCandidatoDeshacer {
+  id: string;
+  animal_id: string | null;
+  fecha_uso: string;
+  created_at: string;
+}
+
+/**
+ * Resuelve el uso de pajilla que hay que devolver al deshacer.
+ *
+ * Prioridad: id del callback (botones viejos) → `datos.pajilla_uso_id` →
+ * el uso de la misma vaca y fecha más cercano a `evento.created_at`.
+ * El caller solo pasa candidatos cuando el evento es una inseminación;
+ * si no, `usos` va vacío y no se inventa un uso de otro tipo de evento.
+ */
+export function elegirUsoIdParaDeshacer(args: {
+  usoIdCallback: string | null;
+  datosEvento: unknown;
+  evento: EventoParaDeshacerUso;
+  usos: UsoCandidatoDeshacer[];
+}): string | null {
+  if (args.usoIdCallback && esUuid(args.usoIdCallback)) {
+    return args.usoIdCallback.toLowerCase();
+  }
+  const desdeDatos = usoIdDesdeDatosEvento(args.datosEvento);
+  if (desdeDatos) return desdeDatos;
+
+  const candidatos = args.usos.filter(
+    (u) => u.animal_id === args.evento.animal_id && u.fecha_uso === args.evento.fecha,
+  );
+  if (candidatos.length === 0) return null;
+  const tEvento = Date.parse(args.evento.created_at);
+  if (Number.isNaN(tEvento)) return null;
+  candidatos.sort(
+    (a, b) =>
+      Math.abs(Date.parse(a.created_at) - tEvento) -
+      Math.abs(Date.parse(b.created_at) - tEvento),
+  );
+  return candidatos[0].id;
+}
+
+/** Atribución que el bot escribe con service_role (auth.uid() es NULL). */
+export function atribucionDesdeFilaTelegram(
+  fila: { usuario_id: string | null; nombre_display: string | null } | null,
+): { usuarioId: string | null; nombreDisplay: string | null } {
+  return {
+    usuarioId: fila?.usuario_id ?? null,
+    nombreDisplay: fila?.nombre_display ?? null,
+  };
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
Fixes #204.

## Problem

Martha registered Electra + Jericó twice on 2026-09-08 via Telegram. Both writes succeeded (`hato_eventos` + `hato_pajillas_uso`). She saw **Error registrando el evento**. Stock went 3 → 1.

The Deshacer button built `hato_ev_undo:${eventoUuid}:${usoUuid}` (~86 bytes). Telegram rejects `callback_data` over 64 bytes. The success reply failed. The conversation catch treated that as a write failure. The path without pajilla (`…:-`, ~51 bytes) never hit this.

`created_by` and `datos.registrado_por` were also NULL on those rows. `ctx.telegramUser` is a custom flavor and does not survive grammY conversation replay.

## Change

- Deshacer `callback_data` is only `hato_ev_undo:${eventoId}` (49 bytes).
- Undo looks up the pajilla uso from `datos.pajilla_uso_id`, or from the same animal + date closest in time. Old two-UUID callbacks still parse.
- If the success keyboard fails after a successful write, the bot still replies that the event was saved.
- Attribution is resolved at write time from `telegram_usuarios` via `ctx.from.id`.

No migration. Telegram still writes direct. `chequeo_vaca_id` stays null. Service role still sets `created_by` explicitly.

Both edge-function trees stay in sync:
- `src/supabase/functions/server/telegram/`
- `supabase/functions/make-server-1ccce916/telegram/`

## Deploy

This change is **inert until the edge function is redeployed**. The webhook serves the deployed copy, not `main`.

```bash
npx supabase functions deploy make-server-1ccce916
```

The webhook secret and `setWebhook` do not need a change. Only the handler source changed.

## Verify

- Unit tests in `src/__tests__/eventoHatoUndo.test.ts`: old callback > 64 bytes; new callback ≤ 64; undo lookup by event; attribution helper; both trees identical.
- After deploy: register an insemination with pajilla → must see **Registrado** and Deshacer. Tap Deshacer → event and uso gone, stock restored.

Do not merge from this PR without the deploy step, or production keeps the false error.
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-e89fdad7-5fca-4bd3-b529-156b23d0c301?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-e89fdad7-5fca-4bd3-b529-156b23d0c301&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

