### PR TITLE
fix(inventario): correct the August ronda exception from 3 bultos to 150 kilos

### DIFF
--- a/src/sql/migrations/145_excepcion_ronda_bultos_a_kilos.sql
+++ b/src/sql/migrations/145_excepcion_ronda_bultos_a_kilos.sql
@@ -1,0 +1,185 @@
+-- Migración 145: corregir la cantidad física de la excepción de la ronda de agosto
+--                (3 bultos registrados como 3, cuando el producto se mide en kilos)
+--
+-- Hallazgo #61 del barrido de mantenimiento, PARTE B. `clase datos`.
+-- Aprobada por Santiago en intercambio en vivo el 2026-09-11 sobre la propuesta
+-- que ya estaba filada en `Accion recomendada` desde la corrida 2026-08-31-lunes.
+-- El `UPDATE`, su ROLLBACK y su conteo de filas son los de esa propuesta, literales.
+--
+-- QUÉ PASÓ. Uriel dictó «tres bultos de 15-15-15 de 50 kilos». El sistema guardó
+-- `cantidad_fisica = 3`. El producto se mide en `Kilos` con `presentacion_kg_l =
+-- 50,00`, así que la cifra real es 150. David capturó el movimiento correcto por su
+-- cuenta —`movimientos_inventario` `840899f6-…`, Entrada de 150,00— y por eso el
+-- inventario nunca estuvo mal. Lo que quedó mal es el REGISTRO DE TRAZABILIDAD: la
+-- excepción dice 3 donde la realidad fueron 150, un factor de 50, y es la fila que
+-- leería una auditoría para responder «de qué tamaño fue la diferencia».
+--
+-- POR QUÉ NO SE VIO. Ni la pantalla que confirma Uriel ni el informe de cierre
+-- imprimían la unidad. El PR #220 (PARTE A) ya lo arregló y está desplegado, así que
+-- esta clase de error vuelve a ser visible. Esta migración repara el dato que aquel
+-- defecto dejó escrito.
+--
+-- LA ARITMÉTICA ES EXACTA, NO UNA ESTIMACIÓN: 3 × 50,00 = 150,00, y 150,00 es
+-- literalmente la `cantidad` del movimiento que la propia excepción enlaza en
+-- `captura_movimiento_id`. No se infiere la cifra: se toma de la fila enlazada.
+--
+-- QUÉ **NO** TOCA, y cada exclusión tiene su motivo:
+--   · `productos.cantidad_actual` — ya vale 150,00 y es correcto. Subirlo otra vez
+--     fabricaría 150 kg de fertilizante inexistente: es exactamente el remedio que se
+--     refutó el 2026-08-10 y que la migración 119 dejó documentado.
+--   · `teorico_conteo` — se queda en 0. El teórico al momento del conteo era 0 y sigue
+--     siendo 0; corregir el físico no reescribe el teórico.
+--   · `rondas_reportes` — R-10 congela un informe emitido a propósito. Reescribirlo
+--     mataría el contrato de idempotencia del módulo. El informe de agosto conserva su
+--     cifra rancia, y eso es el contrato funcionando, no un descuido.
+--   · `movimientos_inventario` — la fila de David ya es correcta.
+--
+-- Filas afectadas: **1**.
+
+-- ---------------------------------------------------------------------------
+-- RESPALDO (esquema `respaldos`, nunca `public` -- lección de la 081)
+-- ---------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS respaldos.backup_145_excepcion_bultos AS
+SELECT * FROM rondas_excepciones
+ WHERE id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2';
+
+ALTER TABLE respaldos.backup_145_excepcion_bultos ENABLE ROW LEVEL SECURITY;
+REVOKE ALL ON respaldos.backup_145_excepcion_bultos FROM anon, authenticated, PUBLIC;
+
+-- ---------------------------------------------------------------------------
+-- PRECONDICIONES
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_fisica      NUMERIC;
+  v_teorico     NUMERIC;
+  v_estado      TEXT;
+  v_mov_id      UUID;
+  v_mov_cant    NUMERIC;
+  v_presenta    NUMERIC;
+  v_unidad      TEXT;
+  v_stock       NUMERIC;
+  v_respaldo    BIGINT;
+BEGIN
+  SELECT e.cantidad_fisica, e.teorico_conteo, e.estado::text, e.captura_movimiento_id
+    INTO v_fisica, v_teorico, v_estado, v_mov_id
+    FROM rondas_excepciones e
+   WHERE e.id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2';
+
+  IF NOT FOUND THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): no existe la excepción 1d903165-6aa4-4c5d-8dbf-04067de3cbf2.';
+  END IF;
+
+  -- El estado exacto que la propuesta filada asumió.
+  IF v_estado <> 'resuelta_con_captura' THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): la excepción está en estado % y la propuesta asumió resuelta_con_captura. Revisar antes de reintentar.', v_estado;
+  END IF;
+  IF v_fisica <> 3 THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): cantidad_fisica es % y no 3 -- o ya se aplicó esta migración, o alguien la editó. No sobrescribir.', v_fisica;
+  END IF;
+  IF v_teorico <> 0 THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): teorico_conteo es % y la propuesta asumió 0.', v_teorico;
+  END IF;
+
+  -- La cifra correcta NO se infiere: sale del movimiento que la excepción enlaza.
+  IF v_mov_id IS NULL THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): la excepción no enlaza un movimiento de captura -- sin él no hay fuente para los 150.';
+  END IF;
+  SELECT m.cantidad INTO v_mov_cant FROM movimientos_inventario m WHERE m.id = v_mov_id;
+  IF v_mov_cant IS DISTINCT FROM 150.00 THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): el movimiento enlazado tiene cantidad % y no 150,00.', v_mov_cant;
+  END IF;
+
+  -- Y tiene que cerrar contra la presentación del producto: 3 bultos x 50 kg.
+  SELECT p.presentacion_kg_l, p.unidad_medida, p.cantidad_actual
+    INTO v_presenta, v_unidad, v_stock
+    FROM productos p
+    JOIN rondas_excepciones e ON e.producto_id = p.id
+   WHERE e.id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2';
+  IF v_presenta IS DISTINCT FROM 50.00 OR v_unidad <> 'Kilos' THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): el producto no es Kilos con presentacion 50,00 (es % / %). La aritmética 3 x 50 = 150 ya no se sostiene.', v_unidad, v_presenta;
+  END IF;
+  IF v_fisica * v_presenta <> v_mov_cant THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): % x % no da % -- la conversión de bultos a kilos no cierra.', v_fisica, v_presenta, v_mov_cant;
+  END IF;
+
+  -- El inventario real ya está bien y esta migración no lo toca.
+  IF v_stock IS DISTINCT FROM 150.00 THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): productos.cantidad_actual es % y no 150,00. Esta migración NO ajusta stock, así que un stock distinto significa que el supuesto cambió.', v_stock;
+  END IF;
+
+  SELECT count(*) INTO v_respaldo FROM respaldos.backup_145_excepcion_bultos;
+  IF v_respaldo <> 1 THEN
+    RAISE EXCEPTION '145 ABORTADA (pre): el respaldo tiene % filas y debe tener exactamente 1.', v_respaldo;
+  END IF;
+
+  RAISE NOTICE '145 (pre): OK. 3 bultos x 50,00 kg = 150,00, que es la cantidad del movimiento enlazado.';
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- LA CORRECCIÓN. Literal de la propuesta filada el 2026-08-31.
+-- ---------------------------------------------------------------------------
+UPDATE rondas_excepciones
+   SET cantidad_fisica = 150,
+       updated_at = now()
+ WHERE id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2'
+   AND cantidad_fisica = 3
+   AND estado = 'resuelta_con_captura';
+
+-- ---------------------------------------------------------------------------
+-- POSTCONDICIONES
+-- ---------------------------------------------------------------------------
+DO $$
+DECLARE
+  v_fisica   NUMERIC;
+  v_teorico  NUMERIC;
+  v_estado   TEXT;
+  v_stock    NUMERIC;
+  v_malos    BIGINT;
+BEGIN
+  SELECT e.cantidad_fisica, e.teorico_conteo, e.estado::text
+    INTO v_fisica, v_teorico, v_estado
+    FROM rondas_excepciones e
+   WHERE e.id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2';
+
+  IF v_fisica <> 150 THEN
+    RAISE EXCEPTION '145 ABORTADA (post): cantidad_fisica quedó en % y no en 150.', v_fisica;
+  END IF;
+  IF v_teorico <> 0 THEN
+    RAISE EXCEPTION '145 ABORTADA (post): teorico_conteo cambió a % -- esta migración no lo toca.', v_teorico;
+  END IF;
+  IF v_estado <> 'resuelta_con_captura' THEN
+    RAISE EXCEPTION '145 ABORTADA (post): el estado cambió a % -- esta migración no lo toca.', v_estado;
+  END IF;
+
+  -- El stock real tiene que seguir intacto. Si cambió, esta migración hizo algo
+  -- que no debía y hay que abortar antes de confirmar.
+  SELECT p.cantidad_actual INTO v_stock
+    FROM productos p JOIN rondas_excepciones e ON e.producto_id = p.id
+   WHERE e.id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2';
+  IF v_stock IS DISTINCT FROM 150.00 THEN
+    RAISE EXCEPTION '145 ABORTADA (post): productos.cantidad_actual cambió a % -- esta migración NO debe tocar stock.', v_stock;
+  END IF;
+
+  -- Exactamente una fila de la ronda cambió, y es la nuestra.
+  SELECT count(*) INTO v_malos
+    FROM rondas_excepciones
+   WHERE id <> '1d903165-6aa4-4c5d-8dbf-04067de3cbf2'
+     AND updated_at >= now() - interval '1 minute';
+  IF v_malos <> 0 THEN
+    RAISE EXCEPTION '145 ABORTADA (post): % excepciones ajenas cambiaron en el último minuto.', v_malos;
+  END IF;
+
+  RAISE NOTICE '145 (post): OK. La excepción dice 150 Kilos. El stock sigue en 150,00 y el informe de agosto conserva su texto.';
+END $$;
+
+-- ---------------------------------------------------------------------------
+-- ROLLBACK (no ejecutar salvo instrucción explícita del dueño).
+--
+--   UPDATE rondas_excepciones
+--      SET cantidad_fisica = 3, updated_at = now()
+--    WHERE id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2';
+--
+-- El respaldo `respaldos.backup_145_excepcion_bultos` conserva la fila entera tal
+-- como estaba, incluido su `updated_at` original (2026-08-29 00:24:00.679558+00).
+-- ---------------------------------------------------------------------------


