### PR TITLE
fix(sql): renumber 140_respaldo_pl to 144 and put the suite back in the green

### DIFF
--- a/src/sql/migrations/143_respaldo_pl_chequeo_vacas.sql
+++ b/src/sql/migrations/143_respaldo_pl_chequeo_vacas.sql
@@ -1,11 +1,41 @@
 -- =============================================================================
--- 140_respaldo_pl_chequeo_vacas.sql
+-- 143_respaldo_pl_chequeo_vacas.sql
 --
 -- RENUMERADA 138 -> 140 al integrar con `main`: dos sesiones paralelas ya
 -- habían tomado 138 (`pajillas_jerico_stock_cero`) y 139
 -- (`hato_duplicados_guardarrail`). El guard `hatoSchemaContract.test.ts` lo
 -- atrapó. Es la misma colisión que la 101/102 y las 124-130 -- verificar el
 -- catálogo VIVO antes de numerar, nunca un número heredado de un documento.
+--
+-- RENUMERADA OTRA VEZ, 140 -> 143 (2026-09-11). La renumeración anterior dejó
+-- DOS ficheros con prefijo `140` -- éste y `140_hato_registrar_tratamiento.sql`
+-- -- y `hatoSchemaContract.test.ts` llevaba desde el 2026-09-09 EN ROJO por eso,
+-- o sea que la suite entera dejó de ser señal durante dos días. Se mueve éste y
+-- no el otro por tener menos superficie de citas.
+--
+-- EL NÚMERO 143 ES SÓLO EL SIGUIENTE SLOT LIBRE, NO LA POSICIÓN CRONOLÓGICA.
+-- Mismo criterio que las 067 / 079 / 108. Esta migración corrió el 2026-09-09
+-- (ledger `20260909002311`), o sea ANTES que `140_hato_registrar_tratamiento`
+-- (`20260909002904`) y antes que la 141 (`20260909130404`). El orden de los
+-- nombres de fichero no reconstruye el orden de aplicación -- para eso está el
+-- ledger, que es quien manda.
+--
+-- EL LEDGER NO SE DESALINEA CON ESTE RENOMBRE, y por eso se puede hacer: sus
+-- filas se llaman `renombrar_respaldo_pl_a_140` y
+-- `hato_registrar_tratamiento_renumerada_140`, no se indexan por el nombre del
+-- fichero, y la clave es `version`. El `_a_140` de esa fila es un nombre
+-- histórico: describe la renumeración de 2026-09-09, no dónde vive el fichero
+-- hoy. NO se toca -- una fila del ledger de una migración ya aplicada no se
+-- edita.
+--
+-- EL CONTENIDO NO SE TOCA. Está aplicada. El renombre es del fichero y nada más.
+--
+-- AL ELEGIR EL SIGUIENTE NÚMERO, MIRÁ TAMBIÉN LAS RAMAS ABIERTAS. 142 está
+-- tomada por `142_alertas_defaults_campo_secado_tratamiento.sql`, en la rama de
+-- la PR #218, sin fusionar -- las tres fuentes que sí manda revisar el runbook
+-- (ficheros en `main`, `supabase_migrations.schema_migrations`, esquema
+-- `respaldos`) están limpias en 142, y aun así el número está ocupado. Es
+-- exactamente la forma en que nació esta colisión.
 --
 -- RESPALDO PREVIO al cambio de semántica de `hato_chequeo_vacas.pl`.
 --

--- a/src/sql/migrations/144_respaldo_pl_chequeo_vacas.sql
+++ b/src/sql/migrations/144_respaldo_pl_chequeo_vacas.sql
@@ -1,5 +1,5 @@
 -- =============================================================================
--- 143_respaldo_pl_chequeo_vacas.sql
+-- 144_respaldo_pl_chequeo_vacas.sql
 --
 -- RENUMERADA 138 -> 140 al integrar con `main`: dos sesiones paralelas ya
 -- habían tomado 138 (`pajillas_jerico_stock_cero`) y 139
@@ -7,13 +7,13 @@
 -- atrapó. Es la misma colisión que la 101/102 y las 124-130 -- verificar el
 -- catálogo VIVO antes de numerar, nunca un número heredado de un documento.
 --
