### PR TITLE
refactor: one copy of the gravedad threshold per tree, plus a guard that finds copies by shape

### DIFF
--- a/src/__tests__/umbralGravedadContract.test.ts
+++ b/src/__tests__/umbralGravedadContract.test.ts
@@ -1,0 +1,287 @@
+// ARCHIVO: __tests__/umbralGravedadContract.test.ts
+// DESCRIPCIÓN: El corte de gravedad de una plaga es 10 % / 30 % sobre la
+// incidencia (Baja < 10 ≤ Media < 30 ≤ Alta). Es contrato del proyecto, vive en
+// `clasificarGravedad` (`src/utils/calculosMonitoreo.ts`) y el CLAUDE.md raíz
+// prohíbe re-derivarlo en línea.
+//
+// POR QUÉ EXISTE ESTE GUARD — y por qué busca por FORMA y no por nombre:
+//
+// El corte se ha duplicado dos veces y las dos veces el mecanismo de detección
+// falló, siempre por la misma razón: buscaba el NOMBRE `clasificarGravedad`.
+//
+//   1. `CargaMasiva.tsx` llevaba su propia copia con un corte de 15 %. Etiquetó
+//      mal 48 filas de `monitoreos`; la migración 117 corrigió el dato y el
+//      PR #151 el código.
+//   2. El bot de Telegram llevaba una TERCERA implementación llamada
+//      `calcularGravedad` (`telegram/conversations/monitoreo.ts`, más su espejo
+//      en `supabase/functions/make-server-1ccce916/`). Escribía `gravedad_texto`
+//      y `gravedad_numerica` en filas reales de `monitoreos`.
+//      `grep -rn calcularGravedad src/__tests__/` devolvía CERO: ninguna guarda,
+//      ningún test de paridad y ninguna barrida la veían. Comprobado antes de
+//      cerrarla: cambiarle el corte de 10 a 15 — el defecto exacto del punto 1 —
+//      dejaba la suite entera en verde (172 ficheros, 3.713 tests).
+//
+// Por eso este guard no busca un identificador. Barre `src/` y `supabase/` y
+// encuentra CUALQUIER sitio que compare un número contra un rótulo de gravedad,
+// se llame como se llame, y falla ante cualquier fichero que no esté en el
+// inventario de abajo. Es el mismo patrón de `jornalDivisorContract.test.ts`,
+// que existe porque el divisor del jornal vivía en tres árboles que no pueden
+// importarse entre sí. **Buscar por nombre es lo que falló acá.**
+//
+// LO QUE ESTE GUARD NO HACE: no opina sobre los valores 10 y 30. Son una
+// decisión del dueño; el guard sólo exige que haya UNA copia y que las demás la
+// importen.
+
+import { describe, it, expect } from 'vitest';
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join, relative } from 'node:path';
+import { clasificarGravedad } from '@/utils/calculosMonitoreo';
+import { clasificarGravedad as clasificarEdge } from '../supabase/functions/server/priorizacion-scouting';
+
+const RAIZ = join(__dirname, '..', '..');
+const leer = (rel: string) => readFileSync(join(RAIZ, rel), 'utf-8');
+
+// ---------------------------------------------------------------------------
+// Inventario — todo sitio del repo que roza el corte de gravedad
+// ---------------------------------------------------------------------------
+
+/**
+ * Todo fichero que la barrida de abajo encuentra, con su papel:
+ *
+ * - `declara`: tiene el corte escrito. Son los ÚNICOS tres ficheros que pueden
+ *   tenerlo, uno por árbol, porque los tres árboles no pueden importarse entre
+ *   sí (navegador, edge function `src/supabase/...`, copia desplegada
+ *   `supabase/functions/...`).
+ * - `otro`: usa los rótulos Alta/Media/Baja para algo que NO es derivar la
+ *   gravedad de una plaga a partir de un número — prioridad de una tarea,
+ *   colorear un valor ya clasificado, o agregar el `gravedad_texto` que la base
+ *   ya tiene guardado.
+ *
+ * Un fichero que aparezca en la barrida y no esté acá hace fallar el test. Eso
+ * es deliberado: la única forma de agregarlo es decidir cuál de los dos papeles
+ * cumple, que es exactamente la decisión que nadie tomó con el bot de Telegram.
+ */
+type Papel = 'declara' | 'otro';
+
+const INVENTARIO: Record<string, Papel> = {
+  // La fuente de verdad.
+  'src/utils/calculosMonitoreo.ts': 'declara',
+  // Puerto Deno + su copia desplegada. `priorizacion-scouting.ts` no tiene NI UN
+  // import, así que cualquier módulo del árbol edge puede tomarle el corte.
+  'src/supabase/functions/server/priorizacion-scouting.ts': 'declara',
+  'supabase/functions/make-server-1ccce916/priorizacion-scouting.ts': 'declara',
+
+  // Pinta el resultado de `clasificarGravedad`; el `> 0` que la barrida ve es
+  // un guardia de render, no un corte.
+  'src/components/monitoreo/RegistroMonitoreo.tsx': 'otro',
+  'src/components/monitoreo/DashboardMonitoreoV3.tsx': 'otro',
+  // Prioridad de una tarea de Labores, no gravedad de una plaga.
+  'src/components/dashboard/AlertList.tsx': 'otro',
+  // Agrega `gravedad_texto` ya guardado en `monitoreos`; nunca lo deriva.
+  'src/supabase/functions/server/chat.tsx': 'otro',
+  'supabase/functions/make-server-1ccce916/chat.tsx': 'otro',
+};
+
+/**
+ * Ficheros que clasifican la gravedad y DEBEN importar el corte, nunca
+ * reescribirlo. Esta lista sí va por nombre, y ése es justamente su límite: es
+ * una comprobación secundaria. La que de verdad cierra el agujero es la barrida
+ * por forma, porque un quinto sitio con otro nombre no estaría acá.
+ */
+const CONSUMIDORES = [
+  'src/components/monitoreo/RegistroMonitoreo.tsx',
+  'src/components/monitoreo/DashboardMonitoreoV3.tsx',
+  'src/components/monitoreo/CargaMasiva.tsx',
+  'src/components/monitoreo/MapaCalorIncidencias.tsx',
+  'src/supabase/functions/server/telegram/conversations/monitoreo.ts',
+  'supabase/functions/make-server-1ccce916/telegram/conversations/monitoreo.ts',
+];
+
+// ---------------------------------------------------------------------------
+// Barrida
+// ---------------------------------------------------------------------------
+
+const DIRS_RAIZ = ['src', 'supabase'];
+const SALTAR = new Set(['node_modules', 'build', 'dist', '.git', '__tests__']);
+
+function ficherosDeCodigo(): string[] {
+  const out: string[] = [];
+  const caminar = (dir: string) => {
+    for (const entrada of readdirSync(dir)) {
+      if (SALTAR.has(entrada)) continue;
+      const p = join(dir, entrada);
+      if (statSync(p).isDirectory()) caminar(p);
+      else if (/\.(ts|tsx)$/.test(entrada)) out.push(p);
+    }
+  };
+  for (const d of DIRS_RAIZ) caminar(join(RAIZ, d));
+  return out;
+}
+
+const ROTULO = /['"`](Baja|Media|Alta)['"`]/;
+
+/** Un corte es un número comparado, o una cota nombrada de una tabla de rangos. */
+const EXPRESIONES_DE_CORTE = [
+  /(?:>=|<=|>|<)\s*(\d+(?:\.\d+)?)/g,
+  /\b(?:min|max|minimo|maximo|desde|hasta|umbral|corte|limite)\s*[:=]\s*(\d+(?:\.\d+)?)/gi,
+];
+
+/** Cuántas líneas alrededor del rótulo se miran para encontrar su corte. */
+const VENTANA = 3;
+
+/**
+ * Red 1 — la FORMA del clasificador: un número comparado cerca de un rótulo de
+ * gravedad. Independiente del nombre de la función, del `if`/`switch`/ternario
+ * que se use y de si el fichero exporta o no.
+ */
+function cortesAdyacentesARotulo(contenido: string): string[] {
+  const lineas = contenido.split('\n');
+  const cortes = new Set<string>();
+  lineas.forEach((linea, i) => {
+    if (!ROTULO.test(linea)) return;
+    const ventana = lineas.slice(Math.max(0, i - VENTANA), i + VENTANA + 1).join('\n');
+    for (const re of EXPRESIONES_DE_CORTE) {
+      for (const m of ventana.matchAll(re)) cortes.add(m[1]);
+    }
+  });
+  return [...cortes].sort();
+}
+
+/**
+ * Red 2 — más ancha y más tonta, para las formas que la red 1 no ve (una tabla
+ * de rangos sin operadores, por ejemplo): los tres rótulos y los dos números en
+ * el mismo fichero.
+ */
+function tieneRotulosYAmbosNumeros(contenido: string): boolean {
+  const tresRotulos = ['Baja', 'Media', 'Alta'].every((l) =>
+    new RegExp(`['"\`]${l}['"\`]`).test(contenido),
+  );
+  if (!tresRotulos) return false;
+  return /(?<![\w.])10(?![\w.])/.test(contenido) && /(?<![\w.])30(?![\w.])/.test(contenido);
+}
+
+const IMPORTA_EL_CORTE =
+  /import\s*(?:type\s*)?\{[^}]*\bclasificarGravedad\b[^}]*\}\s*from\s*['"][^'"]*(?:calculosMonitoreo|priorizacion-scouting)(?:\.ts)?['"]/;
+
+interface Hallazgo {
+  rel: string;
+  cortes: string[];
+  redAncha: boolean;
+}
+
+const HALLAZGOS: Hallazgo[] = ficherosDeCodigo()
+  .map((abs) => {
+    const contenido = readFileSync(abs, 'utf-8');
+    return {
+      rel: relative(RAIZ, abs).split('\\').join('/'),
+      cortes: cortesAdyacentesARotulo(contenido),
+      redAncha: tieneRotulosYAmbosNumeros(contenido),
+    };
+  })
+  .filter((h) => h.cortes.length > 0 || h.redAncha);
+
+const porRel = (rel: string) => HALLAZGOS.find((h) => h.rel === rel);
+
+// ---------------------------------------------------------------------------
+
+describe('umbral de gravedad — el corte 10 % / 30 %', () => {
+  it('los límites son exactos y cerrados por abajo', () => {
+    expect(clasificarGravedad(0)).toEqual({ texto: 'Baja', numerica: 1 });
+    expect(clasificarGravedad(9.99)).toEqual({ texto: 'Baja', numerica: 1 });
+    expect(clasificarGravedad(10)).toEqual({ texto: 'Media', numerica: 2 });
+    expect(clasificarGravedad(29.99)).toEqual({ texto: 'Media', numerica: 2 });
+    expect(clasificarGravedad(30)).toEqual({ texto: 'Alta', numerica: 3 });
+  });
+
+  it('el puerto Deno contesta lo mismo que el navegador', () => {
+    for (const inc of [0, 9.99, 10, 14.9, 15, 29.99, 30, 100]) {
+      expect(clasificarEdge(inc), `incidencia ${inc}`).toEqual(clasificarGravedad(inc));
+    }
+  });
+
+  it('el corte viejo de 15 % ya no clasifica a nadie como Baja', () => {
+    // Es el defecto que costó las 48 filas de la migración 117.
+    expect(clasificarGravedad(12.5).texto).toBe('Media');
+    expect(clasificarEdge(12.5).texto).toBe('Media');
+  });
+});
+
+describe('guard estático — toda copia del corte, encontrada por FORMA', () => {
+  it('la barrida ve algo: el detector no está roto en silencio', () => {
+    // Sin esto, un cambio que rompa las expresiones regulares dejaría el guard
+    // en verde permanente sin mirar un solo fichero.
+    expect(HALLAZGOS.length).toBeGreaterThanOrEqual(3);
+    expect(porRel('src/utils/calculosMonitoreo.ts')?.cortes).toEqual(['10', '30']);
+  });
+
+  it('ningún fichero fuera del inventario compara un número contra un rótulo de gravedad', () => {
+    const intrusos = HALLAZGOS.filter((h) => h.cortes.length > 0 && !(h.rel in INVENTARIO)).map(
+      (h) => `${h.rel} (cortes: ${h.cortes.join(', ')})`,
+    );
+    expect(
+      intrusos,
+      'Copia no inventariada del corte de gravedad. Si deriva la gravedad de un ' +
+        'número, importá `clasificarGravedad` en vez de reescribirla; si usa los ' +
+        'rótulos para otra cosa, agregala al INVENTARIO como `otro`.',
+    ).toEqual([]);
+  });
+
+  it('ningún fichero fuera del inventario junta los tres rótulos con 10 y 30', () => {
+    const intrusos = HALLAZGOS.filter((h) => h.redAncha && !(h.rel in INVENTARIO)).map((h) => h.rel);
+    expect(intrusos, 'Posible tabla de rangos con el corte de gravedad escrito a mano.').toEqual([]);
+  });
+
+  it('el inventario no tiene entradas muertas', () => {
+    const muertas = Object.keys(INVENTARIO).filter((rel) => !porRel(rel));
+    expect(
+      muertas,
+      'Estas entradas ya no aparecen en la barrida: borralas del INVENTARIO para que no lo pudran.',
+    ).toEqual([]);
+  });
+
+  const DECLARAN = Object.entries(INVENTARIO)
+    .filter(([, papel]) => papel === 'declara')
+    .map(([rel]) => rel);
+
+  it('sólo tres ficheros declaran el corte, uno por árbol', () => {
+    expect(DECLARAN).toHaveLength(3);
+  });
+
+  it.each(DECLARAN)('%s declara exactamente 10 y 30, ningún otro corte', (rel) => {
+    expect(porRel(rel)!.cortes, `${rel} cambió el corte de gravedad`).toEqual(['10', '30']);
+  });
+
+  const OTROS = Object.entries(INVENTARIO)
+    .filter(([, papel]) => papel === 'otro')
+    .map(([rel]) => rel);
+
+  it.each(OTROS)('%s no reescribe los cortes 10 y 30 junto a un rótulo', (rel) => {
+    const cortes = porRel(rel)?.cortes ?? [];
+    expect(
+      cortes.filter((c) => c === '10' || c === '30'),
+      `${rel} pasó de usar los rótulos a derivar la gravedad: importá clasificarGravedad`,
+    ).toEqual([]);
+  });
+
+  it.each(CONSUMIDORES)('%s importa el corte en vez de reescribirlo', (rel) => {
+    expect(
+      IMPORTA_EL_CORTE.test(leer(rel)),
+      `${rel} clasifica la gravedad pero no importa clasificarGravedad`,
+    ).toBe(true);
+  });
+
+  it('las dos copias del árbol de edge function coinciden', () => {
+    // El espejo `supabase/functions/make-server-1ccce916/` se mantiene a mano.
+    // Sólo difieren en la primera línea, la cabecera `// ARCHIVO:`.
+    const sinCabecera = (rel: string) => leer(rel).split('\n').slice(1).join('\n');
+    for (const rel of [
+      'telegram/conversations/monitoreo.ts',
+      'priorizacion-scouting.ts',
+    ]) {
+      expect(
+        sinCabecera(`src/supabase/functions/server/${rel}`),
+        `${rel} derivó entre los dos árboles de edge function`,
+      ).toBe(sinCabecera(`supabase/functions/make-server-1ccce916/${rel}`));
+    }
+  });
+});

