### PR TITLE
chore: add Cloud Agent dev environment config

### DIFF
--- a/.cursor/environment.json
+++ b/.cursor/environment.json
@@ -1,0 +1,11 @@
+{
+  "name": "Escocia OS",
+  "install": "npm install",
+  "terminals": [
+    {
+      "name": "dev",
+      "command": "npm run dev",
+      "description": "Vite dev server on http://localhost:3000 (needs VITE_SUPABASE_URL and VITE_SUPABASE_ANON_KEY set as secrets to reach the backend)."
+    }
+  ]
+}


### PR DESCRIPTION
<!-- CURSOR_AGENT_PR_BODY_BEGIN -->
## What

Adds `.cursor/environment.json` so Cloud Agents set up this codebase automatically:

- `install`: `npm install`
- `terminals`: a `dev` terminal running `npm run dev` (Vite on port 3000)

## Why

The repo had no linked Cloud Agent environment. This makes dependency install and the dev server reproducible for future agents. No source files changed.

## Environment setup performed and verified

| Step | Result |
|------|--------|
| `npm install` | 504 packages, exit 0 |
| `npm run typecheck` (`tsc --noEmit`) | clean |
| `npm run lint` | 0 errors (908 pre-existing `any` warnings, allowed by config) |
| `npm test` (vitest) | 3760 passed / 3762 |
| `npm run build` | built in ~10s |
| `npm run dev` | serves HTTP 200 at http://localhost:3000, login UI renders |

Note: 2 pre-existing test failures in `src/__tests__/tableCrudoTrinquete.test.ts` (a static "raw table" debt ratchet for two `hato` components) exist on the untouched base branch and are unrelated to environment setup.

## Secrets required

The app reads `VITE_SUPABASE_URL` and `VITE_SUPABASE_ANON_KEY` at runtime (`src/utils/supabase/client.ts`). They must be added in the Cloud Agent Secrets panel to reach the Supabase backend. For this verification a placeholder `.env.local` (gitignored) let the front-end boot; backend calls were expected to fail.

## Screenshot — login page rendering

[Escocia OS login page](https://cursor.com/agents/bc-4ef69e3b-6fd6-44c9-84de-8e2b64a56881/artifacts?path=%2Fopt%2Fcursor%2Fartifacts%2Fescocia-os-login.webp)


<sub>To show artifacts inline, <a href="https://cursor.com/dashboard/cloud-agents#my-pull-requests">enable</a> in settings.</sub>
<!-- CURSOR_AGENT_PR_BODY_END -->

<div><a href="https://cursor.com/agents/bc-4ef69e3b-6fd6-44c9-84de-8e2b64a56881?cursor_ref=pr_footer&cursor_cta=open_in_web"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-web-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-web-light.png"><img alt="Open in Web" width="114" height="28" src="https://cursor.com/assets/images/open-in-web-dark.png"></picture></a>&nbsp;<a href="https://cursor.com/background-agent?bcId=bc-4ef69e3b-6fd6-44c9-84de-8e2b64a56881&cursor_ref=pr_footer&cursor_cta=open_in_cursor"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/assets/images/open-in-cursor-dark.png"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/assets/images/open-in-cursor-light.png"><img alt="Open in Cursor" width="131" height="28" src="https://cursor.com/assets/images/open-in-cursor-dark.png"></picture></a>&nbsp;</div>