--- RENUMERADA OTRA VEZ, 140 -> 143 (2026-09-11). La renumeración anterior dejó
+-- RENUMERADA OTRA VEZ, 140 -> 144 (2026-09-11). La renumeración anterior dejó
 -- DOS ficheros con prefijo `140` -- éste y `140_hato_registrar_tratamiento.sql`
 -- -- y `hatoSchemaContract.test.ts` llevaba desde el 2026-09-09 EN ROJO por eso,
 -- o sea que la suite entera dejó de ser señal durante dos días. Se mueve éste y
 -- no el otro por tener menos superficie de citas.
 --
--- EL NÚMERO 143 ES SÓLO EL SIGUIENTE SLOT LIBRE, NO LA POSICIÓN CRONOLÓGICA.
+-- EL NÚMERO 144 ES SÓLO EL SIGUIENTE SLOT LIBRE, NO LA POSICIÓN CRONOLÓGICA.
 -- Mismo criterio que las 067 / 079 / 108. Esta migración corrió el 2026-09-09
 -- (ledger `20260909002311`), o sea ANTES que `140_hato_registrar_tratamiento`
 -- (`20260909002904`) y antes que la 141 (`20260909130404`). El orden de los
@@ -30,12 +30,27 @@
 --
 -- EL CONTENIDO NO SE TOCA. Está aplicada. El renombre es del fichero y nada más.
 --
--- AL ELEGIR EL SIGUIENTE NÚMERO, MIRÁ TAMBIÉN LAS RAMAS ABIERTAS. 142 está
--- tomada por `142_alertas_defaults_campo_secado_tratamiento.sql`, en la rama de
--- la PR #218, sin fusionar -- las tres fuentes que sí manda revisar el runbook
--- (ficheros en `main`, `supabase_migrations.schema_migrations`, esquema
--- `respaldos`) están limpias en 142, y aun así el número está ocupado. Es
--- exactamente la forma en que nació esta colisión.
+-- AL ELEGIR EL SIGUIENTE NÚMERO, MIRÁ TAMBIÉN LAS RAMAS ABIERTAS. Ni 142 ni 143
+-- estaban libres, y NINGUNA de las dos aparece en las tres fuentes que sí manda
+-- revisar el runbook (ficheros en `main`, `supabase_migrations.schema_migrations`,
+-- esquema `respaldos`), que están limpias en ambos números:
+--
+--   142 -> `142_alertas_defaults_campo_secado_tratamiento.sql`, rama de la PR #218
+--   143 -> `143_fn_ronda_actor_correo_para_movimientos.sql`, rama de la PR #222
+--
+-- Las dos ramas están abiertas y sin fusionar. Es exactamente la forma en que
+-- nació la colisión que este fichero arregla -- y volvió a pasar HOY, dentro de
+-- la misma hora: este fichero se escribió primero como 143 y hubo que moverlo a
+-- 144 cuando la 222 tomó el 143 en paralelo. Dos ramas activas eligen el mismo
+-- "siguiente libre" porque las dos miran un catálogo que no incluye a la otra.
+--
+-- El barrido que lo detecta, y que hay que correr JUSTO ANTES de fijar el número:
+--
+--   git fetch origin --prune
+--   for r in $(git for-each-ref --format='%(refname)' refs/remotes/origin); do
+--     git ls-tree -r --name-only "$r" -- src/sql/migrations/ 2>/dev/null \
+--       | grep -E "/${N}_" && echo "OCUPADO en $r"
+--   done
 --
 -- RESPALDO PREVIO al cambio de semántica de `hato_chequeo_vacas.pl`.
 --


### PR DESCRIPTION
## Bug

Notion finding #92 (P2, Confianza Alta, clase `codigo`), filed during today's drain run.

`src/sql/migrations/` carries **two files with the `140` prefix** —
`140_hato_registrar_tratamiento.sql` and `140_respaldo_pl_chequeo_vacas.sql` — left over from
the renumbering of 2026-09-09. `hatoSchemaContract.test.ts` detects exactly this and has been
**red since `11c2a93` (2026-09-09)**.

## Why it is worth a PR of its own