--- a/src/supabase/functions/server/telegram/conversations/monitoreo.ts
+++ b/src/supabase/functions/server/telegram/conversations/monitoreo.ts
@@ -12,6 +12,15 @@ import { InlineKeyboard } from "npm:grammy@1";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 import type { BotContext } from "../types.ts";
+// El corte de gravedad (10 % / 30 %) es contrato del proyecto y tiene UNA sola
+// copia por árbol. `priorizacion-scouting.ts` es el puerto Deno de
+// `src/utils/calculosMonitoreo.ts` y no tiene ni un import propio, así que es el
+// sitio del que este árbol toma las funciones puras de monitoreo — igual que ya
+// hace `chat.tsx`. Antes acá vivía una TERCERA implementación llamada
+// `calcularGravedad`: coincidía en los números, pero ninguna guarda la veía
+// porque todas buscaban el nombre `clasificarGravedad`. La guarda que cierra ese
+// agujero es `src/__tests__/umbralGravedadContract.test.ts`, que busca por forma.
+import { clasificarGravedad } from "../../priorizacion-scouting.ts";
 
 const PLAGAS_PER_PAGE = 8;
 
@@ -19,15 +28,6 @@ function getSupabaseAdmin() {
   const url = Deno.env.get("SUPABASE_URL")!;
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
   return createClient(url, serviceKey, { auth: { persistSession: false } });
-}
-
-function calcularGravedad(incidencia: number): {
-  texto: "Baja" | "Media" | "Alta";
-  numerica: 1 | 2 | 3;
-} {
-  if (incidencia < 10) return { texto: "Baja", numerica: 1 };
-  if (incidencia < 30) return { texto: "Media", numerica: 2 };
-  return { texto: "Alta", numerica: 3 };
 }
 
 function gravedadEmoji(texto: string): string {
@@ -765,7 +765,7 @@ export async function monitoreoConversation(
           const severidad = arbolesMonitoreados > 0
             ? pd.individuos / arbolesMonitoreados
             : 0;
-          const gravedad = calcularGravedad(incidencia);
+          const gravedad = clasificarGravedad(incidencia);
 
           summaryLines.push(
             `🐛 *${pd.plagaNombre}*`,
@@ -873,7 +873,7 @@ export async function monitoreoConversation(
             const incidencia = arbolesMonitoreados > 0
               ? (pd.arbolesAfectados / arbolesMonitoreados) * 100
               : 0;
-            const gravedad = calcularGravedad(incidencia);
+            const gravedad = clasificarGravedad(incidencia);
 
             const record: Record<string, unknown> = {
               fecha_monitoreo: fechaMonitoreo,

--- a/supabase/functions/make-server-1ccce916/telegram/conversations/monitoreo.ts
+++ b/supabase/functions/make-server-1ccce916/telegram/conversations/monitoreo.ts
@@ -12,6 +12,15 @@ import { InlineKeyboard } from "npm:grammy@1";
 import { createClient } from "npm:@supabase/supabase-js@2";
 
 import type { BotContext } from "../types.ts";
+// El corte de gravedad (10 % / 30 %) es contrato del proyecto y tiene UNA sola
+// copia por árbol. `priorizacion-scouting.ts` es el puerto Deno de
+// `src/utils/calculosMonitoreo.ts` y no tiene ni un import propio, así que es el
+// sitio del que este árbol toma las funciones puras de monitoreo — igual que ya
+// hace `chat.tsx`. Antes acá vivía una TERCERA implementación llamada
+// `calcularGravedad`: coincidía en los números, pero ninguna guarda la veía
+// porque todas buscaban el nombre `clasificarGravedad`. La guarda que cierra ese
+// agujero es `src/__tests__/umbralGravedadContract.test.ts`, que busca por forma.
+import { clasificarGravedad } from "../../priorizacion-scouting.ts";
 
 const PLAGAS_PER_PAGE = 8;
 
@@ -19,15 +28,6 @@ function getSupabaseAdmin() {
   const url = Deno.env.get("SUPABASE_URL")!;
   const serviceKey = Deno.env.get("SUPABASE_SERVICE_ROLE_KEY")!;
   return createClient(url, serviceKey, { auth: { persistSession: false } });
-}
-
-function calcularGravedad(incidencia: number): {
-  texto: "Baja" | "Media" | "Alta";
-  numerica: 1 | 2 | 3;
-} {
-  if (incidencia < 10) return { texto: "Baja", numerica: 1 };
-  if (incidencia < 30) return { texto: "Media", numerica: 2 };
-  return { texto: "Alta", numerica: 3 };
 }
 
 function gravedadEmoji(texto: string): string {
@@ -765,7 +765,7 @@ export async function monitoreoConversation(
           const severidad = arbolesMonitoreados > 0
             ? pd.individuos / arbolesMonitoreados
             : 0;
-          const gravedad = calcularGravedad(incidencia);
+          const gravedad = clasificarGravedad(incidencia);
 
           summaryLines.push(
             `🐛 *${pd.plagaNombre}*`,
@@ -873,7 +873,7 @@ export async function monitoreoConversation(
             const incidencia = arbolesMonitoreados > 0
               ? (pd.arbolesAfectados / arbolesMonitoreados) * 100
               : 0;
-            const gravedad = calcularGravedad(incidencia);
+            const gravedad = clasificarGravedad(incidencia);
 
             const record: Record<string, unknown> = {
               fecha_monitoreo: fechaMonitoreo,


### PR DESCRIPTION
Closes maintenance finding #48 (P2, Confianza Alta, Clase codigo).

## The finding

The 10 % / 30 % gravedad cut lived in **four** places. The fourth was a third
implementation named **`calcularGravedad`**, in the Telegram bot
(`src/supabase/functions/server/telegram/conversations/monitoreo.ts:24` and its
mirror in `supabase/functions/make-server-1ccce916/`). It is not decorative: the
bot calls it at `:768` and `:876` to write `gravedad_texto` and
`gravedad_numerica` into real `monitoreos` rows.

All four agreed numerically. **The problem was the name.** Every guard, parity
test and sweep in this repo searches for `clasificarGravedad`, so
`grep -rn calcularGravedad src/__tests__/` returned **zero**. The copy was also
invisible to the toolchain: `tsconfig.json` excludes `src/supabase` and
`eslint.config.js` ignores it, so neither `tsc` nor eslint ever read that file.

This is the same defect that already cost 48 mislabelled rows — `CargaMasiva`
carried its own copy with a 15 % cut, migration 117 corrected the data and
PR #151 the code — but with the detection mechanism switched off.

## Reproduction, before any change

I injected the exact finding #12 defect into both bot copies (`< 10` → `< 15`)
and ran the whole suite:

```
Test Files  1 failed | 171 passed (172)
     Tests  1 failed | 3712 passed (3713)
```

The single failure was `hatoSchemaContract.test.ts`, about a duplicate migration
prefix `140` — **pre-existing on `origin/main`**, verified on a clean tree, and
unrelated. So a divergent threshold writing to production produced **zero**
failures.

Production check (read-only): `monitoreos` holds **4.244** rows, all with
`gravedad_texto`. **0** violate the 10/30 cut today. **658** would violate a
15/30 cut — that is the blast radius the missing guard was leaving open.

## What changed

**1. The bot stops declaring the cut and imports it.**
`priorizacion-scouting.ts` is the Deno port of `src/utils/calculosMonitoreo.ts`,
has no imports of its own, and is already in the deployed bundle because
`chat.tsx` imports it. The repo goes from 5 files carrying the cut to 3 — one
per tree, since the three trees cannot import each other.

Equivalence: the deleted copy used `< 10` / `< 30`; the port uses `>= 30` /
`>= 10`. These agree for every real number. They diverge only on `NaN`, which is
unreachable here — every numeric input passes `parseInt` + an explicit `isNaN`
rejection, and `arbolesMonitoreados` is rejected unless `> 0`.

**2. `src/__tests__/umbralGravedadContract.test.ts` — the half that closes the
hole.** It searches by **shape, not by name**, modelled on
`jornalDivisorContract.test.ts`:

- sweeps `src/` and `supabase/` for any number compared against a `Baja`/`Media`/
  `Alta` label within ±3 lines, in any form (`if`, `switch`, ternary, or a named
  bound in a range table);
- a wider net for the three labels plus both literals in one file;
- every file either net finds must sit in an explicit inventory, classified
  `declara` or `otro`;
- the three `declara` files must carry exactly 10 and 30 and nothing else;
- the inventory may not rot — a dead entry fails the test.

No threshold value changes. 10 and 30 are the owner's decision.

## How it was verified

Both directions, which is the point:

- **Red before the change**: with only the test file added and the bot untouched,
  4 failures, all naming the two bot copies, through three independent
  mechanisms — "copia no inventariada" (narrow net), "posible tabla de rangos"
  (wide net), and "clasifica la gravedad pero no importa clasificarGravedad".
- **Catches a renamed copy**: a probe file with a different name
  (`nivelDeAfectacion`) and a different shape (`switch (true)`) in a brand-new
  path was caught by both nets. Probe removed.
- **Green after the change**: 23 tests pass.

```
npm run lint       0 errors, 898 warnings   (baseline was 906; no new warnings)
npm run typecheck  clean, exit 0
npm test           172 passed | 1 failed (173 files)
                   3735 passed | 1 failed (3736 tests)
```

The one failure is the pre-existing `hatoSchemaContract.test.ts` duplicate-`140`
assertion described above. It is red on `origin/main` and this branch does not
touch it. Everything else is green, and this branch adds 23 tests.

## Rollback

`git revert` the single commit. The change is confined to three files, two of
which are byte-identical mirrors. Reverting restores the local
`calcularGravedad` and removes the guard; no data, migration or RLS is involved.

## After merge

**The edge function must be redeployed** — the change touches
`telegram/conversations/monitoreo.ts` in both trees:

```
npx supabase functions deploy make-server-1ccce916
```

Until that deploy runs, the bot keeps executing the old bundle, which behaves
identically anyway (the numbers never differed).

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9

---
_Generated by [Claude Code](https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9)_