### PR DESCRIPTION
## What

Notion finding **#61, PARTE B** — `clase datos`. Approved by Santiago in a live exchange on
2026-09-11, against the proposal filed in `Accion recomendada` since the `2026-08-31-lunes` run. The
`UPDATE` and its `ROLLBACK` are that proposal, literally — not recomposed.

## The defect

Uriel dictated *«tres bultos de 15-15-15 de 50 kilos»*. The system stored `cantidad_fisica = 3`. The
product is measured in `Kilos` with `presentacion_kg_l = 50,00`, so the real figure is **150** — a
factor of 50.

**The inventory was never wrong.** David captured the correct movement himself
(`movimientos_inventario` `840899f6-…`, Entrada of 150,00), and `productos.cantidad_actual` has read
150,00 throughout. What is wrong is the **traceability record**: the exception row says 3 where
reality was 150, and that row is what an audit reads to answer "how big was the discrepancy".

It went unseen because neither the screen Uriel confirms nor the closing report printed the unit.
**PR #220 fixed that and is deployed**, so this class of error is visible again. This migration
repairs the data that defect left behind.

## The figure is not inferred

`150,00` is literally the `cantidad` of the movement the exception already links through
`captura_movimiento_id`, and `3 × 50,00` closes against it. The pre-conditions require **both**
independently before writing:

