### PR TITLE
fix(telegram): cancelar usa exitAll(), porque exit() sin nombre no hace nada

### DIFF
--- a/src/__tests__/telegramSalidaConversacion.test.ts
+++ b/src/__tests__/telegramSalidaConversacion.test.ts
@@ -68,10 +68,19 @@ describe('salida de conversación del bot de Telegram', () => {
         expect(cancelar).toBeGreaterThan(instala);
       });
 
-      it('la salida llama a ctx.conversation.exit()', () => {
+      it('la salida llama a exitAll(), nunca al exit() pelado', () => {
         const desde = texto.indexOf(REGISTRO_CANCELAR);
-        const cuerpo = texto.slice(desde, desde + 400);
-        expect(cuerpo).toContain('ctx.conversation.exit()');
+        const cuerpo = texto.slice(desde, desde + 900);
+        expect(cuerpo).toContain('ctx.conversation.exitAll()');
+      });
+
+      // `exit(name: string)` pide el nombre de UNA conversación. Sin argumento
+      // el plugin evalúa `data[undefined]`, no encuentra la clave y retorna:
+      // no lanza, no avisa, no cierra nada. Así estuvo el bot hasta el
+      // 2026-09-09, y nadie lo vio porque sin conversación abierta el comando
+      // igual contestaba «Operación cancelada».
+      it('en ningún lado se llama a exit() sin nombre', () => {
+        expect(texto).not.toContain('conversation.exit()');
       });
     });
   }

--- a/src/supabase/functions/server/telegram/bot.ts
+++ b/src/supabase/functions/server/telegram/bot.ts
@@ -246,7 +246,12 @@ function getBot(): Bot<BotContext> {
   // siendo una acción de un usuario registrado.
   bot.command("cancelar", async (ctx) => {
     ctx.session.pendienteNotaRonda = null;
-    await ctx.conversation.exit();
+    // `exitAll()`, NUNCA `exit()`. La firma es `exit(name: string)`: con el
+    // nombre de UNA conversación. Llamarla sin argumento no falla y no avisa —
+    // el plugin evalúa `data[undefined]`, no encuentra la clave y retorna. Era
+    // un no-op, y por eso nadie lo notó: sin conversación abierta el comando
+    // igual contestaba «Operación cancelada» y pintaba el menú.
+    await ctx.conversation.exitAll();
     await ctx.reply("Operación cancelada.");
     await sendMainMenu(ctx);
   });

--- a/supabase/functions/make-server-1ccce916/telegram/bot.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/bot.ts
@@ -246,7 +246,12 @@ function getBot(): Bot<BotContext> {
   // siendo una acción de un usuario registrado.
   bot.command("cancelar", async (ctx) => {
     ctx.session.pendienteNotaRonda = null;
-    await ctx.conversation.exit();
+    // `exitAll()`, NUNCA `exit()`. La firma es `exit(name: string)`: con el
+    // nombre de UNA conversación. Llamarla sin argumento no falla y no avisa —
+    // el plugin evalúa `data[undefined]`, no encuentra la clave y retorna. Era
+    // un no-op, y por eso nadie lo notó: sin conversación abierta el comando
+    // igual contestaba «Operación cancelada» y pintaba el menú.
+    await ctx.conversation.exitAll();
     await ctx.reply("Operación cancelada.");
     await sendMainMenu(ctx);
   });


### PR DESCRIPTION
Cierra la otra mitad del incidente del #210. Sin esto, aquel PR sólo volvió
alcanzable un comando inerte.

## El defecto

`ctx.conversation.exit()` se llamaba **sin argumento**. La firma de
`@grammyjs/conversations@2.1.1` pide el nombre de UNA conversación:

```js
// out/plugin.js
async exit(name) {
    const data = getData();
    if (data[name] === undefined) return;   // <- siempre acá
    ...
}
```

Con `name === undefined` el plugin evalúa `data[undefined]`, no encuentra la
clave y retorna. No lanza y no avisa. Era un no-op desde siempre.

El método que purga todo el estado es **`exitAll()`**.

## Por qué nadie lo vio

Dos capas fallaron a la vez.

1. **Se ve funcionando.** Sin conversación abierta el comando igual contesta
   «Operación cancelada» y pinta el menú — que es exactamente lo que se
   observa al probarlo a mano. La única forma de notar el no-op es probarlo
   *con* una conversación abierta, y hasta el #210 eso era imposible: el
   comando ni siquiera llegaba a ejecutarse.
2. **No lo toma ninguna herramienta.** `src/supabase/` está en el `ignores` de
   ESLint y no pasa por `tsc`, así que el argumento faltante nunca se marcó.

## Por qué urge

Tras el despliegue del #210 el estado es **peor** que antes: el usuario
encerrado escribe `/cancelar`, lee «Operación cancelada» y sigue encerrado.
El mensaje afirma que salió. Antes no contestaba nada, que al menos no mentía.

## Alcance

- `telegram/bot.ts` en los **dos** árboles de edge function: una línea,
  `exit()` → `exitAll()`, más el comentario que explica la firma.
- `telegramSalidaConversacion.test.ts`: la guarda ahora exige `exitAll()` y
  **prohíbe** el `exit()` pelado en los dos árboles.

Sin migración, sin cambio de esquema, sin filas tocadas.

## Comprobación

- Defecto verificado contra el código del plugin (`npm pack
  @grammyjs/conversations@2`, `out/plugin.js` y `out/plugin.d.ts`), no contra
  la documentación.
- Rama rebasada sobre `main` (`d08fe82`): el #211 también editó `bot.ts` en los
  dos árboles, así que la versión anterior de esta rama lo habría pisado. El
  cherry-pick automezcló y los dos árboles quedan idénticos.
- 159 pruebas en verde, incluidas las cuatro que tocó el #211
  (`telegramFechaDDMM`, `eventoHatoUndo`, `arbolEdgeFunctionParidad`,
  `telegramSalidaConversacion`).

## Después de fusionar

Hace falta desplegar: `npx supabase functions deploy make-server-1ccce916`.
Hasta entonces las salidas que sí sirven son el botón «❌ Cancelar» del propio
flujo y borrar la fila del usuario en `telegram_conversations`.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01QkpvqRAw2TWm5NncmhhcNB


---
_Generated by [Claude Code](https://claude.ai/code/session_01QkpvqRAw2TWm5NncmhhcNB)_