### PR TITLE
chore(po): one worktree per agent, and raise Friday's codigo cap to 5

### DIFF
--- a/escociaos-po/runbooks/run-jueves.md
+++ b/escociaos-po/runbooks/run-jueves.md
@@ -20,6 +20,12 @@ Same protocol as Monday (constitution §4) with these narrowings:
 **Phase 0** — identical boot (clone, contracts, write mode, dead-man check,
 dedupe set). Run id `YYYY-MM-DD-jueves`.
 
+> **Including step 2b: one `git worktree` per agent, `npm ci` once before dispatch.**
+> This is the run that proved why. On 2026-09-10 the four agents shared a checkout,
+> so `npm test` was forbidden to them — and a `main` that had been red since
+> 2026-09-09 went unreported through a complete operational pulse. **Thursday must
+> never again dispatch a roster that cannot run the suite.**
+
 **Phase 1** — 4 agents, each explicitly scoped to **what changed since Monday**:
 
 - `data-integrity` — **the last 72 hours of writes only**, not a full sweep.

--- a/escociaos-po/runbooks/run-lunes.md
+++ b/escociaos-po/runbooks/run-lunes.md
@@ -17,6 +17,33 @@ First Monday of the month adds: `feature-strategy` · `code-quality`.
 1. Run id: `YYYY-MM-DD-lunes`.
 2. Clone: `git clone --depth 50 https://github.com/sforero94/Escociaos.git /tmp/escociaos`.
    `npm ci` only if PRs are on the menu this run (lint/typecheck/test gate).