```
3 (cantidad_fisica)  ×  50,00 (presentacion_kg_l)  =  150,00 (movimiento enlazado)
```

If either side stops holding, the migration aborts instead of writing.

## Live pre-state, verified before composing

```
estado                 resuelta_con_captura
cantidad_fisica        3            fisico_origen: dictado
teorico_conteo         0
captura_movimiento_id  840899f6-5ad8-45a0-81fb-47fecea1a5f1  → Entrada 150.00
producto               15-15-15 · Kilos · presentacion_kg_l 50.00
cantidad_actual        150.00       (already correct)
```

## What it deliberately does NOT touch

- **`productos.cantidad_actual`** — already 150,00. Raising it again would fabricate 150 kg of
  fertiliser that does not exist. That is exactly the remedy refuted on 2026-08-10 and documented in
  migration 119.
- **`teorico_conteo`** — stays 0. Correcting the physical count does not rewrite the theoretical one.
- **`rondas_reportes`** — R-10 freezes an emitted report on purpose. Rewriting it would break the
  module's idempotency contract. The August report keeps its stale figure, and that is the contract
  working.
- **`movimientos_inventario`** — David's row is already correct.

## Guards

Pre: exception exists · state is `resuelta_con_captura` · `cantidad_fisica = 3` (so a second run
aborts rather than double-applying) · `teorico_conteo = 0` · linked movement exists and is 150,00 ·
product is Kilos at 50,00 · the multiplication closes · stock is already 150,00 · backup holds
exactly 1 row.

Post: figure is 150 · `teorico_conteo` and `estado` unchanged · **stock still 150,00** (if this
migration moved stock it aborts) · no other exception row changed in the last minute.

Backup in `respaldos.backup_145_excepcion_bultos` — the `respaldos` schema, never `public`
(migration 081), RLS on, no grants for `anon`/`authenticated`.

**Rows affected: 1.**

## Numbering

`145`. Verified free against `main`, the ledger, the `respaldos` schema **and every open remote
branch** — the sweep that today's `142`/`143` collisions made non-optional.

## Verification

`hatoSchemaContract.test.ts` — 126 passed, no duplicate prefix.

## Rollback

```sql
UPDATE rondas_excepciones SET cantidad_fisica = 3, updated_at = now()
 WHERE id = '1d903165-6aa4-4c5d-8dbf-04067de3cbf2';
```

The backup keeps the whole row including its original `updated_at`.

## Still open on #61

**PARTE C** — making the `captura_david` path reconfirm the quantity, as migration 132 already does
for `/proponer`. That is a behaviour change, not a repair, and it is a separate decision.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9

---
_Generated by [Claude Code](https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9)_