### PR TITLE
fix(inventario): print the unit of measure with every ronda quantity

### DIFF
--- a/src/__tests__/rondaInventarioInterpretacion.test.ts
+++ b/src/__tests__/rondaInventarioInterpretacion.test.ts
@@ -86,7 +86,8 @@ function resolverFilaPreview(hallazgo: HallazgoCrudo, alcance: readonly Producto
   // El teórico SIEMPRE sale del alcance congelado (R-5), nunca de lo que
   // dijo Uriel -- acá el fixture guarda el teórico junto al alcance para
   // simular `rondas_inventario_alcance.cantidad_teorica`.
-  const teorico = (alcance.find((p) => p.productoId === resolucion.productoId) as ProductoEnAlcanceConTeorico).teoricoFoto;
+  const itemAlcance = alcance.find((p) => p.productoId === resolucion.productoId) as ProductoEnAlcanceConTeorico;
+  const teorico = itemAlcance.teoricoFoto;
   const fisicoResuelto = derivarFisico(hallazgo, teorico);
   const causa = hallazgo.causaClave ? buscarCausaRaiz(hallazgo.causaClave) : undefined;
 
@@ -95,7 +96,9 @@ function resolverFilaPreview(hallazgo: HallazgoCrudo, alcance: readonly Producto
     productoIdentificado: true,
     productoId: resolucion.productoId,
     nombreProducto: resolucion.nombreProducto,
-    unidad: 'Kilos',
+    // La unidad sale del alcance congelado, igual que el teórico (R-5) --
+    // el fixture la guarda al lado para simular `rondas_inventario_alcance.unidad`.
+    unidad: itemAlcance.unidadFoto,
     fisico: fisicoResuelto.estado === 'resuelto' ? fisicoResuelto.fisico : null,
     fisicoOrigen: fisicoResuelto.estado === 'resuelto' ? fisicoResuelto.origen : null,
     teorico,
@@ -110,6 +113,7 @@ function resolverFilaPreview(hallazgo: HallazgoCrudo, alcance: readonly Producto
 
 interface ProductoEnAlcanceConTeorico extends ProductoEnAlcance {
   teoricoFoto: number;
+  unidadFoto: string | null;
 }
 
 function respuestaModelo(hallazgos: Array<Record<string, unknown>>, observacionesLibres: string[] = [], avisos: string[] = []) {
@@ -127,8 +131,8 @@ const TRANSCRITO_FIXTURE_1 =
  * teórico 100 kg, Martillos con teórico 8 unidades -- los mismos números que
  * el dueño escribió como salida esperada. */
 const ALCANCE_FIXTURE_1: ProductoEnAlcanceConTeorico[] = [
-  { productoId: 'prod-silicalmag', nombre: 'Silicalmag', teoricoFoto: 100 },
-  { productoId: 'prod-martillos', nombre: 'Martillos', teoricoFoto: 8 },
+  { productoId: 'prod-silicalmag', nombre: 'Silicalmag', teoricoFoto: 100, unidadFoto: 'Kilos' },
+  { productoId: 'prod-martillos', nombre: 'Martillos', teoricoFoto: 8, unidadFoto: 'Unidades' },
 ];
 
 /** La salida del modelo intérprete para este transcrito -- construida a
@@ -212,8 +216,11 @@ describe('fixture #1 -- §11.1 del brief de producto (literal)', () => {
     expect(renderPreviewTelegram(preview)).toBe(
       [
         'Esto entendí de tu nota:',
-        '- Silicalmag: hay 90, deberían haber 100. Error de captura previa -- David lo resuelve',
-        '- Martillos: hay 5 (derivado), deberían haber 8. pasa a Santiago',
+        // ESCO-61: cada cifra lleva la unidad del alcance congelado, y son
+        // dos unidades DISTINTAS en el mismo preview -- que es justo por lo
+        // que omitirlas hacía ilegible el informe.
+        '- Silicalmag: hay 90 Kilos, deberían haber 100 Kilos. Error de captura previa -- David lo resuelve',
+        '- Martillos: hay 5 Unidades (derivado), deberían haber 8 Unidades. pasa a Santiago',
         '',
         '¿Confirmas? [Confirmar] [Corregir] [Descartar]',
       ].join('\n'),
@@ -391,7 +398,7 @@ describe('adversarial: "faltan 3" sin cantidad física dictada -> derivado, rotu
     // con `fisico: null`, así que `previewConfirmable` deja el botón
     // [Confirmar] apagado y Uriel tiene que corregir por texto (A-9).
     const alcance: ProductoEnAlcanceConTeorico[] = [
-      { productoId: 'p-15', nombre: '15-15-15', teoricoFoto: 0 },
+      { productoId: 'p-15', nombre: '15-15-15', teoricoFoto: 0, unidadFoto: 'Kilos' },
     ];
     const fila = resolverFilaPreview(hallazgo, alcance);
     expect(fila.fisico).toBeNull();

--- a/src/__tests__/rondaInventarioParidadServidor.test.ts
+++ b/src/__tests__/rondaInventarioParidadServidor.test.ts
@@ -174,9 +174,11 @@ describe('paridad de comportamiento reporteCierre', () => {
     },
     valoracion: { incluyeValoracion: false, valorTotalActual: null, valorTotalMesAnterior: null },
     excepciones: [
-      { productoNombre: 'Silicalmag', estado: 'ajuste_aplicado', fisico: 90, teorico: 100, causaEtiqueta: 'Error de captura previa', via: 'captura_david' },
+      { productoNombre: 'Silicalmag', estado: 'ajuste_aplicado', fisico: 90, teorico: 100, unidad: 'Kilos', causaEtiqueta: 'Error de captura previa', via: 'captura_david' },
     ],
-    movimientosRondaAbierta: [],
+    movimientosRondaAbierta: [
+      { productoNombre: 'Silicalmag', tipoMovimiento: 'Entrada', cantidad: 10, unidad: 'Kilos', origen: 'captura_excepcion', responsable: 'David' },
+    ],
     observacionesLibres: ['Se encontraron 2 canecas vacías sin identificar'],
     hallazgosNarradosSinConfirmar: 1,
   };

--- a/src/__tests__/rondaInventarioUnidades.test.ts
+++ b/src/__tests__/rondaInventarioUnidades.test.ts
@@ -1,0 +1,169 @@
+// ARCHIVO: src/__tests__/rondaInventarioUnidades.test.ts
+// DESCRIPCIÓN: Regresión de ESCO-61 -- el preview de Uriel y el reporte de
+// cierre imprimían cantidades PELADAS, sin unidad de medida, aun teniendo la
+// unidad a mano.
+//
+// EL CASO REAL, `rondas_reportes.texto_telegram` de la primera ronda cerrada
+// (emitido 2026-08-30 12:00:02Z), que se contradice a sí mismo:
+//
+//   Resueltas con captura (1):
+//   - 15-15-15: hay 3, deberían haber 0
+//   ...
+//   Movimientos de inventario ocurridos con la ronda abierta (1):
+//   - 15-15-15: Entrada de 150 (captura de excepción) -- Santiago Forero
+//
+// Mismo producto, misma ronda, mismo informe: 3 contra 150. El `3` se
+// registró en BULTOS y el `150` en kilos (`productos.unidad_medida` del
+// 15-15-15 es 'Kilos', `presentacion_kg_l` 50,00 -- el transcrito decía
+// "tres bultos de 15-15-15 de 50 kilos"). Con la unidad impresa, las dos
+// cifras dejan de parecer la misma magnitud y la contradicción se vuelve
+// legible en el propio informe.
+//
+// La unidad SIEMPRE estuvo disponible: `FilaPreview.unidad` la puebla
+// `resolverHallazgos.ts` desde el alcance congelado, y el tick lee
+// `rondas_inventario_alcance.unidad` / `productos.unidad_medida`. Sólo no se
+// imprimía.
+//
+// Este fichero prueba el TEXTO, que es lo único que el humano lee.
+
+import { describe, it, expect } from 'vitest';
+import { construirPreview, renderPreviewTelegram, type FilaPreview } from '@/utils/rondaInventario/preview';
+import {
+  construirReporteCierre,
+  renderReporteCierreTelegram,
+  type InputReporteCierre,
+} from '@/utils/rondaInventario/reporteCierre';
+
+// ---------------------------------------------------------------------------
+// 1. Preview de Uriel (§5.6/CA-30)
+// ---------------------------------------------------------------------------
+
+const FILA_BASE: FilaPreview = {
+  productoMencionado: '15-15-15',
+  productoIdentificado: true,
+  productoId: 'prod-15-15-15',
+  nombreProducto: '15-15-15',
+  unidad: 'Kilos',
+  fisico: 3,
+  fisicoOrigen: 'dictado',
+  teorico: 0,
+  causaClave: null,
+  causaEtiqueta: null,
+  via: 'captura_david',
+  explicacionCitada: null,
+  fragmentoLiteral: 'tres bultos de 15-15-15 de 50 kilos',
+  fueraDeAlcance: false,
+};
+
+describe('preview -- la cantidad nunca se imprime sin unidad (ESCO-61)', () => {
+  it('físico y teórico llevan los dos la unidad del alcance congelado', () => {
+    const texto = renderPreviewTelegram(construirPreview([FILA_BASE]));
+
+    expect(texto).toContain('hay 3 Kilos, deberían haber 0 Kilos');
+    // La redacción sin unidad es exactamente la que produjo el informe
+    // contradictorio -- no debe poder volver.
+    expect(texto).not.toContain('hay 3, deberían haber 0');
+  });
+
+  it('un físico DERIVADO lleva la unidad antes de la marca "(derivado)"', () => {
+    const texto = renderPreviewTelegram(
+      construirPreview([{ ...FILA_BASE, fisico: 5, fisicoOrigen: 'derivado', teorico: 8 }]),
+    );
+
+    expect(texto).toContain('hay 5 Kilos (derivado), deberían haber 8 Kilos');
+  });
+
+  it('sin unidad conocida (`null`) no inventa ninguna -- imprime la cifra pelada', () => {
+    const texto = renderPreviewTelegram(construirPreview([{ ...FILA_BASE, unidad: null }]));
+
+    expect(texto).toContain('hay 3, deberían haber 0');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// 2. Reporte de cierre (§8.3/CA-19) -- el informe que se contradecía
+// ---------------------------------------------------------------------------
+
+const INPUT_CASO_REAL: InputReporteCierre = {
+  cabecera: {
+    periodo: '2026-08-01',
+    cerradaEn: '2026-08-29',
+    cerradoPorNombre: 'Santiago Forero',
+    alcanceDeclarado: 'completo',
+    alcanceNota: null,
+    esLineaBase: true,
+  },
+  valoracion: { incluyeValoracion: false, valorTotalActual: null, valorTotalMesAnterior: null },
+  excepciones: [
+    {
+      productoNombre: '15-15-15',
+      estado: 'resuelta_con_captura',
+      fisico: 3,
+      teorico: 0,
+      unidad: 'Kilos',
+      causaEtiqueta: null,
+      via: 'captura_david',
+    },
+  ],
+  movimientosRondaAbierta: [
+    {
+      productoNombre: '15-15-15',
+      tipoMovimiento: 'Entrada',
+      cantidad: 150,
+      unidad: 'Kilos',
+      origen: 'captura_excepcion',
+      responsable: 'Santiago Forero',
+    },
+  ],
+  observacionesLibres: [],
+  hallazgosNarradosSinConfirmar: 1,
+};
+
+describe('reporte de cierre -- excepciones y movimientos llevan unidad (ESCO-61)', () => {
+  it('la línea de la excepción imprime la unidad en las dos cifras', () => {
+    const texto = renderReporteCierreTelegram(construirReporteCierre(INPUT_CASO_REAL));
+
+    expect(texto).toContain('- 15-15-15: hay 3 Kilos, deberían haber 0 Kilos');
+    expect(texto).not.toContain('hay 3, deberían haber 0');
+  });
+
+  it('la línea del movimiento imprime la unidad de la cantidad', () => {
+    const texto = renderReporteCierreTelegram(construirReporteCierre(INPUT_CASO_REAL));
+
+    expect(texto).toContain('- 15-15-15: Entrada de 150 Kilos (captura de excepción) -- Santiago Forero');
+    expect(texto).not.toContain('Entrada de 150 (');
+  });
+
+  it('las dos cifras del caso real quedan contrastables en el MISMO informe', () => {
+    const texto = renderReporteCierreTelegram(construirReporteCierre(INPUT_CASO_REAL));
+
+    // Lo que hacía ilegible la contradicción era que «3» y «150» se leían
+    // como la misma magnitud. Con la unidad, las dos líneas del mismo
+    // producto se pueden comparar.
+    expect(texto).toContain('3 Kilos');
+    expect(texto).toContain('150 Kilos');
+  });
+
+  it('sin unidad conocida (`null`) ninguna de las dos líneas inventa una', () => {
+    const sinUnidad: InputReporteCierre = {
+      ...INPUT_CASO_REAL,
+      excepciones: [{ ...INPUT_CASO_REAL.excepciones[0], unidad: null }],
+      movimientosRondaAbierta: [{ ...INPUT_CASO_REAL.movimientosRondaAbierta[0], unidad: null }],
+    };
+    const texto = renderReporteCierreTelegram(construirReporteCierre(sinUnidad));
+
+    expect(texto).toContain('- 15-15-15: hay 3, deberían haber 0');
+    expect(texto).toContain('- 15-15-15: Entrada de 150 (captura de excepción) -- Santiago Forero');
+  });
+
+  it('una excepción sin cifra completa sigue diciendo «sin cifra completa», con o sin unidad', () => {
+    const incompleta: InputReporteCierre = {
+      ...INPUT_CASO_REAL,
+      excepciones: [{ ...INPUT_CASO_REAL.excepciones[0], fisico: null, teorico: null }],
+    };
+    const texto = renderReporteCierreTelegram(construirReporteCierre(incompleta));
+
+    expect(texto).toContain('- 15-15-15: sin cifra completa');
+    expect(texto).not.toContain('sin cifra completa Kilos');
+  });
+});

--- a/src/supabase/functions/server/ronda-inventario-tick.ts
+++ b/src/supabase/functions/server/ronda-inventario-tick.ts
@@ -411,8 +411,11 @@ async function obtenerExcepcionesParaReporte(sb: SupabaseClient, rondaId: string
   // Nombre del producto: SNAPSHOT del alcance congelado (R-5), nunca un JOIN
   // vivo a `productos` -- un rename posterior no debe reescribir lo que
   // Uriel vio en campo (mismo criterio que `rondas_inventario_alcance` ya
-  // documenta).
+  // documenta). ESCO-61: la UNIDAD sale del mismo snapshot y por el mismo
+  // motivo -- es la unidad contra la que se contó, no la que el catálogo
+  // tenga hoy.
   const nombresPorProducto = new Map(alcance.map((a) => [a.producto_id, a.nombre_producto]));
+  const unidadesPorProducto = new Map(alcance.map((a) => [a.producto_id, a.unidad]));
 
   return ((excepciones ?? []) as Array<{
     producto_id: string;
@@ -432,6 +435,7 @@ async function obtenerExcepcionesParaReporte(sb: SupabaseClient, rondaId: string
       estado: fila.estado as EstadoExcepcionRonda,
       fisico: fila.cantidad_fisica,
       teorico: fila.teorico_conteo,
+      unidad: unidadesPorProducto.get(fila.producto_id) ?? null,
       causaEtiqueta,
       via: fila.via_propuesta,
     };
@@ -444,8 +448,15 @@ type FilaMovimientoInventario = {
   tipo_movimiento: string;
   cantidad: number;
   responsable: string | null;
-  producto: { nombre: string } | { nombre: string }[] | null;
+  producto: ProductoDeMovimiento | ProductoDeMovimiento[] | null;
 };
+
+/** ESCO-61: `unidad_medida` viaja junto al nombre para que la cantidad del
+ * movimiento no se imprima pelada. Se lee en VIVO de `productos` -- a
+ * diferencia de la excepción, que usa el snapshot congelado -- porque el
+ * movimiento puede ser de un producto que nunca estuvo en el alcance de la
+ * ronda (`entrada_fuera_de_alcance`, P-3), y ahí el snapshot no tiene fila. */
+type ProductoDeMovimiento = { nombre: string; unidad_medida: string | null };
 
 /**
  * R-9/CA-19 (§8.3 punto 4): "todo movimiento de inventario OCURRIDO con la
@@ -491,7 +502,7 @@ async function obtenerMovimientosRondaAbierta(sb: SupabaseClient, ronda: RondaCe
     if (fila.aplicacion_movimiento_id) movimientoIdsDeExcepcion.add(fila.aplicacion_movimiento_id);
   }
 
-  const SELECT_MOVIMIENTO = 'id, producto_id, tipo_movimiento, cantidad, responsable, producto:productos(nombre)';
+  const SELECT_MOVIMIENTO = 'id, producto_id, tipo_movimiento, cantidad, responsable, producto:productos(nombre, unidad_medida)';
   const [{ data: movimientosLigados, error: errorLigados }, { data: movimientosVentana, error: errorVentana }, alcance] = await Promise.all([
     movimientoIdsDeExcepcion.size > 0
       ? sb.from('movimientos_inventario').select(SELECT_MOVIMIENTO).in('id', [...movimientoIdsDeExcepcion])
@@ -530,6 +541,7 @@ async function obtenerMovimientosRondaAbierta(sb: SupabaseClient, ronda: RondaCe
       productoNombre: producto?.nombre ?? '(producto)',
       tipoMovimiento: m.tipo_movimiento,
       cantidad: Math.abs(m.cantidad),
+      unidad: producto?.unidad_medida ?? null,
       origen,
       responsable: m.responsable,
     };

--- a/src/supabase/functions/server/rondaInventario/preview.ts
+++ b/src/supabase/functions/server/rondaInventario/preview.ts
@@ -38,6 +38,7 @@
 
 import type { FisicoOrigen } from './interpretarNota.ts';
 import type { ViaExcepcion } from './causasRaiz.ts';
+import { sufijoUnidad } from './resolucion.ts';
 
 // ---------------------------------------------------------------------------
 // 1. Una fila del preview -- ya resuelta (producto, físico, vía)
@@ -149,9 +150,16 @@ function renderFila(fila: FilaPreview): string {
     return `${fila.nombreProducto}: falta la cantidad física para poder confirmar`;
   }
 
+  // ESCO-61: la unidad va SIEMPRE pegada a la cifra, en las dos. `fila.unidad`
+  // ya venía poblada desde el alcance congelado (`resolverHallazgos.ts`) y
+  // simplemente no se imprimía, así que «hay 3, deberían haber 0» no decía si
+  // eran bultos o kilos -- la misma ambigüedad que dejó un reporte de cierre
+  // contradiciéndose contra su propio movimiento de 150. `sufijoUnidad`
+  // devuelve cadena vacía cuando no hay unidad: nunca se inventa una.
+  const unidad = sufijoUnidad(fila.unidad);
   const fisicoTexto = fila.fisicoOrigen === 'derivado'
-    ? `${formatearCantidad(fila.fisico)} (derivado)`
-    : formatearCantidad(fila.fisico);
+    ? `${formatearCantidad(fila.fisico)}${unidad} (derivado)`
+    : `${formatearCantidad(fila.fisico)}${unidad}`;
 
   const causaTexto = fila.causaEtiqueta ? `${fila.causaEtiqueta} -- ` : '';
   // CA-4: este producto no estaba en el alcance que se congeló al abrir la
@@ -159,7 +167,7 @@ function renderFila(fila: FilaPreview): string {
   // lea como si el sistema ya lo estuviera contando.
   const fueraDeAlcanceTexto = fila.fueraDeAlcance ? ' (no estaba en el alcance -- se agrega al confirmar)' : '';
 
-  return `${fila.nombreProducto}${fueraDeAlcanceTexto}: hay ${fisicoTexto}, deberían haber ${formatearCantidad(fila.teorico)}. ${causaTexto}${fraseVia(fila.via)}`;
+  return `${fila.nombreProducto}${fueraDeAlcanceTexto}: hay ${fisicoTexto}, deberían haber ${formatearCantidad(fila.teorico)}${unidad}. ${causaTexto}${fraseVia(fila.via)}`;
 }
 
 /**

--- a/src/supabase/functions/server/rondaInventario/reporteCierre.ts
+++ b/src/supabase/functions/server/rondaInventario/reporteCierre.ts
@@ -35,6 +35,7 @@
 // conteo, aunque el render de §8.3 los agrupe bajo tres títulos.
 
 import type { ViaExcepcion } from './causasRaiz.ts';
+import { sufijoUnidad } from './resolucion.ts';
 
 // ---------------------------------------------------------------------------
 // 1. Formato colombiano local -- mismo motivo que preview.ts: este módulo se
@@ -131,6 +132,11 @@ export interface ExcepcionReporteCierre {
   estado: EstadoExcepcionRonda;
   fisico: number | null;
   teorico: number | null;
+  /** ESCO-61: unidad de medida de las dos cifras de arriba, tomada del
+   * alcance CONGELADO de la ronda (`rondas_inventario_alcance.unidad`, mismo
+   * snapshot del que sale `productoNombre` -- R-5). `null` cuando no se
+   * conoce: la cifra se imprime pelada, nunca con una unidad inventada. */
+  unidad: string | null;
   causaEtiqueta: string | null;
   via: ViaExcepcion | null;
 }
@@ -147,6 +153,11 @@ export interface MovimientoReporteCierre {
   productoNombre: string;
   tipoMovimiento: string;
   cantidad: number;
+  /** ESCO-61: unidad de medida de `cantidad` (`productos.unidad_medida`).
+   * Sin ella, un movimiento en kilos y una excepción contada en bultos se
+   * leían como la misma magnitud dentro del MISMO informe. `null` = no se
+   * conoce; se imprime la cifra pelada. */
+  unidad: string | null;
   origen: OrigenMovimientoRondaAbierta;
   responsable: string | null;
 }
@@ -226,8 +237,11 @@ const TITULOS: Record<DesenlaceReporte, string> = {
 };
 
 function renderExcepcion(e: ExcepcionReporteCierre): string {
+  // ESCO-61: la unidad va pegada a cada cifra, nunca al final de la frase --
+  // «sin cifra completa» no lleva unidad porque no hay cifra que calificar.
+  const unidad = sufijoUnidad(e.unidad);
   const cifras = e.fisico !== null && e.teorico !== null
-    ? `hay ${formatearCantidadCO(e.fisico)}, deberían haber ${formatearCantidadCO(e.teorico)}`
+    ? `hay ${formatearCantidadCO(e.fisico)}${unidad}, deberían haber ${formatearCantidadCO(e.teorico)}${unidad}`
     : 'sin cifra completa';
   const causa = e.causaEtiqueta ? ` -- ${e.causaEtiqueta}` : '';
   return `- ${e.productoNombre}: ${cifras}${causa}`;
@@ -241,7 +255,7 @@ const ETIQUETA_ORIGEN_MOVIMIENTO: Record<OrigenMovimientoRondaAbierta, string> =
 
 function renderMovimiento(m: MovimientoReporteCierre): string {
   const responsable = m.responsable ? ` -- ${m.responsable}` : '';
-  return `- ${m.productoNombre}: ${m.tipoMovimiento} de ${formatearCantidadCO(m.cantidad)} (${ETIQUETA_ORIGEN_MOVIMIENTO[m.origen]})${responsable}`;
+  return `- ${m.productoNombre}: ${m.tipoMovimiento} de ${formatearCantidadCO(m.cantidad)}${sufijoUnidad(m.unidad)} (${ETIQUETA_ORIGEN_MOVIMIENTO[m.origen]})${responsable}`;
 }
 
 /**

--- a/src/supabase/functions/server/rondaInventario/resolucion.ts
+++ b/src/supabase/functions/server/rondaInventario/resolucion.ts
@@ -55,7 +55,17 @@ function formatearCantidadResolucion(valor: number): string {
   }).format(valor);
 }
 
-function sufijoUnidad(unidad: string | null): string {
+/** Unidad de medida como SUFIJO de una cantidad ya formateada -- ' Kilos',
+ * ' Litros', o cadena vacía si no se conoce (nunca una unidad inventada ni un
+ * marcador de relleno).
+ *
+ * Exportado desde acá porque es el único helper de unidad del módulo:
+ * `preview.ts` y `reporteCierre.ts` lo consumen en vez de reimplementarlo
+ * (ESCO-61 -- los dos imprimían cantidades peladas mientras esta pantalla
+ * intermedia sí mostraba la unidad, y esa asimetría produjo un reporte de
+ * cierre que se contradecía a sí mismo: «hay 3» contra «Entrada de 150» para
+ * el mismo producto, porque el 3 era en bultos y el 150 en kilos). */
+export function sufijoUnidad(unidad: string | null): string {
   return unidad ? ` ${unidad}` : '';
 }
 

--- a/src/utils/rondaInventario/preview.ts
+++ b/src/utils/rondaInventario/preview.ts
@@ -21,6 +21,7 @@
 
 import type { FisicoOrigen } from './interpretarNota';
 import type { ViaExcepcion } from './causasRaiz';
+import { sufijoUnidad } from './resolucion';
 
 // ---------------------------------------------------------------------------
 // 1. Una fila del preview -- ya resuelta (producto, físico, vía)
@@ -132,9 +133,16 @@ function renderFila(fila: FilaPreview): string {
     return `${fila.nombreProducto}: falta la cantidad física para poder confirmar`;
   }
 
+  // ESCO-61: la unidad va SIEMPRE pegada a la cifra, en las dos. `fila.unidad`
+  // ya venía poblada desde el alcance congelado (`resolverHallazgos.ts`) y
+  // simplemente no se imprimía, así que «hay 3, deberían haber 0» no decía si
+  // eran bultos o kilos -- la misma ambigüedad que dejó un reporte de cierre
+  // contradiciéndose contra su propio movimiento de 150. `sufijoUnidad`
+  // devuelve cadena vacía cuando no hay unidad: nunca se inventa una.
+  const unidad = sufijoUnidad(fila.unidad);
   const fisicoTexto = fila.fisicoOrigen === 'derivado'
-    ? `${formatearCantidad(fila.fisico)} (derivado)`
-    : formatearCantidad(fila.fisico);
+    ? `${formatearCantidad(fila.fisico)}${unidad} (derivado)`
+    : `${formatearCantidad(fila.fisico)}${unidad}`;
 
   const causaTexto = fila.causaEtiqueta ? `${fila.causaEtiqueta} -- ` : '';
   // CA-4: este producto no estaba en el alcance que se congeló al abrir la
@@ -142,7 +150,7 @@ function renderFila(fila: FilaPreview): string {
   // lea como si el sistema ya lo estuviera contando.
   const fueraDeAlcanceTexto = fila.fueraDeAlcance ? ' (no estaba en el alcance -- se agrega al confirmar)' : '';
 
-  return `${fila.nombreProducto}${fueraDeAlcanceTexto}: hay ${fisicoTexto}, deberían haber ${formatearCantidad(fila.teorico)}. ${causaTexto}${fraseVia(fila.via)}`;
+  return `${fila.nombreProducto}${fueraDeAlcanceTexto}: hay ${fisicoTexto}, deberían haber ${formatearCantidad(fila.teorico)}${unidad}. ${causaTexto}${fraseVia(fila.via)}`;
 }
 
 /**

--- a/src/utils/rondaInventario/reporteCierre.ts
+++ b/src/utils/rondaInventario/reporteCierre.ts
@@ -18,6 +18,7 @@
 // conteo, aunque el render de §8.3 los agrupe bajo tres títulos.
 
 import type { ViaExcepcion } from './causasRaiz';
+import { sufijoUnidad } from './resolucion';
 
 // ---------------------------------------------------------------------------
 // 1. Formato colombiano local -- mismo motivo que preview.ts: este módulo se
@@ -114,6 +115,11 @@ export interface ExcepcionReporteCierre {
   estado: EstadoExcepcionRonda;
   fisico: number | null;
   teorico: number | null;
+  /** ESCO-61: unidad de medida de las dos cifras de arriba, tomada del
+   * alcance CONGELADO de la ronda (`rondas_inventario_alcance.unidad`, mismo
+   * snapshot del que sale `productoNombre` -- R-5). `null` cuando no se
+   * conoce: la cifra se imprime pelada, nunca con una unidad inventada. */
+  unidad: string | null;
   causaEtiqueta: string | null;
   via: ViaExcepcion | null;
 }
@@ -130,6 +136,11 @@ export interface MovimientoReporteCierre {
   productoNombre: string;
   tipoMovimiento: string;
   cantidad: number;
+  /** ESCO-61: unidad de medida de `cantidad` (`productos.unidad_medida`).
+   * Sin ella, un movimiento en kilos y una excepción contada en bultos se
+   * leían como la misma magnitud dentro del MISMO informe. `null` = no se
+   * conoce; se imprime la cifra pelada. */
+  unidad: string | null;
   origen: OrigenMovimientoRondaAbierta;
   responsable: string | null;
 }
@@ -209,8 +220,11 @@ const TITULOS: Record<DesenlaceReporte, string> = {
 };
 
 function renderExcepcion(e: ExcepcionReporteCierre): string {
+  // ESCO-61: la unidad va pegada a cada cifra, nunca al final de la frase --
+  // «sin cifra completa» no lleva unidad porque no hay cifra que calificar.
+  const unidad = sufijoUnidad(e.unidad);
   const cifras = e.fisico !== null && e.teorico !== null
-    ? `hay ${formatearCantidadCO(e.fisico)}, deberían haber ${formatearCantidadCO(e.teorico)}`
+    ? `hay ${formatearCantidadCO(e.fisico)}${unidad}, deberían haber ${formatearCantidadCO(e.teorico)}${unidad}`
     : 'sin cifra completa';
   const causa = e.causaEtiqueta ? ` -- ${e.causaEtiqueta}` : '';
   return `- ${e.productoNombre}: ${cifras}${causa}`;
@@ -224,7 +238,7 @@ const ETIQUETA_ORIGEN_MOVIMIENTO: Record<OrigenMovimientoRondaAbierta, string> =
 
 function renderMovimiento(m: MovimientoReporteCierre): string {
   const responsable = m.responsable ? ` -- ${m.responsable}` : '';
-  return `- ${m.productoNombre}: ${m.tipoMovimiento} de ${formatearCantidadCO(m.cantidad)} (${ETIQUETA_ORIGEN_MOVIMIENTO[m.origen]})${responsable}`;
+  return `- ${m.productoNombre}: ${m.tipoMovimiento} de ${formatearCantidadCO(m.cantidad)}${sufijoUnidad(m.unidad)} (${ETIQUETA_ORIGEN_MOVIMIENTO[m.origen]})${responsable}`;
 }
 
 /**

--- a/src/utils/rondaInventario/resolucion.ts
+++ b/src/utils/rondaInventario/resolucion.ts
@@ -38,7 +38,17 @@ function formatearCantidadResolucion(valor: number): string {
   }).format(valor);
 }
 
-function sufijoUnidad(unidad: string | null): string {
+/** Unidad de medida como SUFIJO de una cantidad ya formateada -- ' Kilos',
+ * ' Litros', o cadena vacía si no se conoce (nunca una unidad inventada ni un
+ * marcador de relleno).
+ *
+ * Exportado desde acá porque es el único helper de unidad del módulo:
+ * `preview.ts` y `reporteCierre.ts` lo consumen en vez de reimplementarlo
+ * (ESCO-61 -- los dos imprimían cantidades peladas mientras esta pantalla
+ * intermedia sí mostraba la unidad, y esa asimetría produjo un reporte de
+ * cierre que se contradecía a sí mismo: «hay 3» contra «Entrada de 150» para
+ * el mismo producto, porque el 3 era en bultos y el 150 en kilos). */
+export function sufijoUnidad(unidad: string | null): string {
   return unidad ? ` ${unidad}` : '';
 }
 

--- a/supabase/functions/make-server-1ccce916/ronda-inventario-tick.ts
+++ b/supabase/functions/make-server-1ccce916/ronda-inventario-tick.ts
@@ -411,8 +411,11 @@ async function obtenerExcepcionesParaReporte(sb: SupabaseClient, rondaId: string
   // Nombre del producto: SNAPSHOT del alcance congelado (R-5), nunca un JOIN
   // vivo a `productos` -- un rename posterior no debe reescribir lo que
   // Uriel vio en campo (mismo criterio que `rondas_inventario_alcance` ya
-  // documenta).
+  // documenta). ESCO-61: la UNIDAD sale del mismo snapshot y por el mismo
+  // motivo -- es la unidad contra la que se contó, no la que el catálogo
+  // tenga hoy.
   const nombresPorProducto = new Map(alcance.map((a) => [a.producto_id, a.nombre_producto]));
+  const unidadesPorProducto = new Map(alcance.map((a) => [a.producto_id, a.unidad]));
 
   return ((excepciones ?? []) as Array<{
     producto_id: string;
@@ -432,6 +435,7 @@ async function obtenerExcepcionesParaReporte(sb: SupabaseClient, rondaId: string
       estado: fila.estado as EstadoExcepcionRonda,
       fisico: fila.cantidad_fisica,
       teorico: fila.teorico_conteo,
+      unidad: unidadesPorProducto.get(fila.producto_id) ?? null,
       causaEtiqueta,
       via: fila.via_propuesta,
     };
@@ -444,8 +448,15 @@ type FilaMovimientoInventario = {
   tipo_movimiento: string;
   cantidad: number;
   responsable: string | null;
-  producto: { nombre: string } | { nombre: string }[] | null;
+  producto: ProductoDeMovimiento | ProductoDeMovimiento[] | null;
 };
+
+/** ESCO-61: `unidad_medida` viaja junto al nombre para que la cantidad del
+ * movimiento no se imprima pelada. Se lee en VIVO de `productos` -- a
+ * diferencia de la excepción, que usa el snapshot congelado -- porque el
+ * movimiento puede ser de un producto que nunca estuvo en el alcance de la
+ * ronda (`entrada_fuera_de_alcance`, P-3), y ahí el snapshot no tiene fila. */
+type ProductoDeMovimiento = { nombre: string; unidad_medida: string | null };
 
 /**
  * R-9/CA-19 (§8.3 punto 4): "todo movimiento de inventario OCURRIDO con la
@@ -491,7 +502,7 @@ async function obtenerMovimientosRondaAbierta(sb: SupabaseClient, ronda: RondaCe
     if (fila.aplicacion_movimiento_id) movimientoIdsDeExcepcion.add(fila.aplicacion_movimiento_id);
   }
 
-  const SELECT_MOVIMIENTO = 'id, producto_id, tipo_movimiento, cantidad, responsable, producto:productos(nombre)';
+  const SELECT_MOVIMIENTO = 'id, producto_id, tipo_movimiento, cantidad, responsable, producto:productos(nombre, unidad_medida)';
   const [{ data: movimientosLigados, error: errorLigados }, { data: movimientosVentana, error: errorVentana }, alcance] = await Promise.all([
     movimientoIdsDeExcepcion.size > 0
       ? sb.from('movimientos_inventario').select(SELECT_MOVIMIENTO).in('id', [...movimientoIdsDeExcepcion])
@@ -530,6 +541,7 @@ async function obtenerMovimientosRondaAbierta(sb: SupabaseClient, ronda: RondaCe
       productoNombre: producto?.nombre ?? '(producto)',
       tipoMovimiento: m.tipo_movimiento,
       cantidad: Math.abs(m.cantidad),
+      unidad: producto?.unidad_medida ?? null,
       origen,
       responsable: m.responsable,
     };

--- a/supabase/functions/make-server-1ccce916/rondaInventario/preview.ts
+++ b/supabase/functions/make-server-1ccce916/rondaInventario/preview.ts
@@ -38,6 +38,7 @@
 
 import type { FisicoOrigen } from './interpretarNota.ts';
 import type { ViaExcepcion } from './causasRaiz.ts';
+import { sufijoUnidad } from './resolucion.ts';
 
 // ---------------------------------------------------------------------------
 // 1. Una fila del preview -- ya resuelta (producto, físico, vía)
@@ -149,9 +150,16 @@ function renderFila(fila: FilaPreview): string {
     return `${fila.nombreProducto}: falta la cantidad física para poder confirmar`;
   }
 
+  // ESCO-61: la unidad va SIEMPRE pegada a la cifra, en las dos. `fila.unidad`
+  // ya venía poblada desde el alcance congelado (`resolverHallazgos.ts`) y
+  // simplemente no se imprimía, así que «hay 3, deberían haber 0» no decía si
+  // eran bultos o kilos -- la misma ambigüedad que dejó un reporte de cierre
+  // contradiciéndose contra su propio movimiento de 150. `sufijoUnidad`
+  // devuelve cadena vacía cuando no hay unidad: nunca se inventa una.
+  const unidad = sufijoUnidad(fila.unidad);
   const fisicoTexto = fila.fisicoOrigen === 'derivado'
-    ? `${formatearCantidad(fila.fisico)} (derivado)`
-    : formatearCantidad(fila.fisico);
+    ? `${formatearCantidad(fila.fisico)}${unidad} (derivado)`
+    : `${formatearCantidad(fila.fisico)}${unidad}`;
 
   const causaTexto = fila.causaEtiqueta ? `${fila.causaEtiqueta} -- ` : '';
   // CA-4: este producto no estaba en el alcance que se congeló al abrir la
@@ -159,7 +167,7 @@ function renderFila(fila: FilaPreview): string {
   // lea como si el sistema ya lo estuviera contando.
   const fueraDeAlcanceTexto = fila.fueraDeAlcance ? ' (no estaba en el alcance -- se agrega al confirmar)' : '';
 
-  return `${fila.nombreProducto}${fueraDeAlcanceTexto}: hay ${fisicoTexto}, deberían haber ${formatearCantidad(fila.teorico)}. ${causaTexto}${fraseVia(fila.via)}`;
+  return `${fila.nombreProducto}${fueraDeAlcanceTexto}: hay ${fisicoTexto}, deberían haber ${formatearCantidad(fila.teorico)}${unidad}. ${causaTexto}${fraseVia(fila.via)}`;
 }
 
 /**

--- a/supabase/functions/make-server-1ccce916/rondaInventario/reporteCierre.ts
+++ b/supabase/functions/make-server-1ccce916/rondaInventario/reporteCierre.ts
@@ -35,6 +35,7 @@
 // conteo, aunque el render de §8.3 los agrupe bajo tres títulos.
 
 import type { ViaExcepcion } from './causasRaiz.ts';
+import { sufijoUnidad } from './resolucion.ts';
 
 // ---------------------------------------------------------------------------
 // 1. Formato colombiano local -- mismo motivo que preview.ts: este módulo se
@@ -131,6 +132,11 @@ export interface ExcepcionReporteCierre {
   estado: EstadoExcepcionRonda;
   fisico: number | null;
   teorico: number | null;
+  /** ESCO-61: unidad de medida de las dos cifras de arriba, tomada del
+   * alcance CONGELADO de la ronda (`rondas_inventario_alcance.unidad`, mismo
+   * snapshot del que sale `productoNombre` -- R-5). `null` cuando no se
+   * conoce: la cifra se imprime pelada, nunca con una unidad inventada. */
+  unidad: string | null;
   causaEtiqueta: string | null;
   via: ViaExcepcion | null;
 }
@@ -147,6 +153,11 @@ export interface MovimientoReporteCierre {
   productoNombre: string;
   tipoMovimiento: string;
   cantidad: number;
+  /** ESCO-61: unidad de medida de `cantidad` (`productos.unidad_medida`).
+   * Sin ella, un movimiento en kilos y una excepción contada en bultos se
+   * leían como la misma magnitud dentro del MISMO informe. `null` = no se
+   * conoce; se imprime la cifra pelada. */
+  unidad: string | null;
   origen: OrigenMovimientoRondaAbierta;
   responsable: string | null;
 }
@@ -226,8 +237,11 @@ const TITULOS: Record<DesenlaceReporte, string> = {
 };
 
 function renderExcepcion(e: ExcepcionReporteCierre): string {
+  // ESCO-61: la unidad va pegada a cada cifra, nunca al final de la frase --
+  // «sin cifra completa» no lleva unidad porque no hay cifra que calificar.
+  const unidad = sufijoUnidad(e.unidad);
   const cifras = e.fisico !== null && e.teorico !== null
-    ? `hay ${formatearCantidadCO(e.fisico)}, deberían haber ${formatearCantidadCO(e.teorico)}`
+    ? `hay ${formatearCantidadCO(e.fisico)}${unidad}, deberían haber ${formatearCantidadCO(e.teorico)}${unidad}`
     : 'sin cifra completa';
   const causa = e.causaEtiqueta ? ` -- ${e.causaEtiqueta}` : '';
   return `- ${e.productoNombre}: ${cifras}${causa}`;
@@ -241,7 +255,7 @@ const ETIQUETA_ORIGEN_MOVIMIENTO: Record<OrigenMovimientoRondaAbierta, string> =
 
 function renderMovimiento(m: MovimientoReporteCierre): string {
   const responsable = m.responsable ? ` -- ${m.responsable}` : '';
-  return `- ${m.productoNombre}: ${m.tipoMovimiento} de ${formatearCantidadCO(m.cantidad)} (${ETIQUETA_ORIGEN_MOVIMIENTO[m.origen]})${responsable}`;
+  return `- ${m.productoNombre}: ${m.tipoMovimiento} de ${formatearCantidadCO(m.cantidad)}${sufijoUnidad(m.unidad)} (${ETIQUETA_ORIGEN_MOVIMIENTO[m.origen]})${responsable}`;
 }
 
 /**

--- a/supabase/functions/make-server-1ccce916/rondaInventario/resolucion.ts
+++ b/supabase/functions/make-server-1ccce916/rondaInventario/resolucion.ts
@@ -55,7 +55,17 @@ function formatearCantidadResolucion(valor: number): string {
   }).format(valor);
 }
 
-function sufijoUnidad(unidad: string | null): string {
+/** Unidad de medida como SUFIJO de una cantidad ya formateada -- ' Kilos',
+ * ' Litros', o cadena vacía si no se conoce (nunca una unidad inventada ni un
+ * marcador de relleno).
+ *
+ * Exportado desde acá porque es el único helper de unidad del módulo:
+ * `preview.ts` y `reporteCierre.ts` lo consumen en vez de reimplementarlo
+ * (ESCO-61 -- los dos imprimían cantidades peladas mientras esta pantalla
+ * intermedia sí mostraba la unidad, y esa asimetría produjo un reporte de
+ * cierre que se contradecía a sí mismo: «hay 3» contra «Entrada de 150» para
+ * el mismo producto, porque el 3 era en bultos y el 150 en kilos). */
+export function sufijoUnidad(unidad: string | null): string {
   return unidad ? ` ${unidad}` : '';
 }
 


### PR DESCRIPTION
## Bug

Notion finding #61 (P2, Confianza Alta, clase `codigo`). The ronda preview and the
closing report print quantities with no unit of measure. The closing report
therefore contradicts itself about the same product in the same message.

## Evidence

`rondas_reportes.texto_telegram` of the first real closed ronda, emitted
2026-08-30 12:00:02Z, read live from production during this run:

```
Resueltas con captura (1):
- 15-15-15: hay 3, deberían haber 0
...
Movimientos de inventario ocurridos con la ronda abierta (1):
- 15-15-15: Entrada de 150 (captura de excepción) -- Santiago Forero
```

Same product, same ronda, same report: 3 against 150. The `3` was recorded in
**bultos**; `productos.unidad_medida` of the 15-15-15 is `Kilos` with
`presentacion_kg_l = 50,00`, and the transcript said "tres bultos de 15-15-15 de
50 kilos". The `150` kg movement David captured is the real one. Nothing on the
page told the reader the two figures were in different units.

## Root cause

The unit was always available and simply never rendered.

- `src/utils/rondaInventario/preview.ts:145` — `renderFila` builds
  `hay ${fisicoTexto}, deberían haber ${formatearCantidad(fila.teorico)}`.
  `FilaPreview.unidad` is populated by `resolverHallazgos.ts:176` from the frozen
  scope and is never read.
- `src/utils/rondaInventario/reporteCierre.ts:213` and `:227` do the same, and
  there `ExcepcionReporteCierre` and `MovimientoReporteCierre` did not even have a
  `unidad` field.
- By contrast, David's intermediate screen **does** print units
  (`resolucion.ts:41` `sufijoUnidad`, used at `:92-94`). The unit showed up only
  in the step nobody uses to decide.

## Fix (Part A only)

- `resolucion.ts`: export the existing `sufijoUnidad` helper. No second and no
  third copy of it.
- `preview.ts`: append the unit to both figures. A derived físico reads
  `hay 5 Kilos (derivado)` — the unit stays glued to the number, before the
  marker.
- `reporteCierre.ts`: add `unidad: string | null` to `ExcepcionReporteCierre` and
  `MovimientoReporteCierre`, and render it on both lines.
- `ronda-inventario-tick.ts` (both trees): populate the new field. The exception
  takes its unit from the **frozen** scope (`rondas_inventario_alcance.unidad`,
  the same snapshot the product name comes from — R-5). The movement takes it
  **live** from `productos.unidad_medida`, because a movement can be for a product
  that was never in the scope (`entrada_fuera_de_alcance`, P-3), where the
  snapshot has no row.

A `null` unit still prints the bare figure. No unit is ever invented, and
"sin cifra completa" never gets a unit appended.

## Verification

New regression test `src/__tests__/rondaInventarioUnidades.test.ts` (8 tests).
Before the fix it failed 5 of 8, and the render it produced matched the live
`texto_telegram` byte-for-byte, including both contradicting lines. After the fix
all 8 pass.

Two existing fixtures were updated to the corrected text:
`rondaInventarioInterpretacion.test.ts` (the CA-30 fixture now carries two
different units — `Kilos` for Silicalmag, `Unidades` for Martillos — which is
exactly the case omitting them made illegible) and the `reporteCierre` parity
fixture in `rondaInventarioParidadServidor.test.ts`, which also gained a
movement so the new field is exercised on both implementations.

- `npx vitest run` — **173 files / 3.721 tests**, 172 files / 3.720 pass.
- `npm run lint` — **0 errors**, 898 warnings (all pre-existing; this branch adds
  none).
- `npx tsc --noEmit` — clean.

**One pre-existing failure, not from this branch**: `hatoSchemaContract.test.ts`
fails on duplicate migration prefix `140`
(`140_hato_registrar_tratamiento.sql` and `140_respaldo_pl_chequeo_vacas.sql`).
Verified by stashing this branch and re-running against clean `origin/main`
(`0aba907`) — it fails there identically. Untouched here.

## Deploy

**The edge function must be redeployed after merge**:
`npx supabase functions deploy make-server-1ccce916`. Both trees
(`src/supabase/functions/server/` and `supabase/functions/make-server-1ccce916/`)
were regenerated with `docs/inventario/regenerar-copias-ronda-inventario.py`;
`--check` passes on all 16 copies.

## Rollback

Revert the commit. The change is render-only plus one added optional field; no
migration, no data write, no schema change.

## Deliberately left out

- **Part B (`clase datos`, needs Santiago's approval)**: the
  `UPDATE rondas_excepciones SET cantidad_fisica = 150 …` that would correct the
  stored bultos-vs-kilos figure. Not composed and not run — nobody is watching
  this run and there is no one to authorise a production data write.
- **Part C**: making the `captura_david` path reconfirm the quantity is a
  separate behaviour change, not bundled.
- **`rondas_reportes` is untouched.** R-10 freezes an emitted report on purpose;
  rewriting the existing one would break the module's idempotency contract. The
  already-emitted report keeps its text — only reports emitted from now on carry
  units.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9


---
_Generated by [Claude Code](https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9)_