### PR TITLE
fix: word the tratamiento_paso alert by date instead of a fixed "para hoy"

### DIFF
--- a/src/__tests__/hatoAlertas.test.ts
+++ b/src/__tests__/hatoAlertas.test.ts
@@ -250,6 +250,25 @@ describe('generarAlertasPendientes — tratamiento_paso', () => {
     const alertas = generarAlertasPendientes([], [pasoFuturo], CONFIG, new Set(), FECHA_REF);
     expect(alertas).toHaveLength(0);
   });
+
+  // Caso real de producción (2026-09-09): las dos primeras alertas que esta
+  // regla generó en su vida traían fechas de julio y decían "para hoy". El
+  // selector dispara con `fecha_programada <= fechaReferencia`, así que un
+  // paso vencido entra igual que uno de hoy; el mensaje tiene que decirlo.
+  it('un paso VENCIDO no dice "para hoy" y nombra la fecha en que venció', () => {
+    const pasoVencido = { ...paso, fecha_programada: '2026-07-16' };
+    const alertas = generarAlertasPendientes([], [pasoVencido], CONFIG, new Set(), FECHA_REF);
+    expect(alertas).toHaveLength(1);
+    expect(alertas[0].mensaje).not.toContain('para hoy');
+    expect(alertas[0].mensaje).toContain('2026-07-16');
+  });
+
+  it('un paso programado para HOY sigue diciendo "para hoy"', () => {
+    const pasoDeHoy = { ...paso, fecha_programada: FECHA_REF };
+    const alertas = generarAlertasPendientes([], [pasoDeHoy], CONFIG, new Set(), FECHA_REF);
+    expect(alertas).toHaveLength(1);
+    expect(alertas[0].mensaje).toContain('para hoy');
+  });
 });
 
 describe('regla_clave — estabilidad e idempotencia', () => {
@@ -633,6 +652,43 @@ describe('construirMensajeAlerta', () => {
       fecha_programada: '2026-07-20',
     });
     expect(msg).toContain('Aplicar estrumate');
+  });
+
+  it('tratamiento_paso vencido: el texto depende de la fecha, no es "para hoy" fijo', () => {
+    const msg = construirMensajeAlerta({
+      tipo: 'tratamiento_paso',
+      nombre: 'CUCA',
+      numero: 141,
+      fecha_programada: '2026-07-16',
+      fecha_referencia: '2026-09-09',
+    });
+    expect(msg).not.toContain('para hoy');
+    expect(msg).toContain('2026-07-16');
+    expect(msg).toContain('CUCA');
+  });
+
+  it('tratamiento_paso del día: conserva "para hoy" con su fecha', () => {
+    const msg = construirMensajeAlerta({
+      tipo: 'tratamiento_paso',
+      nombre: 'FABIOLA',
+      numero: 176,
+      fecha_programada: '2026-09-11',
+      fecha_referencia: '2026-09-11',
+    });
+    expect(msg).toContain('para hoy');
+    expect(msg).toContain('2026-09-11');
+  });
+
+  it('tratamiento_paso sin fecha_programada: nunca afirma que venció, dice que no hay fecha', () => {
+    const msg = construirMensajeAlerta({
+      tipo: 'tratamiento_paso',
+      nombre: 'CUÑA',
+      numero: 43,
+      fecha_programada: null,
+      fecha_referencia: '2026-09-09',
+    });
+    expect(msg).toContain('sin fecha registrada');
+    expect(msg).not.toContain('VENCIDO');
   });
 
   it('cada tipo produce un texto distinto (no hay una plantilla genérica compartida por error)', () => {

--- a/src/supabase/functions/server/hato-alertas.ts
+++ b/src/supabase/functions/server/hato-alertas.ts
@@ -186,6 +186,13 @@ export interface ContextoMensajeAlerta {
   vacas_count?: number;
   descripcion_paso?: string | null;
   fecha_programada?: string | null;
+  /** Solo `tratamiento_paso`: el "hoy" del tick (`fechaReferencia`), para que
+   * el texto distinga un paso que vence HOY de uno ya VENCIDO. El selector de
+   * `generarAlertasPendientes` dispara con `fecha_programada <= fechaReferencia`,
+   * así que un paso atrasado entra igual que uno del día -- sin esta fecha el
+   * mensaje afirmaría "para hoy" al lado de una fecha de hace dos meses
+   * (ocurrió en producción el 2026-09-09). Ausente => no se afirma vencimiento. */
+  fecha_referencia?: string | null;
 }
 
 /**
@@ -199,12 +206,23 @@ export function construirMensajeAlerta(ctx: ContextoMensajeAlerta): string {
   switch (ctx.tipo) {
     case 'secado_due':
       return `${presentacion} se debe secar hoy (fecha programada: ${ctx.fecha_secar ?? 'sin fecha registrada'}). ¿Ya se secó?`;
-    case 'tratamiento_paso':
+    case 'tratamiento_paso': {
+      // El texto depende de la fecha: la regla dispara con
+      // `fecha_programada <= fechaReferencia`, así que un paso ATRASADO llega
+      // por el mismo camino que uno del día. Sin fecha de referencia no se
+      // afirma vencimiento -- afirmar "venció" sin con qué compararlo sería
+      // inventar, el mismo criterio de "sin dato, nunca 0" del resto del módulo.
+      const programada = ctx.fecha_programada;
+      const vencido =
+        programada != null && ctx.fecha_referencia != null && programada < ctx.fecha_referencia;
+      const cuando = vencido
+        ? `VENCIDO desde el ${programada}`
+        : `programado para hoy (${programada ?? 'sin fecha registrada'})`;
       return (
-        `Recordatorio: ${presentacion} tiene un paso de tratamiento programado para hoy` +
-        ` (${ctx.fecha_programada ?? 'sin fecha registrada'})` +
+        `Recordatorio: ${presentacion} tiene un paso de tratamiento ${cuando}` +
         `${ctx.descripcion_paso ? `: "${ctx.descripcion_paso}"` : ''}. ¿Ya se hizo?`
       );
+    }
     case 'rechequeo_due': {
       // Alerta DE HATO: el chequeo es un evento de rebaño, así que el mensaje
       // nombra el conteo y la fecha -- nunca `presentacion`, que describe a un
@@ -415,6 +433,7 @@ export function generarAlertasPendientes(
         numero: paso.numero,
         descripcion_paso: paso.descripcion,
         fecha_programada: paso.fecha_programada,
+        fecha_referencia: fechaReferencia,
       }),
     });
   }

--- a/src/utils/hatoAlertas.ts
+++ b/src/utils/hatoAlertas.ts
@@ -169,6 +169,13 @@ export interface ContextoMensajeAlerta {
   vacas_count?: number;
   descripcion_paso?: string | null;
   fecha_programada?: string | null;
+  /** Solo `tratamiento_paso`: el "hoy" del tick (`fechaReferencia`), para que
+   * el texto distinga un paso que vence HOY de uno ya VENCIDO. El selector de
+   * `generarAlertasPendientes` dispara con `fecha_programada <= fechaReferencia`,
+   * así que un paso atrasado entra igual que uno del día -- sin esta fecha el
+   * mensaje afirmaría "para hoy" al lado de una fecha de hace dos meses
+   * (ocurrió en producción el 2026-09-09). Ausente => no se afirma vencimiento. */
+  fecha_referencia?: string | null;
 }
 
 /**
@@ -182,12 +189,23 @@ export function construirMensajeAlerta(ctx: ContextoMensajeAlerta): string {
   switch (ctx.tipo) {
     case 'secado_due':
       return `${presentacion} se debe secar hoy (fecha programada: ${ctx.fecha_secar ?? 'sin fecha registrada'}). ¿Ya se secó?`;
-    case 'tratamiento_paso':
+    case 'tratamiento_paso': {
+      // El texto depende de la fecha: la regla dispara con
+      // `fecha_programada <= fechaReferencia`, así que un paso ATRASADO llega
+      // por el mismo camino que uno del día. Sin fecha de referencia no se
+      // afirma vencimiento -- afirmar "venció" sin con qué compararlo sería
+      // inventar, el mismo criterio de "sin dato, nunca 0" del resto del módulo.
+      const programada = ctx.fecha_programada;
+      const vencido =
+        programada != null && ctx.fecha_referencia != null && programada < ctx.fecha_referencia;
+      const cuando = vencido
+        ? `VENCIDO desde el ${programada}`
+        : `programado para hoy (${programada ?? 'sin fecha registrada'})`;
       return (
-        `Recordatorio: ${presentacion} tiene un paso de tratamiento programado para hoy` +
-        ` (${ctx.fecha_programada ?? 'sin fecha registrada'})` +
+        `Recordatorio: ${presentacion} tiene un paso de tratamiento ${cuando}` +
         `${ctx.descripcion_paso ? `: "${ctx.descripcion_paso}"` : ''}. ¿Ya se hizo?`
       );
+    }
     case 'rechequeo_due': {
       // Alerta DE HATO: el chequeo es un evento de rebaño, así que el mensaje
       // nombra el conteo y la fecha -- nunca `presentacion`, que describe a un
@@ -398,6 +416,7 @@ export function generarAlertasPendientes(
         numero: paso.numero,
         descripcion_paso: paso.descripcion,
         fecha_programada: paso.fecha_programada,
+        fecha_referencia: fechaReferencia,
       }),
     });
   }

--- a/supabase/functions/make-server-1ccce916/hato-alertas.ts
+++ b/supabase/functions/make-server-1ccce916/hato-alertas.ts
@@ -186,6 +186,13 @@ export interface ContextoMensajeAlerta {
   vacas_count?: number;
   descripcion_paso?: string | null;
   fecha_programada?: string | null;
+  /** Solo `tratamiento_paso`: el "hoy" del tick (`fechaReferencia`), para que
+   * el texto distinga un paso que vence HOY de uno ya VENCIDO. El selector de
+   * `generarAlertasPendientes` dispara con `fecha_programada <= fechaReferencia`,
+   * así que un paso atrasado entra igual que uno del día -- sin esta fecha el
+   * mensaje afirmaría "para hoy" al lado de una fecha de hace dos meses
+   * (ocurrió en producción el 2026-09-09). Ausente => no se afirma vencimiento. */
+  fecha_referencia?: string | null;
 }
 
 /**
@@ -199,12 +206,23 @@ export function construirMensajeAlerta(ctx: ContextoMensajeAlerta): string {
   switch (ctx.tipo) {
     case 'secado_due':
       return `${presentacion} se debe secar hoy (fecha programada: ${ctx.fecha_secar ?? 'sin fecha registrada'}). ¿Ya se secó?`;
-    case 'tratamiento_paso':
+    case 'tratamiento_paso': {
+      // El texto depende de la fecha: la regla dispara con
+      // `fecha_programada <= fechaReferencia`, así que un paso ATRASADO llega
+      // por el mismo camino que uno del día. Sin fecha de referencia no se
+      // afirma vencimiento -- afirmar "venció" sin con qué compararlo sería
+      // inventar, el mismo criterio de "sin dato, nunca 0" del resto del módulo.
+      const programada = ctx.fecha_programada;
+      const vencido =
+        programada != null && ctx.fecha_referencia != null && programada < ctx.fecha_referencia;
+      const cuando = vencido
+        ? `VENCIDO desde el ${programada}`
+        : `programado para hoy (${programada ?? 'sin fecha registrada'})`;
       return (
-        `Recordatorio: ${presentacion} tiene un paso de tratamiento programado para hoy` +
-        ` (${ctx.fecha_programada ?? 'sin fecha registrada'})` +
+        `Recordatorio: ${presentacion} tiene un paso de tratamiento ${cuando}` +
         `${ctx.descripcion_paso ? `: "${ctx.descripcion_paso}"` : ''}. ¿Ya se hizo?`
       );
+    }
     case 'rechequeo_due': {
       // Alerta DE HATO: el chequeo es un evento de rebaño, así que el mensaje
       // nombra el conteo y la fecha -- nunca `presentacion`, que describe a un
@@ -415,6 +433,7 @@ export function generarAlertasPendientes(
         numero: paso.numero,
         descripcion_paso: paso.descripcion,
         fecha_programada: paso.fecha_programada,
+        fecha_referencia: fechaReferencia,
       }),
     });
   }


### PR DESCRIPTION
## Bug

The `tratamiento_paso` Telegram alert told Fernando a treatment step was scheduled "para hoy" while printing a date two months in the past.

The rule shipped in S6 (migration 056) and had nothing to fire on until `hato_tratamientos` went from 0 to 28 rows on 2026-09-09 (migration 140). The first two alerts it ever produced carried the defect:

```
Recordatorio: Vaca 141 (CUCA) tiene un paso de tratamiento programado para hoy (2026-07-16). ¿Ya se hizo?
Recordatorio: Vaca 43 (CUÑA) tiene un paso de tratamiento programado para hoy (2026-07-23). ¿Ya se hizo?
```

Both rows are `estado='expirada'`, `created_at=2026-09-09 10:45:04`, `intentos=1`, `respuesta=null`. A third alert on 2026-09-11 (Vaca 176 FABIOLA, `fecha_programada=2026-09-11`) was correct — its step really was due that day.

Who hits it: every Telegram subscriber of `hato.tratamiento_paso`, on every overdue step. The wording makes an overdue step read as a same-day task and contradicts the date beside it.

## Root cause

`src/utils/hatoAlertas.ts:185-190` built the text unconditionally:

```ts
`Recordatorio: ${presentacion} tiene un paso de tratamiento programado para hoy` +
` (${ctx.fecha_programada ?? 'sin fecha registrada'})`
```

The selector at `src/utils/hatoAlertas.ts:387` is `if (paso.fecha_programada > fechaReferencia) continue;`. Every step with `fecha_programada <= hoy` fires, overdue ones included, and they all received the same "para hoy" wording. The message builder never saw the reference date, so it could not tell the two cases apart.

## Fix

`ContextoMensajeAlerta` gains `fecha_referencia`; `generarAlertasPendientes` passes the `fechaReferencia` it already holds. `construirMensajeAlerta` branches:

- overdue (`fecha_programada < fecha_referencia`) → `VENCIDO desde el <fecha>`
- due today → `programado para hoy (<fecha>)`, unchanged
- no `fecha_referencia`, or no `fecha_programada` → never claims the step expired

Minimal by design: the selector, the thresholds, `regla_clave` and the dispatch path are untouched. No row is written or migrated.

Changed in the three mirrored copies in the same commit. The two server copies were regenerated with `docs/hato/regenerar-copias-hato-alertas.py`, never hand-edited — parity is guarded by `src/__tests__/hatoAlertasParidadServidor.test.ts`.

`secado_due` at line 184 has the same shape ("se debe secar hoy (fecha programada: X)"). It is **deliberately not bundled** — it needs its own evidence.

## Verification

Five tests added to `src/__tests__/hatoAlertas.test.ts`. Two fail before the change, for the right reason:

```
FAIL generarAlertasPendientes — tratamiento_paso > un paso VENCIDO no dice "para hoy" y nombra la fecha en que venció
  expected 'Recordatorio: Vaca 12 (CAMPANA) tiene un paso de tratamiento programado para hoy (2026-07-16)...' not to contain 'para hoy'
FAIL construirMensajeAlerta > tratamiento_paso vencido: el texto depende de la fecha, no es "para hoy" fijo
  expected 'Recordatorio: Vaca 141 (CUCA) tiene un paso de tratamiento programado para hoy (2026-07-16)...' not to contain 'para hoy'
```

The other three pin the behaviour that must not change: a step due today keeps "para hoy", and a step with no date says "sin fecha registrada" and never claims it expired.

After the change:

- `npx vitest run` — 172 files, 3.718 tests: **3.717 pass, 1 fails**. The failure is `hatoSchemaContract.test.ts` ("ningún prefijo 053-060 está duplicado"), which is **pre-existing on `main@0aba907`**: `140_hato_registrar_tratamiento.sql` and `140_respaldo_pl_chequeo_vacas.sql` share a prefix, both tracked in HEAD. This PR touches no migration.
- `npm run lint` — 0 errors, 898 warnings (all pre-existing; this PR adds none).
- `npx tsc --noEmit` — clean.
- The alert suite alone: 5 files, 170 tests, all green — including the server parity guard.

## Rollback

Revert the commit. No data change, no migration, no schema change.

## Follow-up

- `npx supabase functions deploy make-server-1ccce916` is **required after merge** — the fix lives in the edge-function trees too, and the daily tick runs there.
- `secado_due` carries the same unconditional "hoy" wording. Not changed here.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9

---
_Generated by [Claude Code](https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9)_