+
+   **2b. One worktree per agent — do this BEFORE dispatching anyone.** Agents that
+   share a single checkout cannot run the suite: installing dependencies moves the
+   tree under everyone else, so the mitigation becomes *turning the tests off*, and
+   a roster that cannot run the tests cannot see a red `main`. That is not
+   hypothetical — it is how `main` sat red for two days across a full Thursday
+   review (finding #92, 2026-09-11), and it is the read-side twin of #85.
+
+   ```sh
+   npm ci                                   # ONCE, in the main checkout, before dispatch
+   for a in <agent-slugs>; do
+     git worktree add -b claude/po-$a "$SCRATCH/wt/$a" origin/main
+     ln -s "$PWD/node_modules" "$SCRATCH/wt/$a/node_modules"
+   done
+   ```
+
+   Each agent gets its own worktree path and its own branch. **Forbid them to `cd`
+   outside it, and to run `git checkout` / `switch` / `reset --hard`** — those are
+   what move the tree under a sibling. The symlinked `node_modules` is what makes
+   one `npm ci` serve everyone.
+
+   Measured cost on 2026-09-11: one `npm ci` (~2 min) plus four `git worktree add`
+   (seconds). In exchange, four agents ran lint, typecheck and the full suite in
+   parallel without colliding, and the two-day-old red surfaced in the first five
+   minutes of the run.
+
+   Clean up with `git worktree remove --force <path>` then `git worktree prune`.
 3. Read `/tmp/escociaos/CLAUDE.md` in full (technical contract), then
    `/tmp/escociaos/escociaos-po/CLAUDE.md` (this operation's constitution) if
    you have not already — the bootstrapper prompt sent you here.

--- a/escociaos-po/runbooks/run-viernes.md
+++ b/escociaos-po/runbooks/run-viernes.md
@@ -38,12 +38,33 @@ requirement and a decision that belong to a live exchange.
 
 ### Caps, per run
 
-- **3** `codigo` PRs.
+- **5** `codigo` PRs.
 - **1** `ddl_aditivo` migration. One. Not "one per finding".
 
 If more qualify, take the highest `Severidad × Esfuerzo⁻¹` (P2 before P3, S
 before M) and **say in the report how many were left and why**. Silent
 truncation is a reporting failure here exactly as it is on Monday.
+
+> **Why `codigo` went 3 → 5 (Santiago, 2026-09-11): «this run is intended to fix
+> and clean the queue, not add to it».** The eligible set ran 6 → 8 → 9 across
+> three consecutive Fridays against a fixed cap of 4 total, so the drain was
+> losing to the fill — which defeats the entire reason the Friday run exists
+> (constitution §3: *Monday and Thursday find; Friday finishes*). The deferred
+> work was not marginal: the five left on 2026-09-11 were all P2, effort S,
+> `Confianza: Alta` — ready work, not open questions.
+>
+> **The `ddl_aditivo` cap stays at 1, and raising it later would be a different
+> argument.** That one is not a throughput limit: it is the blast radius of the
+> single unattended production write the operation permits, and it is what makes
+> the five gates affordable per run. The same day the code cap rose, the adversarial
+> review returned `unsafe` and stopped a migration that would have put an e-mail
+> where the monthly report signs a name. One migration per run is what buys that
+> scrutiny.
+>
+> **Five, and not more, for a concrete reason**: each `codigo` agent needs its own
+> worktree (Phase 0 step 2b) and runs the full suite in it. Five is what the run
+> has been observed to carry inside the 90-minute deadline with the verification
+> gate intact. Raise it again only with a run that finishes early, not on appetite.
 
 ---
 
@@ -51,8 +72,13 @@ truncation is a reporting failure here exactly as it is on Monday.
 
 **Phase 0 — Boot**
 
-Identical to Monday (constitution §4), including the **tool preflight** and the
-**dead-man check**, plus one Friday-specific step:
+Identical to Monday (constitution §4), including the **tool preflight**, the
+**dead-man check** and **step 2b (one `git worktree` per agent, one `npm ci`
+before dispatch)** — non-negotiable here, because every Friday agent opens a PR
+and the constitution requires lint, typecheck and the suite green before it does.
+A shared checkout makes that gate unrunnable, which is how it gets skipped.
+
+Plus one Friday-specific step:
 
 - Read the open backlog from Notion and compute the eligible set above. **If it
   is empty, say so and stop.** A Friday with nothing to drain is the goal state,


### PR DESCRIPTION
Two decisions Santiago made on 2026-09-11. Both are about how the operation runs, not about the
product. Docs only — no source, no migration, no data.

## 1. One worktree per agent — finding #92 part 2, and it closes #85 too

Agents sharing one checkout **cannot run the test suite**: installing dependencies moves the tree
under everybody else, so the mitigation becomes *switching the tests off*. A roster that cannot run
the tests cannot see a red `main`.

That is not hypothetical. It is exactly how `main` stayed red from 2026-09-09 through a **complete
Thursday operational pulse** without one line of signal. The Thursday run's own memory records the
reason in its own words: *«a bug-triage hubo que prohibirle además npm test/lint/typecheck, porque
node_modules no está instalado y instalarlo muta el árbol de los otros tres»*.

The canonical rule goes in `run-lunes.md` as **step 2b**, since Thursday and Friday both define
their boot as "identical to Monday":

```sh
npm ci                                   # ONCE, in the main checkout, before dispatch
for a in <agent-slugs>; do
  git worktree add -b claude/po-$a "$SCRATCH/wt/$a" origin/main
  ln -s "$PWD/node_modules" "$SCRATCH/wt/$a/node_modules"
done
```

Plus the two prohibitions that make it hold: agents may not `cd` outside their worktree, and may not
run `git checkout` / `switch` / `reset --hard` — those are what move the tree under a sibling.

Thursday and Friday also name it explicitly rather than only inheriting it, because those are the
two runs where its absence cost something: Thursday is where the red went unseen, and Friday is where
every agent opens a PR that the constitution requires to be green first.

**Measured cost on 2026-09-11**: one `npm ci` (~2 min) plus four `git worktree add` (seconds). In
exchange four agents ran lint, typecheck and the full suite in parallel without colliding, and the
two-day-old red surfaced in the run's first five minutes.

This is the read-side half of **#85**, which describes the write-side risk of the same shared
checkout. Both close here.

## 2. Friday's `codigo` cap: 3 → 5

Santiago's reason, verbatim: *"this run is intended to fix and clean the queue, not add to it."*

The eligible set ran **6 → 8 → 9** across three consecutive Fridays against a fixed total cap of 4.
The drain was losing to the fill, which defeats the reason the Friday run exists at all
(constitution §3: *Monday and Thursday find; Friday finishes*). The deferred work was not marginal —
the five left behind on 2026-09-11 were all P2, effort S, `Confianza: Alta`.

**Five and not more, for a concrete reason**: each `codigo` agent now needs its own worktree and runs
the full suite in it. Five is what the run was observed to carry inside the 90-minute deadline with
the verification gate intact. Raising it again should follow a run that finishes early, not appetite.

**The `ddl_aditivo` cap stays at 1**, and that is not an oversight. It is not a throughput limit —
it is the blast radius of the single unattended production write the operation permits, and it is
what makes five gates affordable per run. The same day the code cap rose, that review returned
`unsafe` and stopped a migration that would have replaced the monthly report's signature with an
e-mail address. One migration per run is what buys that scrutiny.

## Verification

Docs only. No stale reference to the old cap remains — `grep` over `runbooks/` and the constitution
returns only the new value and its rationale.

---
🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9

---
_Generated by [Claude Code](https://claude.ai/code/session_013NXWS4onAy7p2AbGR5Eqt9)_