The duplicate prefix is cosmetic. What it cost is not: **the whole suite stopped being a
signal for two days.** Every PR opened in that window drags a failure it did not cause, which
forces each author to reason "this red is not mine" — and that is one step away from the
2026-08-27 near-miss, when an agent saw 10 reds and almost filed "the suite is no longer a
signal" as a finding.

The four PRs merged today (#219, #220, #221, #222) each had to carry that caveat.

## Evidence

On `main` before this change:

```
$ npx vitest run
 Test Files  1 failed | 173 passed (174)
      Tests  1 failed | 3748 passed (3749)

 src/__tests__/hatoSchemaContract.test.ts:219:9
- Expected  []
+ Received  [ [ "140", [ "140_hato_registrar_tratamiento.sql", "140_respaldo_pl_chequeo_vacas.sql" ] ] ]
```

## Fix

`git mv 140_respaldo_pl_chequeo_vacas.sql 144_respaldo_pl_chequeo_vacas.sql`, plus a header
note. **The SQL body is not touched** — the migration is applied, and an applied migration is
never edited.

`140_respaldo_pl` is the one that moves because it has the smaller citation surface. Nothing
in the codebase references either filename; the only hits are narrative prose in
`escociaos-po/`, which is describing history and correctly keeps saying `140`.

### The ledger does not desync, and that is what makes the rename safe

Its rows are named `renombrar_respaldo_pl_a_140` and
`hato_registrar_tratamiento_renumerada_140`. They are **not indexed by filename** — the key is
`version`. Verified live:

```
20260909002311  renombrar_respaldo_pl_a_140
20260909002904  hato_registrar_tratamiento_renumerada_140
20260909130404  141_venta_ganado_peso_destare
```

That row keeps its historical name, which describes the 2026-09-09 renumbering and not where
the file lives today. A ledger row for an applied migration is not edited.

### `144` — and the reason it is not `142` or `143` is the whole lesson

**Neither was free, and neither appears in any of the three sources the runbook tells you to
check.** Filenames on `main`, `supabase_migrations.schema_migrations` and the `respaldos`
schema are all clean at both numbers, and both are taken — by open branches:

```
142 -> 142_alertas_defaults_campo_secado_tratamiento.sql   (branch of #218)
143 -> 143_fn_ronda_actor_correo_para_movimientos.sql      (branch of #222)
```

This PR was originally written as `143` and had to move to `144` **within the same hour**, when
#222 independently took `143`. Two active branches pick the same "next free" number because each
one is looking at a catalogue that does not contain the other. That is the root cause of all
three forced renumberings in the last two weeks — `140` twice, now `143` — and it is not fixed
by checking more carefully. The header now carries the sweep that actually finds it:

```sh
git fetch origin --prune
for r in $(git for-each-ref --format='%(refname)' refs/remotes/origin); do
  git ls-tree -r --name-only "$r" -- src/sql/migrations/ 2>/dev/null \
    | grep -E "/${N}_" && echo "OCUPADO en $r"
done
```

### The number is the next free slot, not the chronological position

This migration ran **before** `140_hato_registrar_tratamiento` and before `141`. Filename order
does not reconstruct application order — the ledger does. Same convention the headers of
067 / 079 / 108 already use, now stated in this one.

## Verification

Checked on the tree with **#222 and this PR merged together**, not on this branch alone — the
collision only exists in the combination:

```
140_hato_registrar_tratamiento.sql
141_venta_ganado_peso_destare.sql
143_fn_ronda_actor_correo_para_movimientos.sql   (#222)
144_respaldo_pl_chequeo_vacas.sql                (this PR)
```

Zero duplicate prefixes in the range the guard watches (`>= 053`). Merge order does not matter.

- `npx vitest run` on the merged tree — **175 files / 3759 tests, all green.**
- `npx vitest run` on this branch alone — 174 files / 3749 tests, all green.
- `npm run lint` — 0 errors, 898 warnings (unchanged; this PR adds none).
- `npx tsc --noEmit` — clean.

## Rollback

`git mv` it back. No migration runs, no data is written, no schema changes.

## Deliberately left out

The second half of finding #92 — pinning the one-worktree-per-agent pattern into the three
runbooks, so a review roster is never again forced to choose between running the suite and not
corrupting a shared checkout. That is an operational change and it is yours to approve; it also
closes finding #85, still open, which describes the write-side risk of the same problem.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9